### PR TITLE
ci/circle: fix tests parallelism

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -6,9 +6,9 @@ source "${CI_DIR}/common.sh"
 
 pushd install/koreader && {
     # the circleci command spits out newlines; we want spaces instead
-    BUSTED_SPEC_FILE="$(circleci tests glob "spec/front/unit/*_spec.lua" | circleci tests split --split-by=timings --timings-type=filename | tr '\n' ' ')"
+    BUSTED_OVERRIDES="$(circleci tests glob "spec/front/unit/*_spec.lua" | circleci tests split --split-by=timings --timings-type=filename | tr '\n' ' ')"
 } && popd || exit
 
-make testfront --assume-old=all BUSTED_SPEC_FILE="${BUSTED_SPEC_FILE}"
+make testfront --assume-old=all BUSTED_OVERRIDES="${BUSTED_OVERRIDES}"
 
 # vim: sw=4


### PR DESCRIPTION
Use `BUSTED_OVERRIDES`, as `BUSTED_SPEC_FILE` was removed in 93c7ceccd9f3bab110dc230cfb07ba5ae16ced3c.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12551)
<!-- Reviewable:end -->
