### PR TITLE
kopt: fix OCR segmentation mode

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -24,7 +24,7 @@ local KoptInterface = {
     -- in `$TESSDATA_PREFIX/` on more recent versions).
     tessocr_data = not os.getenv('TESSDATA_PREFIX') and DataStorage:getDataDir().."/data/tessdata" or nil,
     ocr_lang = "eng",
-    ocr_type = 3, -- default 0, for more accuracy use 3
+    ocr_type = -1, -- default: assume a single uniform block of text.
     last_context_size = nil,
     default_context_size = 1024*1024,
 }


### PR DESCRIPTION
Previously unused by `libk2pdfopt`, the `ocr_type` argument passed to `k2pdfopt_tocr_single_word` and forwarded to `ocrtess_ocrwords_from_bmp8` now has a big impact for some languages (e.g. Arabic).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12726)
<!-- Reviewable:end -->
