### PR TITLE
Kobo v5 support

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -12,7 +12,7 @@ local function probeDevice()
         return require("device/kindle/device")
     end
 
-    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh")
+    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/lib/udev/rules.d/99-kobo.rules")
     if kobo_test_stat then
         return require("device/kobo/device")
     end

--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -12,7 +12,7 @@ local function probeDevice()
         return require("device/kindle/device")
     end
 
-    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/lib/udev/rules.d/99-kobo.rules")
+    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/usr/bin/hwdetect.sh")
     if kobo_test_stat then
         return require("device/kobo/device")
     end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1162,6 +1162,14 @@ local function getCodeName()
             std_out:close()
         end
     end
+    -- If that fails, run another script (since kobo v5 firmware)
+    if not codename then
+        local std_out = io.popen("/usr/bin/hwdetect.sh 2>/dev/null", "re")
+        if std_out then
+            codename = std_out:read("*line")
+            std_out:close()
+        end
+    end
     return codename
 end
 

--- a/platform/kobo/enable-wifi.sh
+++ b/platform/kobo/enable-wifi.sh
@@ -211,5 +211,16 @@ esac
 ifconfig "${INTERFACE}" up
 [ "${WIFI_MODULE}" = "dhd" ] && wlarm_le -i "${INTERFACE}" up
 
+# The wifi config moved in FW 5.x
+if [ -f "/mnt/onboard/.kobo/wpa_supplicant.conf" ]; then
+    # FIXME: This *might* be problematic for USBMS, as we allow Wi-Fi during USBMS (and it happens to be super useful for debugging).
+    #        Although wpa_supplicant doesn't appear to keep an fd open to it (good boy!).
+    WPA_SUPP_CONF="/mnt/onboard/.kobo/wpa_supplicant.conf"
+    # -s not supported in FW 5.x
+    WPA_SUPP_EXTRA_PARAMS=""
+else
+    WPA_SUPP_CONF="/etc/wpa_supplicant/wpa_supplicant.conf"
+    WPA_SUPP_EXTRA_PARAMS="-s"
+fi
 pkill -0 wpa_supplicant ||
-    wpa_supplicant -D "${WPA_SUPPLICANT_DRIVER}" -s -i "${INTERFACE}" -c /etc/wpa_supplicant/wpa_supplicant.conf -C /var/run/wpa_supplicant -B
+    wpa_supplicant -D "${WPA_SUPPLICANT_DRIVER}" ${WPA_SUPP_EXTRA_PARAMS} -i "${INTERFACE}" -c "${WPA_SUPP_CONF}" -C /var/run/wpa_supplicant -B

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -217,7 +217,7 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     #       as we want to be able to use our own per-if processes w/ custom args later on.
     #       A SIGTERM does not break anything, it'll just prevent automatic lease renewal until the time
     #       KOReader actually sets the if up itself (i.e., it'll do)...
-    killall -q -TERM nickel hindenburg sickel fickel strickel fontickel adobehost foxitpdf iink dhcpcd-dbus dhcpcd bluealsa bluetoothd fmon nanoclock.lua
+    killall -q -TERM nickel hindenburg sickel fickel strickel fontickel adobehost foxitpdf iink dhcpcd-dbus dhcpcd bluealsa bluetoothd fmon nanoclock.lua memorylogger QtWebEngineProcess
 
     # Wait for Nickel to die... (oh, procps with killall -w, how I miss you...)
     kill_timeout=0
@@ -231,6 +231,7 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     done
     # Remove Nickel's FIFO to avoid udev & udhcpc scripts hanging on open() on it...
     rm -f /tmp/nickel-hardware-status
+    rm -f /var/volatile/tmp/nickel-hardware-status
 
     # We don't need to grab input devices (unless MiniClock is running, in which case that neatly inhibits it while we run).
     if [ ! -d "/tmp/MiniClock" ]; then

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -14,7 +14,7 @@ cd "${KOREADER_DIR:-/dev/null}" || exit
 # To make USBMS behave, relocalize ourselves outside of onboard. Additionally,
 # this is used by KOReader to detect if the original script has changed after
 # an update (requiring a complete restart from the parent launcher).
