### PR TITLE
ReaderView: Don't crash on pre-#11044 highlights without a color field

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -546,7 +546,7 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
         for _, item in ipairs(items) do
             local boxes = self.document:getPageBoxesFromPositions(page, item.pos0, item.pos1)
             if boxes then
-                local color = Blitbuffer.colorFromName(item.color)
+                local color = item.color and Blitbuffer.colorFromName(item.color)
                 if color and not Blitbuffer.isColor8(color) then
                     colorful = true
                 end
@@ -592,7 +592,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
             if end_pos >= cur_view_top then
                 local boxes = self.document:getScreenBoxesFromPositions(item.pos0, item.pos1, true) -- get_segments=true
                 if boxes then
-                    local color = Blitbuffer.colorFromName(item.color)
+                    local color = item.color and Blitbuffer.colorFromName(item.color)
                     if color and not Blitbuffer.isColor8(color) then
                         colorful = true
                     end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -245,7 +245,7 @@ function PdfDocument:saveHighlight(pageno, item)
     local quadpoints, n = _quadpointsFromPboxes(item.pboxes)
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
-    local annot_color =  BlitBuffer.colorFromName(item.color)
+    local annot_color = item.color and BlitBuffer.colorFromName(item.color)
     if item.drawer == "lighten" then
         annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then


### PR DESCRIPTION
(They'll be drawn in gray, as before)

Regression since #11044
(https://github.com/koreader/koreader/pull/11044#issuecomment-2322820971)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12438)
<!-- Reviewable:end -->
