### PR TITLE
Fix terminal broken cursor and backspace

### DIFF
--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -1,5 +1,5 @@
 --[[--
-This plugin provides a terminal emulator (VT52 (+some ANSI))
+This plugin provides a terminal emulator (VT52 (+some ANSI and some VT100))
 
 @module koplugin.terminal
 ]]
@@ -182,7 +182,21 @@ function Terminal:spawnShell(cols, rows)
         if Device:isAndroid() then
             C.setenv("ANDROID", "ANDROID", 1)
         end
-        if C.execlp(shell, shell) ~= 0 then
+
+        local function get_readline_wrapper()
+            if os.execute("which rlfe") == 0 then
+                return "rlfe"
+            elseif os.execute("which rlwrap") == 0 then
+                return "rlwrap"
+            else
+                return
+            end
+        end
+
+        -- Here we use an existing readline wrapper
+        local rlw = get_readline_wrapper()
+
+        if (rlw and C.execlp(rlw, rlw, shell)) or C.execlp(shell, shell) ~= 0 then
             -- the following two prints are shown in the terminal emulator.
             print("Terminal: something has gone really wrong in spawning the shell\n\n:-(\n")
             print("Maybe an incorrect shell: '" .. shell .. "'\n")

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -101,7 +101,7 @@ function Terminal:isExecutable(file)
 end
 
 -- Try SHELL environment variable and some standard shells
-function Terminal:determineShellExecutable()
+function Terminal:getDefaultShellExecutable()
     if self.default_shell_executable then return self.default_shell_executable end
 
     local shell = {"mksh", "ksh", "zsh", "ash", "dash", "sh", "bash"}
@@ -120,7 +120,7 @@ function Terminal:determineShellExecutable()
 end
 
 function Terminal:init()
-    G_reader_settings:readSetting("terminal_shell", self:determineShellExecutable())
+    G_reader_settings:readSetting("terminal_shell", self:getDefaultShellExecutable())
 
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
@@ -619,7 +619,7 @@ Aliases (shortcuts) to frequently used commands can be placed in:
                     self.shell_dialog = InputDialog:new{
                         title = _("Shell to use"),
                         description = T(_("Here you can select the startup shell.\nDefault: %1"),
-                                      self:determineShellExecutable()),
+                                      self:getDefaultShellExecutable()),
                         input = G_reader_settings:readSetting("terminal_shell"),
                         buttons = {{
                             {
@@ -631,7 +631,7 @@ Aliases (shortcuts) to frequently used commands can be placed in:
                             {
                                 text = _("Default"),
                                 callback = function()
-                                    G_reader_settings:saveSetting("terminal_shell", self:determineShellExecutable())
+                                    G_reader_settings:saveSetting("terminal_shell", self:getDefaultShellExecutable())
                                     UIManager:close(self.shell_dialog)
                                     if touchmenu_instance then
                                         touchmenu_instance:updateItems()


### PR DESCRIPTION
This shall fix #12271 

Use `$SHELL` env-variable if available. (thanks to @Frenzie)

Use a read line wrapper (either rlfe or rlwrap) if available so that dash can be used as interactive shell.

(The usage of rlwrap with dash offers a new bug where some chars are displayes duplicated ...
Thats why rlfe is the primary choice. A bug fix will follow next week. Anyway this PR is fully functional.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12375)
<!-- Reviewable:end -->
