### PR TITLE
KOSync/Kobo: Explicitly kill Wi-Fi on suspend

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1344,6 +1344,14 @@ function Kobo:suspend()
         return
     end
 
+    -- Murder Wi-Fi (again, c.f., `Device:onPowerEvent`) if NetworkMgr is attempting to connect or currently connected...
+    -- (Most likely because of a rerunWhenOnline in a Suspend handler)
+    local network_mgr = require("ui/network/manager")
+    if network_mgr:isWifiOn() or network_mgr.pending_connection then
+        logger.info("Kobo suspend: had to kill Wi-Fi")
+        network_mgr:disableWifi()
+    end
+
     logger.info("Kobo suspend: going to sleep . . .")
     UIManager:unschedule(self.checkUnexpectedWakeup)
     -- NOTE: Sleep as little as possible here, sleeping has a tendency to make


### PR DESCRIPTION
Entering suspend with the Wi-Fi chip powered on famously makes a lot of NTX boards implode. To deal with this, we've been killing Wi-Fi before suspend since pretty much ever (in `Generic:onPowerEvent`).

KOSync, on the other hand, will request connectivity in its suspend handler to push reading progress.

The issue is that `Generic:onPowerEvent` kills Wi-Fi *before* sending the `Suspend` event (via `Powerd:beforeSuspend` into `Device:_beforeSuspend`), so that funky edge-case will happily implode kernels ;).

So, fix it on KOSync's side first by explicitly killing Wi-Fi (on platforms where we control it explicitly) in the suspend handler, because even on non-kablooey kernels, it may lead to bad power management issues.

And also fix it on Kobo's side (since most of the affected boards are from NTX), by explicitly double-checking Wi-Fi status in the actual suspend call (i.e., the delayed one, right before actually asking for suspend. Spoiler alert: it'll likely cause that actual suspend request to fail w/ EBUSY, but we already have a robust mechanism to handle that, so it'll retry 15s later).

Fix #12614

(Rebase me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12616)
<!-- Reviewable:end -->
