### PR TITLE
ci/macos: fix possible issue during brew install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           # Remove some installed packages to prevent brew
           # from attempting (and failing) to upgrade them.
           brew uninstall gradle maven
-          brew install --formula --quiet "${packages[@]}"
+          brew install --formula --overwrite --quiet "${packages[@]}"
 
       - name: Update PATH
         run: >


### PR DESCRIPTION
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config
/opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
/opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
```

This only happen with AMD64 runners, and when using the latest runner images (e.g. when the luck of the draw yields 14.7.1 23H222 and not 14.7 23H124).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12767)
<!-- Reviewable:end -->
