### PR TITLE
Collections: fix context menu

### DIFF
--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -154,13 +154,22 @@ function FileManagerCollection:onMenuHold(item)
     table.insert(buttons, {}) -- separator
     table.insert(buttons, {
         filemanagerutil.genResetSettingsButton(doc_settings_or_file, close_dialog_update_callback, is_currently_opened),
+        self._manager:genAddToCollectionButton(file, close_dialog_callback, close_dialog_update_callback),
+    })
+    table.insert(buttons, {
+        {
+            text = _("Delete"),
+            enabled = not is_currently_opened,
+            callback = function()
+                local FileManager = require("apps/filemanager/filemanager")
+                FileManager:showDeleteFileDialog(file, close_dialog_update_callback)
+            end,
+        },
         {
             text = _("Remove from collection"),
             callback = function()
-                UIManager:close(self.collfile_dialog)
                 ReadCollection:removeItem(file, self.collection_name)
-                self._manager:updateItemTable()
-                self._manager.files_updated = true
+                close_dialog_update_callback()
             end,
         },
     })
@@ -583,7 +592,7 @@ end
 
 function FileManagerCollection:genAddToCollectionButton(file_or_files, caller_pre_callback, caller_post_callback, button_disabled)
     return {
-        text = _("Add to collection"),
+        text = _("Collections…"),
         enabled = not button_disabled,
         callback = function()
             if caller_pre_callback then


### PR DESCRIPTION
Consistent with the History context menu. Closes https://github.com/koreader/koreader/issues/12225.

![1](https://github.com/user-attachments/assets/052ed7e9-1030-4fa5-a53d-658a79e34981)

![2](https://github.com/user-attachments/assets/07b587e4-5c16-409d-a392-8947ad83131e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12383)
<!-- Reviewable:end -->
