### PR TITLE
Menu widget: draw focus on focused item

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -510,7 +510,7 @@ function FileChooser:refreshPath()
         self.focused_path = nil
     end
     local subtitle = BD.directory(filemanagerutil.abbreviate(self.path))
-    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path] or 1, itemmatch, subtitle)
+    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path], itemmatch, subtitle)
 end
 
 function FileChooser:changeToPath(path, focused_path)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -510,7 +510,7 @@ function FileChooser:refreshPath()
         self.focused_path = nil
     end
     local subtitle = BD.directory(filemanagerutil.abbreviate(self.path))
-    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path], itemmatch, subtitle)
+    self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path] or 1, itemmatch, subtitle)
 end
 
 function FileChooser:changeToPath(path, focused_path)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -299,6 +299,7 @@ FocusManager.NOT_UNFOCUS = 1
 FocusManager.NOT_FOCUS = 2
 -- In some cases, we may only want to send Focus events on non-Touch devices
 FocusManager.FOCUS_ONLY_ON_NT = (Device:hasDPad() and not Device:isTouchDevice()) and 0 or FocusManager.NOT_FOCUS
+FocusManager.FORCED_FOCUS = 3
 
 --- Move focus to specified widget
 function FocusManager:moveFocusTo(x, y, focus_flags)
@@ -319,8 +320,9 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
         self.selected.x = x
         self.selected.y = y
         -- widget create new layout on update, previous may be removed from new layout.
-        if Device:hasDPad() then
-            if bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
+        local is_forced = focus_flags == FocusManager.FORCED_FOCUS
+        if is_forced or Device:hasDPad() then
+            if is_forced or bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
                 -- NOTE: We can't necessarily guarantee the integrity of self.layout,
                 --       as some callers *will* mangle it and call us expecting to fix things ;).
                 --       Since we do not want to leave *multiple* items (visually) focused,
@@ -335,7 +337,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
                     self:handleEvent(Event:new("Unfocus"))
                 end
             end
-            if bit.band(focus_flags, FocusManager.NOT_FOCUS) ~= FocusManager.NOT_FOCUS then
+            if is_forced or bit.band(focus_flags, FocusManager.NOT_FOCUS) ~= FocusManager.NOT_FOCUS then
                 target_item:handleEvent(Event:new("Focus"))
                 UIManager:setDirty(self.show_parent or self, "fast")
             end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -321,7 +321,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
         self.selected.x = x
         self.selected.y = y
         -- widget create new layout on update, previous may be removed from new layout.
-        if focus_flags == FocusManager.FORCED_FOCUS or Device:hasDPad() then
+        if bit.band(focus_flags, FocusManager.FORCED_FOCUS) == FocusManager.FORCED_FOCUS or Device:hasDPad() then
             if bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
                 -- NOTE: We can't necessarily guarantee the integrity of self.layout,
                 --       as some callers *will* mangle it and call us expecting to fix things ;).

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -299,7 +299,8 @@ FocusManager.NOT_UNFOCUS = 1
 FocusManager.NOT_FOCUS = 2
 -- In some cases, we may only want to send Focus events on non-Touch devices
 FocusManager.FOCUS_ONLY_ON_NT = (Device:hasDPad() and not Device:isTouchDevice()) and 0 or FocusManager.NOT_FOCUS
-FocusManager.FORCED_FOCUS = 3
+-- Draw focus on the Menu widget target item
+FocusManager.FORCED_FOCUS = 4
 
 --- Move focus to specified widget
 function FocusManager:moveFocusTo(x, y, focus_flags)
@@ -320,9 +321,8 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
         self.selected.x = x
         self.selected.y = y
         -- widget create new layout on update, previous may be removed from new layout.
-        local is_forced = focus_flags == FocusManager.FORCED_FOCUS
-        if is_forced or Device:hasDPad() then
-            if is_forced or bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
+        if focus_flags == FocusManager.FORCED_FOCUS or Device:hasDPad() then
+            if bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
                 -- NOTE: We can't necessarily guarantee the integrity of self.layout,
                 --       as some callers *will* mangle it and call us expecting to fix things ;).
                 --       Since we do not want to leave *multiple* items (visually) focused,
@@ -337,7 +337,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
                     self:handleEvent(Event:new("Unfocus"))
                 end
             end
-            if is_forced or bit.band(focus_flags, FocusManager.NOT_FOCUS) ~= FocusManager.NOT_FOCUS then
+            if bit.band(focus_flags, FocusManager.NOT_FOCUS) ~= FocusManager.NOT_FOCUS then
                 target_item:handleEvent(Event:new("Focus"))
                 UIManager:setDirty(self.show_parent or self, "fast")
             end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -299,7 +299,7 @@ FocusManager.NOT_UNFOCUS = 1
 FocusManager.NOT_FOCUS = 2
 -- In some cases, we may only want to send Focus events on non-Touch devices
 FocusManager.FOCUS_ONLY_ON_NT = (Device:hasDPad() and not Device:isTouchDevice()) and 0 or FocusManager.NOT_FOCUS
