### PR TITLE
[ReaderFooter] update status bar in real time when inverting page turning

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2448,7 +2448,8 @@ ReaderFooter.onNetworkDisconnected = ReaderFooter.onNetworkConnected
 function ReaderFooter:onSwapPageTurnButtons()
     if self.settings.page_turning_inverted then
         -- We may receive the event *before* DeviceListener, so delay this to make sure it had a chance to actually swap the settings.
-        UIManager:nextTick(self.maybeUpdateFooter, self)
+        -- Also delay it further to avoid screwing with TouchMenu highlights...
+        UIManager:scheduleIn(0.5, self.maybeUpdateFooter, self)
     end
 end
 ReaderFooter.onToggleReadingOrder = ReaderFooter.onSwapPageTurnButtons

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2445,6 +2445,12 @@ function ReaderFooter:onNetworkConnected()
 end
 ReaderFooter.onNetworkDisconnected = ReaderFooter.onNetworkConnected
 
+function ReaderFooter:onPageTurningInverted()
+    if self.settings.page_turning_inverted then
+        self:maybeUpdateFooter()
+    end
+end
+
 function ReaderFooter:onSetRotationMode()
     self:updateFooterContainer()
     self:resetLayout(true)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2446,7 +2446,10 @@ end
 ReaderFooter.onNetworkDisconnected = ReaderFooter.onNetworkConnected
 
 function ReaderFooter:onSwapPageTurnButtons()
-    UIManager:scheduleIn(0.1, self.autoRefreshFooter)
+    if self.settings.page_turning_inverted then
+        -- We may receive the event *before* DeviceListener, so delay this to make sure it had a chance to actually swap the settings.
+        UIManager:nextTick(self.maybeUpdateFooter, self)
+    end
 end
 ReaderFooter.onToggleReadingOrder = ReaderFooter.onSwapPageTurnButtons
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2445,7 +2445,13 @@ function ReaderFooter:onNetworkConnected()
 end
 ReaderFooter.onNetworkDisconnected = ReaderFooter.onNetworkConnected
 
-function ReaderFooter:onPageTurningInverted()
+function ReaderFooter:onSwapPageTurnButtons()
+    if self.settings.page_turning_inverted then
+        self:maybeUpdateFooter()
+    end
+end
+
+function ReaderFooter:onToggleReadingOrder()
     if self.settings.page_turning_inverted then
         self:maybeUpdateFooter()
     end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2446,16 +2446,9 @@ end
 ReaderFooter.onNetworkDisconnected = ReaderFooter.onNetworkConnected
 
 function ReaderFooter:onSwapPageTurnButtons()
-    if self.settings.page_turning_inverted then
-        self:maybeUpdateFooter()
-    end
+    UIManager:scheduleIn(0.1, self.autoRefreshFooter)
 end
-
-function ReaderFooter:onToggleReadingOrder()
-    if self.settings.page_turning_inverted then
-        self:maybeUpdateFooter()
-    end
-end
+ReaderFooter.onToggleReadingOrder = ReaderFooter.onSwapPageTurnButtons
 
 function ReaderFooter:onSetRotationMode()
     self:updateFooterContainer()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -332,7 +332,6 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtonsLeft()
         if G_reader_settings:isTrue("input_invert_left_page_turn_keys") then
             new_text = _("Left-side page-turn buttons inverted.")
-            G_reader_settings:makeFalse("input_invert_page_turn_keys")
         else
             new_text = _("Left-side page-turn buttons no longer inverted.")
         end
@@ -341,7 +340,6 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtonsRight()
         if G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
             new_text = _("Right-side page-turn buttons inverted.")
-            G_reader_settings:makeFalse("input_invert_page_turn_keys")
         else
             new_text = _("Right-side page-turn buttons no longer inverted.")
         end
@@ -350,8 +348,6 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtons()
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
             new_text = _("Page-turn buttons inverted.")
-            G_reader_settings:makeFalse("input_invert_left_page_turn_keys")
-            G_reader_settings:makeFalse("input_invert_right_page_turn_keys")
         else
             new_text = _("Page-turn buttons no longer inverted.")
         end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -1,6 +1,7 @@
 local Device = require("device")
 local Event = require("ui/event")
 local EventListener = require("ui/widget/eventlistener")
+local InfoMessage = require("ui/widget/infomessage")
 local Notification = require("ui/widget/notification")
 local Screen = Device.screen
 local UIManager = require("ui/uimanager")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -330,22 +330,20 @@ function DeviceListener:onSwapPageTurnButtons(show_notification, side)
     if side == "left" then
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
-        key_name = _("Left-side page-turn buttons")
     elseif side == "right" then
         G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
         Device:invertButtonsRight()
