### PR TITLE
Chore: Don't cache static data tables (ui/elements, ui/data, kb layouts & co)

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -458,7 +458,7 @@ To:
     if Device:supportsScreensaver() then
         self.menu_items.screensaver = {
             text = _("Sleep screen"),
-            sub_item_table = require("ui/elements/screensaver_menu"),
+            sub_item_table = dofile("frontend/ui/elements/screensaver_menu.lua"),
         }
     end
 
@@ -469,7 +469,7 @@ To:
 
     -- Settings > Navigation; this mostly concerns physical keys, and applies *everywhere*
     if Device:hasKeys() then
-        self.menu_items.physical_buttons_setup = require("ui/elements/physical_buttons")
+        self.menu_items.physical_buttons_setup = dofile("frontend/ui/elements/physical_buttons.lua")
     end
 
     -- settings tab - Document submenu
@@ -858,7 +858,7 @@ Tap a book in the search results to open it.]]),
         }
     end
 
-    local order = require("ui/elements/filemanager_menu_order")
+    local order = dofile("frontend/ui/elements/filemanager_menu_order.lua")
 
     local MenuSorter = require("ui/menusorter")
     self.tab_item_table = MenuSorter:mergeAndSort("filemanager", self.menu_items, order)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -858,7 +858,8 @@ Tap a book in the search results to open it.]]),
         }
     end
 
-    local order = dofile("frontend/ui/elements/filemanager_menu_order.lua")
+    -- NOTE: This is cached via require for ui/plugin/insert_menu's sake...
+    local order = require("ui/elements/filemanager_menu_order")
 
     local MenuSorter = require("ui/menusorter")
     self.tab_item_table = MenuSorter:mergeAndSort("filemanager", self.menu_items, order)

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -326,7 +326,8 @@ function ReaderMenu:setUpdateItemTable()
         end
     }
 
-    local order = dofile("frontend/ui/elements/reader_menu_order.lua")
+    -- NOTE: This is cached via require for ui/plugin/insert_menu's sake...
+    local order = require("ui/elements/reader_menu_order")
 
     local MenuSorter = require("ui/menusorter")
     self.tab_item_table = MenuSorter:mergeAndSort("reader", self.menu_items, order)

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -231,7 +231,7 @@ function ReaderMenu:setUpdateItemTable()
         },
     }
 
-    self.menu_items.page_overlap = require("ui/elements/page_overlap")
+    self.menu_items.page_overlap = dofile("frontend/ui/elements/page_overlap.lua")
 
     -- settings tab
     -- insert common settings
@@ -241,11 +241,11 @@ function ReaderMenu:setUpdateItemTable()
 
     if Device:isTouchDevice() then
         -- Settings > Taps & Gestures; mostly concerns touch related page turn stuff, and only applies to Reader
-        self.menu_items.page_turns = require("ui/elements/page_turns")
+        self.menu_items.page_turns = dofile("frontend/ui/elements/page_turns.lua")
     end
     -- Settings > Navigation; while also related to page turns, this mostly concerns physical keys, and applies *everywhere*
     if Device:hasKeys() then
-        self.menu_items.physical_buttons_setup = require("ui/elements/physical_buttons")
+        self.menu_items.physical_buttons_setup = dofile("frontend/ui/elements/physical_buttons.lua")
     end
     -- insert DjVu render mode submenu just before the last entry (show advanced)
     -- this is a bit of a hack
@@ -275,15 +275,8 @@ function ReaderMenu:setUpdateItemTable()
                 end
                 self.ui:saveSettings()
             end,
-            added_by_readermenu_flag = true,
         }
-        local screensaver_sub_item_table = require("ui/elements/screensaver_menu")
-        -- Before inserting this new item, remove any previously added one
-        for i = #screensaver_sub_item_table, 1, -1 do
-            if screensaver_sub_item_table[i].added_by_readermenu_flag then
-                table.remove(screensaver_sub_item_table, i)
-            end
-        end
+        local screensaver_sub_item_table = dofile("frontend/ui/elements/screensaver_menu.lua")
         table.insert(screensaver_sub_item_table, ss_book_settings)
         self.menu_items.screensaver = {
             text = _("Sleep screen"),
@@ -333,7 +326,7 @@ function ReaderMenu:setUpdateItemTable()
         end
     }
 
