### PR TITLE
Menu: Fix fallout from #12583 on hasDPad devices

### DIFF
--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -304,8 +304,6 @@ FocusManager.FORCED_FOCUS = 4
 
 --- Move focus to specified widget
 function FocusManager:moveFocusTo(x, y, focus_flags)
-    print("FocusManager:moveFocusTo:", x, y, focus_flags)
-    print(debug.traceback())
     focus_flags = focus_flags or 0
     if not self.layout then
         return false
@@ -496,7 +494,6 @@ FocusManager.RENDER_IN_NEXT_TICK = true
 --- Container calls this method to re-set focus widget style
 --- Some container regenerate layout on update and lose focus style
 function FocusManager:refocusWidget(nextTick, focus_flags)
-    print("FocusManager:refocusWidget:", nextTick, focus_flags)
     -- On touch devices, we do *not* want to show visual focus changes generated programmatically,
     -- we only want to see them for actual user input events (#12361).
     if not focus_flags then

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -304,6 +304,8 @@ FocusManager.FORCED_FOCUS = 4
 
 --- Move focus to specified widget
 function FocusManager:moveFocusTo(x, y, focus_flags)
+    print("FocusManager:moveFocusTo:", x, y, focus_flags)
+    print(debug.traceback())
     focus_flags = focus_flags or 0
     if not self.layout then
         return false
@@ -494,6 +496,7 @@ FocusManager.RENDER_IN_NEXT_TICK = true
 --- Container calls this method to re-set focus widget style
 --- Some container regenerate layout on update and lose focus style
 function FocusManager:refocusWidget(nextTick, focus_flags)
+    print("FocusManager:refocusWidget:", nextTick, focus_flags)
     -- On touch devices, we do *not* want to show visual focus changes generated programmatically,
     -- we only want to see them for actual user input events (#12361).
     if not focus_flags then

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -994,6 +994,7 @@ function Menu:init()
 end
 
 function Menu:updatePageInfo(select_number)
+    print("Menu:updatePageInfo", select_number)
     if #self.item_table > 0 then
         local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
@@ -1132,24 +1133,27 @@ end
 
 -- merge TitleBar layout into self FocusManager layout
 function Menu:mergeTitleBarIntoLayout()
+    print("Menu:mergeTitleBarIntoLayout")
     if Device:hasSymKey() or Device:hasScreenKB() then
         -- Title bar items can be accessed through key mappings on kindle
         return
     end
-    local menu_item_layout_start_row = 1
     -- On hasFewKeys devices, Menu uses the "Right" key to trigger the context menu: we can't use it to move focus in horizontal directions.
     -- So, add title bar buttons to FocusManager's layout in a vertical-only layout
     local title_bar_layout = self.title_bar:generateVerticalLayout()
-    for _, row in ipairs(title_bar_layout) do
-        table.insert(self.layout, menu_item_layout_start_row, row)
-        menu_item_layout_start_row = menu_item_layout_start_row + 1
+    print("self.selected:", self.selected.x, self.selected.y)
+    print("self.layout:", #self.layout, #self.layout[#self.layout])
+    print("title_bar_layout:", #title_bar_layout, #title_bar_layout[#title_bar_layout])
+    for i, row in ipairs(title_bar_layout) do
+        -- Insert the title bar in the top rows of our layout
+        table.insert(self.layout, i, row)
     end
-    if menu_item_layout_start_row > #self.layout then -- no menu items
-        menu_item_layout_start_row = #self.layout -- avoid index overflow
-    end
+    -- Adjust for the added rows to keep our current selection
+    self.selected.y = math.min(#self.layout, self.selected.y + #title_bar_layout)
+
     if Device:hasDPad() then
         -- Move focus to the first menu item, if any, in keeping with the pre-FocusManager behavior
-        self:moveFocusTo(1, menu_item_layout_start_row, FocusManager.NOT_FOCUS)
+        self:moveFocusTo(self.selected.x, self.selected.y, FocusManager.NOT_FOCUS)
     end
 end
 

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1145,11 +1145,6 @@ function Menu:mergeTitleBarIntoLayout()
     end
     -- Adjust for the added rows to keep our current selection
     self.selected.y = math.min(#self.layout, self.selected.y + #title_bar_layout)
-
-    if Device:hasDPad() then
-        -- Move focus to the first menu item, if any, in keeping with the pre-FocusManager behavior
-        self:moveFocusTo(self.selected.x, self.selected.y, FocusManager.NOT_FOCUS)
-    end
 end
 
 --[[

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1144,7 +1144,7 @@ function Menu:mergeTitleBarIntoLayout()
         table.insert(self.layout, i, row)
     end
     -- Adjust for the added rows to keep our current selection
-    self.selected.y = math.min(#self.layout, self.selected.y + #title_bar_layout)
+    self.selected.y = self.selected.y + #title_bar_layout
 end
 
 --[[

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -994,7 +994,6 @@ function Menu:init()
 end
 
 function Menu:updatePageInfo(select_number)
-    print("Menu:updatePageInfo", select_number)
     if #self.item_table > 0 then
         local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
@@ -1133,7 +1132,6 @@ end
 
 -- merge TitleBar layout into self FocusManager layout
 function Menu:mergeTitleBarIntoLayout()
-    print("Menu:mergeTitleBarIntoLayout")
     if Device:hasSymKey() or Device:hasScreenKB() then
         -- Title bar items can be accessed through key mappings on kindle
         return
@@ -1141,9 +1139,6 @@ function Menu:mergeTitleBarIntoLayout()
     -- On hasFewKeys devices, Menu uses the "Right" key to trigger the context menu: we can't use it to move focus in horizontal directions.
     -- So, add title bar buttons to FocusManager's layout in a vertical-only layout
     local title_bar_layout = self.title_bar:generateVerticalLayout()
-    print("self.selected:", self.selected.x, self.selected.y)
-    print("self.layout:", #self.layout, #self.layout[#self.layout])
-    print("title_bar_layout:", #title_bar_layout, #title_bar_layout[#title_bar_layout])
     for i, row in ipairs(title_bar_layout) do
         -- Insert the title bar in the top rows of our layout
         table.insert(self.layout, i, row)

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1145,6 +1145,7 @@ function Menu:mergeTitleBarIntoLayout()
     end
     -- Adjust for the added rows to keep our current selection
     self.selected.y = self.selected.y + #title_bar_layout
+    logger.dbg("Menu:mergeTitleBarIntoLayout: Adjusted focus position to account for added titlebar rows:", self.selected.x, ",", self.selected.y)
 end
 
 --[[

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -139,6 +139,7 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
 
     -- As done in Menu:updateItems()
     self:updatePageInfo(select_number)
+    Menu.mergeTitleBarIntoLayout(self)
 
     self.show_parent.dithered = self._has_cover_images
     UIManager:setDirty(self.show_parent, function()
@@ -316,7 +317,6 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
             self.showFileDialog_ours = self.showFileDialog
         end)
     end
-    Menu.mergeTitleBarIntoLayout(self)
 end
 
 -- Similar to showFileDialog setup just above, but for History,


### PR DESCRIPTION
Tweak `mergeTitleBarIntoLayout` to keep the current selection (adjusted for the added rows) instead of resetting the focus.

It only actually called `moveFocusTo` on `hasDPad` devices, which explains why this was missed during testing.

Fix https://github.com/koreader/koreader/pull/12583#issuecomment-2423554770

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12657)
<!-- Reviewable:end -->
