### PR TITLE
Cloud Sync: handles potentially incompatible backup and incoming dbs

### DIFF
--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -97,6 +97,10 @@ function SyncService.getReadablePath(server)
     return url
 end
 
+function SyncService.removeLastSyncDB(path)
+    os.remove(path .. ".sync")
+end
+
 -- Prepares three files for sync_cb to call to do the actual syncing:
 -- * local_file (one that is being used)
 -- * income_file (one that has just been downloaded from Cloud to be merged, then to be deleted)

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1229,6 +1229,11 @@ Time is in hours and minutes.]]),
                                     UIManager:close(this)
                                 end
                                 sync_settings.onConfirm = function(sv)
+                                    if server and (server.type ~= sv.type
+                                        or server.url ~= sv.url
+                                        or server.address ~= sv.address) then
+                                            SyncService.removeLastSyncDB(db_location)
+                                    end
                                     self.settings.sync_server = sv
                                     touchmenu_instance:updateItems()
                                 end
@@ -1252,6 +1257,7 @@ Time is in hours and minutes.]]),
                                         ok_text = _("Delete"),
                                         ok_callback = function()
                                             self.settings.sync_server = nil
+                                            SyncService.removeLastSyncDB(db_location)
                                             touchmenu_instance:updateItems()
                                         end,
                                     })

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -234,6 +234,7 @@ function MenuDialog:setupPluginMenu()
                     text = _("Delete"),
                     callback = function()
                         settings.server = nil
+                        SyncService.removeLastSyncDB(DB.path)
                         UIManager:close(self.sync_dialogue)
                     end
                 },
@@ -248,6 +249,11 @@ function MenuDialog:setupPluginMenu()
                         end
 
                         sync_settings.onConfirm = function(chosen_server)
+                            if settings.server.type ~= chosen_server.type
+                                or settings.server.url ~= chosen_server.url
+                                or settings.server.address ~= chosen_server.address then
+                                    SyncService.removeLastSyncDB(DB.path)
+                            end
                             settings.server = chosen_server
                         end
                         UIManager:show(sync_settings)


### PR DESCRIPTION
This pr removes the backup db (sync db) of the cloud syncing strategy when a different server location is used. This is to avoid the situation when later incoming db is not based on previously uploaded sync db.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12470)
<!-- Reviewable:end -->