--- Draw focus on the Menu widget target item
+-- And in some cases, we may want to send both events *regardless* of heuristics or device caps
 FocusManager.FORCED_FOCUS = 4
 
 --- Move focus to specified widget
@@ -322,6 +322,10 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
         self.selected.y = y
         -- widget create new layout on update, previous may be removed from new layout.
         if bit.band(focus_flags, FocusManager.FORCED_FOCUS) == FocusManager.FORCED_FOCUS or Device:hasDPad() then
+            -- If FORCED_FOCUS was requested, we want *all* the events: mask out both NOT_ bits
+            if bit.band(focus_flags, FocusManager.FORCED_FOCUS) == FocusManager.FORCED_FOCUS then
+                focus_flags = bit.band(focus_flags, bit.bnot(bit.bor(FocusManager.NOT_UNFOCUS, FocusManager.NOT_FOCUS)))
+            end
             if bit.band(focus_flags, FocusManager.NOT_UNFOCUS) ~= FocusManager.NOT_UNFOCUS then
                 -- NOTE: We can't necessarily guarantee the integrity of self.layout,
                 --       as some callers *will* mangle it and call us expecting to fix things ;).

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1011,7 +1011,7 @@ function Menu:updatePageInfo(select_number)
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
-            self:moveFocusTo(x, y, is_focused and FocusManager.FORCED_FOCUS or FocusManager.FOCUS_ONLY_ON_NT)
+            self:moveFocusTo(x, y, bit.bor(is_focused and FocusManager.FORCED_FOCUS or 0, FocusManager.FOCUS_ONLY_ON_NT))
         end
         -- update page information
         self.page_info_text:setText(T(_("Page %1 of %2"), self.page, self.page_num))

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1202,8 +1202,8 @@ function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, 
     elseif itemnumber >= 0 then
         itemnumber = math.min(itemnumber, #self.item_table)
         self.page = self:getPageNumber(itemnumber)
-        -- FileChooser should draw focus only when it has focused_path (i.e. itemmatch)
-        if self.path == nil or type(itemmatch) == "table" then
+        -- Draw the focus in FileChooser when it has focused_path (i.e. itemmatch)
+        if self.path ~= nil and type(itemmatch) == "table" then
             self.itemnumber = itemnumber
         end
     end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -989,11 +989,13 @@ function Menu:init()
         self.page = self:getPageNumber(self.item_table.current)
     end
     if not self.path_items then -- not FileChooser
+        print("init called updateItems")
         self:updateItems(1, true)
     end
 end
 
 function Menu:updatePageInfo(select_number)
+    print("Menu:updatePageInfo", select_number, self.itemnumber)
     if #self.item_table > 0 then
         local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
@@ -1011,6 +1013,7 @@ function Menu:updatePageInfo(select_number)
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
+            -- FIXME: FORCED_FOCUS completely obliterates that, though...
             self:moveFocusTo(x, y, bit.bor(is_focused and FocusManager.FORCED_FOCUS or 0, FocusManager.FOCUS_ONLY_ON_NT))
         end
         -- update page information
@@ -1044,6 +1047,7 @@ function Menu:updatePageInfo(select_number)
 end
 
 function Menu:updateItems(select_number, no_recalculate_dimen)
+    print("Menu:updateItems", select_number, no_recalculate_dimen)
     local old_dimen = self.dimen and self.dimen:copy()
     -- self.layout must be updated for focusmanager
     self.layout = {}
@@ -1168,6 +1172,8 @@ end
     which item.key = value
 --]]
 function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, new_subtitle)
+    print("Menu:switchItemTable", new_title, new_item_table, itemnumber, itemmatch, new_subtitle)
+    print(debug.traceback())
     local no_recalculate_dimen = true
 
     if new_item_table then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -995,13 +995,24 @@ end
 
 function Menu:updatePageInfo(select_number)
     if #self.item_table > 0 then
-        if Device:hasDPad() then
+        local is_focused = self.itemnumber and self.itemnumber > 0
+        if is_focused or Device:hasDPad() then
+            self.itemnumber = nil -- focus only once
+            select_number = select_number or 1 -- default to select the first item
+            local x, y
+            local nb_cols = self.layout[1] and #self.layout[1] or 1
+            if nb_cols == 1 then
+                x = 1
+                y = select_number
+            else -- mosaic
+                x = select_number % nb_cols
+                y = (select_number - x) / nb_cols + 1
+            end
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
-            self:moveFocusTo(1, select_number, FocusManager.FOCUS_ONLY_ON_NT)
+            self:moveFocusTo(x, y, is_focused and FocusManager.FORCED_FOCUS or FocusManager.FOCUS_ONLY_ON_NT)
         end
