### PR TITLE
ReaderAnnotation: skip old highlights with invalid xpointers

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -11,6 +11,12 @@ local ReaderAnnotation = WidgetContainer:extend{
 
 function ReaderAnnotation:buildAnnotation(bm, highlights, init)
     -- bm: associated single bookmark ; highlights: tables with all highlights
+    if self.ui.rolling and
+            (not self.document:isXPointerInDocument(bm.page) or
+            (bm.pos1 and not self.document:isXPointerInDocument(bm.pos1))) then
+        logger.warn("Invalid xpointer in old highlight, skipping")
+        return
+    end
     local note = bm.text
     if note == "" then
         note = nil
@@ -80,7 +86,10 @@ end
 function ReaderAnnotation:getAnnotationsFromBookmarksHighlights(bookmarks, highlights, init)
     local annotations = {}
     for i = #bookmarks, 1, -1 do
-        table.insert(annotations, self:buildAnnotation(bookmarks[i], highlights, init))
+        local annotation = self:buildAnnotation(bookmarks[i], highlights, init)
+        if annotation then
+            table.insert(annotations, annotation)
+        end
     end
     if init then
         self:sortItems(annotations)

--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -11,11 +11,17 @@ local ReaderAnnotation = WidgetContainer:extend{
 
 function ReaderAnnotation:buildAnnotation(bm, highlights, init)
     -- bm: associated single bookmark ; highlights: tables with all highlights
-    if self.ui.rolling and
-            (not self.document:isXPointerInDocument(bm.page) or
-            (bm.pos1 and not self.document:isXPointerInDocument(bm.pos1))) then
-        logger.warn("Invalid xpointer in old highlight, skipping")
-        return
+    if self.ui.rolling then
+        local is_invalid
+        if not self.document:isXPointerInDocument(bm.page) then
+            logger.warn("Skipping old bookmark, invalid start xpointer:", bm.page)
+            is_invalid = true
+        end
+        if bm.pos1 and not self.document:isXPointerInDocument(bm.pos1) then
+            logger.warn("Skipping old bookmark, invalid end xpointer:", bm.page)
+            is_invalid = true
+        end
+        if is_invalid then return end
     end
     local note = bm.text
     if note == "" then


### PR DESCRIPTION
Supercedes https://github.com/koreader/koreader/pull/12493.
Closes https://github.com/koreader/koreader/issues/12492. Closes https://github.com/koreader/koreader/issues/12443.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12494)
<!-- Reviewable:end -->
