### PR TITLE
[Non Touch Devices] Replace "until a tap" with "until a button press" (Screen Saver)

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -83,7 +83,7 @@ return {
                     genMenuItem(_("1 second"), "screensaver_delay", "1"),
                     genMenuItem(_("3 seconds"), "screensaver_delay", "3"),
                     genMenuItem(_("5 seconds"), "screensaver_delay", "5"),
-                    genMenuItem(_("Until a tap"), "screensaver_delay", "tap"),
+                    genMenuItem(not require("device"):isTouchDevice() and _("Until a button press") or _("Until a tap"), "screensaver_delay", "tap"),
                     genMenuItem(_("Until 'exit sleep screen' gesture"), "screensaver_delay", "gesture"),
                 },
             },


### PR DESCRIPTION
I am not touching the next option `Until 'exit sleep screen' gesture`:

> This is definitely doable. I can't make any promises, but once we get this merged, it's something I could look into. To be honest, it's not something I use, so it hadn't even occurred to me.

https://github.com/koreader/koreader/pull/12484#issuecomment-2484044364

@Commodore64user please review :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12771)
<!-- Reviewable:end -->
