### PR TITLE
Revert "Profiles: make sure to close menu/quickmenu before executing action"

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1084,9 +1084,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_size = 22,
             callback = function()
                 UIManager:close(quickmenu)
-                UIManager:nextTick(function()
-                    Dispatcher:execute(settings, { qm_show = false })
-                end)
+                Dispatcher:execute(settings, { qm_show = false })
             end,
         }})
     end
@@ -1100,9 +1098,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             font_bold = false,
             callback = function()
                 UIManager:close(quickmenu)
-                UIManager:nextTick(function()
-                    Dispatcher:execute({[v.key] = settings[v.key]})
-                end)
+                Dispatcher:execute({[v.key] = settings[v.key]})
                 if keep_open_on_apply and not util.stringStartsWith(v.key, "touch_input") then
                     quickmenu:setTitle(title)
                     UIManager:show(quickmenu)
@@ -1111,9 +1107,7 @@ function Dispatcher:_showAsMenu(settings, exec_props)
             hold_callback = function()
                 if v.key:sub(1, 13) == "profile_exec_" then
                     UIManager:close(quickmenu)
-                    UIManager:nextTick(function()
-                        UIManager:sendEvent(Event:new(settingsList[v.key].event, settingsList[v.key].arg, { qm_show = true }))
-                    end)
+                    UIManager:sendEvent(Event:new(settingsList[v.key].event, settingsList[v.key].arg, { qm_show = true }))
                 end
             end,
         }})

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -124,14 +124,14 @@ function Profiles:getSubMenuItems()
                 text = _("Execute"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    UIManager:nextTick(self.onProfileExecute, self, k, { qm_show = false })
+                    self:onProfileExecute(k, { qm_show = false })
                 end,
             },
             {
                 text = _("Show as QuickMenu"),
                 callback = function(touchmenu_instance)
                     touchmenu_instance:onClose()
-                    UIManager:nextTick(self.onProfileExecute, self, k, { qm_show = true })
+                    self:onProfileExecute(k, { qm_show = true })
                 end,
             },
             {


### PR DESCRIPTION
Reverts koreader/koreader#12299

See https://github.com/koreader/koreader/pull/12498#issuecomment-2339626911

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12534)
<!-- Reviewable:end -->