-        -- update page information
         self.page_info_text:setText(T(_("Page %1 of %2"), self.page, self.page_num))
         if self.page_num > 1 then
             self.page_info_text:enable()
@@ -1040,10 +1051,6 @@ function Menu:updateItems(select_number, no_recalculate_dimen)
     self.return_button:resetLayout()
     self.content_group:resetLayout()
     self:_recalculateDimen(no_recalculate_dimen)
-    -- default to select the first item
-    if not select_number then
-        select_number = 1
-    end
 
     local items_nb -- number of items in the visible page
     local idx_offset, multilines_show_more_text
@@ -1063,6 +1070,9 @@ function Menu:updateItems(select_number, no_recalculate_dimen)
         local item = self.item_table[index]
         if item == nil then break end
         item.idx = index -- index is valid only for items that have been displayed
+        if index == self.itemnumber then -- focused item
+            select_number = idx
+        end
         local item_shortcut, shortcut_style
         if self.is_enable_shortcut then
             item_shortcut = self.item_shortcuts[idx]
@@ -1189,7 +1199,8 @@ function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, 
     if itemnumber == nil then
         self.page = 1
     elseif itemnumber >= 0 then
-        self.page = self:getPageNumber(itemnumber)
+        self.itemnumber = math.min(itemnumber, #self.item_table)
+        self.page = self:getPageNumber(self.itemnumber)
     end
 
     self:updateItems(1, no_recalculate_dimen)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -989,13 +989,11 @@ function Menu:init()
         self.page = self:getPageNumber(self.item_table.current)
     end
     if not self.path_items then -- not FileChooser
-        print("init called updateItems")
         self:updateItems(1, true)
     end
 end
 
 function Menu:updatePageInfo(select_number)
-    print("Menu:updatePageInfo", select_number, self.itemnumber)
     if #self.item_table > 0 then
         local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
@@ -1013,7 +1011,6 @@ function Menu:updatePageInfo(select_number)
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
-            -- FIXME: FORCED_FOCUS completely obliterates that, though...
             self:moveFocusTo(x, y, bit.bor(is_focused and FocusManager.FORCED_FOCUS or 0, FocusManager.FOCUS_ONLY_ON_NT))
         end
         -- update page information
@@ -1047,7 +1044,6 @@ function Menu:updatePageInfo(select_number)
 end
 
 function Menu:updateItems(select_number, no_recalculate_dimen)
-    print("Menu:updateItems", select_number, no_recalculate_dimen)
     local old_dimen = self.dimen and self.dimen:copy()
     -- self.layout must be updated for focusmanager
     self.layout = {}
@@ -1172,8 +1168,6 @@ end
     which item.key = value
 --]]
 function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, new_subtitle)
-    print("Menu:switchItemTable", new_title, new_item_table, itemnumber, itemmatch, new_subtitle)
-    print(debug.traceback())
     local no_recalculate_dimen = true
 
     if new_item_table then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1013,6 +1013,7 @@ function Menu:updatePageInfo(select_number)
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
             self:moveFocusTo(x, y, is_focused and FocusManager.FORCED_FOCUS or FocusManager.FOCUS_ONLY_ON_NT)
         end
+        -- update page information
         self.page_info_text:setText(T(_("Page %1 of %2"), self.page, self.page_num))
         if self.page_num > 1 then
             self.page_info_text:enable()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -995,8 +995,7 @@ end
 
 function Menu:updatePageInfo(select_number)
     if #self.item_table > 0 then
-        -- See note below, as we treat FileChooser differently here.
-        local is_focused = self.itemnumber and self.itemnumber > (self.path and 1 or 0)
+        local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
             self.itemnumber = nil -- focus only once
             select_number = select_number or 1 -- default to select the first item
@@ -1012,10 +1011,7 @@ function Menu:updatePageInfo(select_number)
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
-            -- NOTE: This gets completely obliterated by FORCED_FOCUS,
-            --       so we fudge the itemnumber check for FileChooser to avoid ever focusing the first item (..),
-            --       to salvage the expected behavior in *that* widget, at least...
-            self:moveFocusTo(x, y, bit.bor(is_focused and FocusManager.FORCED_FOCUS or 0, FocusManager.FOCUS_ONLY_ON_NT))
+            self:moveFocusTo(x, y, is_focused and FocusManager.FORCED_FOCUS or FocusManager.FOCUS_ONLY_ON_NT)
         end
         -- update page information
         self.page_info_text:setText(T(_("Page %1 of %2"), self.page, self.page_num))
