### PR TITLE
Support 'Ctrl' shortcuts on hasKeyboard

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -30,8 +30,8 @@ end
 
 function FileSearcher:registerKeyEvents()
     if Device:hasKeyboard() then
-        self.key_events.ShowFileSearch = { { "Alt", "F" } }
-        self.key_events.ShowFileSearchBlank = { { "Alt", "Shift", "F" }, event = "ShowFileSearch", args = "" }
+        self.key_events.ShowFileSearch = { { "Alt", "F" }, { "Ctrl", "F" } }
+        self.key_events.ShowFileSearchBlank = { { "Alt", "Shift", "F" }, { "Ctrl", "Shift", "F" }, event = "ShowFileSearch", args = "" }
     end
 end
 

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -64,7 +64,7 @@ function ReaderBookmark:onGesture() end
 
 function ReaderBookmark:registerKeyEvents()
     if Device:hasKeyboard() then
-        self.key_events.ShowBookmark = { { "B" } }
+        self.key_events.ShowBookmark = { { "B" }, { "Shift", "Left" } }
         self.key_events.ToggleBookmark = { { "Shift", "Right" } }
     elseif Device:hasScreenKB() then
         self.key_events.ShowBookmark = { { "ScreenKB", "Left" } }

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -166,7 +166,7 @@ end
 
 function ReaderDictionary:registerKeyEvents()
     if Device:hasKeyboard() then
-        self.key_events.ShowDictionaryLookup = { { "Alt", "D" } }
+        self.key_events.ShowDictionaryLookup = { { "Alt", "D" }, { "Ctrl", "D" } }
     end
 end
 

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -85,8 +85,8 @@ SRELL_ERROR_CODES[666] = _("Expression may lead to an extremely long search time
 
 function ReaderSearch:registerKeyEvents()
     if Device:hasKeyboard() then
-        self.key_events.ShowFulltextSearchInputBlank = { { "Alt", "Shift", "S" }, event = "ShowFulltextSearchInput", args = "" }
-        self.key_events.ShowFulltextSearchInputRecent = { { "Alt", "S" }, event = "ShowFulltextSearchInput" }
+        self.key_events.ShowFulltextSearchInputBlank = { { "Alt", "Shift", "S" }, { "Ctrl", "Shift", "S" }, event = "ShowFulltextSearchInput", args = "" }
+        self.key_events.ShowFulltextSearchInputRecent = { { "Alt", "S" }, { "Ctrl", "S" }, event = "ShowFulltextSearchInput" }
     end
 end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -63,7 +63,7 @@ function ReaderToc:registerKeyEvents()
     if Device:hasScreenKB() then
         self.key_events.ShowToc = { { "ScreenKB", "Up" } }
     elseif Device:hasKeyboard() then
-        self.key_events.ShowToc = { { "T" } }
+        self.key_events.ShowToc = { { "T" }, { "Shift", "Up" } }
     end
 end
 

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -39,7 +39,7 @@ end
 
 function ReaderWikipedia:registerKeyEvents()
     if Device:hasKeyboard() then
-        self.key_events.ShowWikipediaLookup = { { "Alt", "W" } }
+        self.key_events.ShowWikipediaLookup = { { "Alt", "W" }, { "Ctrl", "W" } }
     end
 end
 


### PR DESCRIPTION
### what's new

* Support <kbd>ctrl</kbd> keyboard shortcuts where appropriate  See https://github.com/koreader/koreader/pull/12162#issuecomment-2273884263 
Fix #10499 (Again)
*  Bring `ToC` and `Bookmark` shortcuts on par on all NT kindles.

-hey dwarves!- he yelled, -sometimes fighting the dragon isn't the only way, "eat one" I'm going back to The Shire-. -- Bilbo B. (The Hobbit, alternative ending)

Heroism isn't just about facing the beast, but if @ryanwwest has anything else to add after this is merged... I just might. -- somebody (probably).  ;)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12347)
<!-- Reviewable:end -->
