### PR TITLE
tests: speedup persist huge tables test

### DIFF
--- a/spec/unit/persist_spec.lua
+++ b/spec/unit/persist_spec.lua
@@ -95,7 +95,7 @@ describe("Persist module", function()
     end)
 
     it("should work with huge tables", function()
-        local tab = arrayOf(100000)
+        local tab = arrayOf(10000)
         for _, codec in ipairs({"bitser", "luajit"}) do
             local ser = Persist.getCodec(codec).serialize
             local deser = Persist.getCodec(codec).deserialize


### PR DESCRIPTION
For example on my machine:

| test duration (ms) |  master  |             PR |
| :-                 | -:       | -:             |
| regular run        |   859.82 |  104.38 (÷8.2) |
| coverage run       | 40735.60 | 4151.34 (÷9.8) |