### PR TITLE
Fix page gap inconsistencies between doc open & config change

### DIFF
--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -506,13 +506,19 @@ function ReaderTypeset:onSetPageMargins(margins, when_applied_callback)
             text = T(_([[
 Margins set to:
 
-  left: %1 (%2px)
-  right: %3 (%4px)
-  top: %5 (%6px)
-  bottom: %7 (%8px)
+  left: %1
+  right: %2
+  top: %3
+  bottom: %4
+
+  footer: %5 px
 
 Tap to dismiss.]]),
-            margins[1], left, margins[3], right, margins[2], top, margins[4], bottom),
+            optionsutil.formatFlexSize(margins[1], G_reader_settings:readSetting("dimension_units")),
+            optionsutil.formatFlexSize(margins[2], G_reader_settings:readSetting("dimension_units")),
+            optionsutil.formatFlexSize(margins[3], G_reader_settings:readSetting("dimension_units")),
+            optionsutil.formatFlexSize(margins[4], G_reader_settings:readSetting("dimension_units")),
+            self.view.footer.reclaim_height and 0 or self.view.footer:getHeight()),
             dismiss_callback = when_applied_callback,
         })
     end

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -514,10 +514,10 @@ Margins set to:
   footer: %5 px
 
 Tap to dismiss.]]),
-            optionsutil.formatFlexSize(margins[1], G_reader_settings:readSetting("dimension_units")),
-            optionsutil.formatFlexSize(margins[2], G_reader_settings:readSetting("dimension_units")),
-            optionsutil.formatFlexSize(margins[3], G_reader_settings:readSetting("dimension_units")),
-            optionsutil.formatFlexSize(margins[4], G_reader_settings:readSetting("dimension_units")),
+            optionsutil.formatFlexSize(margins[1]),
+            optionsutil.formatFlexSize(margins[2]),
+            optionsutil.formatFlexSize(margins[3]),
+            optionsutil.formatFlexSize(margins[4]),
             self.view.footer.reclaim_height and 0 or self.view.footer:getHeight()),
             dismiss_callback = when_applied_callback,
         })

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1094,7 +1094,7 @@ end
 
 function ReaderView:onPageGapUpdate(page_gap)
     self.page_gap.height = Screen:scaleBySize(page_gap)
-    Notification:notify(T(_("Page gap set to %1."), optionsutil.formatFlexSize(page_gap, G_reader_settings:readSetting("dimension_units"))))
+    Notification:notify(T(_("Page gap set to %1."), optionsutil.formatFlexSize(page_gap)))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1094,7 +1094,7 @@ end
 
 function ReaderView:onPageGapUpdate(page_gap)
     self.page_gap.height = Screen:scaleBySize(page_gap)
-    Notification:notify(T(_("Page gap set to %1 (%2 px)."), page_gap, self.page_gap.height))
+    Notification:notify(T(_("Page gap set to %1."), optionsutil.formatFlexSize(page_gap, G_reader_settings:readSetting("dimension_units", "mm"))))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1092,12 +1092,9 @@ function ReaderView:onSetViewMode(new_mode)
     end
 end
 
---Refresh after changing a variable done by koptoptions.lua since all of them
---requires full screen refresh. If this handler used for changing page gap from
---another source (eg. coptions.lua) triggering a redraw is needed.
 function ReaderView:onPageGapUpdate(page_gap)
-    self.page_gap.height = page_gap
-    Notification:notify(T(_("Page gap set to %1."), page_gap))
+    self.page_gap.height = Screen:scaleBySize(page_gap)
+    Notification:notify(T(_("Page gap set to %1 (%2 px)."), page_gap, self.page_gap.height))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1094,7 +1094,7 @@ end
 
 function ReaderView:onPageGapUpdate(page_gap)
     self.page_gap.height = Screen:scaleBySize(page_gap)
-    Notification:notify(T(_("Page gap set to %1."), optionsutil.formatFlexSize(page_gap, G_reader_settings:readSetting("dimension_units", "mm"))))
+    Notification:notify(T(_("Page gap set to %1."), optionsutil.formatFlexSize(page_gap, G_reader_settings:readSetting("dimension_units"))))
     return true
 end
 

--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -221,9 +221,8 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     G_defaults:readSetting("DCREREADER_CONFIG_T_MARGIN_SIZES_XX_HUGE"),
                 },
                 hide_on_apply = true,
