### PR TITLE
android: tweak update rule

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -68,6 +68,8 @@ update: all
 	# Note: do not remove the module directory so there's no need
 	# for `mk7z.sh` to always recreate `assets.7z` from scratch.
 	rm -rf $(ANDROID_LIBS)
+	# Remove old in-tree build artifacts that could conflict.
+	rm -rf $(ANDROID_LAUNCHER_DIR)/assets/{libs,module}
 	# APK version
 	mkdir -p $(ANDROID_ASSETS)/module $(ANDROID_LIBS)
 	echo $(VERSION) >$(ANDROID_ASSETS)/module/version.txt

--- a/make/android.mk
+++ b/make/android.mk
@@ -1,7 +1,7 @@
 # Use the git commit count as the (integer) Android version code
 ANDROID_VERSION ?= $(shell git rev-list --count HEAD)
 ANDROID_NAME ?= $(VERSION)
-ANDROID_APK = koreader-android-$(ANDROID_ARCH)$(KODEDUG_SUFFIX)-$(VERSION).apk
+ANDROID_APK = koreader-android-$(ANDROID_ARCH)$(KODEDUG_SUFFIX)-$(ANDROID_NAME).apk
 
 # Run. {{{
 

--- a/make/android.mk
+++ b/make/android.mk
@@ -67,7 +67,7 @@ androiddev: update
 update: all
 	# Note: do not remove the module directory so there's no need
 	# for `mk7z.sh` to always recreate `assets.7z` from scratch.
-	rm -rfv $(ANDROID_LIBS)
+	rm -rf $(ANDROID_LIBS)
 	# APK version
 	mkdir -p $(ANDROID_ASSETS)/module $(ANDROID_LIBS)
 	echo $(VERSION) >$(ANDROID_ASSETS)/module/version.txt


### PR DESCRIPTION
- silence unnecessary verbose update step
- tweak APK name: use `ANDROID_NAME` for last part so setting it as an environment variable to something like `dev` allows for a stable APK across different revisions
- remove old in-tree build artifacts that could conflict (`assets/libs` & `assets/module`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12370)
<!-- Reviewable:end -->
