### PR TITLE
screensaver: Add dynamic battery symbol to sleep screen message

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -134,6 +134,7 @@ function Screensaver:expandSpecial(message, fallback)
     local time_left_chapter = _("N/A")
     local time_left_document = _("N/A")
     local batt_lvl = _("N/A")
+    local batt_symbol = _("N/A")
     local props
 
     local ReaderUI = require("apps/reader/readerui")
@@ -193,10 +194,10 @@ function Screensaver:expandSpecial(message, fallback)
         local powerd = Device:getPowerDevice()
         if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
             batt_lvl = powerd:getCapacity() + powerd:getAuxCapacity()
-            batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), aux_batt_lvl)
+           batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), batt_lvl)
         else
             batt_lvl = powerd:getCapacity()
-            batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)
+           batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)
         end
     end
 

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -116,6 +116,7 @@ function Screensaver:expandSpecial(message, fallback)
     -- %h time left in chapter
     -- %H time left in document (if there are hidden flows, time left in current flow)
     -- %b battery level
+    -- %B battery symbol
 
     if G_reader_settings:hasNot("lastfile") then
         return fallback
@@ -192,8 +193,10 @@ function Screensaver:expandSpecial(message, fallback)
         local powerd = Device:getPowerDevice()
         if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
             batt_lvl = powerd:getCapacity() + powerd:getAuxCapacity()
+            batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), aux_batt_lvl)
         else
             batt_lvl = powerd:getCapacity()
+            batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)
         end
     end
 
@@ -207,6 +210,7 @@ function Screensaver:expandSpecial(message, fallback)
         ["%h"] = time_left_chapter,
         ["%H"] = time_left_document,
         ["%b"] = batt_lvl,
+        ["%B"] = batt_symbol,
     }
     ret = ret:gsub("(%%%a)", replace)
 
@@ -329,7 +333,8 @@ Enter a custom message to be displayed on the sleep screen. The following escape
   %p percentage read
   %h time left in chapter
   %H time left in document
-  %b battery level]]),
+  %b battery level
+  %B battery symbol]]),
         input = screensaver_message,
         buttons = {
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -194,10 +194,10 @@ function Screensaver:expandSpecial(message, fallback)
         local powerd = Device:getPowerDevice()
         if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
             batt_lvl = powerd:getCapacity() + powerd:getAuxCapacity()
-           batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), batt_lvl / 2)
+            batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), batt_lvl / 2)
         else
             batt_lvl = powerd:getCapacity()
-           batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)
+            batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)
         end
     end
 

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -194,7 +194,7 @@ function Screensaver:expandSpecial(message, fallback)
         local powerd = Device:getPowerDevice()
         if Device:hasAuxBattery() and powerd:isAuxBatteryConnected() then
             batt_lvl = powerd:getCapacity() + powerd:getAuxCapacity()
-           batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), batt_lvl)
+           batt_symbol = powerd:getBatterySymbol(powerd:isAuxCharged(), powerd:isAuxCharging(), batt_lvl / 2)
         else
             batt_lvl = powerd:getCapacity()
            batt_symbol = powerd:getBatterySymbol(powerd:isCharged(), powerd:isCharging(), batt_lvl)


### PR DESCRIPTION
I have enjoyed (possibly over) customizing my sleep screen message. However I kept getting confused between the book completed percentage and the battery percentage. At first I just tried adding the battery symbol, but when looking into it, it was simpler to just reference the function that returns the dynamic battery icon.

I added the battery symbol to the prompt as %B:
![sleep_screen_message_prompt](https://github.com/user-attachments/assets/ff9bba98-6d5b-4f4b-9650-707da5d8dfa2)

And examples of what it looks like (along with some other fun symbols I found along the way):
![battery_64_percent](https://github.com/user-attachments/assets/d2d466e7-3a41-430b-a733-2b90e4cd14bf)
![battery_89_percent](https://github.com/user-attachments/assets/ce29fd30-3585-4758-93f2-9798c8060925)
![battery_89_percent_charging](https://github.com/user-attachments/assets/5b4fb9ec-cd39-4f2f-9dd4-f7ef44d0d07f)
![battery_100_percent_charged](https://github.com/user-attachments/assets/fcc06d42-0e44-4a7b-9e39-f86e8cdf8473)

This was tested on a Kobo Clara 2E, but since it uses the same code that niluje wrote in `frontend/ui/widget/touchmenu.lua` for the touch menu icon, my guess is it will be device agnostic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12548)
<!-- Reviewable:end -->