-                name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, "mm")
-                end,
+                name_text_hold_callback = optionsutil.showValues,
+                name_text_unit = true,
                 more_options = true,
                 more_options_param = {
                     -- Allow this to tune both top and bottom margins, handling
@@ -275,9 +274,8 @@ In the top menu → Settings → Status bar, you can choose whether the bottom m
                     G_defaults:readSetting("DCREREADER_CONFIG_B_MARGIN_SIZES_XX_HUGE"),
                 },
                 hide_on_apply = true,
-                name_text_hold_callback = function(configurable, opt, prefix)
-                    optionsutil.showValues(configurable, opt, prefix, nil, "mm")
-                end,
+                name_text_hold_callback = optionsutil.showValues,
+                name_text_unit = true,
                 help_text = _([[In the top menu → Settings → Status bar, you can choose whether the bottom margin applies from the bottom of the screen, or from above the status bar.]]),
                 more_options = true,
                 more_options_param = {
@@ -450,8 +448,9 @@ Note that your selected font size is not affected by this setting.]]),
                     local opt = {
                         name = "font_size",
                         name_text = _("Font Size"),
+                        name_text_unit = "pt",
                     }
-                    optionsutil.showValues(configurable, opt, prefix, nil, "pt")
+                    optionsutil.showValues(configurable, opt, prefix)
                 end,
             },
             {   -- ReaderFont

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -359,8 +359,7 @@ left to right or reverse, top to bottom or reverse.]]),
                     return optionsutil.enableIfEquals(configurable, "page_scroll", 1)
                 end,
                 name_text_hold_callback = optionsutil.showValues,
-                name_text_true_values = true,
-                name_text_unit = "px", -- values go through scaleBySize in the event handler
+                name_text_unit = true,
                 help_text = _([[In continuous view mode, sets the thickness of the separator between document pages.]]),
                 more_options = true,
                 more_options_param = {

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -349,16 +349,25 @@ left to right or reverse, top to bottom or reverse.]]),
             {
                 name = "page_gap_height",
                 name_text = _("Page Gap"),
-                toggle = {C_("Page gap", "none"), C_("Page gap", "small"), C_("Page gap", "medium"), C_("Page gap", "large")},
-                values = {0, 8, 16, 32},
+                buttonprogress = true,
+                values = {0, 2, 4, 8, 16, 32, 64},
+                default_pos = 4,
                 default_value = 8,
-                args = {0, 8, 16, 32},
                 event = "PageGapUpdate",
+                args = {0, 2, 4, 8, 16, 32, 64},
                 enabled_func = function (configurable)
                     return optionsutil.enableIfEquals(configurable, "page_scroll", 1)
                 end,
                 name_text_hold_callback = optionsutil.showValues,
+                name_text_true_values = true,
+                name_text_unit = "px", -- values go through scaleBySize in the event handler
                 help_text = _([[In continuous view mode, sets the thickness of the separator between document pages.]]),
+                more_options = true,
+                more_options_param = {
+                    value_step = 1, value_hold_step = 10,
+                    value_min = 0, value_max = 256,
+                    precision = "%.1f",
+                },
             },
             {
                 name = "full_screen",

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240914
+local CURRENT_MIGRATION_DATE = 20240915
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -720,6 +720,16 @@ if last_migration_date < 20240914 then
         G_reader_settings:makeTrue("highlight_write_into_pdf_notify")
     end
     G_reader_settings:delSetting("save_document")
+end
+
+-- 20240915, metric_length -> dimension_units, https://github.com/koreader/koreader/pull/12507
+if last_migration_date < 20240915 then
+    logger.info("Performing one-time migration for 20240915")
+
+    if G_reader_settings:has("metric_length") then
+        G_reader_settings:saveSetting("dimension_units", G_reader_settings:nilOrTrue("metric_length") and "mm" or "in")
+        G_reader_settings:delSetting("metric_length")
+    end
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -36,7 +36,7 @@ local function convertSizeTo(px, format)
     return Screen:scaleBySize(px) / display_dpi * 25.4 * format_factor
 end
 
-local function real_size_string(value, unit)
+function optionsutil.formatFlexSize(value, unit)
     if not value then
         -- This shouldn't really ever happen...
         return ""
@@ -155,21 +155,21 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
         local nb_current, nb_default = tonumber(current), tonumber(default)
         if nb_current == nil or nb_default == nil then
             text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
-                                            real_size_string(value_current or current, unit),
-                                            real_size_string(value_default or default, unit))
+                                            optionsutil.formatFlexSize(value_current or current, unit),
+                                            optionsutil.formatFlexSize(value_default or default, unit))
         elseif value_default then
             text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5 (%6)"), name_text, help_text,
