### PR TITLE
Statistics: fix null terminated strings, add toggle stats

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -761,7 +761,9 @@ function ReaderStatistics:getIdBookDB()
     local title, authors = self.data.title, self.data.authors
     local result = stmt:reset():bind(title, authors, self.doc_md5):step()
     local nr_id = tonumber(result[1])
-    if nr_id == 0 and self.ui.paging then -- old strings are null-terminated
+    if nr_id == 0 and self.ui.paging then
+        -- In the past, title and/or authors strings, got from MuPDF, may have been or not null terminated.
+        -- We need to check with all combinations if a book with these null terminated exists, and use it.
         title = title .. "\0"
         result = stmt:reset():bind(title, authors, self.doc_md5):step()
         nr_id = tonumber(result[1])


### PR DESCRIPTION
(1) Followup to https://github.com/koreader/koreader-base/pull/1921, https://github.com/koreader/koreader/pull/12503: when getting a pdf book id in the stats db, check for old records with null terminated authors and title.
Discussed in https://github.com/koreader/koreader/issues/11318. There are some other reasons for disappearing old stats for pdf (md5 changes when converting/writing to pdf or something else), hence not closing the issue.
(2) Add Dispatcher action for toggling statistics. Closes https://github.com/koreader/koreader/issues/11422.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12547)
<!-- Reviewable:end -->
