### PR TITLE
Highlight: line height

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1231,24 +1231,40 @@ function ReaderHighlight:showHighlightNoteOrDialog(index)
             buttons_table = {
                 {
                     {
-                        text = _("Delete"),
+                        text = _("Delete note"),
+                        callback = function()
+                            UIManager:close(textviewer)
+                            local annotation = self.ui.annotation.annotations[index]
+                            annotation.note = nil
+                            self.ui:handleEvent(Event:new("AnnotationsModified",
+                                    { annotation, nb_highlights_added = 1, nb_notes_added = -1 }))
+                            self:writePdfAnnotation("content", annotation, nil)
+                            if self.view.highlight.note_mark then -- refresh note marker
+                                UIManager:setDirty(self.dialog, "ui")
+                            end
+                        end,
+                    },
+                    {
+                        text = _("Edit note"),
+                        callback = function()
+                            UIManager:close(textviewer)
+                            self:editNote(index)
+                        end,
+                    },
+                },
+                {
+                    {
+                        text = _("Delete highlight"),
                         callback = function()
                             UIManager:close(textviewer)
                             self:deleteHighlight(index)
                         end,
                     },
                     {
-                        text = _("Edit"),
+                        text = _("Highlight menu"),
                         callback = function()
                             UIManager:close(textviewer)
                             self:onShowHighlightDialog(index)
-                        end,
-                    },
-                    {
-                        text = _("Note"),
-                        callback = function()
-                            UIManager:close(textviewer)
-                            self:editNote(index)
                         end,
                     },
                 },

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -14,10 +14,10 @@ local TextViewer = require("ui/widget/textviewer")
 local Translator = require("ui/translator")
 local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
+local ffiUtil = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
 local Size = require("ui/size")
-local ffiUtil = require("ffi/util")
 local time = require("ui/time")
 local _ = require("gettext")
 local C_ = _.pgettext
@@ -476,6 +476,35 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 callback = function(spin)
                     G_reader_settings:saveSetting("highlight_lighten_factor", spin.value)
                     self.view.highlight.lighten_factor = spin.value
+                    UIManager:setDirty(self.dialog, "ui")
+                    touchmenu_instance:updateItems()
+                end,
+            }
+            UIManager:show(spin_widget)
+        end,
+    })
+    table.insert(hl_sub_item_table, {
+        text_func = function()
+            return T(_("Highlight line height: %1\xE2\x80\xAF%"), G_reader_settings:readSetting("highlight_height_pct") or 100)
+        end,
+        enabled_func = function()
+            return self.view.highlight.saved_drawer == "lighten" or self.view.highlight.saved_drawer == "invert"
+        end,
+        callback = function(touchmenu_instance)
+            local spin_widget = SpinWidget:new{
+                value = G_reader_settings:readSetting("highlight_height_pct") or 100,
+                value_min = 0,
+                value_max = 100,
+                value_step = 1,
+                value_hold_step = 10,
+                default_value = 100,
+                unit = "%",
+                keep_shown_on_apply = true,
+                title_text =  _("Highlight line height"),
+                info_text = _("Percentage of the text line height."),
+                callback = function(spin)
+                    local value = spin.value ~= 100 and spin.value or nil
+                    G_reader_settings:saveSetting("highlight_height_pct", value)
                     UIManager:setDirty(self.dialog, "ui")
                     touchmenu_instance:updateItems()
                 end,
@@ -1202,17 +1231,24 @@ function ReaderHighlight:showHighlightNoteOrDialog(index)
             buttons_table = {
                 {
                     {
-                        text = _("Delete highlight"),
+                        text = _("Delete"),
                         callback = function()
                             UIManager:close(textviewer)
                             self:deleteHighlight(index)
                         end,
                     },
                     {
-                        text = _("Edit highlight"),
+                        text = _("Edit"),
                         callback = function()
                             UIManager:close(textviewer)
                             self:onShowHighlightDialog(index)
+                        end,
+                    },
+                    {
+                        text = _("Note"),
+                        callback = function()
+                            UIManager:close(textviewer)
+                            self:editNote(index)
                         end,
                     },
                 },
@@ -1256,7 +1292,7 @@ function ReaderHighlight:onShowHighlightDialog(index)
             {
                 text = _("Note"),
                 callback = function()
-                    self:editHighlight(index)
+                    self:editNote(index)
                     UIManager:close(self.edit_highlight_dialog)
                     self.edit_highlight_dialog = nil
                 end,
@@ -2157,10 +2193,10 @@ function ReaderHighlight:addNote(text)
     if text then -- called from Translator to save translation to note
         self:clear()
     end
-    self:editHighlight(index, true, text)
+    self:editNote(index, true, text)
 end
 
-function ReaderHighlight:editHighlight(index, is_new_note, text)
+function ReaderHighlight:editNote(index, is_new_note, text)
     local note_updated_callback = function()
         if self.view.highlight.note_mark then -- refresh note marker
             UIManager:setDirty(self.dialog, "ui")

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -681,9 +681,9 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             end
             if self.highlight.note_mark == "sideline" then
                 if Blitbuffer.isColor8(color) then
-                    bb:paintRect(note_mark_pos_x, y, self.note_mark_line_w, h, color)
+                    bb:paintRect(note_mark_pos_x, y, self.note_mark_line_w, rect.h, color)
                 else
-                    bb:paintRectRGB32(note_mark_pos_x, y, self.note_mark_line_w, h, color)
+                    bb:paintRectRGB32(note_mark_pos_x, y, self.note_mark_line_w, rect.h, color)
                 end
             elseif self.highlight.note_mark == "sidemark" then
                 self.note_mark_sign:paintTo(bb, note_mark_pos_x, y)

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -615,6 +615,13 @@ end
 
 function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note_mark)
     local x, y, w, h = rect.x, rect.y, rect.w, rect.h
+    if drawer == "lighten" or drawer == "invert" then
+        local pct = G_reader_settings:readSetting("highlight_height_pct")
+        if pct ~= nil then
+            h = math.floor(h * pct / 100)
+            y = y + math.ceil((rect.h - h) / 2)
+        end
+    end
     if drawer == "lighten" then
         if not color then
             bb:darkenRect(x, y, w, h, self.highlight.lighten_factor)

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -15,10 +15,10 @@ local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
 local JSON = require("json")
 local Screen = require("device").screen
-local ffiutil  = require("ffi/util")
+local ffiUtil  = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
-local T = ffiutil.template
+local T = ffiUtil.template
 local _ = require("gettext")
 
 -- From https://cloud.google.com/translate/docs/languages
@@ -225,7 +225,7 @@ end
 function Translator:genSettingsMenu()
     local function genLanguagesItems(setting_name, default_checked_item)
         local items_table = {}
-        for lang_key, lang_name in ffiutil.orderedPairs(SUPPORTED_LANGUAGES) do
+        for lang_key, lang_name in ffiUtil.orderedPairs(SUPPORTED_LANGUAGES) do
             table.insert(items_table, {
                 text_func = function()
                     return T("%1 (%2)", lang_name, lang_key)
@@ -628,7 +628,7 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
                             UIManager:close(ui.highlight.highlight_dialog)
                             ui.highlight.highlight_dialog = nil
                             if index then
-                                ui.highlight:editHighlight(index, false, text_main)
+                                ui.highlight:editNote(index, false, text_main)
                             else
                                 ui.highlight:addNote(text_main)
                             end
@@ -641,7 +641,7 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
                             UIManager:close(ui.highlight.highlight_dialog)
                             ui.highlight.highlight_dialog = nil
                             if index then
-                                ui.highlight:editHighlight(index, false, text_all)
+                                ui.highlight:editNote(index, false, text_all)
                             else
                                 ui.highlight:addNote(text_all)
                             end


### PR DESCRIPTION
(After the release)

(1) Adjustable highlight line height. Discussed in https://github.com/koreader/koreader/issues/10416 and https://github.com/koreader/koreader/issues/11581.

(2) "Note" button in the Note window (on tapping a highlight with note). Closes https://github.com/koreader/koreader/issues/12234.

![1](https://github.com/user-attachments/assets/f6d50023-9fdc-465e-94dd-ffc29a56e74b)

![2](https://github.com/user-attachments/assets/8719d1a3-a580-4d5e-b36b-1982601a3607)

![3](https://github.com/user-attachments/assets/c0c32304-57d9-4451-a613-23aed5c219d8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12721)
<!-- Reviewable:end -->