-                                            current, real_size_string(value_current, unit),
-                                            default, real_size_string(value_default, unit))
+                                            current, optionsutil.formatFlexSize(value_current, unit),
+                                            default, optionsutil.formatFlexSize(value_default, unit))
         else
             text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5"), name_text, help_text,
-                                            current, real_size_string(value_current, unit),
+                                            current, optionsutil.formatFlexSize(value_current, unit),
                                             default)
         end
     else
         text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
-                                            real_size_string(current, unit),
-                                            real_size_string(default, unit))
+                                            optionsutil.formatFlexSize(current, unit),
+                                            optionsutil.formatFlexSize(default, unit))
     end
     UIManager:show(InfoMessage:new{ text=text })
 end
@@ -185,8 +185,8 @@ Current margins:
   left: %1
   right: %2
 Default margins: not set]]),
-                real_size_string(current[1], unit),
-                real_size_string(current[2], unit))
+                optionsutil.formatFlexSize(current[1], unit),
+                optionsutil.formatFlexSize(current[2], unit))
         })
     else
         UIManager:show(InfoMessage:new{
@@ -197,10 +197,10 @@ Current margins:
 Default margins:
   left: %3
   right: %4]]),
-                real_size_string(current[1], unit),
-                real_size_string(current[2], unit),
-                real_size_string(default[1], unit),
-                real_size_string(default[2], unit))
+                optionsutil.formatFlexSize(current[1], unit),
+                optionsutil.formatFlexSize(current[2], unit),
+                optionsutil.formatFlexSize(default[1], unit),
+                optionsutil.formatFlexSize(default[2], unit))
         })
     end
 end

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -44,6 +44,13 @@ local function real_size_string(ko_size, unit)
         shown_unit = C_("Length", "mm")
     elseif unit == "in" then
         shown_unit = C_("Length", "in")
+    elseif unit == "px" then
+        shown_unit = C_("Pixels", "px")
+        if ko_size then
+            return string.format(" (%d %s)", Screen:scaleBySize(ko_size), shown_unit)
+        else
+            return ""
+        end
     else
         shown_unit = unit -- for future units
     end
@@ -58,11 +65,15 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
     local default = G_reader_settings:readSetting(prefix.."_"..option.name)
     local current = configurable[option.name]
     local value_default, value_current
+    unit = unit or option.name_text_unit
+    if unit and unit ~= "pt" and unit ~= "px" then
+        unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
+    end
     if option.toggle and option.values then
         -- build a table so we can see if current/default settings map
         -- to a known setting with a name (in option.toggle)
         local arg_table = {}
-        for i=1,#option.values do
+        for i=1, #option.values do
             local val = option.values[i]
             -- flatten table to a string for easy lookup via arg_table
             if type(val) == "table" then val = table.concat(val, ",") end
@@ -97,14 +108,14 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
             end
         else
             if default then
-                for i=1,#option.labels do
+                for i=1, #option.labels do
                     if default == option.values[i] then
                         default = option.labels[i]
                         break
                     end
                 end
             end
-            for i=1,#option.labels do
+            for i=1, #option.labels do
                 if current == option.values[i] then
                     current = option.labels[i]
                     break
@@ -138,19 +149,19 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
     if option.name_text_true_values and option.toggle and option.values then
         local nb_current, nb_default = tonumber(current), tonumber(default)
         if nb_current == nil or nb_default == nil then
-            text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
-                                            value_current or current, value_default or default)
+            text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
+                                            value_current or current, real_size_string(value_current or current, unit),
+                                            value_default or default, real_size_string(value_default or default, unit))
         elseif value_default then
-            text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5 (%6)"), name_text, help_text,
-                                            current, value_current, default, value_default)
+            text = T(_("%1\n%2\nCurrent value: %3 (%4%5)\nDefault value: %6 (%7%8)"), name_text, help_text,
+                                            current, value_current, real_size_string(value_current, unit),
+                                            default, value_default, real_size_string(value_default, unit))
         else