-        key_name = _("Right-side page-turn buttons")
     else
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()
-        key_name = _("Page-turn buttons")
     end
     if show_notification then
         local new_text
-        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            new_text = key_name .. " " .. _("inverted.")
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys")
+            or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+            new_text = _("Page-turn buttons inverted.")
         else
-            new_text = key_name .. " " .. _("no longer inverted.")
+            new_text = _("Page-turn buttons no longer inverted inverted.")
         end
         Notification:notify(new_text)
     end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -330,9 +330,8 @@ function DeviceListener:onSwapPageTurnButtons(side)
     local new_text
     if side == "left" then
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            UIManager:show(InfoMessage:new{
-                text = _("Not possible to invert left-side page-turn buttons at this moment. Please revert global page-turn inversion first.")
-            })
+            new_text = _("Currently, inverting the left-side page-turn buttons is not possible. Please revert the global page-turn inversion first.")
+            UIManager:show(InfoMessage:new{text = new_text})
             return true
         end
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
@@ -344,9 +343,8 @@ function DeviceListener:onSwapPageTurnButtons(side)
         end
     elseif side == "right" then
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            UIManager:show(InfoMessage:new{
-                text = _("Not possible to invert right-side page-turn buttons at this moment. Please revert global page-turn inversions first.")
-            })
+            new_text = _("Currently, inverting the right-side page-turn buttons is not possible. Please revert the global page-turn inversion first.")
+            UIManager:show(InfoMessage:new{text = new_text})
             return true
         end
         G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
@@ -358,9 +356,8 @@ function DeviceListener:onSwapPageTurnButtons(side)
         end
     else
         if G_reader_settings:isTrue("input_invert_left_page_turn_keys") or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
-            UIManager:show(InfoMessage:new{
-                text = _("Not possible to invert page-turn buttons at this moment. Please revert other page-turn inversions first.")
-            })
+            new_text = _("Currently, inverting the page-turn buttons is not possible. Please revert other page-turn inversions first.")
+            UIManager:show(InfoMessage:new{text = new_text})
             return true
         end
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -328,6 +328,12 @@ end
 function DeviceListener:onSwapPageTurnButtons(side)
     local new_text
     if side == "left" then
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
+            UIManager:show(InfoMessage:new{
+                text = _("Not possible to invert left-side page-turn buttons at this moment. Please revert global page-turn inversion first.")
+            })
+            return true
+        end
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
         if G_reader_settings:isTrue("input_invert_left_page_turn_keys") then
@@ -336,6 +342,12 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Left-side page-turn buttons no longer inverted.")
         end
     elseif side == "right" then
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
+            UIManager:show(InfoMessage:new{
+                text = _("Not possible to invert right-side page-turn buttons at this moment. Please revert global page-turn inversions first.")
+            })
+            return true
+        end
         G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
         Device:invertButtonsRight()
         if G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
@@ -344,6 +356,12 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Right-side page-turn buttons no longer inverted.")
         end
     else
+        if G_reader_settings:isTrue("input_invert_left_page_turn_keys") or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+            UIManager:show(InfoMessage:new{
+                text = _("Not possible to invert page-turn buttons at this moment. Please revert other page-turn inversions first.")
+            })
+            return true
+        end
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -328,7 +328,7 @@ end
 function DeviceListener:onSwapPageTurnButtons(side)
     local new_text
     if side == "left" then
-        -- revert any prior global inversions first. No shenanigans please, as we could end up with an all greyed out menu.
+        -- Revert any prior global inversions first, as we could end up with an all greyed out menu.
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
             G_reader_settings:makeFalse("input_invert_page_turn_keys")
             Device:invertButtons()
@@ -341,7 +341,7 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Left-side page-turn buttons no longer inverted.")
         end
     elseif side == "right" then
-        -- revert any prior global inversions first. No shenanigans please, as we could end up with an all greyed out menu.
+        -- Revert any prior global inversions first, as we could end up with an all greyed out menu.
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
             G_reader_settings:makeFalse("input_invert_page_turn_keys")
             Device:invertButtons()
@@ -354,7 +354,7 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Right-side page-turn buttons no longer inverted.")
         end
     else