-    local order = require("ui/elements/reader_menu_order")
+    local order = dofile("frontend/ui/elements/reader_menu_order.lua")
 
     local MenuSorter = require("ui/menusorter")
     self.tab_item_table = MenuSorter:mergeAndSort("reader", self.menu_items, order)
@@ -452,19 +445,6 @@ function ReaderMenu:onSetDimensions(dimen)
     -- update gesture zones according to new screen dimen
     -- (On CRe, this will get called a second time by ReaderReady once the document is reloaded).
     self:initGesListener()
-end
-
-function ReaderMenu:onCloseDocument()
-    if Device:supportsScreensaver() then
-        -- Remove the item we added (which cleans up references to document
-        -- and doc_settings embedded in functions)
-        local screensaver_sub_item_table = require("ui/elements/screensaver_menu")
-        for i = #screensaver_sub_item_table, 1, -1 do
-            if screensaver_sub_item_table[i].added_by_readermenu_flag then
-                table.remove(screensaver_sub_item_table, i)
-            end
-        end
-    end
 end
 
 function ReaderMenu:_getTabIndexFromLocation(ges)

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -136,7 +136,7 @@ function Device:init()
     self.screen = require("ffi/framebuffer_android"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/android/powerd"):new{device = self}
 
-    local event_map = require("device/android/event_map")
+    local event_map = dofile("frontend/device/android/event_map.lua")
 
     if android.prop.is_tolino then
         -- dpad left/right as page back/forward

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1033,7 +1033,7 @@ function Kindle2:init()
     }
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/kindle/event_map_keyboard"),
+        event_map = dofile("frontend/device/kindle/event_map_keyboard.lua"),
     }
     Kindle.init(self)
 end
@@ -1046,9 +1046,9 @@ function KindleDXG:init()
     }
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/kindle/event_map_keyboard"),
+        event_map = dofile("frontend/device/kindle/event_map_keyboard.lua"),
     }
-    self.keyboard_layout = require("device/kindle/keyboard_layout")
+    self.keyboard_layout = dofile("frontend/device/kindle/keyboard_layout.lua")
     Kindle.init(self)
 end
 
@@ -1061,9 +1061,9 @@ function Kindle3:init()
     }
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/kindle/event_map_kindle4"),
+        event_map = dofile("frontend/device/kindle/event_map_kindle4.lua"),
     }
-    self.keyboard_layout = require("device/kindle/keyboard_layout")
+    self.keyboard_layout = dofile("frontend/device/kindle/keyboard_layout.lua")
     self.k3_alt_plus_key_kernel_translated = dofile("frontend/device/kindle/k3_alt_and_top_row.lua")
     Kindle.init(self)
 end
@@ -1077,7 +1077,7 @@ function Kindle4:init()
     }
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/kindle/event_map_kindle4"),
+        event_map = dofile("frontend/device/kindle/event_map_kindle4.lua"),
     }
     Kindle.init(self)
 end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -134,7 +134,7 @@ function Remarkable:init()
         status_file = self.status_path,
     }
 
-    local event_map = require("device/remarkable/event_map")
+    local event_map = dofile("frontend/device/remarkable/event_map.lua")
     -- If we are launched while Oxide is running, remove Power from the event map
     if oxide_running then
         event_map[116] = nil
@@ -142,7 +142,7 @@ function Remarkable:init()
 
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/remarkable/event_map"),
+        event_map = dofile("frontend/device/remarkable/event_map.lua"),
         wacom_protocol = true,
     }
 

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -196,7 +196,7 @@ function Device:init()
     local input = require("ffi/input")
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/sdl/event_map_sdl2"),
+        event_map = dofile("frontend/device/sdl/event_map_sdl2.lua"),
         handleSdlEv = function(device_input, ev)
 
 
@@ -311,7 +311,7 @@ function Device:init()
         file_chooser = input.file_chooser,
     }
 
-    self.keyboard_layout = require("device/sdl/keyboard_layout")
+    self.keyboard_layout = dofile("frontend/device/sdl/keyboard_layout.lua")
 
     if self.input.gameControllerRumble(0, 0, 0) then
         self.isHapticFeedbackEnabled = yes

