### PR TITLE
input: drop use of `ffi/input`

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -4,54 +4,46 @@ local util = require("ffi/util")
 
 local function probeDevice()
     if isAndroid then
-        util.noSDL()
         return require("device/android/device")
     end
 
     local kindle_test_stat = lfs.attributes("/proc/usid")
     if kindle_test_stat then
-        util.noSDL()
         return require("device/kindle/device")
     end
 
     local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh")
     if kobo_test_stat then
-        util.noSDL()
         return require("device/kobo/device")
     end
 
     local pbook_test_stat = lfs.attributes("/ebrmain")
     if pbook_test_stat then
-        util.noSDL()
         return require("device/pocketbook/device")
     end
 
     local remarkable_test_stat = lfs.attributes("/usr/bin/xochitl")
     if remarkable_test_stat then
-        util.noSDL()
         return require("device/remarkable/device")
     end
 
     local sony_prstux_test_stat = lfs.attributes("/etc/PRSTUX")
     if sony_prstux_test_stat then
-        util.noSDL()
         return require("device/sony-prstux/device")
     end
 
     local cervantes_test_stat = lfs.attributes("/usr/bin/ntxinfo")
     if cervantes_test_stat then
-        util.noSDL()
         return require("device/cervantes/device")
     end
 
     -- add new ports here:
     --
     -- if --[[ implement a proper test instead --]] false then
-    --     util.noSDL()
     --     return require("device/newport/device")
     -- end
 
-    if util.isSDL() then
+    if util.loadSDL2() then
         return require("device/sdl/device")
     end
 

--- a/frontend/device/cervantes/device.lua
+++ b/frontend/device/cervantes/device.lua
@@ -123,9 +123,9 @@ function Cervantes:init()
             [116] = "Power",
         }
     }
-    self.input.open("/dev/input/event0") -- Keys
-    self.input.open("/dev/input/event1") -- touchscreen
-    self.input.open("fake_events") -- usb events
+    self.input:open("/dev/input/event0") -- Keys
+    self.input:open("/dev/input/event1") -- touchscreen
+    self.input:open("fake_events") -- usb events
     self:initEventAdjustHooks()
     Generic.init(self)
 end

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -608,7 +608,7 @@ function Device:exit()
     G_reader_settings:close()
 
     -- I/O teardown
-    self.input.teardown()
+    self.input:teardown()
 end
 
 -- Lifted from busybox's libbb/inet_cksum.c

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -489,7 +489,7 @@ function Kindle:openInputDevices()
         for i = 0, tonumber(dev_count[0]) - 1 do
             local dev = devices[i]
             if dev.matched then
-                self.input.fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
+                self.input:fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
             end
         end
         C.free(devices)
@@ -498,11 +498,11 @@ function Kindle:openInputDevices()
         logger.warn("We failed to auto-detect the proper input devices, input handling may be inconsistent!")
         if self.touch_dev then
             -- We've got a preferred path specified for the touch panel
-            self.input.open(self.touch_dev)
+            self.input:open(self.touch_dev)
         else
             -- That generally works out well enough on legacy devices...
-            self.input.open("/dev/input/event0")
-            self.input.open("/dev/input/event1")
+            self.input:open("/dev/input/event0")
+            self.input:open("/dev/input/event1")
         end
     end
 
@@ -516,14 +516,14 @@ function Kindle:openInputDevices()
             for i = 0, tonumber(dev_count[0]) - 1 do
                 local dev = devices[i]
                 if dev.matched then
-                    self.input.fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
+                    self.input:fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
                 end
             end
             C.free(devices)
         end
     end
 
-    self.input.open("fake_events")
+    self.input:open("fake_events")
 end
 
 function Kindle:otaModel()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -880,9 +880,9 @@ function Kobo:init()
                 -- We need to single out whichever device provides pagination buttons or sleep cover events, as we'll want to tweak key repeat there...
                 -- The first one will do, as it's extremely likely to be event0, and that's pretty fairly set in stone on NTX boards.
                 if (bit.band(dev.type, C.INPUT_PAGINATION_BUTTONS) ~= 0 or bit.band(dev.type, C.INPUT_SLEEP_COVER) ~= 0) and not self.ntx_fd then