-            text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5"), name_text, help_text,
-                                            current, value_current, default)
+            text = T(_("%1\n%2\nCurrent value: %3 (%4%5)\nDefault value: %6"), name_text, help_text,
+                                            current, value_current, real_size_string(value_current, unit),
+                                            default)
         end
     else
-        if unit and unit ~= "pt" then
-            unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
-        end
         text = T(_("%1\n%2\nCurrent value: %3%4\nDefault value: %5%6"), name_text, help_text,
                                             current, real_size_string(current, unit),
                                             default, real_size_string(default, unit))

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -39,18 +39,18 @@ local function convertSizeTo(px, format)
     return Screen:scaleBySize(px) / display_dpi * 25.4 * format_factor
 end
 
-local function real_size_string(ko_size, unit)
-    if not ko_size then
+local function real_size_string(value, unit)
+    if not value then
         -- This shouldn't really ever happen...
         return ""
     end
     if not unit then
-        return tostring(ko_size)
+        return tostring(value)
     end
 
-    ko_size = tonumber(ko_size)
-    if not ko_size then
-        return tostring(ko_size)
+    local size = tonumber(value)
+    if not size then
+        return tostring(value)
     end
 
     local shown_unit = unit
@@ -66,7 +66,7 @@ local function real_size_string(ko_size, unit)
         -- We don't so subpixel positioning ;)
         fmt = "%d (%d %s)"
     end
-    return string.format(fmt, ko_size, convertSizeTo(ko_size, unit), shown_unit)
+    return string.format(fmt, size, convertSizeTo(size, unit), shown_unit)
 end
 
 function optionsutil.showValues(configurable, option, prefix, document, unit)
@@ -74,7 +74,7 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
     local current = configurable[option.name]
     local value_default, value_current
     unit = unit or option.name_text_unit
-    if unit and unit ~= "pt" and unit ~= "px" then
+    if unit and unit ~= "pt" then
         unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
     end
     if option.toggle and option.values then

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -17,10 +17,7 @@ function optionsutil.enableIfEquals(configurable, option, value)
     return configurable[option] == value
 end
 
--- Converts px size to mm, inch or pt
--- if the `metric_length`-setting is not set or true -> mm
--- if the `metric_length`-setting is false -> inch
--- if format == "pt" -> pt
+-- Converts flex px/pt sizes to absolute px, mm, inch or pt
 local function convertSizeTo(px, format)
     local format_factor
 
@@ -75,7 +72,7 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
     local value_default, value_current
     unit = unit or option.name_text_unit
     if unit and unit ~= "pt" then
-        unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
+        unit = G_reader_settings:readSetting("dimension_units", "mm")
     end
     if option.toggle and option.values then
         -- build a table so we can see if current/default settings map
@@ -180,7 +177,7 @@ end
 function optionsutil.showValuesHMargins(configurable, option)
     local default = G_reader_settings:readSetting("copt_"..option.name)
     local current = configurable[option.name]
