### PR TITLE
Display menu preview of italic-only fonts

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -73,7 +73,7 @@ function ReaderFont:setupFaceMenuTable()
     for k, v in ipairs(face_list) do
         local font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v)
         if not font_filename then
-            -- The font may be available only in italic, for example script fonts
+            -- The font may be available only in italic, for example script/cursive fonts
             font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v, nil, true)
         end
         table.insert(self.face_table, {

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -72,6 +72,10 @@ function ReaderFont:setupFaceMenuTable()
     face_list = self:sortFaceList(face_list)
     for k, v in ipairs(face_list) do
         local font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v)
+        if not font_filename then
+            -- The font may be available only in italic, for example script fonts
+            font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v, nil, true)
+        end
         table.insert(self.face_table, {
             text_func = function()
                 -- defaults are hardcoded in credocument.lua
@@ -572,6 +576,9 @@ Enabling this will ignore such font names and make sure your preferred family fo
         }
         for k, v in ipairs(face_list) do
             local font_filename, font_faceindex, is_monospace, has_ot_math, has_emojis = cre.getFontFaceFilenameAndFaceIndex(v)
+            if not font_filename then
+                font_filename, font_faceindex, is_monospace, has_ot_math, has_emojis = cre.getFontFaceFilenameAndFaceIndex(v, nil, true)
+            end
             if i == 1 then
                 face_to_filename[v] = { font_filename, font_faceindex }
             end

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -268,7 +268,7 @@ end
 -- @treturn table @{FontFaceObj}
 function Font:getFace(font, size, faceindex)
     -- default to content font
-    if not font then font = self.cfont end
+    if not font then font = self.fontmap["cfont"] end
 
     if not size then size = self.sizemap[font] end
     -- original size before scaling by screen DPI

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -268,7 +268,7 @@ end
 -- @treturn table @{FontFaceObj}
 function Font:getFace(font, size, faceindex)
     -- default to content font
-    if not font then font = self.fontmap["cfont"] end
+    if not font then font = self.fontmap.cfont end
 
     if not size then size = self.sizemap[font] end
     -- original size before scaling by screen DPI


### PR DESCRIPTION
In font selection menus, ask creengine for italic versions of fonts if there's no regular version to preview. Also prevents a crash when a font can't be previewed in the font family menu.

Bold-only fonts already work, so no need to cover that case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12351)
<!-- Reviewable:end -->
