### PR TITLE
android: fix apkanalyzer location

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -8,7 +8,7 @@ ANDROID_APK = koreader-android-$(ANDROID_ARCH)$(KODEDUG_SUFFIX)-$(ANDROID_NAME).
 PHONY += run
 
 # Tools
-APKANALYZER ?= $(word 1,$(wildcard $(shell command -v apkanalyzer) $(ANDROID_SDK_ROOT)/tools/bin/apkanalyzer))
+APKANALYZER ?= $(ANDROID_SDK_ROOT)/cmdline-tools/latest/bin/apkanalyzer
 
 run: update
 	# get android app id


### PR DESCRIPTION
- fix SDK location: our install has 2 different versions: under `tools/bin/apkanalyzer` and `cmdline-tools/latest/bin/apkanalyzer`, but only the later is functional (trying to use the former raise some classpath exceptions)
- always use the SDK location, don't try to detect it: it's better to fail with a more explanatory "apkanalyzer: command not found" error than having the shell try to run a command with the wrong executable (`manifest …` because `$(APKANALYZER)` is empty)

Close #12562.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12563)
<!-- Reviewable:end -->
