### PR TITLE
PageBrowser: fix drawing of thicker thumbnail frame on tap

### DIFF
--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -1424,7 +1424,11 @@ function PageBrowserWidget:onTap(arg, ges)
                     local orig_bordersize = thumb_frame.bordersize
                     thumb_frame.bordersize = Size.border.thick * 2
                     local b_inc = thumb_frame.bordersize - orig_bordersize
-                    UIManager:widgetRepaint(thumb_frame, thumb_frame.dimen.x-b_inc, thumb_frame.dimen.y-b_inc)
+                    thumb_frame.dimen.x = thumb_frame.dimen.x - b_inc
+                    thumb_frame.dimen.y = thumb_frame.dimen.y - b_inc
+                    thumb_frame.dimen.w = thumb_frame.dimen.w + 2*b_inc
+                    thumb_frame.dimen.h = thumb_frame.dimen.h + 2*b_inc
+                    UIManager:widgetRepaint(thumb_frame, thumb_frame.dimen.x, thumb_frame.dimen.y)
                     Screen:refreshFast(thumb_frame.dimen.x, thumb_frame.dimen.y, thumb_frame.dimen.w, thumb_frame.dimen.h)
                         -- (refresh "fast" will make gray drawn black and may make the
                         -- thumbnail a little uglier - but this enhances the effect


### PR DESCRIPTION
Bottom and right edges were not drawn since some recent FrameContainer tweak.
See https://github.com/koreader/koreader/pull/11364#issuecomment-2310107304.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12432)
<!-- Reviewable:end -->
