### PR TITLE
Document props: fix null terminated strings from MuPDF

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -173,8 +173,10 @@ end
 
 function Document:getProps(cached_doc_metadata)
     local function makeNilIfEmpty(str)
-        if str == "" then
+        if str == nil or str == "" then
             return nil
+        elseif str:sub(-1) == "\0" then
+            return str:sub(1, -2)
         end
         return str
     end


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/12462.

For reference:
https://github.com/koreader/koreader-base/blob/ecf6bc70c8f662ab00e819885b74a937eb59d332/ffi/mupdf.lua#L274-L287

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12468)
<!-- Reviewable:end -->
