### PR TITLE
Bug fix: update page_turning_inverted icon/text

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -377,8 +377,10 @@ local footerTextGeneratorMap = {
     page_turning_inverted = function(footer)
         local symbol_type = footer.settings.item_prefix
         local prefix = symbol_prefix[symbol_type].page_turning_inverted
-        if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys") or
-           G_reader_settings:isTrue("input_invert_right_page_turn_keys") or G_reader_settings:isTrue("inverse_reading_order") then
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") or
+           G_reader_settings:isTrue("input_invert_left_page_turn_keys") or
+           G_reader_settings:isTrue("input_invert_right_page_turn_keys") or
+           footer.ui.view.inverse_reading_order then
             if symbol_type == "icons" or symbol_type == "compact_items" then
                 return symbol_prefix.icons.page_turning_inverted
             else


### PR DESCRIPTION
Bug fix: update page_turning_inverted icon/text when inverse_reading_order is updated in reader UI, not in settings.

Note that reader UI loads inverse_reading_order from settings and then maintains it, allowing users to frequently change this value (e.g. when switching the device between hands.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12386)
<!-- Reviewable:end -->
