### PR TITLE
Disabled rotation map for Android devices where "hw media keys follow gravity"

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -246,6 +246,11 @@ function Device:init()
         end,
     }
 
+    -- disable translation map for specific models
+    if android.prop.model == "xiaomi_reader" or android.prop.model == "moaanmix7" then
+        self.input:disableRotationMap()
+    end
+
     -- check if we have a keyboard
     if android.lib.AConfiguration_getKeyboard(android.app.config)
        == C.ACONFIGURATION_KEYBOARD_QWERTY

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -246,8 +246,8 @@ function Device:init()
         end,
     }
 
-    -- disable translation map for specific models
-    if android.prop.model == "xiaomi_reader" or android.prop.model == "moaanmix7" then
+    -- disable translation for specific models, where media keys follow gravity, see https://github.com/koreader/koreader/issues/12423
+    if android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" then
         self.input:disableRotationMap()
     end
 


### PR DESCRIPTION
- Disabling rotation map for Android devices mentioned in https://github.com/koreader/koreader/issues/9223 and https://github.com/koreader/koreader/issues/12423
- The implementation replaces necessity of using user patches
- The solution is similar to the one used for Pocketbook https://github.com/koreader/koreader/issues/10123

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12557)
<!-- Reviewable:end -->
