### PR TITLE
ci/circle: manually cap build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       CCACHE_MAXSIZE: "128M"
       CLICOLOR_FORCE: "1"
       EMULATE_READER: "1"
-      MAKEFLAGS: "OUTPUT_DIR=build INSTALL_DIR=install"
+      MAKEFLAGS: "PARALLEL_JOBS=3 OUTPUT_DIR=build INSTALL_DIR=install"
     parallelism: 2
     steps:
       # Checkout / fetch. {{{


### PR DESCRIPTION
Can't look at `/sys/fs/cgroup/cpu/cpu.shares` anymore…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12751)
<!-- Reviewable:end -->
