### PR TITLE
InputText: Unbreak onTapTextBox on an already in-focus field

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -144,7 +144,7 @@ local function initTouchEvents()
                 end
                 -- Make sure we're flagged as in focus again.
                 -- NOTE: self:focus() does a full free/reinit cycle, which is completely unnecessary to begin with,
-                --       *and* resets cursor position, which is problematic when tapping on an already in-focus field (#1244).
+                --       *and* resets cursor position, which is problematic when tapping on an already in-focus field (#12444).
                 --       So, just flip our own focused flag, that's the only thing we need ;).
                 self.focused = true
             end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -142,8 +142,11 @@ local function initTouchEvents()
                 if self.keyboard then
                     self.keyboard:showKeyboard()
                 end
-                -- Make sure we're flagged as in focus again
-                self:focus()
+                -- Make sure we're flagged as in focus again.
+                -- NOTE: self:focus() does a full free/reinit cycle, which is completely unnecessary to begin with,
+                --       *and* resets cursor position, which is problematic when tapping on an already in-focus field (#1244).
+                --       So, just flip our own focused flag, that's the only thing we need ;).
+                self.focused = true
             end
             if self._frame_textwidget.dimen ~= nil -- zh keyboard with candidates shown here has _frame_textwidget.dimen = nil
                     and #self.charlist > 0 then -- do not move cursor within a hint


### PR DESCRIPTION
The drive-by fix for the original issue noticed late in #12361 turned out to be a bit heavy-handed ;).

Fix #12444
Regression since #12361

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12449)
<!-- Reviewable:end -->
