### PR TITLE
Minor fixes

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -105,7 +105,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local item_fullpath = item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>")
             local item_name = FFIUtil.basename(util.htmlEntitiesToUtf8(util.urlDecode(item_fullpath)))
             local is_current_dir = item_name == string.sub(folder_path, -#item_name)
-            local is_not_collection = item:find("<[^:]*:resourcetype/>") or
+            local is_not_collection = item:find("<[^:]*:resourcetype%s*/>") or
                                       item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
             local item_path = path .. "/" .. item_name
 

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -194,13 +194,8 @@ function FileManagerHistory:onMenuHold(item)
             text = _("Delete"),
             enabled = not (item.dim or is_currently_opened),
             callback = function()
-                local function post_delete_callback()
-                    UIManager:close(self.histfile_dialog)
-                    self._manager:updateItemTable()
-                    self._manager.files_updated = true
-                end
                 local FileManager = require("apps/filemanager/filemanager")
-                FileManager:showDeleteFileDialog(file, post_delete_callback)
+                FileManager:showDeleteFileDialog(file, close_dialog_update_callback)
             end,
         },
         {

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1286,9 +1286,12 @@ function ReaderHighlight:_getHighlightMenuAnchor()
     elseif position == "bottom" then
         anchor_y = self.screen_h - Size.padding.small
     else -- "gesture"
-        local text_box = self.ui.document:getWordFromPosition(self.gest_pos).sbox
-        if self.ui.paging then
-            text_box = self.view:pageToScreenTransform(self.ui.paging.current_page, text_box)
+        local text_box = self.ui.document:getWordFromPosition(self.gest_pos)
+        if text_box then
+            text_box = text_box.sbox
+            if text_box and self.ui.paging then
+                text_box = self.view:pageToScreenTransform(self.ui.paging.current_page, text_box)
+            end
         end
         if text_box == nil then return end -- fallback to "center"
         anchor_y = text_box.y + text_box.h + Size.padding.small -- do not stick to the box

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -629,9 +629,11 @@ function ReaderSearch:onShowFindAllResults(not_cached)
     if not_cached then
         for _, item in ipairs(self.findall_results) do
             local text = { TextBoxWidget.PTF_HEADER } -- use Poor Text Formatting provided by TextBoxWidget
-            table.insert(text, item.prev_text) -- append context before the word
-            if not item.prev_text:find("%s$") then -- separate prev context
-                table.insert(text, " ")
+            if item.prev_text then
+                table.insert(text, item.prev_text) -- append context before the word
+                if not item.prev_text:find("%s$") then -- separate prev context
+                    table.insert(text, " ")
+                end
             end
             table.insert(text, TextBoxWidget.PTF_BOLD_START) -- start of the word in bold
             -- PDF/Kopt shows full words when only some part matches; let's do the same with CRE
@@ -639,10 +641,12 @@ function ReaderSearch:onShowFindAllResults(not_cached)
             table.insert(text, item.matched_text)
             table.insert(text, item.matched_word_suffix)
             table.insert(text, TextBoxWidget.PTF_BOLD_END) -- end of the word in bold
-            if not item.next_text:find("^[%s%p]") then -- separate next context
-                table.insert(text, " ")
+            if item.next_text then
+                if not item.next_text:find("^[%s%p]") then -- separate next context
+                    table.insert(text, " ")
+                end
+                table.insert(text, item.next_text) -- append context after the word
             end
-            table.insert(text, item.next_text) -- append context after the word
             item.text = table.concat(text)
 
             local pageno = self.ui.rolling and self.ui.document:getPageFromXPointer(item.start) or item.start

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -917,6 +917,7 @@ function InputText:delWord(left_to_cursor)
         return
     end
     local start_pos, end_pos = self:getStringPos(true, left_to_cursor)
+    start_pos = math.min(start_pos, end_pos)
     for i = end_pos, start_pos, -1 do
         table.remove(self.charlist, i)
     end


### PR DESCRIPTION
(1) Virtual keyboard: don't get stuck at the punctuation mark when deleting a word with Backspace swipe north (https://github.com/koreader/koreader/pull/11843#issuecomment-2298619782).
(2) WebDAV: fix `resourcetype` property check (https://github.com/koreader/koreader/issues/12355).
(3) History: re-fetch statuses after deleting a file to update the list (unreported).
(4) Fulltext search: fix building findall result (https://github.com/koreader/koreader/issues/12435).
(5) Highlight: fix crash on showing anchored popup dialog when highlighting the last word of a book (unreported).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12437)
<!-- Reviewable:end -->
