### PR TITLE
[screensaver menu] remove gesture based option from NT devices

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -67,7 +67,7 @@ local settingsList = {
     ----
 
     -- Device
-    exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit sleep screen"), device=true},
+    exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit sleep screen"), device=true, condition=Device:isTouchDevice()},
     start_usbms = {category="none", event="RequestUSBMS", title=_("Start USB storage"), device=true, condition=Device:canToggleMassStorage()},
     suspend = {category="none", event="RequestSuspend", title=_("Sleep"), device=true, condition=Device:canSuspend()},
     restart = {category="none", event="Restart", title=_("Restart KOReader"), device=true, condition=Device:canRestart()},

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20241117
+local CURRENT_MIGRATION_DATE = 20241123
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -749,10 +749,10 @@ if last_migration_date < 20240928 then
     end
 end
 
--- 20241117, Switch "Until 'exit sleep screen' gesture" to "Until a key press" for non-touch devices
+-- 20241123, Switch "Until 'exit sleep screen' gesture" to "Until a key press" for non-touch devices
 -- https://github.com/koreader/koreader/pull/12747
-if last_migration_date < 20241122 then
-    logger.info("Performing one-time migration for 20241117")
+if last_migration_date < 20241123 then
+    logger.info("Performing one-time migration for 20241123")
 
     local Device = require("device")
     if not Device:isTouchDevice() and G_reader_settings:readSetting("screensaver_delay") == "gesture" then

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -10,7 +10,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20240928
+local CURRENT_MIGRATION_DATE = 20241117
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -746,6 +746,17 @@ if last_migration_date < 20240928 then
             end
         end
         G_reader_settings:delSetting("autostart_profiles")
+    end
+end
+
+-- 20241117, Switch "Until 'exit sleep screen' gesture" to "Until a key press" for non-touch devices
+-- https://github.com/koreader/koreader/pull/12747
+if last_migration_date < 20241117 then
+    logger.info("Performing one-time migration for 20241117")
+
+    local Device = require("device")
+    if not Device:isTouchDevice() and G_reader_settings:readSetting("screensaver_delay") == "gesture" then
+        G_reader_settings:saveSetting("screensaver_delay", "tap")
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -751,7 +751,7 @@ end
 
 -- 20241117, Switch "Until 'exit sleep screen' gesture" to "Until a key press" for non-touch devices
 -- https://github.com/koreader/koreader/pull/12747
-if last_migration_date < 20241117 then
+if last_migration_date < 20241122 then
     logger.info("Performing one-time migration for 20241117")
 
     local Device = require("device")

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,3 +1,4 @@
+local Device = require("device")
 local Screensaver = require("ui/screensaver")
 local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
@@ -10,6 +11,14 @@ end
 
 local function isReaderProgressEnabled()
     return Screensaver.getReaderProgress ~= nil and hasLastFile()
+end
+
+local function getUntilTapOrKeyPressText()
+    if Device:isTouchDevice() then
+        return _("Until a tap")
+    else
+        return _("Until a key press")
+    end
 end
 
 local function genMenuItem(text, setting, value, enabled_func, separator)
@@ -26,7 +35,8 @@ local function genMenuItem(text, setting, value, enabled_func, separator)
         separator = separator,
     }
 end
-return {
+
+local menu_items = {
     {
         text = _("Wallpaper"),
         sub_item_table = {
@@ -83,8 +93,7 @@ return {
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(_("Until a tap"), "screensaver_delay", "tap"),
-                    genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
+                    genMenuItem(getUntilTapOrKeyPressText(), "screensaver_delay", "tap"),
                 },
             },
             {
@@ -176,3 +185,9 @@ return {
         },
     },
 }
+
+if Device:isTouchDevice() then
+    table.insert(menu_items[1].sub_item_table[8].sub_item_table, genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture"))
+end
+
+return menu_items

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -13,14 +13,6 @@ local function isReaderProgressEnabled()
     return Screensaver.getReaderProgress ~= nil and hasLastFile()
 end
 
-local function getUntilTapOrKeyPressText()
-    if Device:isTouchDevice() then
-        return _("Until a tap")
-    else
-        return _("Until a key press")
-    end
-end
-
 local function genMenuItem(text, setting, value, enabled_func, separator)
     return {
         text = text,
@@ -93,7 +85,7 @@ local menu_items = {
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(getUntilTapOrKeyPressText(), "screensaver_delay", "tap"),
+                    genMenuItem(Device:isTouchDevice() and _("Until a tap") or _("Until a key press"), "screensaver_delay", "tap"),
                     Device:isTouchDevice() and genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture") or nil,
                 },
             },
@@ -174,20 +166,17 @@ local menu_items = {
                     genMenuItem(_("Bottom"), "screensaver_message_position", "bottom", nil, true),
                 },
             },
+            (Device:canReboot() and Device:canPowerOff()) and {
+                text = _("Hide reboot/poweroff message"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
+                end,
+                callback = function()
+                    G_reader_settings:toggle("screensaver_hide_fallback_msg")
+                end,
+            } or nil,
         },
     },
 }
