### PR TITLE
add faster option to export text selections via qr codes

### DIFF
--- a/plugins/qrclipboard.koplugin/main.lua
+++ b/plugins/qrclipboard.koplugin/main.lua
@@ -8,6 +8,7 @@ local Device = require("device")
 local QRMessage = require("ui/widget/qrmessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local util = require("util")
 local _ = require("gettext")
 
 local QRClipboard = WidgetContainer:extend{
@@ -17,6 +18,27 @@ local QRClipboard = WidgetContainer:extend{
 
 function QRClipboard:init()
     self.ui.menu:registerToMainMenu(self)
+    self:addToHighlightDialog()
+end
+
+function QRClipboard:addToHighlightDialog()
+    -- 12_search is the last item in the highlight dialog. We want to sneak in the 'Generate QR code' item
+    -- second to last, thus name '12_generate' so the alphabetical sort keeps '12_search' last.
+    self.ui.highlight:addToHighlightDialog("12_generate_qr_code", function(this)
+        return {
+            text = _("Generate QR code"),
+            enabled = Device:hasClipboard(),
+            callback = function()
+                Device.input.setClipboardText(util.cleanupSelectedText(this.selected_text.text))
+                UIManager:show(QRMessage:new{
+                    text = Device.input.getClipboardText(),
+                    width = Device.screen:getWidth(),
+                    height = Device.screen:getHeight()
+                })
+                this:onClose()
+            end,
+        }
+    end)
 end
 
 function QRClipboard:addToMainMenu(menu_items)


### PR DESCRIPTION
### what's new:

This pull request introduces a new method to add the QR code generation option to the highlight dialogue, to allow users to generate a QR code from selected text. No longer do users need to make a selection, copy it and then go through menus with multiple taps or key presses to generate a QR code.

### implementation:

* [`plugins/qrclipboard.koplugin/main.lua`](diffhunk://#diff-be908c8cc0d929ec81f56dea5b9e12d85175edbae3541475de3071368c4a0d81R21-R41): Introduced `addToHighlightDialog` method to add the "Generate QR code" option to the highlight dialogue. This method copies selected text to the clipboard (automatically) and then displays the QR code.

### screenshots:

<p align="center">
<img src="https://github.com/user-attachments/assets/1cc9ffdb-6b52-42a0-a013-2e0cf2917ccc" width=40% height=40%> 
</p>

* fix #11909

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12746)
<!-- Reviewable:end -->