-    local unit = G_reader_settings:nilOrTrue("metric_length") and "mm" or "in"
+    local unit = G_reader_settings:readSetting("dimension_units", "mm")
     if not default then
         UIManager:show(InfoMessage:new{
             text = T(_([[

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -64,7 +64,7 @@ local function formatFlexSize(value, unit)
         shown_unit = C_("Length", "in")
     elseif unit == "px" then
         shown_unit = C_("Pixels", "px")
-        -- We don't so subpixel positioning ;)
+        -- We don't do subpixel positioning ;)
         fmt = "%d (%d %s)"
     end
 
@@ -83,6 +83,14 @@ function optionsutil.formatFlexSize(value, unit)
     return formatFlexSize(value, unit)
 end
 
+-- This is used extensively in ui/data/(cre|kopt)options as a `name_text_hold_callback`.
+-- `ConfigOption` will *never* pass the `unit` argument, though,
+-- so if it's unset, we'll try to pull it from `option`'s `name_text_unit` field.
+-- This field can be left unset (which is the vast majority of cases),
+-- in which case we don't do anything fancy with the value,
+-- or it can be set to an explicit unit (e.g., "pt" or "px"),
+-- in which case we append the results of a conversion to that unit in the final string.
+-- It can also be set to `true`, in which case the unit is pulled from user settings ("dimension_units").
 function optionsutil.showValues(configurable, option, prefix, document, unit)
     local default = G_reader_settings:readSetting(prefix.."_"..option.name)
     local current = configurable[option.name]

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -185,7 +185,7 @@ function optionsutil.showValuesHMargins(configurable, option)
         UIManager:show(InfoMessage:new{
             text = T(_([[
 Current margins:
-  left:  %1
+  left: %1
   right: %2
 Default margins: not set]]),
                 real_size_string(current[1], unit),
@@ -195,10 +195,10 @@ Default margins: not set]]),
         UIManager:show(InfoMessage:new{
             text = T(_([[
 Current margins:
-  left:  %1
+  left: %1
   right: %2
 Default margins:
-  left:  %3
+  left: %3
   right: %4]]),
                 real_size_string(current[1], unit),
                 real_size_string(current[2], unit),

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -24,16 +24,20 @@ local function convertSizeTo(px, format)
     if format == "px" then
         return Screen:scaleBySize(px)
     elseif format == "pt" then
-        format_factor = 1 * (2660 / 1000) -- see https://www.wikiwand.com/en/Metric_typographic_units
+        -- PostScript point,
+        -- c.f., https://en.wikipedia.org/wiki/Metric_typographic_units
+        --     & https://freetype.org/freetype2/docs/glyphs/glyphs-2.html
+        format_factor = 72
     elseif format == "in" then
-        format_factor = 1 / 25.4
+        format_factor = 1
     else
         -- i.e., Metric
-        format_factor = 1
+        format_factor = 25.4
     end
 
-    local display_dpi = Device:getDeviceScreenDPI() or Screen:getDPI() -- use device hardcoded dpi if available
-    return Screen:scaleBySize(px) / display_dpi * 25.4 * format_factor
+    -- We want the actual physical screen DPI if available, not a user override
+    local display_dpi = Device:getDeviceScreenDPI() or Screen:getDPI()
+    return Screen:scaleBySize(px) / display_dpi * format_factor
 end
 
 function optionsutil.formatFlexSize(value, unit)

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -40,7 +40,7 @@ local function convertSizeTo(px, format)
     return Screen:scaleBySize(px) / display_dpi * format_factor
 end
 
-function optionsutil.formatFlexSize(value, unit)
+local function formatFlexSize(value, unit)
     if not value then
         -- This shouldn't really ever happen...
         return ""
@@ -75,6 +75,12 @@ function optionsutil.formatFlexSize(value, unit)
     else
         return string.format(fmt, size, convertSizeTo(size, unit), shown_unit)
     end
+end
+
+-- Public wrapper for callers outside of ConfigOption, where we can't pull name_text_unit from option
+function optionsutil.formatFlexSize(value, unit)
+    unit = unit or G_reader_settings:readSetting("dimension_units", "mm")
+    return formatFlexSize(value, unit)
 end
 
 function optionsutil.showValues(configurable, option, prefix, document, unit)
@@ -166,21 +172,21 @@ function optionsutil.showValues(configurable, option, prefix, document, unit)
         local nb_current, nb_default = tonumber(current), tonumber(default)
         if nb_current == nil or nb_default == nil then
             text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
-                                            optionsutil.formatFlexSize(value_current or current, unit),
-                                            optionsutil.formatFlexSize(value_default or default, unit))
+                                            formatFlexSize(value_current or current, unit),
+                                            formatFlexSize(value_default or default, unit))
         elseif value_default then
             text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5 (%6)"), name_text, help_text,
-                                            current, optionsutil.formatFlexSize(value_current, unit),
-                                            default, optionsutil.formatFlexSize(value_default, unit))
+                                            current, formatFlexSize(value_current, unit),
+                                            default, formatFlexSize(value_default, unit))
         else
             text = T(_("%1\n%2\nCurrent value: %3 (%4)\nDefault value: %5"), name_text, help_text,
-                                            current, optionsutil.formatFlexSize(value_current, unit),
+                                            current, formatFlexSize(value_current, unit),
                                             default)
         end
     else
         text = T(_("%1\n%2\nCurrent value: %3\nDefault value: %4"), name_text, help_text,
-                                            optionsutil.formatFlexSize(current, unit),
-                                            optionsutil.formatFlexSize(default, unit))
+                                            formatFlexSize(current, unit),
+                                            formatFlexSize(default, unit))
     end
     UIManager:show(InfoMessage:new{ text=text })
 end
@@ -196,8 +202,8 @@ Current margins:
   left: %1
   right: %2
 Default margins: not set]]),
-                optionsutil.formatFlexSize(current[1], unit),
-                optionsutil.formatFlexSize(current[2], unit))
+                formatFlexSize(current[1], unit),
+                formatFlexSize(current[2], unit))
         })
     else
         UIManager:show(InfoMessage:new{
@@ -208,10 +214,10 @@ Current margins:
 Default margins:
   left: %3
   right: %4]]),
