### PR TITLE
add provider module

### DIFF
--- a/frontend/provider.lua
+++ b/frontend/provider.lua
@@ -1,0 +1,92 @@
+--[[ 
+
+Provider is a singleton that holds thirdparty implementations for features.
+
+To be used on plugins, prefixed with "provider-", that implement specific feature APIs.
+
+]]--
+
+local util = require("util")
+
+local function aTable(t)
+    if type(t) ~= "table" then
+        return {}
+    end
+    return t
+end
+
+local Provider = {
+    features = {
+        ["exporter"] = {},
+    },
+}
+
+function Provider:_isValidFeature(s)
+    return self.features[s] ~= nil
+end
+
+--[[--
+Registers an implementation of a feature.
+
+@param feature string that identifies the feature
+@param name string that identifies the provider
+@param impl table with implementation details
+@treturn bool registered
+]]
+function Provider:register(feature, name, impl)
+    if type(name) ~= "string" or type(feature) ~= "string" or type(impl) ~= "table" then
+        return false
+    end
+    if self:_isValidFeature(feature) then
+        self.features[feature][name] = impl
+        return true
+    end
+    return false
+end
+
+--[[--
+Unregisters an implementation of a feature.
+
+@param feature string feature identifier
+@param name string provider identifier
+@treturn bool unregistered
+]]
+function Provider:unregister(feature, name)
+    if type(name) ~= "string" or type(feature) ~= "string" then
+        return false
+    end
+    if self:_isValidFeature(feature) then
+        self.features[feature][name] = nil
+        return true
+    end
+    return false
+end
+
+--[[--
+Counts providers for a given feature
+
+@param feature string feature identifier
+@treturn int number
+]]
+function Provider:size(feature)
+    local count = 0
+    if self:_isValidFeature(feature) then
+        count = util.tableSize(aTable(self.features[feature]))
+    end
+    return count
+end
+
+--[[--
+Get providers for a given feature
+
+@param feature string feature identifier
+@treturn table provider/implementation k/v pairs.
+]]
+function Provider:getProvidersTable(feature)
+    if self:_isValidFeature(feature) then
+	return aTable(self.features[feature])
+    end
+    return aTable()
+end
+
+return Provider

