### PR TITLE
Input: Ignore ABS_X, ABS_Y & ABS_PRESSURE for snow_protocol

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1538,6 +1538,7 @@ function KindleBasic3:init()
     -- so we have to rely on contact lift detection via BTN_TOUCH:0,
     -- c.f., https://github.com/koreader/koreader/issues/5070
     self.input.snow_protocol = true
+    self.input.handleTouchEv = self.input.handleTouchEvSnow
 end
 
 function KindlePaperWhite5:init()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1054,6 +1054,7 @@ end
 function Kobo:setTouchEventHandler()
     if self.touch_snow_protocol then
         self.input.snow_protocol = true
+        self.input.handleTouchEv = self.input.handleTouchEvSnow
     elseif self.touch_phoenix_protocol then
         self.input.handleTouchEv = self.input.handleTouchEvPhoenix
     elseif not self:hasMultitouch() then


### PR DESCRIPTION
On Monza, the lift frame can report these for *multiple contacts* without an id or a slot, which is super-duper invalid -_-".

(And we have ABS_MT_POSITION_X & ABS_MT_POSITION_Y for the "saner" frames, plus these devices generally don't support pens, so we don't make use of pressure).

(Also, switched to a dedicated handler like for the phoenix quirks, to avoid bogging down the standard handler with hacks for broken drivers).

Fix #11910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12427)
<!-- Reviewable:end -->
