### PR TITLE
fix bug preventing export to joplin;

### DIFF
--- a/plugins/exporter.koplugin/target/joplin.lua
+++ b/plugins/exporter.koplugin/target/joplin.lua
@@ -329,7 +329,8 @@ function JoplinExporter:export(t)
     local markdown_settings = plugin_settings.markdown
     local notebook_id = self.settings.notebook_guid
     for _, booknotes in pairs(t) do
-        local note = md.prepareBookContent(booknotes, markdown_settings.formatting_options, markdown_settings.highlight_formatting)
+        local note_tbl = md.prepareBookContent(booknotes, markdown_settings.formatting_options, markdown_settings.highlight_formatting)
+        local note = table.concat(note_tbl, "\n")
         local note_id = self:findNoteByTitle(booknotes.title, notebook_id)
 
         local response


### PR DESCRIPTION
This PR addresses the bug reported in #12180

The Joplin api endpoint koreader uses to send highlights expects a JSON object with a string field `body` ([joplin docs](https://joplinapp.org/help/api/references/rest_api/#post-notes)) but koreader currently sends an array.

Example trying to export a highlight:
```
> 2024/09/01 15:46:56.000272134  length=157 from=0 to=156
POST /notes?token=<token> HTTP/1.1\r
> 2024/09/01 15:46:56.000286062  length=423 from=157 to=579
User-Agent: KOReader/2024.07 (https://koreader.rocks/) LuaSocket/3.1.0\r
TE: trailers\r
Content-Type: application/json\r
Connection: close, TE\r
Host: 192.168.178.72:41190\r
Content-Length: 231\r
\r
{"title":"<book title>","body":["# <heading>","##### <author>\\n","## <chapter>","### <page  number & date/time>","<highlighted text>"], ...}< 2024/09/01 15:46:56.000291193  length=1526 from=0 to=1525
HTTP/1.1 500 Internal Server Error\r
Content-Type: application/json\r
Access-Control-Allow-Origin: *\r
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE\r
Access-Control-Allow-Headers: X-Requested-With,content-type\r
Date: Sun, 01 Sep 2024 13:46:56 GMT\r
Connection: close\r
Transfer-Encoding: chunked\r
\r
4ad\r
{"error":"Internal Server Error: Input data should be a String: \\n\\nError: Input data should be a String\\n    at MarkdownIt.parse (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/node_modules/markdown-it/lib/index.js:519:11)\\n    at Object.extractFileUrls (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/markdownUtils.js:61:35)\\n    at Object.extractImageUrls (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/markdownUtils.js:96:30)\\n    at MarkupLanguageUtils.extractImageUrls (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/markupLanguageUtils.js:25:40)\\n    at extractMediaUrls (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/services/rest/routes/notes.js:376:66)\\n    at /Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/services/rest/routes/notes.js:403:23\\n    at Generator.next (<anonymous>)\\n    at fulfilled (/Applications/Joplin.app/Contents/Resources/app.asar/node_modules/@joplin/lib/services/rest/routes/notes.js:5:58)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"}\r
0\r
\r
```

As fair as I can understand this bug was introduced in https://github.com/koreader/koreader/commit/4f75e4163626314bc4fc1b3193b7a5b6f026243d

The `prepareBookContent` function would previously return out a string, but after the changes from https://github.com/koreader/koreader/commit/4f75e4163626314bc4fc1b3193b7a5b6f026243d it returns a table which is then joined with newline characters after it's being called (in the markdown exporter). This function is also used for joplin export but it seems it slipped through when those changes were made.

I tested this fix locally and it could successfully export to joplin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12446)
<!-- Reviewable:end -->
