### PR TITLE
FileManager: Handle the FlushSettings event

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -761,6 +761,11 @@ function FileManager:onClose()
     return true
 end
 
+function FileManager:onFlushSettings()
+    self:handleEvent(Event:new("SaveSettings"))
+    G_reader_settings:flush()
+end
+
 function FileManager:onCloseWidget()
     if FileManager.instance == self then
         logger.dbg("Tearing down FileManager", tostring(self))


### PR DESCRIPTION
It's used on Android when we're murdered by the task switcher, and when doing an OTA update.

Fix #12124

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12425)
<!-- Reviewable:end -->
