### PR TITLE
ProgressWidget: fix misalignment

### DIFF
--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -159,8 +159,8 @@ function ProgressWidget:paintTo(bb, x, y)
             tick_x = math.floor(tick_x)
             width = math.ceil(width)
 
-            bb:paintRect(x + self.margin_h + self.bordersize + tick_x,
-                         fill_y,
+            bb:paintRect(math.ceil(x + self.margin_h + self.bordersize + tick_x),
+                         math.ceil(fill_y),
                          width,
                          math.ceil(fill_height),
                          self.altcolor)
@@ -175,8 +175,8 @@ function ProgressWidget:paintTo(bb, x, y)
             fill_x = math.floor(fill_x)
         end
 
-        bb:paintRect(fill_x,
-                     fill_y,
+        bb:paintRect(math.ceil(fill_x),
+                     math.ceil(fill_y),
                      math.ceil(fill_width * self.percentage),
                      math.ceil(fill_height),
                      self.fillcolor)
@@ -200,8 +200,8 @@ function ProgressWidget:paintTo(bb, x, y)
             end
             tick_x = math.floor(tick_x)
 
-            bb:paintRect(x + self.margin_h + self.bordersize + tick_x,
-                         fill_y,
+            bb:paintRect(math.ceil(x + self.margin_h + self.bordersize + tick_x),
+                         math.ceil(fill_y),
                          self.tick_width,
                          math.ceil(fill_height),
                          self.bordercolor)

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -141,7 +141,7 @@ function ProgressWidget:paintTo(bb, x, y)
         -- Otherwise, we have to start with the background.
         bb:paintRoundedRect(x, y, my_size.w, my_size.h, self.bgcolor, self.radius)
         -- Then the border around that.
-        bb:paintBorder(x, y,
+        bb:paintBorder(math.floor(x), math.floor(y),
                        my_size.w, my_size.h,
                        self.bordersize, self.bordercolor, self.radius)
     end
@@ -159,8 +159,8 @@ function ProgressWidget:paintTo(bb, x, y)
             tick_x = math.floor(tick_x)
             width = math.ceil(width)
 
-            bb:paintRect(math.ceil(x + self.margin_h + self.bordersize + tick_x),
-                         math.ceil(fill_y),
+            bb:paintRect(x + self.margin_h + self.bordersize + tick_x,
+                         fill_y,
                          width,
                          math.ceil(fill_height),
                          self.altcolor)
@@ -175,8 +175,8 @@ function ProgressWidget:paintTo(bb, x, y)
             fill_x = math.floor(fill_x)
         end
 
-        bb:paintRect(math.ceil(fill_x),
-                     math.ceil(fill_y),
+        bb:paintRect(fill_x,
+                     fill_y,
                      math.ceil(fill_width * self.percentage),
                      math.ceil(fill_height),
                      self.fillcolor)
@@ -200,8 +200,8 @@ function ProgressWidget:paintTo(bb, x, y)
             end
             tick_x = math.floor(tick_x)
 
-            bb:paintRect(math.ceil(x + self.margin_h + self.bordersize + tick_x),
-                         math.ceil(fill_y),
+            bb:paintRect(x + self.margin_h + self.bordersize + tick_x,
+                         fill_y,
                          self.tick_width,
                          math.ceil(fill_height),
                          self.bordercolor)


### PR DESCRIPTION
I've observed a slight misalignment in the progress widget on the reading progress page on my Kobo Libra 2. 
![image](https://github.com/user-attachments/assets/2ab592d8-ea37-4217-bc42-ef262c153a7c)
Especially, the problem becomes particularly noticeable when I try to change fonts on the reading progress page.

The progress widget use paintRect and paintBorder to draw the background and the border sharing the same starting pos x and y. The misalignment is due to the different rounding method. [paintRect floors x and y](https://github.com/koreader/koreader-base/blob/0efd201bdfd948e2336ca83120335767c2a59cdd/ffi/blitbuffer.lua#L1174) but [paintBorder ceils x and y](https://github.com/koreader/koreader-base/blob/0efd201bdfd948e2336ca83120335767c2a59cdd/ffi/blitbuffer.lua#L2062).
This misalignment problem occurs when x or y is not integer.

I've made a minor adjustment to the progress widget to address this issue without significantly impacting other functionalities. However, I suspect that similar misalignments could occur elsewhere. I'm willing to address any additional issues when i notice.

After fix:
![image](https://github.com/user-attachments/assets/85f25034-0b05-4912-b6b0-5ed3173a7886)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12526)
<!-- Reviewable:end -->
