### PR TITLE
make: work around make < 4.4 wildcard bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ INSTALL_FILES=reader.lua setupkoenv.lua frontend resources defaults.lua datastor
 		l10n tools README.md COPYING
 
 OUTPUT_DIR_ARTIFACTS = $(abspath $(OUTPUT_DIR))/!(cache|cmake|data|history|staging|thirdparty)
-OUTPUT_DIR_DATAFILES = $(wildcard $(OUTPUT_DIR)/data/*)
+OUTPUT_DIR_DATAFILES = $(OUTPUT_DIR)/data/*
 
 all: base
 	install -d $(INSTALL_DIR)/koreader


### PR DESCRIPTION
Cf. https://savannah.gnu.org/bugs/?func=detailitem&item_id=41273

This would result in release archives not including some data files (e.g. `ca-bundle.crt` and `KoboUSBMS.tar.gz`).

Close #12724.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12725)
<!-- Reviewable:end -->
