### PR TITLE
android: drop unnecessary code

### DIFF
--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -1,5 +1,4 @@
 local android = require("android")
-android.dl.library_path = android.dl.library_path .. ":" .. android.dir .. "/libs"
 
 -- setup Lua paths, and ffi helper / override
 require("setupkoenv")


### PR DESCRIPTION
No need for dlopen machinery with monolibtic library.

Depend on https://github.com/koreader/android-luajit-launcher/pull/519.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12594)
<!-- Reviewable:end -->