-                optionsutil.formatFlexSize(current[1], unit),
-                optionsutil.formatFlexSize(current[2], unit),
-                optionsutil.formatFlexSize(default[1], unit),
-                optionsutil.formatFlexSize(default[2], unit))
+                formatFlexSize(current[1], unit),
+                formatFlexSize(current[2], unit),
+                formatFlexSize(default[1], unit),
+                formatFlexSize(default[2], unit))
         })
     end
 end

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -63,7 +63,14 @@ function optionsutil.formatFlexSize(value, unit)
         -- We don't so subpixel positioning ;)
         fmt = "%d (%d %s)"
     end
-    return string.format(fmt, size, convertSizeTo(size, unit), shown_unit)
+
+    if G_reader_settings:isTrue("dimension_units_append_px") and unit ~= "px" then
+        local px_str = C_("Pixels", "px")
+        return string.format(fmt .. " [%d %s]", size, convertSizeTo(size, unit), shown_unit,
+                                                      convertSizeTo(size, "px"), px_str)
+    else
+        return string.format(fmt, size, convertSizeTo(size, unit), shown_unit)
+    end
 end
 
 function optionsutil.showValues(configurable, option, prefix, document, unit)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -721,6 +721,19 @@ common_settings.units = {
         return T(_("Dimension units: %1"), unit)
     end,
     sub_item_table = {
+        {
+            text = _("Also show values in pixels"),
+            checked_func = function()
+                return G_reader_settings:isTrue("dimension_units_append_px")
+            end,
+            enabled_func = function()
+                return G_reader_settings:readSetting("dimension_units") ~= "px"
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("dimension_units_append_px")
+            end,
+            separator = true,
+        },
         genGenericMenuEntry(_("Metric system"),   "dimension_units", "mm", nil, true),
         genGenericMenuEntry(_("Imperial system"), "dimension_units", "in", nil, true),
         genGenericMenuEntry(_("Pixels"),          "dimension_units", "px", nil, true),

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -716,20 +716,15 @@ common_settings.keyboard_layout = {
 common_settings.font_ui_fallbacks = require("ui/elements/font_ui_fallbacks")
 
 common_settings.units = {
-    text = _("Units"),
+    text_func = function()
+        local unit = G_reader_settings:readSetting("dimension_units", "mm")
+        return T(_("Dimension units: %1"), unit)
+    end,
     sub_item_table = {
-        {
-            text = _("Metric length"),
-            checked_func = function()
-                return G_reader_settings:readSetting("metric_length", true)
-            end,
-            callback = function(touchmenu_instance)
-                G_reader_settings:toggle("metric_length")
-                if touchmenu_instance then touchmenu_instance:updateItems() end
-            end,
-            keep_menu_open = true,
-        },
-    },
+        genGenericMenuEntry(_("Metric system"),   "dimension_units", "mm", nil, true),
+        genGenericMenuEntry(_("Imperial system"), "dimension_units", "in", nil, true),
+        genGenericMenuEntry(_("Pixels"),          "dimension_units", "px", nil, true),
+    }
 }
 
 common_settings.screenshot = {


### PR DESCRIPTION
Specifically, doc open runs the value through `scaleBySize`, as expected, but the event handler did not.

Switch the setting to a buttonprogress to allow using more_options in a less clunky fashion.

Also show the actual value in pixels in the long-press recap & notification.
This involved an extension of some helpers in optionsutil, and made me realize that I find showing these flex pixels as actual device pixels instead of mm/in much much much much more relevant, so, err, RFC to actually do something more involved on that front (expand the mm/in toggle to a mm/in/px tristate? Always show px in addition to mm/in?)

![pagegap-buttonprogress](https://github.com/user-attachments/assets/ef431936-de3e-431c-bd14-5be5d8ccd4e2)

(Rebase me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12507)
<!-- Reviewable:end -->
