### PR TITLE
tests: speedup readhistory reduce test

### DIFF
--- a/spec/unit/readhistory_spec.lua
+++ b/spec/unit/readhistory_spec.lua
@@ -267,16 +267,18 @@ describe("ReadHistory module", function()
         end
         rm(file("history.lua"))
         local h = reload()
-        for i = 1000, 1, -1 do
+        for i = 600, 1, -1 do
             touch(to_file(i))
-            h:addItem(to_file(i))
+            h:addItem(to_file(i), nil, i ~= 1)
         end
 
-        for i = 1, 500 do  -- at most 500 items are stored
+        -- at most 500 items are stored
+        assert.is.same(500, #h.hist)
+        for i = 1, 500 do
             assert_item_is(h, i, string.format("%04d", i))
         end
 
-        for i = 1, 1000 do
+        for i = 1, 600 do
             rm(to_file(i))
         end
     end)


### PR DESCRIPTION
For example on my machine:

| test duration (ms) |  master  |             PR |
| :-                 | -:       | -:             |
| regular run        |  2645.94 | 106.83 (÷24.8) |
| coverage run       | 26133.27 | 641.59 (÷40.7) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12785)
<!-- Reviewable:end -->