-                    self.ntx_fd = self.input.fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
+                    self.ntx_fd = self.input:fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
                 else
-                    self.input.fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
+                    self.input:fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
                 end
             end
         end
@@ -891,9 +891,9 @@ function Kobo:init()
         -- Auto-detection failed, warn and fall back to defaults
         logger.warn("We failed to auto-detect the proper input devices, input handling may be inconsistent!")
         -- Various HW Buttons, Switches & Synthetic NTX events
-        self.ntx_fd = self.input.open(self.ntx_dev)
+        self.ntx_fd = self.input:open(self.ntx_dev)
         -- Touch panel
-        self.input.open(self.touch_dev)
+        self.input:open(self.touch_dev)
     end
 
     -- NOTE: On devices with a gyro, there may be a dedicated input device outputting the raw accelerometer data

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -243,7 +243,7 @@ function PocketBook:init()
     self._model_init()
     -- NOTE: This is the odd one out actually calling input.open as a *method*,
     --       which the imp supports to get access to self.input.raw_input
-    if (not self.input.raw_input) or (not pcall(self.input.open, self.input)) then
+    if (not self.input.raw_input) or (not pcall(self.input.open, self.input, self.input)) then
         inkview.OpenScreen()
         -- Raw mode open failed (no permissions?), so we'll run the usual way.
         -- Disable touch coordinate translation as inkview will do that.

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -167,9 +167,9 @@ function Remarkable:init()
         self.input_ts = "/dev/input/touchscreen0"
     end
 
-    self.input.open(self.input_wacom) -- Wacom
-    self.input.open(self.input_ts) -- Touchscreen
-    self.input.open(self.input_buttons) -- Buttons
+    self.input:open(self.input_wacom) -- Wacom
+    self.input:open(self.input_ts) -- Touchscreen
+    self.input:open(self.input_buttons) -- Buttons
 
     local scalex = screen_width / self.mt_width
     local scaley = screen_height / self.mt_height
@@ -202,7 +202,7 @@ function Remarkable:init()
     end
 
     -- USB plug/unplug, battery charge/not charging are generated as fake events
-    self.input.open("fake_events")
+    self.input:open("fake_events")
 
     local rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
     self.screen.native_rotation_mode = rotation_mode

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -308,7 +308,6 @@ function Device:init()
         gameControllerRumble = function(left_intensity, right_intensity, duration)
             return input.gameControllerRumble(left_intensity, right_intensity, duration)
         end,
-        file_chooser = input.file_chooser,
     }
 
     self.keyboard_layout = dofile("frontend/device/sdl/keyboard_layout.lua")

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -193,7 +193,6 @@ function Device:init()
     local ok, re = pcall(self.screen.setWindowIcon, self.screen, "resources/koreader.png")
     if not ok then logger.warn(re) end
 
-    local input = require("ffi/input")
     self.input = require("device/input"):new{
         device = self,
         event_map = dofile("frontend/device/sdl/event_map_sdl2.lua"),
@@ -295,18 +294,6 @@ function Device:init()
             elseif ev.code == SDL_TEXTINPUT then
                 UIManager:sendEvent(Event:new("TextInput", tostring(ev.value)))
             end
-        end,
-        hasClipboardText = function()
-            return input.hasClipboardText()
-        end,
-        getClipboardText = function()
-            return input.getClipboardText()
-        end,
-        setClipboardText = function(text)
-            return input.setClipboardText(text)
-        end,
-        gameControllerRumble = function(left_intensity, right_intensity, duration)
-            return input.gameControllerRumble(left_intensity, right_intensity, duration)
         end,
     }
 

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -59,10 +59,10 @@ function SonyPRSTUX:init()
         event_map = dofile("frontend/device/sony-prstux/event_map.lua"),
     }
 
