### PR TITLE
Screensaver: add option to rotate to fit screen

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -38,7 +38,7 @@ return {
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
-                text = _("Border fill and fit"),
+                text = _("Border fill, rotation, and fit"),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -38,7 +38,7 @@ return {
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
             separator = true,
             {
-                text = _("Border fill"),
+                text = _("Border fill and fit"),
                 enabled_func = function()
                     return G_reader_settings:readSetting("screensaver_type") == "cover"
                            or G_reader_settings:readSetting("screensaver_type") == "document_cover"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -65,7 +65,7 @@ return {
                         end,
                     },
                     {
-                        text = _("Rotate cover to fit screen"),
+                        text = _("Auto-rotate cover for best fit"),
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit")
                         end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -67,10 +67,10 @@ return {
                     {
                         text = _("Rotate cover to fit screen"),
                         checked_func = function()
-                            return G_reader_settings:isTrue("screensaver_autorotate_images")
+                            return G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit")
                         end,
                         callback = function(touchmenu_instance)
-                            G_reader_settings:flipNilOrFalse("screensaver_autorotate_images")
+                            G_reader_settings:flipNilOrFalse("screensaver_rotate_auto_for_best_fit")
                             touchmenu_instance:updateItems()
                         end,
                     }

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -65,7 +65,7 @@ return {
                         end,
                     },
                     {
-                        text = _("Auto-rotate cover for best fit"),
+                        text = _("Rotate cover for best fit"),
                         checked_func = function()
                             return G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit")
                         end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -64,6 +64,16 @@ return {
                             Screensaver:setStretchLimit(touchmenu_instance)
                         end,
                     },
+                    {
+                        text = _("Rotate cover to fit screen"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("screensaver_autorotate_images")
+                        end,
+                        callback = function(touchmenu_instance)
+                            G_reader_settings:flipNilOrFalse("screensaver_autorotate_images")
+                            touchmenu_instance:updateItems()
+                        end,
+                    }
                 },
             },
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -49,8 +49,8 @@ end
 if G_reader_settings:hasNot("screensaver_stretch_images") then
     G_reader_settings:makeFalse("screensaver_stretch_images")
 end
-if G_reader_settings:hasNot("screensaver_autorotate_images") then
-    G_reader_settings:makeFalse("screensaver_autorotate_images")
+if G_reader_settings:hasNot("screensaver_rotate_auto_for_best_fit") then
+    G_reader_settings:makeFalse("screensaver_rotate_auto_for_best_fit")
 end
 if G_reader_settings:hasNot("screensaver_delay") then
     G_reader_settings:saveSetting("screensaver_delay", "disable")
@@ -512,7 +512,7 @@ function Screensaver:show()
 
     -- We mostly always suspend in Portrait/Inverted Portrait mode...
     -- ... except when we just show an InfoMessage or when the screensaver
-    -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5920).
+    -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290).
     -- We also exclude full-screen widgets that work fine in Landscape mode,
     -- like ReadingProgress and BookStatus (c.f., #5724)
     if self:modeExpectsPortrait() then
@@ -556,7 +556,7 @@ function Screensaver:show()
             widget_settings.image = self.image
             widget_settings.image_disposable = true
         elseif self.image_file then
-            if G_reader_settings:isTrue("screensaver_autorotate_images") then
+            if G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit") then
                 -- We need to load the image here to determine whether to rotate
                 if util.getFileNameSuffix(self.image_file) == "svg" then
                     widget_settings.image = RenderImage:renderSVGImageFile(self.image_file, nil, nil, 1)
@@ -573,10 +573,9 @@ function Screensaver:show()
             end
             widget_settings.alpha = true
         end
-        if G_reader_settings:isTrue("screensaver_autorotate_images") then
+        if G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit") then
             local angle = rotation_mode == 3 and 180 or 0 -- match mode if possible
-            if (widget_settings.image:getWidth() < widget_settings.image:getHeight())
-                ~= (widget_settings.width < widget_settings.height) then
+            if (widget_settings.image:getWidth() < widget_settings.image:getHeight()) ~= (widget_settings.width < widget_settings.height) then
                 angle = angle + 90
             end
             widget_settings.rotation_angle = angle

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -576,7 +576,7 @@ function Screensaver:show()
         if G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit") then
             local angle = rotation_mode == 3 and 180 or 0 -- match mode if possible
             if (widget_settings.image:getWidth() < widget_settings.image:getHeight()) ~= (widget_settings.width < widget_settings.height) then
-                angle = angle + 90
+                angle = angle + (G_reader_settings:isTrue("imageviewer_rotation_landscape_invert") and -90 or 90)
             end
             widget_settings.rotation_angle = angle
         end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -572,7 +572,7 @@ function Screensaver:show()
                 widget_settings.file_do_cache = false
             end
             widget_settings.alpha = true
-        end
+        end -- set cover or file
         if G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit") then
             local angle = rotation_mode == 3 and 180 or 0 -- match mode if possible
             if (widget_settings.image:getWidth() < widget_settings.image:getHeight()) ~= (widget_settings.width < widget_settings.height) then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -11,6 +11,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local ImageWidget = require("ui/widget/imagewidget")
 local Math = require("optmath")
 local OverlapGroup = require("ui/widget/overlapgroup")
+local RenderImage = require("ui/renderimage")
 local ScreenSaverWidget = require("ui/widget/screensaverwidget")
 local ScreenSaverLockWidget = require("ui/widget/screensaverlockwidget")
 local SpinWidget = require("ui/widget/spinwidget")
@@ -47,6 +48,9 @@ if G_reader_settings:hasNot("screensaver_message_position") then
 end
 if G_reader_settings:hasNot("screensaver_stretch_images") then
     G_reader_settings:makeFalse("screensaver_stretch_images")
+end
+if G_reader_settings:hasNot("screensaver_autorotate_images") then
+    G_reader_settings:makeFalse("screensaver_autorotate_images")
 end
 if G_reader_settings:hasNot("screensaver_delay") then
     G_reader_settings:saveSetting("screensaver_delay", "disable")
@@ -504,13 +508,15 @@ function Screensaver:show()
         return
     end
 
+    local rotation_mode = Screen:getRotationMode()
+
     -- We mostly always suspend in Portrait/Inverted Portrait mode...
     -- ... except when we just show an InfoMessage or when the screensaver
-    -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5290).
+    -- is disabled, as it plays badly with Landscape mode (c.f., #4098 and #5920).
     -- We also exclude full-screen widgets that work fine in Landscape mode,
     -- like ReadingProgress and BookStatus (c.f., #5724)
     if self:modeExpectsPortrait() then
-        Device.orig_rotation_mode = Screen:getRotationMode()
+        Device.orig_rotation_mode = rotation_mode
         -- Leave Portrait & Inverted Portrait alone, that works just fine.
         if bit.band(Device.orig_rotation_mode, 1) == 1 then
             -- i.e., only switch to Portrait if we're currently in *any* Landscape orientation (odd number)
@@ -550,9 +556,30 @@ function Screensaver:show()
             widget_settings.image = self.image
             widget_settings.image_disposable = true
         elseif self.image_file then
-            widget_settings.file = self.image_file
-            widget_settings.file_do_cache = false
+            if G_reader_settings:isTrue("screensaver_autorotate_images") then
+                -- We need to load the image here to determine whether to rotate
+                if util.getFileNameSuffix(self.image_file) == "svg" then
+                    widget_settings.image = RenderImage:renderSVGImageFile(self.image_file, nil, nil, 1)
+                else
+                    widget_settings.image = RenderImage:renderImageFile(self.image_file, false, nil, nil)
+                end
+                if not widget_settings.image then
+                    widget_settings.image = RenderImage:renderCheckerboard(Screen:getWidth(), Screen:getHeight(), Screen.bb:getType())
+                end
+                widget_settings.image_disposable = true
+            else
+                widget_settings.file = self.image_file
+                widget_settings.file_do_cache = false
+            end
             widget_settings.alpha = true
+        end
+        if G_reader_settings:isTrue("screensaver_autorotate_images") then
+            local angle = rotation_mode == 3 and 180 or 0 -- match mode if possible
+            if (widget_settings.image:getWidth() < widget_settings.image:getHeight())
+                ~= (widget_settings.width < widget_settings.height) then
+                angle = angle + 90
+            end
+            widget_settings.rotation_angle = angle
         end
         widget = ImageWidget:new(widget_settings)
     elseif self.screensaver_type == "bookstatus" then


### PR DESCRIPTION
Checkbox in Wallpaper->Border fill to rotate images to fill as much of the screen as possible. It's basically what NiLuJe suggested in #11856 about checking the image's orientation. Passing a buffer directly avoids the ImageWidget cache trick that loads and stretches in one step.

A note about SVG: They're rendered here in their "native" resolution and so won't scale up correctly when rotated. Some math could fix that, but I doubt many people use SVG wallpapers.

I considered adding a rotate_to_fit setting to ImageWidget instead (ignoring orientation), but rotating *before* stretching a loaded file would require some refactoring, or at least an ugly-specific setting to disable the cache hack in _loadfile().

Test images if you like:
PNG
![test-wallpaper](https://github.com/user-attachments/assets/c5b9c0ca-83e4-4b8e-ad2d-48de25bfb923)
SVG
![test-wallpaper](https://github.com/user-attachments/assets/9bf74555-00a1-4048-bdfb-a3bd89de30ea)

Fix #11856 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12366)
<!-- Reviewable:end -->