--- a/frontend/device/sony-prstux/device.lua
+++ b/frontend/device/sony-prstux/device.lua
@@ -56,7 +56,7 @@ function SonyPRSTUX:init()
     self.powerd = require("device/sony-prstux/powerd"):new{device = self}
     self.input = require("device/input"):new{
         device = self,
-        event_map = require("device/sony-prstux/event_map"),
+        event_map = dofile("frontend/device/sony-prstux/event_map.lua"),
     }
 
     self.input.open("/dev/input/event0") -- Keys

--- a/frontend/ui/data/keyboardlayouts/ar_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ar_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local ar_popup = require("ui/data/keyboardlayouts/keypopup/ar_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local ar_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/ar_popup.lua")
 local com = en_popup.com -- comma (,)
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at

--- a/frontend/ui/data/keyboardlayouts/bn_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/bn_keyboard.lua
@@ -1,4 +1,4 @@
-local bn_popup = require("ui/data/keyboardlayouts/keypopup/bn_popup")
+local bn_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/bn_popup.lua")
 local pco = bn_popup.pco
 local cop = bn_popup.cop
 local cse = bn_popup.cse

--- a/frontend/ui/data/keyboardlayouts/cs_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/cs_keyboard.lua
@@ -1,4 +1,4 @@
-local cs_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/sk_keyboard"))
+local cs_keyboard = dofile("frontend/ui/data/keyboardlayouts/sk_keyboard.lua")
 
 local keys = cs_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/da_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/da_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the norwegian keyboard layout (deep copy, to not alter it)
-local da_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/no_keyboard"))
+-- Start with the norwegian keyboard layout
+local da_keyboard = dofile("frontend/ui/data/keyboardlayouts/no_keyboard.lua")
 
 local keys = da_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/de_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/de_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local de_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local de_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 local keys = de_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/el_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/el_keyboard.lua
@@ -1,4 +1,4 @@
-local el_popup = require("ui/data/keyboardlayouts/keypopup/el_popup")
+local el_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/el_popup.lua")
 local pco = el_popup.pco
 local cop = el_popup.cop
 local cse = el_popup.cse

--- a/frontend/ui/data/keyboardlayouts/en_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/en_keyboard.lua
@@ -1,4 +1,4 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
 local pco = en_popup.pco
 local cop = en_popup.cop
 local cse = en_popup.cse

--- a/frontend/ui/data/keyboardlayouts/es_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/es_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local es_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local es_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 local keys = es_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/fa_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/fa_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local fa_popup = require("ui/data/keyboardlayouts/keypopup/fa_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local fa_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/fa_popup.lua")
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at
 local alef = fa_popup.alef

--- a/frontend/ui/data/keyboardlayouts/fr_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/fr_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local fr_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local fr_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 -- Swap the four AZWQ keys (only in the lowercase and
 -- uppercase letters layouts) to change it from QWERTY to AZERTY

--- a/frontend/ui/data/keyboardlayouts/he_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/he_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local he_popup = require("ui/data/keyboardlayouts/keypopup/he_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local he_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/he_popup.lua")
 local pco = en_popup.pco
 local cop = en_popup.cop
 local cse = en_popup.cse

--- a/frontend/ui/data/keyboardlayouts/ja_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ja_keyboard.lua
@@ -18,7 +18,7 @@ local C_ = _.pgettext
 local N_ = _.ngettext
 local T = require("ffi/util").template
 
-local K = require("frontend/ui/data/keyboardlayouts/ja_keyboard_keys")
+local K = dofile("frontend/ui/data/keyboardlayouts/ja_keyboard_keys.lua")
 
 local DEFAULT_KEITAI_TAP_INTERVAL_S = 2
 

--- a/frontend/ui/data/keyboardlayouts/ka_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ka_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local ka_popup = require("ui/data/keyboardlayouts/keypopup/ka_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local ka_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/ka_popup.lua")
 local com = en_popup.com -- comma (,)
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at

--- a/frontend/ui/data/keyboardlayouts/ko_KR_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ko_KR_keyboard.lua
@@ -103,7 +103,7 @@ local wrapInputBox = function(inputbox)
 end
 
 -- Belows are just same as the English keyboard popup
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
 local com = en_popup.com -- comma (,)
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at

