### PR TITLE
ReaderView: Fix a couple of edge-cases in onReaderFooterVisibilityChange

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -700,7 +700,6 @@ function ReaderView:recalculate()
     self.dialog.dithered = nil
 
     if self.ui.paging and self.state.page then
-        print("recalculate for",  self.ui.paging, self.state.page)
         self.page_area = self:getPageArea(
             self.state.page,
             self.state.zoom,
@@ -994,25 +993,16 @@ function ReaderView:onTogglePageChangeAnimation()
 end
 
 function ReaderView:onReaderFooterVisibilityChange()
-    print("ReaderView:onReaderFooterVisibilityChange", self.ui.paging, self.state.page)
     -- Don't bother ReaderRolling with this nonsense, the footer's height is NOT handled via visible_area there ;)
     if self.ui.paging and self.state.page then
         -- We don't need to do anything if reclaim is enabled ;).
         if not self.footer.settings.reclaim_height then
             -- NOTE: Mimic what onSetFullScreen does, since, without reclaim, toggling the footer affects the available area,
             --       so we need to recompute the full layout.
-            logger.dbg("before:", self.visible_area, self.page_area, self.state.offset)
-            for page, state in ipairs(self.page_states) do
-                logger.dbg(page, state)
-            end
             -- NOTE: ReaderView:recalculate will snap visible_area to page_area edges (depending on zoom direction).
-            --       We don't actually want to move here, so save & restore our current visible_area *coordinates*.
+            --       We don't actually want to move here, so save & restore our current visible_area *coordinates*...
             local x, y = self.visible_area.x, self.visible_area.y
             self.ui:handleEvent(Event:new("SetDimensions", Screen:getSize()))
-            logger.dbg("after:", self.visible_area, self.page_area, self.state.offset)
-            for page, state in ipairs(self.page_states) do
-                logger.dbg(page, state)
-            end
             self.visible_area.x = x
             self.visible_area.y = y
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1009,8 +1009,8 @@ function ReaderView:onReaderFooterVisibilityChange()
             -- Now, for scroll mode, ReaderView:recalculate does *not* affect any of the actual page_states,
             -- so we'll fudge the bottom page's visible area ourselves,
             -- so as not to leave a blank area behind the footer when hiding it...
-            -- This might cause the next scroll to scroll a footer height's less than expected,
-            -- but that shouldn't be a real issue in practice...
+            -- This might cause the next scroll to scroll a footer height's *less* than expected,
+            -- but that should be hardly noticeable, and since we scroll less, it won't skip over anything.
             if self.page_scroll then
                 local bottom_state = self.page_states[#self.page_states]
                 if self.footer_visible then

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1012,11 +1012,14 @@ function ReaderView:onReaderFooterVisibilityChange()
             -- This might cause the next scroll to scroll a footer height's *less* than expected,
             -- but that should be hardly noticeable, and since we scroll less, it won't skip over anything.
             if self.page_scroll then
-                local bottom_state = self.page_states[#self.page_states]
-                if self.footer_visible then
-                    bottom_state.visible_area.h = bottom_state.visible_area.h - self.footer:getHeight()
-                else
-                    bottom_state.visible_area.h = bottom_state.visible_area.h + self.footer:getHeight()
+                local bottom_page = self.page_states[#self.page_states]
+                -- Not sure if this can ever be `nil`...
+                if bottom_page then
+                    if self.footer_visible then
+                        bottom_page.visible_area.h = bottom_page.visible_area.h - self.footer:getHeight()
+                    else
+                        bottom_page.visible_area.h = bottom_page.visible_area.h + self.footer:getHeight()
+                    end
                 end
             end
         end


### PR DESCRIPTION
Namely, it trips a `recalculate` that snaps `visible_area` to `page_area` edges (depending on zoom/reading direction), while we do *NOT* actually want to move the view, just increase/decrease its height ;).

(This *might* happen more reliably than it used to since https://github.com/koreader/koreader/pull/11425 & https://github.com/koreader/koreader/pull/11557)

Also deal with scroll mode while I'm here, as recalculate doesn't affect scroll mode at all, since that uses an *array* of on-screen pages, each with their own visible_area, page_area & state.

Fix #12454

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12466)
<!-- Reviewable:end -->