-        -- revert any prior inversions first. No shenanigans please, as we could end up with an all greyed out menu.
+        -- Revert any prior inversions first, as we could end up with an all greyed out menu.
         if G_reader_settings:isTrue("input_invert_left_page_turn_keys") and G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
             G_reader_settings:makeFalse("input_invert_left_page_turn_keys")
             G_reader_settings:makeFalse("input_invert_right_page_turn_keys")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -332,6 +332,7 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtonsLeft()
         if G_reader_settings:isTrue("input_invert_left_page_turn_keys") then
             new_text = _("Left-side page-turn buttons inverted.")
+            G_reader_settings:makeFalse("input_invert_page_turn_keys")
         else
             new_text = _("Left-side page-turn buttons no longer inverted.")
         end
@@ -340,6 +341,7 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtonsRight()
         if G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
             new_text = _("Right-side page-turn buttons inverted.")
+            G_reader_settings:makeFalse("input_invert_page_turn_keys")
         else
             new_text = _("Right-side page-turn buttons no longer inverted.")
         end
@@ -348,6 +350,8 @@ function DeviceListener:onSwapPageTurnButtons(side)
         Device:invertButtons()
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
             new_text = _("Page-turn buttons inverted.")
+            G_reader_settings:makeFalse("input_invert_left_page_turn_keys")
+            G_reader_settings:makeFalse("input_invert_right_page_turn_keys")
         else
             new_text = _("Page-turn buttons no longer inverted.")
         end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -326,7 +326,6 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
 end
 
 function DeviceListener:onSwapPageTurnButtons(show_notification, side)
-    local key_name
     if side == "left" then
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -1,7 +1,6 @@
 local Device = require("device")
 local Event = require("ui/event")
 local EventListener = require("ui/widget/eventlistener")
-local InfoMessage = require("ui/widget/infomessage")
 local Notification = require("ui/widget/notification")
 local Screen = Device.screen
 local UIManager = require("ui/uimanager")
@@ -329,10 +328,10 @@ end
 function DeviceListener:onSwapPageTurnButtons(side)
     local new_text
     if side == "left" then
+        -- revert any prior global inversions first. No shenanigans please, as we could end up with an all greyed out menu.
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            new_text = _("Currently, inverting the left-side page-turn buttons is not possible. Please revert the global page-turn inversion first.")
-            UIManager:show(InfoMessage:new{text = new_text})
-            return true
+            G_reader_settings:makeFalse("input_invert_page_turn_keys")
+            Device:invertButtons()
         end
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
@@ -342,10 +341,10 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Left-side page-turn buttons no longer inverted.")
         end
     elseif side == "right" then
+        -- revert any prior global inversions first. No shenanigans please, as we could end up with an all greyed out menu.
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            new_text = _("Currently, inverting the right-side page-turn buttons is not possible. Please revert the global page-turn inversion first.")
-            UIManager:show(InfoMessage:new{text = new_text})
-            return true
+            G_reader_settings:makeFalse("input_invert_page_turn_keys")
+            Device:invertButtons()
         end
         G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
         Device:invertButtonsRight()
@@ -355,10 +354,21 @@ function DeviceListener:onSwapPageTurnButtons(side)
             new_text = _("Right-side page-turn buttons no longer inverted.")
         end
     else
-        if G_reader_settings:isTrue("input_invert_left_page_turn_keys") or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
-            new_text = _("Currently, inverting the page-turn buttons is not possible. Please revert other page-turn inversions first.")
-            UIManager:show(InfoMessage:new{text = new_text})
+        -- revert any prior inversions first. No shenanigans please, as we could end up with an all greyed out menu.
+        if G_reader_settings:isTrue("input_invert_left_page_turn_keys") and G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+            G_reader_settings:makeFalse("input_invert_left_page_turn_keys")
+            G_reader_settings:makeFalse("input_invert_right_page_turn_keys")
+            G_reader_settings:makeFalse("input_invert_page_turn_keys")
+            Device:invertButtons()
+            new_text = _("Page-turn buttons no longer inverted.")
+            Notification:notify(new_text)
             return true
+        elseif G_reader_settings:isTrue("input_invert_left_page_turn_keys") then
+            G_reader_settings:makeFalse("input_invert_left_page_turn_keys")
+            Device:invertButtonsLeft()
+        elseif G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+            G_reader_settings:makeFalse("input_invert_right_page_turn_keys")
+            Device:invertButtonsRight()
         end
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -325,7 +325,7 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
     G_reader_settings:flipNilOrTrue("refresh_on_pages_with_images")
 end
 
-function DeviceListener:onSwapPageTurnButtons(show_notification, side)
+function DeviceListener:onSwapPageTurnButtons(side)
     if side == "left" then
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
@@ -336,16 +336,14 @@ function DeviceListener:onSwapPageTurnButtons(show_notification, side)
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()
     end
