### PR TITLE
SyncService: Only require online connectivity when using Dropbox

### DIFF
--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -122,9 +122,17 @@ end
 -- and renamed to replace the old cached file (thus the naming). The cached file stays (in the same folder) till being replaced
 -- in the next round.
 function SyncService.sync(server, file_path, sync_cb, is_silent)
-    if NetworkMgr:willRerunWhenOnline(function() SyncService.sync(server, file_path, sync_cb, is_silent) end) then
-        return
+    if server.type == "dropbox" then
+        if NetworkMgr:willRerunWhenOnline(function() SyncService.sync(server, file_path, sync_cb, is_silent) end) then
+            return
+        end
+    else
+        -- NOTE: Align behavior with CloudStorage:openCloudServer, where only Dropbox requires isOnline
+        if NetworkMgr:willRerunWhenConnected(function() SyncService.sync(server, file_path, sync_cb, is_silent) end) then
+            return
+        end
     end
+
     local file_name = ffiutil.basename(file_path)
     local income_file_path = file_path .. ".temp" -- file downloaded from server
     local cached_file_path = file_path .. ".sync" -- file uploaded to server last time


### PR DESCRIPTION
Aligns with the CloudStorage behavior.

Fix #12518

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12520)
<!-- Reviewable:end -->