-if [ "${SCRIPT_DIR}" != "/tmp" ]; then
+if [ "${SCRIPT_DIR}" != "/tmp" ] && [ "${SCRIPT_DIR}" != "/var/volatile/tmp" ]; then
     cp -pf "${0}" "/tmp/koreader.sh"
     chmod 777 "/tmp/koreader.sh"
     exec "/tmp/koreader.sh" "$@"

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -231,7 +231,6 @@ if [ "${VIA_NICKEL}" = "true" ]; then
     done
     # Remove Nickel's FIFO to avoid udev & udhcpc scripts hanging on open() on it...
     rm -f /tmp/nickel-hardware-status
-    rm -f /var/volatile/tmp/nickel-hardware-status
 
     # We don't need to grab input devices (unless MiniClock is running, in which case that neatly inhibits it while we run).
     if [ ! -d "/tmp/MiniClock" ]; then

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -249,6 +249,11 @@ if [ -z "${PRODUCT}" ]; then
     export PRODUCT
 fi
 
+if [ -z "${PRODUCT}" ]; then
+    PRODUCT="$(/usr/bin/hwdetect.sh 2>/dev/null)"
+    export PRODUCT
+fi
+
 # PLATFORM is used in koreader for the path to the Wi-Fi drivers (as well as when restarting nickel)
 if [ -z "${PLATFORM}" ]; then
     # shellcheck disable=SC2046

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -20,10 +20,10 @@ unset FBINK_FORCE_ROTA
 
 # kobo v5 animation is originally done in display-init, we copy the neccessary parts here.
 if [ -e "/etc/init.d/display-init.sh" ]; then
-    export PATH=/sbin:/usr/sbin:/bin:/usr/bin
-    export PRODUCT=$(hwdetect.sh)
+    PRODUCT=$(hwdetect.sh)
+    export PRODUCT
     echo "Starting boot animation..."
-    animator.sh /etc/images/${PRODUCT}-on-*.raw.gz &
+    animator.sh /etc/images/"${PRODUCT}"-on-*.raw.gz &
 fi
 
 if [ -e "/etc/init.d/on-animator.sh" ]; then

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -137,6 +137,10 @@ if [ -e "/etc/init.d/z-nickel-hardware-status" ]; then
     # on v5 use the existing startup scripts
     # Clear LD_LIBRARY_PATH as it gets prepended by start script
     export LD_LIBRARY_PATH=
+    # since sometime after 5.2, pulseaudio is started in rc.local. Detect and kill:
+    if grep "pulseaudio" "/etc/rc.local"; then
+        killall pulseaudio
+    fi
     /etc/init.d/z-nickel-hardware-status
     sync
     /etc/rc.local

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -136,7 +136,7 @@ fi
 if [ -e "/etc/init.d/z-nickel-hardware-status" ]; then
     # on v5 use the existing startup scripts
     # Clear LD_LIBRARY_PATH as it gets prepended by start script
-    export LD_LIBRARY_PATH=
+    unset LD_LIBRARY_PATH
     # since sometime after 5.2, pulseaudio is started in rc.local. Detect and kill:
     if grep "pulseaudio" "/etc/rc.local"; then
         killall pulseaudio

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -18,8 +18,12 @@ unset LC_ALL STARDICT_DATA_DIR EXT_FONT_DIR
 unset KO_DONT_GRAB_INPUT
 unset FBINK_FORCE_ROTA
 
+# kobo v5 animation is originally done in display-init, we copy the neccessary parts here.
 if [ -e "/etc/init.d/display-init.sh" ]; then
-    /etc/init.d/display-init.sh
+    export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+    export PRODUCT=$(hwdetect.sh)
+    echo "Starting boot animation..."
+    animator.sh /etc/images/${PRODUCT}-on-*.raw.gz &
 fi
 
 if [ -e "/etc/init.d/on-animator.sh" ]; then


### PR DESCRIPTION
This adds basic support for the recent v5 line of Kobo firmwares.

It is not production ready and I also did not yet include a generator for update.tar.

Should the kobo target just output two files?

Also see #12047 and https://github.com/NiLuJe/kfmon/pull/11

## ToDo

- [x] proper solution for wpa_supplicant parameters - use `-s` on older readers
- [ ] ~~generate update.tar~~
- [ ] ~~update toolchain with new target for kobo_v5~~
- [x] fix `nickel.sh` (currently: reader reboots)
- [x] fix `nickel.sh` again :-) 
- [ ] ~~fix sshd (libcrypt.so.1 missing; might be fixed with new toolchain)~~

## maybe todos

- [ ] ~~fix USBMS (currently: needs right environment set which works via updated kfmon)~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12401)
<!-- Reviewable:end -->
