### PR TITLE
OTA: Make the final ConfirmBox undismissable

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -401,8 +401,8 @@ function DeviceListener:onRequestUSBMS()
     MassStorage:start(false)
 end
 
-function DeviceListener:onExit()
-    self.ui.menu:exitOrRestart()
+function DeviceListener:onExit(callback)
+    self.ui.menu:exitOrRestart(callback)
 end
 
 function DeviceListener:onRestart()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -455,9 +455,11 @@ function Device:install()
             UIManager:show(InfoMessage:new{
                 text = _("The update will be applied the next time KOReader is started."),
                 unmovable = true,
+                dismissable = false,
             })
         end,
         unmovable = true,
+        dismissable = false,
     })
 end
 


### PR DESCRIPTION
It's relatively easy to miss-click the buttons, especially on devices with questionable touch panels...

And while doing so is perfectly fine, ~~you miss the InfoMessage telling you that the update will be applied on restart, which is potentially confusing.~~.

(Turns out it's only *mildly* confusing, I was just confused about my own half-remembered confusion ;p).

Re: #12674

(Rebase me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12676)
<!-- Reviewable:end -->
