### PR TITLE
wbuilder: fix environment

### DIFF
--- a/tools/wbuilder.lua
+++ b/tools/wbuilder.lua
@@ -1,9 +1,7 @@
 -- widget test utility
 -- usage: ./luajit tools/wtest.lua
 
-print(package.path)
-package.path = "common/?.lua;frontend/?.lua;" .. package.path
-package.cpath = "common/?.so;common/?.dll;/usr/lib/lua/?.so;" .. package.cpath
+require("setupkoenv")
 
 -- Load default settings
 G_defaults = require("luadefaults"):open()


### PR DESCRIPTION
Use `setupkoenv` to setup LUA paths and ensure `ffi.loadlib` is loaded.

Close #12664.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12665)
<!-- Reviewable:end -->