-
-if Device:canReboot() and Device:canPowerOff() then
-    table.insert(menu_items[2].sub_item_table, {
-        text = _("Hide reboot/poweroff message"),
-        checked_func = function()
-            return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
-        end,
-        callback = function()
-            G_reader_settings:toggle("screensaver_hide_fallback_msg")
-        end,
-    })
-end
 
 return menu_items

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -38,7 +38,6 @@ return {
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
-            separator = true,
             {
                 text = _("Border fill, rotation, and fit"),
                 enabled_func = function()

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -94,6 +94,7 @@ local menu_items = {
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(getUntilTapOrKeyPressText(), "screensaver_delay", "tap"),
+                    -- "Until 'exit sleep screen' gesture" is added later to touch devices
                 },
             },
             {
@@ -187,7 +188,9 @@ local menu_items = {
 }
 
 if Device:isTouchDevice() then
-    table.insert(menu_items[1].sub_item_table[8].sub_item_table, genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture"))
+    table.insert(menu_items[1].sub_item_table[8].sub_item_table,
+        genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture")
+    )
 end
 
 return menu_items

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -28,7 +28,7 @@ local function genMenuItem(text, setting, value, enabled_func, separator)
     }
 end
 
-local menu_items = {
+return {
     {
         text = _("Wallpaper"),
         sub_item_table = {
@@ -178,5 +178,3 @@ local menu_items = {
         },
     },
 }
-
-return menu_items

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -94,7 +94,7 @@ local menu_items = {
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
                     genMenuItem(getUntilTapOrKeyPressText(), "screensaver_delay", "tap"),
-                    -- "Until 'exit sleep screen' gesture" is added later to touch devices
+                    Device:isTouchDevice() and genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture") or nil,
                 },
             },
             {
@@ -174,23 +174,20 @@ local menu_items = {
                     genMenuItem(_("Bottom"), "screensaver_message_position", "bottom", nil, true),
                 },
             },
-            {
-                text = _("Hide reboot/poweroff message"),
-                checked_func = function()
-                    return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
-                end,
-                callback = function()
-                    G_reader_settings:toggle("screensaver_hide_fallback_msg")
-                end,
-            },
         },
     },
 }
 
-if Device:isTouchDevice() then
-    table.insert(menu_items[1].sub_item_table[8].sub_item_table,
-        genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture")
-    )
+if Device:canReboot() or Device:canPowerOff() then
+    table.insert(menu_items[2].sub_item_table, {
+        text = _("Hide reboot/poweroff message"),
+        checked_func = function()
+            return G_reader_settings:isTrue("screensaver_hide_fallback_msg")
+        end,
+        callback = function()
+            G_reader_settings:toggle("screensaver_hide_fallback_msg")
+        end,
+    })
 end
 
 return menu_items

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -178,7 +178,7 @@ local menu_items = {
     },
 }
 
-if Device:canReboot() or Device:canPowerOff() then
+if Device:canReboot() and Device:canPowerOff() then
     table.insert(menu_items[2].sub_item_table, {
         text = _("Hide reboot/poweroff message"),
         checked_func = function()


### PR DESCRIPTION
### what's new:

* Added a new local function `getUntilTapOrKeyPressText` to return appropriate text based on whether the device is a touch device or not.
* Refactored the return statement to use a local `menu_items` table.
* Conditionally added the `Until 'exit sleep screen' gesture` menu item only to touch devices.

issue was first documented here #12744

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12747)
<!-- Reviewable:end -->