-    if show_notification then
-        local new_text
-        if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys")
-            or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
-            new_text = _("Page-turn buttons inverted.")
-        else
-            new_text = _("Page-turn buttons no longer inverted.")
-        end
-        Notification:notify(new_text)
+    local new_text
+    if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys")
+        or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+        new_text = _("Page-turn buttons inverted.")
+    else
+        new_text = _("Page-turn buttons no longer inverted.")
     end
+    Notification:notify(new_text)
     return true
 end
 

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -328,12 +328,15 @@ end
 function DeviceListener:onSwapPageTurnButtons(show_notification, side)
     local key_name
     if side == "left" then
+        G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
         key_name = _("Left-side page-turn buttons")
     elseif side == "right" then
+        G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
         Device:invertButtonsRight()
         key_name = _("Right-side page-turn buttons")
     else
+        G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()
         key_name = _("Page-turn buttons")
     end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -325,7 +325,7 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
     G_reader_settings:flipNilOrTrue("refresh_on_pages_with_images")
 end
 
-function DeviceListener:onSwapPageTurnButtons(show_notification)
+function DeviceListener:onSwapPageTurnButtons(show_notification, side)
     local key_name
     if side == "left" then
         Device:invertButtonsLeft()

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -343,7 +343,7 @@ function DeviceListener:onSwapPageTurnButtons(show_notification, side)
             or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
             new_text = _("Page-turn buttons inverted.")
         else
-            new_text = _("Page-turn buttons no longer inverted inverted.")
+            new_text = _("Page-turn buttons no longer inverted.")
         end
         Notification:notify(new_text)
     end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -326,14 +326,23 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
 end
 
 function DeviceListener:onSwapPageTurnButtons(show_notification)
-    G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
-    Device:invertButtons()
+    local key_name
+    if side == "left" then
+        Device:invertButtonsLeft()
+        key_name = _("Left-side page-turn buttons")
+    elseif side == "right" then
+        Device:invertButtonsRight()
+        key_name = _("Right-side page-turn buttons")
+    else
+        Device:invertButtons()
+        key_name = _("Page-turn buttons")
+    end
     if show_notification then
         local new_text
         if G_reader_settings:isTrue("input_invert_page_turn_keys") then
-            new_text = _("Page-turn buttons inverted.")
+            new_text = key_name .. " " .. _("inverted.")
         else
-            new_text = _("Page-turn buttons no longer inverted.")
+            new_text = key_name .. " " .. _("no longer inverted.")
         end
         Notification:notify(new_text)
     end

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -326,22 +326,31 @@ function DeviceListener:onToggleFlashOnPagesWithImages()
 end
 
 function DeviceListener:onSwapPageTurnButtons(side)
+    local new_text
     if side == "left" then
         G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
         Device:invertButtonsLeft()
+        if G_reader_settings:isTrue("input_invert_left_page_turn_keys") then
+            new_text = _("Left-side page-turn buttons inverted.")
+        else
+            new_text = _("Left-side page-turn buttons no longer inverted.")
+        end
     elseif side == "right" then
         G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
         Device:invertButtonsRight()
+        if G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
+            new_text = _("Right-side page-turn buttons inverted.")
+        else
+            new_text = _("Right-side page-turn buttons no longer inverted.")
+        end
     else
         G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
         Device:invertButtons()
-    end
-    local new_text
-    if G_reader_settings:isTrue("input_invert_page_turn_keys") or G_reader_settings:isTrue("input_invert_left_page_turn_keys")
-        or G_reader_settings:isTrue("input_invert_right_page_turn_keys") then
-        new_text = _("Page-turn buttons inverted.")
-    else
-        new_text = _("Page-turn buttons no longer inverted.")
+        if G_reader_settings:isTrue("input_invert_page_turn_keys") then
+            new_text = _("Page-turn buttons inverted.")
+        else
+            new_text = _("Page-turn buttons no longer inverted.")
+        end
     end
     Notification:notify(new_text)
     return true

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -80,7 +80,9 @@ local settingsList = {
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true, condition=Device:isTouchDevice()},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true, condition=Device:isTouchDevice()},
     ----
