### PR TITLE
Kobo: Minor simplification after #12616

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1347,7 +1347,7 @@ function Kobo:suspend()
     -- Murder Wi-Fi (again, c.f., `Device:onPowerEvent`) if NetworkMgr is attempting to connect or currently connected...
     -- (Most likely because of a rerunWhenOnline in a Suspend handler)
     local network_mgr = require("ui/network/manager")
-    if network_mgr:isWifiOn() or network_mgr.pending_connection then
+    if network_mgr:isWifiOn() then
         logger.info("Kobo suspend: had to kill Wi-Fi")
         network_mgr:disableWifi()
     end


### PR DESCRIPTION
The only codepath that sets `pending_connection` to `true` in `NetworkManager` calls `turnOnWifi` right after, so we can't really ever see `pending_connection` w/o `isWifiOn` being also `true` ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12629)
<!-- Reviewable:end -->