--- a/frontend/ui/data/keyboardlayouts/no_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/no_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local no_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local no_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 local keys = no_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/pl_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/pl_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local pl_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local pl_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 local keys = pl_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/ro_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ro_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local ro_popup = require("ui/data/keyboardlayouts/keypopup/ro_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local ro_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/ro_popup.lua")
 local com = en_popup.com -- comma (,)
 local prd = en_popup.prd -- period (.)
 local _at = en_popup._at

--- a/frontend/ui/data/keyboardlayouts/ru_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/ru_keyboard.lua
@@ -1,4 +1,4 @@
-local ru_popup = require("ui/data/keyboardlayouts/keypopup/ru_popup")
+local ru_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/ru_popup.lua")
 local pco = ru_popup.pco
 local cop = ru_popup.cop
 local cse = ru_popup.cse

--- a/frontend/ui/data/keyboardlayouts/sk_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/sk_keyboard.lua
@@ -1,5 +1,5 @@
-local en_popup = require("ui/data/keyboardlayouts/keypopup/en_popup")
-local sk_popup = require("ui/data/keyboardlayouts/keypopup/sk_popup")
+local en_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua")
+local sk_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/sk_popup.lua")
 
 local pco = en_popup.pco
 local cop = en_popup.cop

--- a/frontend/ui/data/keyboardlayouts/sv_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/sv_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the norwegian keyboard layout (deep copy, to not alter it)
-local sv_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/no_keyboard"))
+-- Start with the norwegian keyboard layout
+local sv_keyboard = dofile("frontend/ui/data/keyboardlayouts/no_keyboard.lua")
 
 local keys = sv_keyboard.keys
 

--- a/frontend/ui/data/keyboardlayouts/th_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/th_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local th_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local th_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 -- Swap the four AZWQ keys (only in the lowercase and
 -- uppercase letters layouts) to change it from QWERTY to AZERTY

--- a/frontend/ui/data/keyboardlayouts/tr_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/tr_keyboard.lua
@@ -1,5 +1,5 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local tr_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local tr_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
 local keys = tr_keyboard.keys
 -- Insert 2 additional key at the end of first 3 rows after numeric row.

--- a/frontend/ui/data/keyboardlayouts/uk_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/uk_keyboard.lua
@@ -1,4 +1,4 @@
-local uk_popup = require("ui/data/keyboardlayouts/keypopup/uk_popup")
+local uk_popup = dofile("frontend/ui/data/keyboardlayouts/keypopup/uk_popup.lua")
 local pco = uk_popup.pco
 local cop = uk_popup.cop
 local cse = uk_popup.cse

--- a/frontend/ui/data/keyboardlayouts/vi_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/vi_keyboard.lua
@@ -1,11 +1,11 @@
--- Start with the english keyboard layout (deep copy, to not alter it)
-local vi_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local vi_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 
-local IME = require("frontend/ui/data/keyboardlayouts/generic_ime")
+local IME = require("ui/data/keyboardlayouts/generic_ime")
 local util = require("util")
 
 -- see https://www.hieuthi.com/blog/2017/03/21/all-vietnamese-syllables.html
-local code_map = require("frontend/ui/data/keyboardlayouts/vi_telex_data")
+local code_map = dofile("frontend/ui/data/keyboardlayouts/vi_telex_data.lua")
 local ime = IME:new{
     code_map = code_map,
     partial_separators = {},

--- a/frontend/ui/data/keyboardlayouts/zh_CN_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/zh_CN_keyboard.lua
@@ -1,12 +1,12 @@
-local IME = require("frontend/ui/data/keyboardlayouts/generic_ime")
+local IME = require("ui/data/keyboardlayouts/generic_ime")
 local util = require("util")
 local _ = require("gettext")
 
--- Start with the english keyboard layout (deep copy, to not alter it)
-local py_keyboard = require("util").tableDeepCopy(require("ui/data/keyboardlayouts/en_keyboard"))
+-- Start with the english keyboard layout
+local py_keyboard = dofile("frontend/ui/data/keyboardlayouts/en_keyboard.lua")
 local SETTING_NAME = "keyboard_chinese_pinyin_settings"
 
-local code_map = require("frontend/ui/data/keyboardlayouts/zh_pinyin_data")
+local code_map = dofile("frontend/ui/data/keyboardlayouts/zh_pinyin_data.lua")
 local settings = G_reader_settings:readSetting(SETTING_NAME, {show_candi=true})
 local ime = IME:new {
     code_map = code_map,

--- a/frontend/ui/data/keyboardlayouts/zh_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/zh_keyboard.lua
@@ -15,9 +15,9 @@ rf. https://en.wikipedia.org/wiki/Stroke_count_method
 
 --]]
 
