### PR TITLE
Avoid crashing in ReaderAnnotation:isItemInPositionOrderRolling

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -283,11 +283,14 @@ function ReaderAnnotation:isItemInPositionOrderRolling(a, b)
     end
     local compare_xp = self.document:compareXPointers(a.page, b.page)
     if not compare_xp then
-        -- if compare_xp is nil, some xpointer is invalid and "a" will be sorted first to page 1
+        -- if compare_xp is nil, some xpointer is invalid. Fallback to compare
+        -- xpointer raw strings to avoid crashing table.sort.
         logger.warn("Invalid start xpointer in highlight:", a.page, b.page)
         return a.page < b.page
     end
     if not a.drawer or compare_xp ~= 0 then
+        -- Note, compareXPointers compares b.page to a.page, so the result
+        -- needs to be reversed.
         return compare_xp > 0
     end
     -- both highlights with the same start, compare ends


### PR DESCRIPTION
When the annotations are invalid - most likely caused by cre change, the sort function should still produce consistent sorting rather than always returning true. Otherwise the table.sort would crash with `invalid order function for sorting`.
See https://github.com/koreader/koreader/issues/12492

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12493)
<!-- Reviewable:end -->