-    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg=true, title=_("Invert page turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
+    swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args={true, "left"}, title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args={true, "right"}, title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg=true, title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
@@ -310,6 +312,8 @@ local dispatcher_menu_order = {
     "toggle_touch_input",
     ----
     "swap_page_turn_buttons",
+    "swap_left_page_turn_buttons",
+    "swap_right_page_turn_buttons",
     ----
     "toggle_key_repeat",
     "toggle_gsensor",

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -80,9 +80,9 @@ local settingsList = {
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true, condition=Device:isTouchDevice()},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true, condition=Device:isTouchDevice()},
     ----
-    swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args={true, "left"}, title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
-    swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args={true, "right"}, title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
-    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg=true, title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
+    swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args="left", title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args="right", title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -80,8 +80,8 @@ local settingsList = {
     touch_input_off = {category="none", event="IgnoreTouchInput", arg=true, title=_("Disable touch input"), device=true, condition=Device:isTouchDevice()},
     toggle_touch_input = {category="none", event="IgnoreTouchInput", title=_("Toggle touch input"), device=true, separator=true, condition=Device:isTouchDevice()},
     ----
-    swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args="left", title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
-    swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", args="right", title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg="left", title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
+    swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg="right", title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
     swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -33,7 +33,7 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "left"))
+            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", "left"))
         end,
     })
     table.insert(PhysicalButtons.sub_item_table, {
@@ -45,7 +45,7 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "right"))
+            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", "right"))
         end,
         separator = true,
     })

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -8,7 +8,7 @@ local PhysicalButtons = {
     text = _("Physical buttons"), -- Mainly so as to differentiate w/ "Page Turns" when in readermenu...
     sub_item_table = {
         {
-            text = _("Invert page turn buttons"),
+            text = _("Invert page-turn buttons"),
             enabled_func = function()
                 return not (G_reader_settings:isTrue("input_invert_left_page_turn_keys") or G_reader_settings:isTrue("input_invert_right_page_turn_keys"))
             end,
@@ -16,6 +16,7 @@ local PhysicalButtons = {
                 return G_reader_settings:isTrue("input_invert_page_turn_keys")
             end,
             callback = function()
+                G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
                 UIManager:broadcastEvent(Event:new("SwapPageTurnButtons"))
             end,
             separator = true,
@@ -25,7 +26,7 @@ local PhysicalButtons = {
 
 if Device:hasDPad() and Device:useDPadAsActionKeys() then
     table.insert(PhysicalButtons.sub_item_table, {
-        text = _("Invert left-side page turn buttons"),
+        text = _("Invert left-side page-turn buttons"),
         enabled_func = function()
             return not G_reader_settings:isTrue("input_invert_page_turn_keys")
         end,
@@ -34,11 +35,11 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
-            Device:invertButtonsLeft()
+            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "left"))
         end,
     })
     table.insert(PhysicalButtons.sub_item_table, {
-        text = _("Invert right-side page turn buttons"),
+        text = _("Invert right-side page-turn buttons"),
         enabled_func = function()
             return not G_reader_settings:isTrue("input_invert_page_turn_keys")
         end,
@@ -47,7 +48,7 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
-            Device:invertButtonsRight()
+            UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "right"))
         end,
         separator = true,
     })

--- a/frontend/ui/elements/physical_buttons.lua
+++ b/frontend/ui/elements/physical_buttons.lua
@@ -16,7 +16,6 @@ local PhysicalButtons = {
                 return G_reader_settings:isTrue("input_invert_page_turn_keys")
             end,
             callback = function()
-                G_reader_settings:flipNilOrFalse("input_invert_page_turn_keys")
                 UIManager:broadcastEvent(Event:new("SwapPageTurnButtons"))
             end,
             separator = true,
@@ -34,7 +33,6 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_left_page_turn_keys")
         end,
         callback = function()
-            G_reader_settings:flipNilOrFalse("input_invert_left_page_turn_keys")
             UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "left"))
         end,
     })
@@ -47,7 +45,6 @@ if Device:hasDPad() and Device:useDPadAsActionKeys() then
             return G_reader_settings:isTrue("input_invert_right_page_turn_keys")
         end,
         callback = function()
-            G_reader_settings:flipNilOrFalse("input_invert_right_page_turn_keys")
             UIManager:broadcastEvent(Event:new("SwapPageTurnButtons", false, "right"))
         end,
         separator = true,


### PR DESCRIPTION
### what's new

* currently, the page-turn item introduced in #12249 will not automatically update the status bar. This removes the need to make manual changes (i.e turn the page) before changes are reflected on screen.
* update `onSwapPageTurnButtons` event handler to deal with all turn-page inversions
* adds two dispatcher entries so they can be used through Profiles.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12424)
<!-- Reviewable:end -->
