### PR TITLE
Profiles: auto-execute on events

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -502,6 +502,7 @@ function ReaderUI:init()
         v()
     end
     self.postReaderReadyCallback = nil
+    self.reloading = nil
 
     Device:setIgnoreInput(false) -- Allow processing of events (on Android).
     Input:inhibitInputUntil(0.2)
@@ -688,6 +689,7 @@ function ReaderUI:doShowReader(file, provider, seamless)
         dimen = Screen:getSize(),
         covers_fullscreen = true, -- hint for UIManager:_repaint()
         document = document,
+        reloading = self.reloading,
     }
 
     Screen:setWindowTitle(reader.doc_props.display_title)
@@ -850,6 +852,7 @@ function ReaderUI:reloadDocument(after_close_callback, seamless)
     -- Mimic onShowingReader's refresh optimizations
     self.tearing_down = true
     self.dithered = nil
+    self.reloading = true
 
     self:handleEvent(Event:new("CloseReaderMenu"))
     self:handleEvent(Event:new("CloseConfigMenu"))

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240915
+local CURRENT_MIGRATION_DATE = 20240927
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -729,6 +729,21 @@ if last_migration_date < 20240915 then
     if G_reader_settings:has("metric_length") then
         G_reader_settings:saveSetting("dimension_units", G_reader_settings:nilOrTrue("metric_length") and "mm" or "in")
         G_reader_settings:delSetting("metric_length")
+    end
+end
+
+-- 20240927, Profiles auto-execute, https://github.com/koreader/koreader/pull/12564
+if last_migration_date < 20240927 then
+    logger.info("Performing one-time migration for 20240927")
+
+    if G_reader_settings:has("autostart_profiles") then
+        local profiles = G_reader_settings:readSetting("autostart_profiles")
+        local autoexec = G_reader_settings:readSetting("profiles_autoexec", {})
+        autoexec.Start = autoexec.Start or {}
+        for profile in pairs(profiles) do
+            autoexec.Start[profile] = true
+        end
+        G_reader_settings:delSetting("autostart_profiles")
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240927
+local CURRENT_MIGRATION_DATE = 20240928
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -732,16 +732,18 @@ if last_migration_date < 20240915 then
     end
 end
 
--- 20240927, Profiles auto-execute, https://github.com/koreader/koreader/pull/12564
-if last_migration_date < 20240927 then
-    logger.info("Performing one-time migration for 20240927")
+-- 20240928, Profiles auto-execute, https://github.com/koreader/koreader/pull/12564
+if last_migration_date < 20240928 then
+    logger.info("Performing one-time migration for 20240928")
 
     if G_reader_settings:has("autostart_profiles") then
         local profiles = G_reader_settings:readSetting("autostart_profiles")
-        local autoexec = G_reader_settings:readSetting("profiles_autoexec", {})
-        autoexec.Start = autoexec.Start or {}
-        for profile in pairs(profiles) do
-            autoexec.Start[profile] = true
+        if next(profiles) then
+            local autoexec = G_reader_settings:readSetting("profiles_autoexec", {})
+            autoexec.Start = autoexec.Start or {}
+            for profile in pairs(profiles) do
+                autoexec.Start[profile] = true
+            end
         end
         G_reader_settings:delSetting("autostart_profiles")
     end


### PR DESCRIPTION
Added opening and closing document so far.

![1](https://github.com/user-attachments/assets/358e2914-cc38-4380-8b2b-91d48014ed2c)

![2](https://github.com/user-attachments/assets/c17303fb-18c9-4fe3-afbc-ac13f66e0f7e)

Automation usage examples:
-show ToC on opening a document
-set different frontlight levels for FM and Reader
-disable touch input in Reader for devices with page-turn buttons and enable it in FM

Further possible development:
-add more events
-extend `ReaderReady` event to handle doc props, for example, execute different profiles depending on doc language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12564)
<!-- Reviewable:end -->
