### PR TITLE
PDF: no "Contrast set to" notification on opening

### DIFF
--- a/frontend/apps/reader/modules/readerkoptlistener.lua
+++ b/frontend/apps/reader/modules/readerkoptlistener.lua
@@ -21,7 +21,7 @@ function ReaderKoptListener:onReadSettings(config)
     normal_zoom_mode = ReaderZooming.zoom_mode_label[normal_zoom_mode] and normal_zoom_mode or ReaderZooming.DEFAULT_ZOOM_MODE
     self.normal_zoom_mode = normal_zoom_mode
     self:setZoomMode(normal_zoom_mode)
-    self.ui:handleEvent(Event:new("GammaUpdate", self.document.configurable.contrast))
+    self.ui:handleEvent(Event:new("GammaUpdate", self.document.configurable.contrast, true)) -- no notification
     -- since K2pdfopt v2.21 negative value of word spacing is also used, for config
     -- compatability we should manually change previous -1 to a more reasonable -0.2
     if self.document.configurable.word_spacing == -1 then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -955,12 +955,14 @@ function ReaderView:onReaderFooterVisibilityChange()
     end
 end
 
-function ReaderView:onGammaUpdate(gamma)
+function ReaderView:onGammaUpdate(gamma, no_notification)
     self.state.gamma = gamma
     if self.page_scroll then
         self.ui:handleEvent(Event:new("UpdateScrollPageGamma", gamma))
     end
-    Notification:notify(T(_("Contrast set to: %1."), gamma))
+    if not no_notification then
+        Notification:notify(T(_("Contrast set to: %1."), gamma))
+    end
 end
 
 -- For ReaderKOptListener


### PR DESCRIPTION
Self-explained.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12391)
<!-- Reviewable:end -->
