### PR TITLE
Adjust Minimum Font Size in Terminal Emulator

### DIFF
--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -590,7 +590,7 @@ Aliases (shortcuts) to frequently used commands can be placed in:
                     local cur_size = G_reader_settings:readSetting("terminal_font_size")
                     local size_spin = SpinWidget:new{
                         value = cur_size,
-                        value_min = 10,
+                        value_min = 8,
                         value_max = 30,
                         value_hold_step = 2,
                         default_value = 14,


### PR DESCRIPTION
This pull request makes a minor adjustment to the terminal emulator's minimum font size in KOReader. It aims to prevent content from being truncated, allowing users to view more information on Kindle. 

Thank you for considering this update!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12752)
<!-- Reviewable:end -->
