### PR TITLE
Add PocketBook Verse Pro Color (PB634K3)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -653,7 +653,6 @@ local PocketBook634K3 = PocketBook:extend{
 }
 
 function PocketBook634K3._fb_init(fb, finfo, vinfo)
-    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
     vinfo.bits_per_pixel = 24
 end
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -891,7 +891,7 @@ elseif codename == "633" then
 elseif codename == "634" then
     return PocketBook634
 elseif codename == "634K3" then
-    return PocketBook634K3    
+    return PocketBook634K3
 elseif codename == "640" then
     return PocketBook640
 elseif codename == "641" then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -650,8 +650,6 @@ local PocketBook634K3 = PocketBook:extend{
     canUseCBB = no, -- 24bpp
     isAlwaysPortrait = yes,
     hasNaturalLight = yes,
-    -- c.f., https://github.com/koreader/koreader/issues/9556
-    inkview_translates_buttons = true,
 }
 
 function PocketBook634K3._fb_init(fb, finfo, vinfo)

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -641,6 +641,24 @@ local PocketBook634 = PocketBook:extend{
     hasNaturalLight = yes,
 }
 
+-- PocketBook Verse Pro Color (PB634K3)
+local PocketBook634K3 = PocketBook:extend{
+    model = "PBVerseProColor",
+    display_dpi = 300,
+    hasColorScreen = yes,
+    canHWDither = yes, -- Adjust color saturation with inkview
+    canUseCBB = no, -- 24bpp
+    isAlwaysPortrait = yes,
+    hasNaturalLight = yes,
+    -- c.f., https://github.com/koreader/koreader/issues/9556
+    inkview_translates_buttons = true,
+}
+
+function PocketBook634K3._fb_init(fb, finfo, vinfo)
+    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
+    vinfo.bits_per_pixel = 24
+end
+
 -- PocketBook Aqua (640)
 local PocketBook640 = PocketBook:extend{
     model = "PBAqua",
@@ -872,6 +890,8 @@ elseif codename == "633" then
     return PocketBook633
 elseif codename == "634" then
     return PocketBook634
+elseif codename == "634K3" then
+    return PocketBook634K3    
 elseif codename == "640" then
     return PocketBook640
 elseif codename == "641" then


### PR DESCRIPTION
To add the new PocketBook Verse Pro Color (PB634K3) with a 6-inch E Ink Kaleido™ 3 screen.

[crash.log](https://github.com/user-attachments/files/16908777/crash.log)

![IMG_20240906_144306_038](https://github.com/user-attachments/assets/1ff03e98-61fa-4fce-bdda-5a716aa65b8c)
![spec](https://github.com/user-attachments/assets/c958cb3a-fe4a-4cd7-815d-cd67354a71a2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12476)
<!-- Reviewable:end -->
