### PR TITLE
Profiles: add "on rotation" auto-execute event

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -90,11 +90,11 @@ local CreOptions = {
                     end
                 end,
                 -- For Dispatcher & onMakeDefault's sake
-                labels = {C_("Rotation", "⤹ 90°"), C_("Rotation", "↑ 0°"), C_("Rotation", "⤸ 90°"), C_("Rotation", "↓ 180°")},
+                labels = optionsutil.rotation_labels,
                 alternate = false,
-                values = {Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE, Screen.DEVICE_ROTATED_UPRIGHT, Screen.DEVICE_ROTATED_CLOCKWISE, Screen.DEVICE_ROTATED_UPSIDE_DOWN},
+                values = optionsutil.rotation_modes,
                 default_value = Screen.DEVICE_ROTATED_UPRIGHT,
-                args = {Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE, Screen.DEVICE_ROTATED_UPRIGHT, Screen.DEVICE_ROTATED_CLOCKWISE, Screen.DEVICE_ROTATED_UPSIDE_DOWN},
+                args = optionsutil.rotation_modes,
                 current_func = function() return Screen:getRotationMode() end,
                 event = "SetRotationMode",
                 name_text_hold_callback = optionsutil.showValues,

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -76,11 +76,11 @@ local KoptOptions = {
                     end
                 end,
                 -- For Dispatcher & onMakeDefault's sake
-                labels = {C_("Rotation", "⤹ 90°"), C_("Rotation", "↑ 0°"), C_("Rotation", "⤸ 90°"), C_("Rotation", "↓ 180°")},
+                labels = optionsutil.rotation_labels,
                 alternate = false,
-                values = {Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE, Screen.DEVICE_ROTATED_UPRIGHT, Screen.DEVICE_ROTATED_CLOCKWISE, Screen.DEVICE_ROTATED_UPSIDE_DOWN},
+                values = optionsutil.rotation_modes,
                 default_value = Screen.DEVICE_ROTATED_UPRIGHT,
-                args = {Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE, Screen.DEVICE_ROTATED_UPRIGHT, Screen.DEVICE_ROTATED_CLOCKWISE, Screen.DEVICE_ROTATED_UPSIDE_DOWN},
+                args = optionsutil.rotation_modes,
                 current_func = function() return Screen:getRotationMode() end,
                 event = "SetRotationMode",
                 name_text_hold_callback = optionsutil.showValues,

--- a/frontend/ui/data/optionsutil.lua
+++ b/frontend/ui/data/optionsutil.lua
@@ -11,7 +11,20 @@ local T = require("ffi/util").template
 local logger = require("logger")
 local Screen = Device.screen
 
-local optionsutil = {}
+local optionsutil = {
+    rotation_labels = {
+        C_("Rotation", "⤹ 90°"),
+        C_("Rotation", "↑ 0°"),
+        C_("Rotation", "⤸ 90°"),
+        C_("Rotation", "↓ 180°"),
+    },
+    rotation_modes = {
+        Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE, -- 3
+        Screen.DEVICE_ROTATED_UPRIGHT,           -- 0
+        Screen.DEVICE_ROTATED_CLOCKWISE,         -- 1
+        Screen.DEVICE_ROTATED_UPSIDE_DOWN,       -- 2
+    },
+}
 
 function optionsutil.enableIfEquals(configurable, option, value)
     return configurable[option] == value

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -78,10 +78,10 @@ When unchecked, the default rotation of the file browser and the default/saved r
         })
 
         if FileManager.instance then
-            table.insert(rotation_table, genMenuItem(C_("Rotation", "⤹ 90°"), Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE))
-            table.insert(rotation_table, genMenuItem(C_("Rotation", "↑ 0°"), Screen.DEVICE_ROTATED_UPRIGHT))
-            table.insert(rotation_table, genMenuItem(C_("Rotation", "⤸ 90°"), Screen.DEVICE_ROTATED_CLOCKWISE))
-            table.insert(rotation_table, genMenuItem(C_("Rotation", "↓ 180°"), Screen.DEVICE_ROTATED_UPSIDE_DOWN))
+            local optionsutil = require("ui/data/optionsutil")
+            for i, mode in ipairs(optionsutil.rotation_modes) do
+                table.insert(rotation_table, genMenuItem(optionsutil.rotation_labels[i], mode))
+            end
         end
 
         rotation_table[#rotation_table].separator = true

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -3,7 +3,6 @@ local Event = require("ui/event")
 local FileManager = require("apps/filemanager/filemanager")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
-local C_ = _.pgettext
 local Screen = Device.screen
 
 local function genMenuItem(text, mode)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -9,6 +9,7 @@ local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
 local T = FFIUtil.template
+local logger = require("logger")
 local util = require("util")
 
 local autostart_done
@@ -488,6 +489,7 @@ function Profiles:executeAutoExec(event)
     if self.autoexec[event] then
         for profile_name in pairs(self.autoexec[event]) do
             if self.data[profile_name] then
+                logger.dbg("Profiles - auto executing:", profile_name)
                 UIManager:nextTick(function()
                     Dispatcher:execute(self.data[profile_name])
                 end)
@@ -522,6 +524,7 @@ function Profiles:onSetRotationMode(rotation)
                 if self.ui.config then -- close bottom menu to let Dispatcher execute profile
                     self.ui.config:onCloseConfigMenu()
                 end
+                logger.dbg("Profiles - auto executing:", profile_name)
                 UIManager:nextTick(function()
                     Dispatcher:execute(self.data[profile_name])
                 end)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -138,12 +138,30 @@ function Profiles:getSubMenuItems()
             },
             {
                 text = _("Auto-execute"),
+                checked_func = function()
+                    for _, profiles in pairs(self.autoexec) do
+                        if profiles[k] then
+                            return true
+                        end
+                    end
+                end,
                 sub_item_table = {
                     self:genAutoExecMenuItem(_("on KOReader start"), "Start", k),
                     self:genAutoExecMenuItem(_("on document opening"), "ReaderReady", k),
                     self:genAutoExecMenuItem(_("on document closing"), "CloseDocument", k),
                     self:genAutoExecMenuItem(_("on rotation"), "SetRotationMode", k),
                 },
+                hold_callback = function(touchmenu_instance)
+                    for event, profiles in pairs(self.autoexec) do
+                        if profiles[k] then
+                            self.autoexec[event][k] = nil
+                            if next(self.autoexec[event]) == nil then
+                                self.autoexec[event] = nil
+                            end
+                        end
+                    end
+                    touchmenu_instance:updateItems()
+                end,
                 separator = true,
             },
             {


### PR DESCRIPTION
For example, auto set 2-columns in landscape mode:

![1](https://github.com/user-attachments/assets/ac31a710-1492-45d6-8acc-7be3a46e3bb1)

![2](https://github.com/user-attachments/assets/32cb2e6f-1deb-4ef5-b962-f3bb27d4b804)

![3](https://github.com/user-attachments/assets/f71f714d-6490-494c-89c9-0e19aacf54bc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12612)
<!-- Reviewable:end -->
