### PR TITLE
Exporter: choose highlight styles to be exported

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1770,6 +1770,10 @@ function ReaderHighlight:onCycleHighlightAction()
     return true
 end
 
+function ReaderHighlight.getHighlightStyles()
+    return highlight_style
+end
+
 function ReaderHighlight:getHighlightStyleString(style) -- for bookmark list
     for _, v in ipairs(highlight_style) do
         if v[2] == style then

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -247,6 +247,7 @@ function MyClipping:parseAnnotations(annotations, book)
                 note    = item.note and self:getText(item.note),
                 chapter = item.chapter,
                 drawer  = item.drawer,
+                color   = item.color,
             }
             table.insert(book, { clipping })
         end

--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -236,8 +236,9 @@ function MyClipping:getImage(image)
 end
 
 function MyClipping:parseAnnotations(annotations, book)
+    local settings = G_reader_settings:readSetting("exporter")
     for _, item in ipairs(annotations) do
-        if item.drawer then
+        if item.drawer and not (settings.highlight_styles and settings.highlight_styles[item.drawer] == false) then
             local clipping = {
                 sort    = "highlight",
                 page    = item.pageref or item.pageno,
@@ -264,49 +265,52 @@ function MyClipping:parseHighlight(highlights, bookmarks, book)
                                "%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d") .. "$"
 
     local orphan_highlights = {}
+    local settings = G_reader_settings:readSetting("exporter")
     for page, items in pairs(highlights) do
         for _, item in ipairs(items) do
-            local clipping = {
-                sort    = "highlight",
-                page    = page,
-                time    = self:getTime(item.datetime or ""),
-                text    = self:getText(item.text),
-                chapter = item.chapter,
-                drawer  = item.drawer,
-            }
-            local bookmark_found = false
-            for _, bookmark in pairs(bookmarks) do
-                if bookmark.datetime == item.datetime then
-                    if bookmark.text then
-                        local bookmark_quote = bookmark.text:match(pattern)
-                        if bookmark_quote ~= clipping.text and bookmark.text ~= clipping.text then
-                            -- use modified quoted text or entire bookmark text if it's not a match
-                            clipping.note = bookmark_quote or bookmark.text
+            if not (settings.highlight_styles and settings.highlight_styles[item.drawer] == false) then
+                local clipping = {
+                    sort    = "highlight",
+                    page    = page,
+                    time    = self:getTime(item.datetime or ""),
+                    text    = self:getText(item.text),
+                    chapter = item.chapter,
+                    drawer  = item.drawer,
+                }
+                local bookmark_found = false
+                for _, bookmark in pairs(bookmarks) do
+                    if bookmark.datetime == item.datetime then
+                        if bookmark.text then
+                            local bookmark_quote = bookmark.text:match(pattern)
+                            if bookmark_quote ~= clipping.text and bookmark.text ~= clipping.text then
+                                -- use modified quoted text or entire bookmark text if it's not a match
+                                clipping.note = bookmark_quote or bookmark.text
+                            end
                         end
+                        bookmark_found = true
+                        break
                     end
-                    bookmark_found = true
-                    break
                 end
-            end
-            if not bookmark_found then
-                table.insert(orphan_highlights, { clipping })
-            end
-            if item.text == "" and item.pos0 and item.pos1 and
-                    item.pos0.x and item.pos0.y and
-                    item.pos1.x and item.pos1.y then
-                -- highlights in reflowing mode don't have page in pos
-                if item.pos0.page == nil then item.pos0.page = page end
-                if item.pos1.page == nil then item.pos1.page = page end
-                local image = {}
-                image.file = book.file
-                image.pos0, image.pos1 = item.pos0, item.pos1
-                image.pboxes = item.pboxes
-                image.drawer = item.drawer
-                clipping.image = self:getImage(image)
-            end
-            --- @todo Store chapter info when exporting highlights.
-            if (bookmark_found and clipping.text and clipping.text ~= "") or clipping.image then
-                table.insert(book, { clipping })
+                if not bookmark_found then
+                    table.insert(orphan_highlights, { clipping })
+                end
+                if item.text == "" and item.pos0 and item.pos1 and
+                        item.pos0.x and item.pos0.y and
+                        item.pos1.x and item.pos1.y then
+                    -- highlights in reflowing mode don't have page in pos
+                    if item.pos0.page == nil then item.pos0.page = page end
+                    if item.pos1.page == nil then item.pos1.page = page end
+                    local image = {}
+                    image.file = book.file
+                    image.pos0, image.pos1 = item.pos0, item.pos1
+                    image.pboxes = item.pboxes
+                    image.drawer = item.drawer
+                    clipping.image = self:getImage(image)
+                end
+                --- @todo Store chapter info when exporting highlights.
+                if (bookmark_found and clipping.text and clipping.text ~= "") or clipping.image then
+                    table.insert(book, { clipping })
+                end
             end
         end
     end


### PR DESCRIPTION
Cannot find the feature request, maybe it was on mobileread.
The use case was learning new words: highlighting them with a dedicated style (along with other usual highlights/notes), adding notes with translation, and then exporting only them for further repetitive learning.

![1](https://github.com/user-attachments/assets/884fdb2e-08aa-478f-8d4c-1d8e3d4958b7)

![2](https://github.com/user-attachments/assets/83c2652f-2413-420c-95ce-7ab593bdda48)

(A lot of diffs in clip.lua are just wrapping into `if`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12431)
<!-- Reviewable:end -->
