### PR TITLE
Various notification, text editor and footnote popup minor fixes

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -968,8 +968,8 @@ function ReaderRolling:onBatchedUpdateDone()
     if self.batched_update_count <= 0 then
         self.batched_update_count = 0
         -- Be sure any Notification gets a chance to be painted before
-        -- a blocking rerendering
-        UIManager:nextTick(self.onUpdatePos, self)
+        -- a blocking rerendering (:nextTick() is not enough)
+        UIManager:tickAfterNext(self.onUpdatePos, self)
     end
 end
 

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -1171,16 +1171,15 @@ function ReaderStyleTweak:editBookTweak(touchmenu_instance)
             editor.save_callback_called = true
             return true, msg
         end,
-        close_callback = function()
+        close_callback = function(close_status)
             -- save_callback() will always have shown some notification,
-            -- so don't add another one
-            if not editor.save_callback_called then
+            -- so don't add another one.
+            -- If close_status is false, text was modified but then discarded, and
+            -- InputDialog will show our close_discarded_notif_text
+            if not editor.save_callback_called and close_status ~= false then
                 UIManager:show(Notification:new{
-                    text = NOT_MODIFIED_MSG,
+                    text = NOT_MODIFIED_MSG
                 })
-                -- This has to be the same message above and below: when
-                -- discarding, we can't prevent these 2 notifications from
-                -- being shown: having them identical will hide that.
             end
         end,
         close_discarded_notif_text = NOT_MODIFIED_MSG,

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -72,6 +72,10 @@ body > li { list-style-type: none; }
 /* Remove any (possibly multiple) backlinks in Wikipedia EPUBs footnotes */
 .noprint { display: none; }
 
+/* Let MuPDF know about crengine internal block elements,
+ * so it doesn't render them inline */
+autoBoxing, floatBox, tabularBox { display: block; }
+
 /* Style some FB2 tags not known to MuPDF */
 strike, strikethrough { text-decoration: line-through; }
 underline   { text-decoration: underline; }

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -36,13 +36,27 @@ function HtmlBoxWidget:init()
     end
 end
 
-function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml)
+-- These are generic "fixes" to MuPDF HTML stylesheet:
+-- - MuPDF doesn't set some elements as being display:block, and would
+--   consider them inline, and would badly handle <BR/> inside them.
+--   Note: this is a generic issue with <BR/> inside inline elements, see:
+--   https://github.com/koreader/koreader/issues/12258#issuecomment-2267629234
+local mupdf_css_fixes = [[
+article, aside, button, canvas, datalist, details, dialog, dir, fieldset, figcaption,
+figure, footer, form, frame, frameset, header, hgroup, iframe, legend, listing,
+main, map, marquee, multicol, nav, noembed, noframes, noscript, optgroup, output,
+plaintext, search, select, summary, template, textarea, video, xmp {
+  display: block;
+}
+]]
+
+function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css_fixes)
     -- fz_set_user_css is tied to the context instead of the document so to easily support multiple
     -- HTML dictionaries with different CSS, we embed the stylesheet into the HTML instead of using
     -- that function.
     local head = ""
