### PR TITLE
input: fix loading of `fbink_input` library

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -476,8 +476,9 @@ end
 
 function Kindle:openInputDevices()
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
-    local ok, FBInkInput = pcall(ffi.loadlib, "fbink_input")
+    local ok, FBInkInput = pcall(ffi.loadlib, "fbink_input", 1)
     if not ok then
+        print("fbink_input not loaded:", FBInkInput)
         -- NOP fallback for the testsuite...
         FBInkInput = { fbink_input_scan = function() end }
     end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -862,8 +862,9 @@ function Kobo:init()
     self:initEventAdjustHooks()
 
     -- Auto-detect input devices (via FBInk's fbink_input_scan)
-    local ok, FBInkInput = pcall(ffi.loadlib, "fbink_input")
+    local ok, FBInkInput = pcall(ffi.loadlib, "fbink_input", 1)
     if not ok then
+        print("fbink_input not loaded:", FBInkInput)
         -- NOP fallback for the testsuite...
         FBInkInput = { fbink_input_scan = NOP }
     end

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -291,7 +291,7 @@ end)
 local function findKeyboards()
     local keyboards = {}
 
-    local FBInkInput = ffi.loadlib("fbink_input")
+    local FBInkInput = ffi.loadlib("fbink_input", 1)
     local dev_count = ffi.new("size_t[1]")
     local devices = FBInkInput.fbink_input_scan(C.INPUT_KEYBOARD, 0, 0, dev_count)
     if devices ~= nil then
@@ -312,7 +312,7 @@ end
 local function checkKeyboard(path)
     local keyboard
 
-    local FBInkInput = ffi.loadlib("fbink_input")
+    local FBInkInput = ffi.loadlib("fbink_input", 1)
     local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEYBOARD, 0, 0)
     if dev ~= nil then
         if dev.matched then


### PR DESCRIPTION
The library is versioned.

Cf. https://github.com/koreader/koreader/issues/12558#issuecomment-2377658280.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12560)
<!-- Reviewable:end -->
