### PR TITLE
Add numerical key_codes to event_map on kindle 3

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -67,7 +67,7 @@ function ReaderPaging:registerKeyEvents()
         self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
         self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
     end
-    if Device:hasKeyboard() then
+    if Device:hasKeyboard() and not Device.model == "Kindle3" then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }
         self.key_events.Goto11    = { { "2" }, event = "GotoPercent", args = 11,  }
         self.key_events.Goto22    = { { "3" }, event = "GotoPercent", args = 22,  }

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -136,7 +136,7 @@ function ReaderRolling:registerKeyEvents()
         self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
         self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
     end
-    if Device:hasKeyboard() then
+    if Device:hasKeyboard() and not Device.model == "Kindle3" then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }
         self.key_events.Goto11    = { { "2" }, event = "GotoPercent", args = 11,  }
         self.key_events.Goto22    = { { "3" }, event = "GotoPercent", args = 22,  }

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -38,7 +38,11 @@ function ReaderWikipedia:init()
 end
 
 function ReaderWikipedia:registerKeyEvents()
-    if Device:hasKeyboard() then
+    if Device:hasKeyboard() and Device.model == "Kindle3" then
+        -- Any user facing documentation should advertise this shortcut as Alt+W, as that is what
+        -- the user must input in order to use it.
+        self.key_events.ShowWikipediaLookup = { { "2" } }
+    elseif Device:hasKeyboard() then
         self.key_events.ShowWikipediaLookup = { { "Alt", "W" }, { "Ctrl", "W" } }
     end
 end

--- a/frontend/device/kindle/event_map_kindle4.lua
+++ b/frontend/device/kindle/event_map_kindle4.lua
@@ -3,6 +3,10 @@ event map for Kindle devices on FW 3.x & 4.x
 --]]
 
 return {
+    -- NOTE: Although Kindle 3 does not have numerical keys, these key codes are still registered when pressing 'Alt'+'QWERTYUIOP'
+    --       So, as far as kindle is concerned Alt+Q = 1, Alt+W = 2, ... Alt+P = 0
+    [2]  = "1", [3]  = "2", [4]  = "3", [5]  = "4", [6]  = "5", [7]  = "6", [8]  = "7", [9]  = "8", [10] = "9", [11] = "0",
+    -- Physical keys
     [16] = "Q", [17] = "W", [18] = "E", [19] = "R", [20] = "T", [21] = "Y", [22] = "U", [23] = "I", [24] = "O", [25] = "P",
     [30] = "A", [31] = "S", [32] = "D", [33] = "F", [34] = "G", [35] = "H", [36] = "J", [37] = "K", [38] = "L", [14] = "Del",
     [44] = "Z", [45] = "X", [46] = "C", [47] = "V", [48] = "B", [49] = "N", [50] = "M", [52] = ".",


### PR DESCRIPTION
### what's new:

* Add numerical key codes to the kindle 3's (firmware 3.x) event map
* Fix Wikipedia shortcut. See [#12162](https://github.com/koreader/koreader/pull/12162#issuecomment-2291193242)