### PR TITLE
 ReaderHighlight: Highlight menu, change 'Delete' to Trash can icon 

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1229,7 +1229,7 @@ function ReaderHighlight:onShowHighlightDialog(index)
     local buttons = {
         {
             {
-                text = ("\u{F48E}"), -- Trash can (icon to prevent confusion of Delete/Details buttons)
+                text = "\u{F48E}", -- Trash can (icon to prevent confusion of Delete/Details buttons)
                 callback = function()
                     self:deleteHighlight(index)
                     UIManager:close(self.edit_highlight_dialog)

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -590,7 +590,7 @@ Aliases (shortcuts) to frequently used commands can be placed in:
                     local cur_size = G_reader_settings:readSetting("terminal_font_size")
                     local size_spin = SpinWidget:new{
                         value = cur_size,
-                        value_min = 10,
+                        value_min = 8,
                         value_max = 30,
                         value_hold_step = 2,
                         default_value = 14,


### PR DESCRIPTION
Closes #12754; as discussed there.

Other icons or text labels would also be okay, this is only to prevent user confusion of the easily mixed up Details/Delete buttons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12758)
<!-- Reviewable:end -->
