### PR TITLE
android: switch to monolibtic mode

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -83,7 +83,6 @@ update: all
 	# binaries are stored as shared libraries to prevent W^X exception on Android 10+
 	# https://developer.android.com/about/versions/10/behavior-changes-10#execute-permission
 	llvm-strip --strip-unneeded $(INSTALL_DIR)/koreader/sdcv -o $(ANDROID_LIBS)/libsdcv.so
-	printf '%s\n' 'libs .' 'sdcv libsdcv.so' >$(ANDROID_ASSETS)/module/map.txt
 	# assets are compressed manually and stored inside the APK.
 	cd $(INSTALL_DIR)/koreader && \
 		./tools/mk7z.sh \


### PR DESCRIPTION
We can get rid of the `libs` and `sdcv` symlink in application files.

Depend on https://github.com/koreader/koreader-base/pull/1920.

Close #12348.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12576)
<!-- Reviewable:end -->