@@ -1204,8 +1200,12 @@ function Menu:switchItemTable(new_title, new_item_table, itemnumber, itemmatch, 
     if itemnumber == nil then
         self.page = 1
     elseif itemnumber >= 0 then
-        self.itemnumber = math.min(itemnumber, #self.item_table)
-        self.page = self:getPageNumber(self.itemnumber)
+        itemnumber = math.min(itemnumber, #self.item_table)
+        self.page = self:getPageNumber(itemnumber)
+        -- FileChooser should draw focus only when it has focused_path (i.e. itemmatch)
+        if self.path == nil or type(itemmatch) == "table" then
+            self.itemnumber = itemnumber
+        end
     end
 
     self:updateItems(1, no_recalculate_dimen)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -995,7 +995,8 @@ end
 
 function Menu:updatePageInfo(select_number)
     if #self.item_table > 0 then
-        local is_focused = self.itemnumber and self.itemnumber > 0
+        -- See note below, as we treat FileChooser differently here.
+        local is_focused = self.itemnumber and self.itemnumber > (self.path and 1 or 0)
         if is_focused or Device:hasDPad() then
             self.itemnumber = nil -- focus only once
             select_number = select_number or 1 -- default to select the first item
@@ -1011,6 +1012,9 @@ function Menu:updatePageInfo(select_number)
             -- Reset focus manager accordingly.
             -- NOTE: Since this runs automatically on init,
             --       we use FOCUS_ONLY_ON_NT as we don't want to see the initial underline on Touch devices.
+            -- NOTE: This gets completely obliterated by FORCED_FOCUS,
+            --       so we fudge the itemnumber check for FileChooser to avoid ever focusing the first item (..),
+            --       to salvage the expected behavior in *that* widget, at least...
             self:moveFocusTo(x, y, bit.bor(is_focused and FocusManager.FORCED_FOCUS or 0, FocusManager.FOCUS_ONLY_ON_NT))
         end
         -- update page information

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -91,10 +91,6 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
     self.page_info:resetLayout()
     self.return_button:resetLayout()
     self.content_group:resetLayout()
-    -- default to select the first item
-    if not select_number then
-        select_number = 1
-    end
 
     -- Reset the list of items not found in db that will need to
     -- be updated by a scheduled action
@@ -131,8 +127,7 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
 
     -- Specific UI building implementation (defined in some other module)
     self._has_cover_images = false
-    self:_updateItemsBuildUI()
-
+    select_number = self:_updateItemsBuildUI() or select_number
     -- Set the local variables with the things we know
     -- These are used only by extractBooksInDirectory(), which should
     -- use the cover_specs set for FileBrowser, and not those from History.

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -981,11 +981,15 @@ function ListMenu:_updateItemsBuildUI()
     }
     table.insert(self.item_group, line_widget)
     local idx_offset = (self.page - 1) * self.perpage
+    local select_number
     for idx = 1, self.perpage do
         local index = idx_offset + idx
         local entry = self.item_table[index]
         if entry == nil then break end
         entry.idx = index
+        if index == self.itemnumber then -- focused item
+            select_number = idx
+        end
         -- Keyboard shortcuts, as done in Menu
         local item_shortcut, shortcut_style
         if self.is_enable_shortcut then
@@ -1020,6 +1024,7 @@ function ListMenu:_updateItemsBuildUI()
         end
 
     end
+    return select_number
 end
 
 return ListMenu

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -959,11 +959,15 @@ function MosaicMenu:_updateItemsBuildUI()
     local cur_row = nil
     local idx_offset = (self.page - 1) * self.perpage
     local line_layout = {}
+    local select_number
     for idx = 1, self.perpage do
         local index = idx_offset + idx
         local entry = self.item_table[index]
         if entry == nil then break end
         entry.idx = index
+        if index == self.itemnumber then -- focused item
+            select_number = idx
+        end
         -- Keyboard shortcuts, as done in Menu
         local item_shortcut, shortcut_style
         if self.is_enable_shortcut then
@@ -1017,6 +1021,7 @@ function MosaicMenu:_updateItemsBuildUI()
     end
     table.insert(self.layout, line_layout)
     table.insert(self.item_group, VerticalSpan:new{ width = self.item_margin }) -- bottom padding
+    return select_number
 end
 
 return MosaicMenu


### PR DESCRIPTION
(1) Focus on the last opened book when closing Reader. Closes https://github.com/koreader/koreader/issues/12574.
(2) Focus on the folder when going up to the parent folder.
(3) Focus on a target item (like "Last bookmark" in bookmark list, or "Current page" in fulltext search results list etc.)
Since the Menu widget is affected, the focus may appear in some other (unexpected) places. If it is the case and annoying, the corresponding module to be fixed, after testing in the field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12583)
<!-- Reviewable:end -->