-local IME = require("frontend/ui/data/keyboardlayouts/generic_ime")
+local IME = require("ui/data/keyboardlayouts/generic_ime")
 local util = require("util")
-local JA = require("ui/data/keyboardlayouts/ja_keyboard_keys")
+local JA = dofile("frontend/ui/data/keyboardlayouts/ja_keyboard_keys.lua")
 local _ = require("gettext")
 
 local SHOW_CANDI_KEY = "keyboard_chinese_stroke_show_candidates"
@@ -73,7 +73,7 @@ local genMenuItems = function(self)
     }
 end
 
-local code_map = require("frontend/ui/data/keyboardlayouts/zh_stroke_data")
+local code_map = dofile("frontend/ui/data/keyboardlayouts/zh_stroke_data.lua")
 local ime = IME:new{
     code_map = code_map,
     key_map = {

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -265,10 +265,10 @@ NetworkMgr:getMenuTable(common_settings)
 common_settings.screen = {
     text = _("Screen"),
 }
-common_settings.screen_rotation = require("ui/elements/screen_rotation_menu_table")
-common_settings.screen_dpi = require("ui/elements/screen_dpi_menu_table")
-common_settings.screen_eink_opt = require("ui/elements/screen_eink_opt_menu_table")
-common_settings.screen_notification = require("ui/elements/screen_notification_menu_table")
+common_settings.screen_rotation = dofile("frontend/ui/elements/screen_rotation_menu_table.lua")
+common_settings.screen_dpi = dofile("frontend/ui/elements/screen_dpi_menu_table.lua")
+common_settings.screen_eink_opt = dofile("frontend/ui/elements/screen_eink_opt_menu_table.lua")
+common_settings.screen_notification = dofile("frontend/ui/elements/screen_notification_menu_table.lua")
 
 if Device:isTouchDevice() then
     common_settings.taps_and_gestures = {
@@ -283,13 +283,13 @@ if Device:isTouchDevice() then
             UIManager:broadcastEvent(Event:new("IgnoreHoldCorners"))
         end,
     }
-    common_settings.screen_disable_double_tab = require("ui/elements/screen_disable_double_tap_table")
-    common_settings.menu_activate = require("ui/elements/menu_activate")
+    common_settings.screen_disable_double_tab = dofile("frontend/ui/elements/screen_disable_double_tap_table.lua")
+    common_settings.menu_activate = dofile("frontend/ui/elements/menu_activate.lua")
 end
 
 -- NOTE: Allow disabling color if it's mistakenly enabled on a Grayscale screen (after a settings import?)
 if Screen:isColorEnabled() or Screen:isColorScreen() then
-    common_settings.color_rendering = require("ui/elements/screen_color_menu_table")
+    common_settings.color_rendering = dofile("frontend/ui/elements/screen_color_menu_table.lua")
 end
 
 -- fullscreen toggle for supported devices
@@ -710,10 +710,10 @@ common_settings.device = {
 
 common_settings.keyboard_layout = {
     text = _("Keyboard"),
-    sub_item_table = require("ui/elements/menu_keyboard_layout"),
+    sub_item_table = dofile("frontend/ui/elements/menu_keyboard_layout.lua"),
 }
 
-common_settings.font_ui_fallbacks = require("ui/elements/font_ui_fallbacks")
+common_settings.font_ui_fallbacks = dofile("frontend/ui/elements/font_ui_fallbacks.lua")
 
 common_settings.units = {
     text = _("Units"),

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -13,8 +13,8 @@ local eink_settings_table = {
                 G_reader_settings:saveSetting("low_pan_rate", Screen.low_pan_rate)
             end,
         },
-        require("ui/elements/flash_ui"),
-        require("ui/elements/flash_keyboard"),
+        dofile("frontend/ui/elements/flash_ui.lua"),
+        dofile("frontend/ui/elements/flash_keyboard.lua"),
         {
             text = _("Avoid mandatory black flashes in UI"),
             checked_func = function() return G_reader_settings:isTrue("avoid_flashing_ui") end,
@@ -26,9 +26,9 @@ local eink_settings_table = {
 }
 
 if Device:hasEinkScreen() then
-    table.insert(eink_settings_table.sub_item_table, 1, require("ui/elements/refresh_menu_table"))
+    table.insert(eink_settings_table.sub_item_table, 1, dofile("frontend/ui/elements/refresh_menu_table.lua"))
     if (Screen.wf_level_max or 0) > 0 then
-        table.insert(eink_settings_table.sub_item_table, require("ui/elements/waveform_level"))
+        table.insert(eink_settings_table.sub_item_table, dofile("frontend/ui/elements/waveform_level.lua"))
     end
 end
 

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -22,10 +22,10 @@ local MenuSorter = {
 function MenuSorter:readMSSettings(config_prefix)
     if config_prefix then
         local menu_order = string.format(
-            "%s/%s_menu_order", DataStorage:getSettingsDir(), config_prefix)
+            "%s/%s_menu_order.lua", DataStorage:getSettingsDir(), config_prefix)
 
-        if lfs.attributes(menu_order..".lua") then
-            return require(menu_order) or {}
+        if lfs.attributes(menu_order) then
+            return dofile(menu_order) or {}
         end
     end
     return {}

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -5,7 +5,6 @@ menu_items and a separate menu order.
 
 local DataStorage = require("datastorage")
 local FFIUtil = require("ffi/util")
-local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local _ = require("gettext")
 

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -5,6 +5,7 @@ menu_items and a separate menu order.
 
 local DataStorage = require("datastorage")
 local FFIUtil = require("ffi/util")
+local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local _ = require("gettext")
 
@@ -23,8 +24,9 @@ function MenuSorter:readMSSettings(config_prefix)
         local menu_order = string.format(
             "%s/%s_menu_order.lua", DataStorage:getSettingsDir(), config_prefix)
 
-        local ok, data = pcall(dofile, menu_order)
-        return ok and data or {}
+        if lfs.attributes(menu_order) then
+            return dofile(menu_order) or {}
+        end
     end
     return {}
 end

--- a/frontend/ui/menusorter.lua
+++ b/frontend/ui/menusorter.lua
@@ -24,9 +24,8 @@ function MenuSorter:readMSSettings(config_prefix)
         local menu_order = string.format(
             "%s/%s_menu_order.lua", DataStorage:getSettingsDir(), config_prefix)
 
-        if lfs.attributes(menu_order) then
-            return dofile(menu_order) or {}
-        end
+        local ok, data = pcall(dofile, menu_order)
+        return ok and data or {}
     end
     return {}
 end

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -6,7 +6,6 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local event_map_keyboard = require("event_map_keyboard")
 local util = require("util")
 local _ = require("gettext")
 
@@ -398,7 +397,7 @@ function ExternalKeyboard:setupKeyboard(data)
     -- Using a new table avoids mutating the original event map.
     local event_map = {}
     util.tableMerge(event_map, Device.input.event_map)
-    util.tableMerge(event_map, event_map_keyboard)
+    util.tableMerge(event_map, dofile("plugins/externalkeyboard.koplugin/event_map_keyboard.lua"))
     Device.input.event_map = event_map
     Device.hasKeyboard = yes
     Device.hasKeys = yes

--- a/spec/unit/menu_table_screen_color_spec.lua
+++ b/spec/unit/menu_table_screen_color_spec.lua
@@ -2,7 +2,7 @@ describe("menu table screen color module", function()
     local menu, Screen, CanvasContext
     setup(function()
         require("commonrequire")
-        menu = require("ui/elements/screen_color_menu_table")
+        menu = dofile("frontend/ui/elements/screen_color_menu_table.lua")
         Screen = require("device").screen
         CanvasContext = require("document/canvascontext")
     end)


### PR DESCRIPTION
Using `require` didn't make much sense since most of them are only used in a single place anyway, and it takes care of a few weird interactions in the process (besides not polluting `package.loaded` with useless crap ;)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12519)
<!-- Reviewable:end -->
