### PR TITLE
input: fix kobo init

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -902,7 +902,7 @@ function Kobo:init()
     --       and it's usually *extremely* verbose, so it'd just be a waste of processing power.
     -- fake_events is only used for usb plug & charge events so far (generated via uevent, c.f., input/iput-kobo.h in base).
     -- NOTE: usb hotplug event is also available in /tmp/nickel-hardware-status (... but only when Nickel is running ;p)
-    self.input.open("fake_events")
+    self.input:open("fake_events")
 
     -- See if the device supports key repeat
     -- This is *not* behind a hasKeys check, because we mainly use it to stop SleepCover chatter,


### PR DESCRIPTION
I missed converting one call of `Input.open` to a method call in #12486.

Cf. https://github.com/koreader/koreader/issues/12522#issuecomment-2374556131.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12553)
<!-- Reviewable:end -->