-    self.input.open("/dev/input/event0") -- Keys
-    self.input.open("/dev/input/event1") -- touchscreen
-    self.input.open("/dev/input/event2") -- power button
-    self.input.open("fake_events") -- usb plug-in/out and charging/not-charging
+    self.input:open("/dev/input/event0") -- Keys
+    self.input:open("/dev/input/event1") -- touchscreen
+    self.input:open("/dev/input/event2") -- power button
+    self.input:open("fake_events") -- usb plug-in/out and charging/not-charging
     self.input:registerEventAdjustHook(adjustTouchEvt)
 
     local rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE

--- a/make/appimage.mk
+++ b/make/appimage.mk
@@ -11,7 +11,7 @@ update: all
 	$(SYMLINK) resources/koreader.png $(INSTALL_DIR)/koreader/
 	sed -e 's/%%VERSION%%/$(VERSION)/' -e 's/%%DATE%%/$(RELEASE_DATE)/' $(PLATFORM_DIR)/common/koreader.metainfo.xml >$(INSTALL_DIR)/koreader/koreader.appdata.xml
 	# TODO at best this is DebUbuntu specific
-	$(SYMLINK) /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/libSDL2.so
+	$(SYMLINK) /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0 $(INSTALL_DIR)/koreader/libs/
 	# required for our stock Ubuntu SDL even though we don't use sound
 	# the readlink is a half-hearted attempt at being generic; the echo libsndio.so.7.0 is specific to the nightly builds
 	$(SYMLINK) /usr/lib/x86_64-linux-gnu/$(shell readlink /usr/lib/x86_64-linux-gnu/libsndio.so || echo libsndio.so.7.0) $(INSTALL_DIR)/koreader/libs/

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -247,7 +247,7 @@ function ExternalKeyboard:_onEvdevInputRemove(event_path)
     end
 
     -- Close our Input handle on it
-    Device.input.close(event_path)
+    Device.input:close(event_path)
 
     ExternalKeyboard.keyboard_fds[event_path] = nil
     ExternalKeyboard.connected_keyboards = ExternalKeyboard.connected_keyboards - 1
@@ -363,7 +363,7 @@ function ExternalKeyboard:setupKeyboard(data)
     logger.dbg("ExternalKeyboard:setupKeyboard", keyboard_info.name, "@", keyboard_info.event_path, "- has_dpad:", keyboard_info.has_dpad)
     -- Check if we already know about this event file.
     if ExternalKeyboard.keyboard_fds[keyboard_info.event_path] == nil then
-        local ok, fd = pcall(Device.input.fdopen, keyboard_info.event_fd, keyboard_info.event_path, keyboard_info.name)
+        local ok, fd = pcall(Device.input.fdopen, Device.input, keyboard_info.event_fd, keyboard_info.event_path, keyboard_info.name)
         if not ok then
             UIManager:show(InfoMessage:new{
                 text = "Error opening keyboard:\n" .. tostring(fd),

--- a/spec/unit/device_spec.lua
+++ b/spec/unit/device_spec.lua
@@ -41,6 +41,8 @@ describe("device module", function()
     before_each(function()
         package.loaded["ffi/framebuffer_mxcfb"] = mock_fb
         mock_input = require("device/input")
+        mock_input.input = {}
+        mock_input.gameControllerRumble = function() return false end
         stub(mock_input, "open")
         stub(os, "getenv")
         stub(os, "execute")
@@ -308,9 +310,8 @@ describe("device module", function()
             package.unload("device/kindle/device")
             io.open = make_io_open_kindle_model_override("G0B0GCXXX")
 
-            mock_ffi_input = require("ffi/input")
-            stub(mock_ffi_input, "waitForEvent")
-            mock_ffi_input.waitForEvent.returns(true, {
+            stub(mock_input.input, "waitForEvent")
+            mock_input.input.waitForEvent.returns(true, {
                 {
                     type = C.EV_ABS,
                     time = {
@@ -333,7 +334,7 @@ describe("device module", function()
             kindle_dev.input:waitEvent()
             assert.stub(UIManager.onRotation).was_called()
 
-            mock_ffi_input.waitForEvent:revert()
+            mock_input.input.waitForEvent:revert()
             UIManager.onRotation:revert()
         end)
     end)


### PR DESCRIPTION
In preparation of koreader/koreader-base/pull/1929.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12486)
<!-- Reviewable:end -->
