### PR TITLE
Dispatcher/DeviceListener: Temporarily turn on Accelerometer/GSensor for 5 sec

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -206,6 +206,19 @@ if Device:hasGSensor() then
         Notification:notify(new_text)
         return true
     end
+    
+    function DeviceListener:onTempGSensorOn()
+        if not G_reader_settings:isTrue("input_ignore_gsensor") then
+            Notification:notify("Accelerometer rotation events already on.")
+        else
+            Device:toggleGSensor()
+            Notification:notify("Accelerometer rotation events on for 5 seconds.")
+            UIManager:scheduleIn(5.0, function()
+                Device:toggleGSensor()
+                end)
+        end
+        return true
+    end
 
     function DeviceListener:onLockGSensor()
         G_reader_settings:flipNilOrFalse("input_lock_gsensor")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -208,15 +208,17 @@ if Device:hasGSensor() then
     end
 
     function DeviceListener:onTempGSensorOn()
-        if not G_reader_settings:isTrue("input_ignore_gsensor") then
-            Notification:notify("Accelerometer rotation events already on.")
+        local new_text
+        if G_reader_settings:nilOrFalse("input_ignore_gsensor") then
+            new_text = _("Accelerometer rotation events already on.")
         else
-            Device:toggleGSensor()
-            Notification:notify("Accelerometer rotation events on for 5 seconds.")
+            Device:toggleGSensor(true)
+            new_text = _("Accelerometer rotation events on for 5 seconds.")
             UIManager:scheduleIn(5.0, function()
-                Device:toggleGSensor()
+                Device:toggleGSensor(false)
                 end)
         end
+        Notification:notify(new_text)
         return true
     end
 

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -216,7 +216,7 @@ if Device:hasGSensor() then
             new_text = _("Accelerometer rotation events on for 5 seconds.")
             UIManager:scheduleIn(5.0, function()
                 Device:toggleGSensor(false)
-                end)
+            end)
         end
         Notification:notify(new_text)
         return true

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -206,7 +206,7 @@ if Device:hasGSensor() then
         Notification:notify(new_text)
         return true
     end
-    
+
     function DeviceListener:onTempGSensorOn()
         if not G_reader_settings:isTrue("input_ignore_gsensor") then
             Notification:notify("Accelerometer rotation events already on.")

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -84,6 +84,7 @@ local settingsList = {
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
+    temp_gsensor_on = {category="none", event="TempGSensorOn", title=_("Enable accelerometer for 5 seconds"), device=true, condition=Device:hasGSensor()},
     lock_gsensor = {category="none", event="LockGSensor", title=_("Lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
@@ -310,6 +311,7 @@ local dispatcher_menu_order = {
     ----
     "toggle_key_repeat",
     "toggle_gsensor",
+    "temp_gsensor_on",
     "lock_gsensor",
     "rotation_mode",
     "toggle_rotation",


### PR DESCRIPTION
Adds to Dispatcher the option to temporarily turn on the accelerometer for 5 seconds. This allows users who normally like to keep the accelerometer to OFF to call this feature, rotate their device, and then forget about it (no need to remember turning it back off).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12419)
<!-- Reviewable:end -->
