### PR TITLE
Bug Fix: DPad conflict on Kindle Keyboard

### DIFF
--- a/frontend/apps/reader/modules/readerpanning.lua
+++ b/frontend/apps/reader/modules/readerpanning.lua
@@ -21,7 +21,7 @@ end
 function ReaderPanning:onGesture() end
 
 function ReaderPanning:registerKeyEvents()
-    if Device:hasKeyboard() then
+    if Device:hasKeyboard() and Device:hasDPad() and not Device:useDPadAsActionKeys() then
         self.key_events = {
             -- these will all generate the same event, just with different arguments
             MoveUp = {

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -231,15 +231,21 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
     -- we use same pos. 4 as below so we are always above "keyboard apperance settings"
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' + 'Home'."),
+        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home'."),
         checked_func = function()
             return G_reader_settings:nilOrTrue("virtual_keyboard_enabled")
         end,
         callback = function()
             G_reader_settings:flipNilOrTrue("virtual_keyboard_enabled")
             if G_reader_settings:isFalse("virtual_keyboard_enabled") then
+                local keyboard_infomessage
+                if Device:hasScreenKB() then
+                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'ScreenKB' + 'Home'.")
+                else
+                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home'.")
+                end
                 UIManager:show(InfoMessage:new{
-                    text = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home'.")
+                    text = keyboard_infomessage
                 })
             end
         end,


### PR DESCRIPTION
### what's new:

* Fix conflicting mapping on kindles with keyboards. see https://github.com/koreader/koreader/issues/12340#issuecomment-2284928923
* Add infoMessage to Kindle 4 with correct modifier (genuine overlook from #12162 )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12341)
<!-- Reviewable:end -->
