### PR TITLE
[DictQuickLookup] shortcuts for editing searches

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -105,12 +105,19 @@ function DictQuickLookup:init()
         self.key_events.ReadNextResult = { { Input.group.PgFwd } }
         self.key_events.Close = { { Input.group.Back } }
         self.key_events.MenuKeyPress = { { "Menu" } }
+        self.key_event.DictQuickLookupToHome = { { "Home" } }
         if Device:hasKeyboard() then
             self.key_events.ChangeToPrevDict = { { "Shift", "Left" } }
             self.key_events.ChangeToNextDict = { { "Shift", "Right" } }
+            self.key_events.LookupInputWordClear = { { Input.group.Alphabet }, event = "LookupInputWord" }
+            -- We need to concat here so that the 'del' event press, which propagates to inputText (desirable for previous key_event,
+            -- i.e., LookupInputWordClear) does not remove the last char of self.word
+            self.key_events.LookupInputWord = { { Device:hasSymKey() and "Del" or "Backspace" }, args = self.word .." " }
         elseif Device:hasScreenKB() then
             self.key_events.ChangeToPrevDict = { { "ScreenKB", "Left" } }
             self.key_events.ChangeToNextDict = { { "ScreenKB", "Right" } }
+            -- same case as hasKeyboard
+            self.key_events.LookupInputWord = { { "ScreenKB", "Back" }, args = self.word .." " }
         end
     end
     if Device:isTouchDevice() then
@@ -284,11 +291,11 @@ function DictQuickLookup:init()
         padding_left = Size.padding.small,
         callback = function()
             -- allow adjusting the queried word
-            self:lookupInputWord(self.word)
+            self:onLookupInputWord(self.word)
         end,
         hold_callback = function()
             -- allow adjusting the current result word
-            self:lookupInputWord(self.lookupword)
+            self:onLookupInputWord(self.lookupword)
         end,
         overlap_align = "right",
         show_parent = self,
@@ -1169,6 +1176,11 @@ function DictQuickLookup:onHoldClose(no_clear)
     return true
 end
 
+function DictQuickLookup:onDictQuickLookupToHome()
+    self:onHoldClose()
+    self.ui:onHome()
+end
+
 function DictQuickLookup:onSwipe(arg, ges)
     if ges.pos:intersectWith(self.definition_widget.dimen) then
     -- if we want changeDict to still work with swipe outside window :
@@ -1255,7 +1267,7 @@ function DictQuickLookup:onForwardingPanRelease(arg, ges)
     return self.movable:onMovablePanRelease(arg, ges)
 end
 
-function DictQuickLookup:lookupInputWord(hint)
+function DictQuickLookup:onLookupInputWord(hint)
     self.input_dialog = InputDialog:new{
         title = _("Enter a word or phrase to look up"),
         input = hint,

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -105,7 +105,6 @@ function DictQuickLookup:init()
         self.key_events.ReadNextResult = { { Input.group.PgFwd } }
         self.key_events.Close = { { Input.group.Back } }
         self.key_events.MenuKeyPress = { { "Menu" } }
-        self.key_event.DictQuickLookupToHome = { { "Home" } }
         if Device:hasKeyboard() then
             self.key_events.ChangeToPrevDict = { { "Shift", "Left" } }
             self.key_events.ChangeToNextDict = { { "Shift", "Right" } }
@@ -1174,11 +1173,6 @@ function DictQuickLookup:onHoldClose(no_clear)
         window:onClose(no_clear)
     end
     return true
-end
-
-function DictQuickLookup:onDictQuickLookupToHome()
-    self:onHoldClose()
-    self.ui:onHome()
 end
 
 function DictQuickLookup:onSwipe(arg, ges)


### PR DESCRIPTION
### what's new

* Adds key events to edit dictionary queries i.e., self.word
* ~~Adds Home event~~
* local dict-widget's type to search

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12539)
<!-- Reviewable:end -->