--- a/frontend/provider.lua
+++ b/frontend/provider.lua
@@ -1,4 +1,4 @@
---[[ 
+--[[
 
 Provider is a singleton that holds thirdparty implementations for features.
 
@@ -84,7 +84,7 @@ Get providers for a given feature
 ]]
 function Provider:getProvidersTable(feature)
     if self:_isValidFeature(feature) then
-	return aTable(self.features[feature])
+        return aTable(self.features[feature])
     end
     return aTable()
 end

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -133,13 +133,10 @@ local Exporter = WidgetContainer:extend{
     name = "exporter",
 }
 
-function Exporter:_updateTargets()
-    self.targets = genExportersTable(self.path)
-end
-
 function Exporter:init()
     migrateSettings()
     self.parser = MyClipping:new{}
+    self.targets = genExportersTable(self.path)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end
@@ -266,7 +263,6 @@ function Exporter:exportClippings(clippings)
 end
 
 function Exporter:addToMainMenu(menu_items)
-    self:_updateTargets()
     local formats_submenu, share_submenu, styles_submenu = {}, {}, {}
     for k, v in pairs(self.targets) do
         formats_submenu[#formats_submenu + 1] = v:getMenuTable()

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -31,6 +31,7 @@ local Dispatcher = require("dispatcher")
 local InfoMessage = require("ui/widget/infomessage")
 local MyClipping = require("clip")
 local NetworkMgr = require("ui/network/manager")
+local Provider = require("provider")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -99,27 +100,42 @@ local function updateMyClippings(clippings, new_clippings)
     return clippings
 end
 
+local targets = {
+    html = require("target/html"),
+    joplin = require("target/joplin"),
+    json = require("target/json"),
+    markdown = require("target/markdown"),
+    my_clippings = require("target/my_clippings"),
+    nextcloud = require("target/nextcloud"),
+    readwise = require("target/readwise"),
+    text = require("target/text"),
+    xmnote = require("target/xmnote"),
+}
+
+local function genExportersTable(path)
+    local t = {}
+    for k, v in pairs(targets) do
+        t[k] = v
+    end
+    if Provider:size("exporter") > 0 then
+        local tbl = Provider:getProvidersTable("exporter")
+        for k, v in pairs(tbl) do
+            t[k] = v
+        end
+    end
+    for _, v in pairs(t) do
+        v.path = path
+    end
+    return t
+end
+
 local Exporter = WidgetContainer:extend{
     name = "exporter",
-    targets = {
-        html = require("target/html"),
-        joplin = require("target/joplin"),
-        json = require("target/json"),
-        markdown = require("target/markdown"),
-        my_clippings = require("target/my_clippings"),
-        nextcloud = require("target/nextcloud"),
-        readwise = require("target/readwise"),
-        text = require("target/text"),
-        xmnote = require("target/xmnote"),
-    },
 }
 
 function Exporter:init()
     migrateSettings()
     self.parser = MyClipping:new{}
-    for _, v in pairs(self.targets) do
-        v.path = self.path
-    end
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end
@@ -246,6 +262,7 @@ function Exporter:exportClippings(clippings)
 end
 
 function Exporter:addToMainMenu(menu_items)
+    self.targets = genExportersTable(self.path)
     local formats_submenu, share_submenu, styles_submenu = {}, {}, {}
     for k, v in pairs(self.targets) do
         formats_submenu[#formats_submenu + 1] = v:getMenuTable()

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -133,6 +133,10 @@ local Exporter = WidgetContainer:extend{
     name = "exporter",
 }
 
+function Exporter:_updateTargets()
+    self.targets = genExportersTable(self.path)
+end
+
 function Exporter:init()
     migrateSettings()
     self.parser = MyClipping:new{}
@@ -262,7 +266,7 @@ function Exporter:exportClippings(clippings)
 end
 
 function Exporter:addToMainMenu(menu_items)
-    self.targets = genExportersTable(self.path)
+    self:_updateTargets()
     local formats_submenu, share_submenu, styles_submenu = {}, {}, {}
     for k, v in pairs(self.targets) do
         formats_submenu[#formats_submenu + 1] = v:getMenuTable()

--- a/setupkoenv.lua
+++ b/setupkoenv.lua
@@ -1,6 +1,6 @@
 -- Set search path for `require()`.
 package.path =
-    "common/?.lua;frontend/?.lua;" ..
+    "common/?.lua;frontend/?.lua;plugins/exporter.koplugin/?.lua;" ..
     package.path
 package.cpath =
     "common/?.so;common/?.dll;/usr/lib/lua/?.so;" ..

--- a/spec/unit/exporter_plugin_main_spec.lua
+++ b/spec/unit/exporter_plugin_main_spec.lua
@@ -13,6 +13,8 @@ describe("Exporter plugin module", function()
                 document = DocumentRegistry:openDocument(sample_epub),
             }
 
+        readerui.exporter:_updateTargets()
+
         sample_clippings = {
             ["Title1"] = {
                 [1] = {

--- a/spec/unit/exporter_plugin_main_spec.lua
+++ b/spec/unit/exporter_plugin_main_spec.lua
@@ -13,8 +13,6 @@ describe("Exporter plugin module", function()
                 document = DocumentRegistry:openDocument(sample_epub),
             }
 
-        readerui.exporter:_updateTargets()
-
         sample_clippings = {
             ["Title1"] = {
                 [1] = {

--- a/spec/unit/provider_spec.lua
+++ b/spec/unit/provider_spec.lua
@@ -1,7 +1,6 @@
 describe("Provider module", function()
     local Provider
     local t
-    local fail = { a = function() end, }
 
     setup(function()
         require("commonrequire")
@@ -15,21 +14,21 @@ describe("Provider module", function()
         assert.is_false(Provider:unregister())
     end)
     it("should register a proper provider with empty implementation", function()
-        assert.is_true(Provider:register("test", "exporter", {}))
+        assert.is_true(Provider:register("exporter", "test", {}))
     end)
     it("should override an implementation for the same name of the same kind", function()
-        assert.is_true(Provider:register("test", "exporter", { test  = function() end }))
+        assert.is_true(Provider:register("exporter", "test", { test  = function() end }))
         assert.is_true(type(Provider.features["exporter"]["test"].test) == "function")
     end)
     it("should unregister a provider", function()
-        assert.is_true(Provider:unregister("test", "exporter"))
+        assert.is_true(Provider:unregister("exporter", "test"))
     end)
     it("should count providers for a specific feature", function()
-        assert.is_true(Provider:register("test1", "exporter", {}))
-        assert.is_true(Provider:register("test2", "exporter", {}))
-        assert.is_true(Provider:register("test3", "exporter", {}))
+        assert.is_true(Provider:register("exporter", "test1", {}))
+        assert.is_true(Provider:register("exporter", "test2", {}))
+        assert.is_true(Provider:register("exporter", "test3", {}))
         assert.is_true(Provider:size("exporter") == 3)
-    end)       
+    end)
 
     it("should dump a table of providers for a specific feature", function()
         assert.are.same(Provider.features["exporter"],

--- a/spec/unit/provider_spec.lua
+++ b/spec/unit/provider_spec.lua
@@ -1,0 +1,42 @@
+describe("Provider module", function()
+    local Provider
+    local t
+    local fail = { a = function() end, }
+
+    setup(function()
+        require("commonrequire")
+        Provider = require("provider")
+    end)
+
+    it("should fail to register an improper provider", function()
+        assert.is_false(Provider:register())
+    end)
+    it("should fail to unregister an improper provider", function()
+        assert.is_false(Provider:unregister())
+    end)
+    it("should register a proper provider with empty implementation", function()
+        assert.is_true(Provider:register("test", "exporter", {}))
+    end)
+    it("should override an implementation for the same name of the same kind", function()
+        assert.is_true(Provider:register("test", "exporter", { test  = function() end }))
+        assert.is_true(type(Provider.features["exporter"]["test"].test) == "function")
+    end)
+    it("should unregister a provider", function()
+        assert.is_true(Provider:unregister("test", "exporter"))
+    end)
+    it("should count providers for a specific feature", function()
+        assert.is_true(Provider:register("test1", "exporter", {}))
+        assert.is_true(Provider:register("test2", "exporter", {}))
+        assert.is_true(Provider:register("test3", "exporter", {}))
+        assert.is_true(Provider:size("exporter") == 3)
+    end)       
+
+    it("should dump a table of providers for a specific feature", function()
+        assert.are.same(Provider.features["exporter"],
+            Provider:getProvidersTable("exporter"))
+    end)
+    it("should dump an empty table for an invalid feature", function()
+        t = Provider:getProvidersTable("invalid")
+        assert.is_true(type(t) == "table")
+    end)
+end)


### PR DESCRIPTION
Some background in #7279

- Implements a `Provider` singleton that plugins can use to extend supported features

Thirdparty plugin developers can use:

```lua
local Provider = require("provider")
Provider:register("exporter", "my-service", my-implementation)
```
where `my-implementation` is a table that implements the interface for an exporter target.

- Makes the exporter plugin compatible with thirdparty providers

- Splits plugin loading into two steps: **discovery** and **load**. That way we get a list of all candidate plugins to load for the different paths and we sort those starting with "provider" to be load before the rest of them.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12641)
<!-- Reviewable:end -->