-    if css then
-        head = string.format("<head><style>%s</style></head>", css)
+    if css or not no_css_fixes then
+        head = string.format("<head><style>\n%s\n%s</style></head>", mupdf_css_fixes, css or "")
     end
     local html = string.format("<html>%s<body>%s</body></html>", head, body)
 

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -159,6 +159,7 @@ local InputDialog = FocusManager:extend{
                       -- - on success: as the notification text instead of the default one
                       -- - on failure: in an InfoMessage
     close_callback = nil, -- Called when closing (if discarded or saved, after save_callback if saved)
+                          -- (passed true/false if text modified and saved/discarded, nil if closed with text unmodified)
     edited_callback = nil,  -- Called on each text modification
 
     -- For use by TextEditor plugin:
@@ -844,7 +845,7 @@ function InputDialog:_addSaveCloseButtons()
                     cancel_text = self.close_cancel_button_text or _("Cancel"),
                     choice1_text = self.close_discard_button_text or _("Discard"),
                     choice1_callback = function()
-                        if self.close_callback then self.close_callback() end
+                        if self.close_callback then self.close_callback(false) end
                         UIManager:close(self)
                         UIManager:show(Notification:new{
                             text = self.close_discarded_notif_text or _("Changes discarded"),
@@ -863,7 +864,7 @@ function InputDialog:_addSaveCloseButtons()
                                     })
                                 end
                             else -- nil or true
-                                if self.close_callback then self.close_callback() end
+                                if self.close_callback then self.close_callback(true) end
                                 UIManager:close(self)
                                 UIManager:show(Notification:new{
                                     text = msg or _("Saved"),

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1443,7 +1443,7 @@ function TextBoxWidget:_getXYForCharPos(charpos)
         charpos = self.charpos
     end
     if self.text == nil or string.len(self.text) == 0 then
-        return 0, 0
+        return 0, 0, 1
     end
     -- Find the line number: scan up/down from current virtual_line_num
     local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1644,7 +1644,7 @@ function TextBoxWidget:moveCursorToCharPos(charpos)
     self.charpos = charpos
     self.prev_virtual_line_num = self.virtual_line_num
     local x, y, screen_line_num = self:_getXYForCharPos() -- we can get y outside current view
-    self.current_line_num = screen_line_num
+    self.current_line_num = screen_line_num + self.virtual_line_num - 1
     -- adjust self.virtual_line_num for overflowed y to have y in current view
     if y < 0 then
         local scroll_lines = math.ceil( -y / self.line_height_px )
@@ -1886,7 +1886,7 @@ function TextBoxWidget:moveCursorDown()
 end
 
 function TextBoxWidget:moveCursorHome()
-    self:moveCursorToCharPos(self.vertical_string_list[self.current_line_num] and self.vertical_string_list[self.current_line_num].offset or #self.charlist)
+    self:moveCursorToCharPos(self.vertical_string_list[self.current_line_num] and self.vertical_string_list[self.current_line_num].offset or 1)
 end
 
 function TextBoxWidget:moveCursorEnd()


### PR DESCRIPTION
#### ReaderRolling: fix batched notifications sometimes not shown

When a profile changes a few settings (ie. font), a few notifications may be stacked, before the single rerendering happens. If that rendering takes some time, the notifications' timeout may close them as soon as it is done, before they get a chance to be painted/refreshed.
So, delay a bit more that rerendering to be sure the notifications are shown.
(Fix 2nd item at https://github.com/koreader/koreader/pull/10083#issuecomment-1646985078.)

#### Book style tweak editor: fix double notification on discard

Avoid two identical stacked notifications "Book tweak not modified" after Close + Discard when text was modified.
(I may have been a bit too lazy to fix that at the time I made it...)

#### TextBoxWidget: fix handling of Home/End keys on a scrollable edit box

See https://github.com/koreader/koreader/pull/9586#issuecomment-2308894830.

#### HtmlBoxWidget: help MuPDF with block elements it doesn't know

MuPDF's own stylesheet is incomplete, and doesn't specify that a few common (and uncommon) elements are display:block, so it would consider them inline, and render them badly (MuPDF also doesn't handle well <BR/> inside inline elements, so this fixes <br/> ones in these elements). See https://github.com/koreader/koreader/issues/12258#issuecomment-2267629234.
Fix this in HtmlBoxWidget so it solves any issue in HTML dict and popup footnote.
For popup footnotes, also include crengine internal block elements, as we may indeed get them in the HTML content.
Closes #12258 (at least for the paragraph break part - I don't think we can easily and nicely get images, which must also be rare - MuPDF may show them as [IMAGE], and the user can jump to the footnote in the book to see that image properly rendered).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12406)
<!-- Reviewable:end -->
