### PR TITLE
Defaults: Deprecate DKOPTREADER_CONFIG_DOC_LANGS_TEXT

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -88,7 +88,6 @@ DKOPTREADER_CONFIG_CONTRAST = 1.0,        -- range from 0.2 to 2.0
 DKOPTREADER_CONFIG_WORD_SPACINGS = {0.05, -0.2, 0.375},    -- range from (+/-)0.05 to (+/-)0.5
 DKOPTREADER_CONFIG_DEFAULT_WORD_SPACING = -0.2,            -- range from (+/-)0.05 to (+/-)0.5
 -- document languages for OCR
-DKOPTREADER_CONFIG_DOC_LANGS_TEXT = {"English", "Chinese"},
 DKOPTREADER_CONFIG_DOC_LANGS_CODE = {"eng", "chi_sim"},    -- language code, make sure you have corresponding training data
 DKOPTREADER_CONFIG_DOC_DEFAULT_LANG_CODE = "eng",          -- that have filenames starting with the language codes
 

--- a/frontend/apps/filemanager/filemanagersetdefaults.lua
+++ b/frontend/apps/filemanager/filemanagersetdefaults.lua
@@ -57,8 +57,15 @@ function SetDefaultsWidget:init()
     end
 
     for k, v in pairs(rw_defaults) do
-        self.state[k].value = v
-        self.state[k].custom = true
+        -- Warn if we encounter a deprecated (or unknown) customized key
+        if not self.state[k] then
+            logger.warn("G_defaults: Found an unknown key in custom settings:", k)
+            -- Should we just delete it?
+            --G_defaults:delSetting(k)
+        else
+            self.state[k].value = v
+            self.state[k].custom = true
+        end
     end
 
     -- Prepare our menu entires

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240731
+local CURRENT_MIGRATION_DATE = 20240911
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -695,6 +695,17 @@ if last_migration_date < 20240731 then
         settings.progress_margin_width = Device:isAndroid() and Device.screen:scaleByDPI(16) or 10
         G_reader_settings:saveSetting("footer", settings)
     end
+end
+
+-- 20240911, Defaults: Deprecate DKOPTREADER_CONFIG_DOC_LANGS_TEXT after #11977, https://github.com/koreader/koreader/pull/12504
+if last_migration_date < 20240911 then
+    logger.info("Performing one-time migration for 20240911")
+
+    if G_defaults:hasBeenCustomized("DKOPTREADER_CONFIG_DOC_LANGS_TEXT") then
+        G_defaults:delSetting("DKOPTREADER_CONFIG_DOC_LANGS_TEXT")
+    end
+
+    G_defaults:flush()
 end
 
 -- We're done, store the current migration date


### PR DESCRIPTION
It's no longer in use since #11977, dropping it ensures we stop showing it in the advanced settings UI.

(Rebase me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12504)
<!-- Reviewable:end -->
