### PR TITLE
Schedule next standby on AutoStandby plugin init

### DIFF
--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -47,7 +47,7 @@ function AutoStandby:init()
     --   1. When KOReader starts -> to prevent the device from instantly going into standby
     --   2. During a transition  -> since the standby scheduled following the input event leading to the transition has been unscheduled
     --        to avoid going into standby during the transition, re-schedule the next standby
-    AutoStandby:_scheduleNext(os.time(), self.settings.data)
+    self:_scheduleNext(os.time(), self.settings.data)
 end
 
 function AutoStandby:onCloseWidget()

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -52,7 +52,7 @@ end
 
 function AutoStandby:onCloseWidget()
     logger.dbg("AutoStandby:onCloseWidget() instance=", tostring(self))
-    -- Unschedule to next standby to avoid going into standby during a transition
+    -- Unschedule the next standby to avoid going into standby during a transition
     UIManager:unschedule(AutoStandby.allow)
 end
 

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -35,7 +35,7 @@ function AutoStandby:_scheduleNext()
     if PowerD:getCapacityHW() <= config.bat then
         -- battery is below threshold, so allow standby aggressively
         logger.dbg("AutoStandby: battery below threshold, enabling aggressive standby")
-        AutoStandby:allow()
+        self:allow()
         return
     elseif t > AutoStandby.lastInput + config.max then
         -- too far apart, so reset delay
@@ -49,17 +49,17 @@ function AutoStandby:_scheduleNext()
 
     AutoStandby.lastInput = t
 
-    if not AutoStandby:isAllowedByConfig() then
+    if not self:isAllowedByConfig() then
         -- all standbys forbidden, always prevent
-        AutoStandby:prevent()
+        self:prevent()
         return
     elseif AutoStandby.delay == 0 then
         -- If delay is 0 now, just allow straight
-        AutoStandby:allow()
+        self:allow()
         return
     end
     -- otherwise prevent for a while for duration of the delay
-    AutoStandby:prevent()
+    self:prevent()
     -- and schedule standby re-enable once delay expires
     UIManager:scheduleIn(AutoStandby.delay, AutoStandby.allow, AutoStandby)
 end

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -25,9 +25,7 @@ local AutoStandby = WidgetContainer:extend{
 }
 
 -- Schedule the next standby for when it's actually due
-function AutoStandby:_scheduleNext()
-    local t = os.time()
-    local config = AutoStandby.settings.data
+function AutoStandby:_scheduleNext(t, config)
 
     -- Nuke past timer as we'll reschedule the allow (or not)
     UIManager:unschedule(AutoStandby.allow)
@@ -87,7 +85,7 @@ function AutoStandby:init()
     --   1. When KOReader starts -> to prevent the device from instantly going into standby
     --   2. During a transition  -> since the standby scheduled following the input event leading to the transition has been unscheduled
     --        to avoid going into standby during the transition, re-schedule the next standby
-    AutoStandby:_scheduleNext()
+    AutoStandby:_scheduleNext(os.time(), self.settings.data)
 end
 
 function AutoStandby:onCloseWidget()
@@ -126,7 +124,7 @@ function AutoStandby:onInputEvent()
         return
     end
 
-    self:_scheduleNext()
+    self:_scheduleNext(t, config)
 end
 
 -- Prevent standby (by timer)

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -126,7 +126,7 @@ function AutoStandby:onInputEvent()
         return
     end
 
-    self._scheduleNext()
+    self:_scheduleNext()
 end
 
 -- Prevent standby (by timer)

--- a/plugins/autostandby.koplugin/main.lua
+++ b/plugins/autostandby.koplugin/main.lua
@@ -45,7 +45,7 @@ function AutoStandby:init()
 
     -- Schedule the next standby on plugin init, either:
     --   1. When KOReader starts -> to prevent the device from instantly going into standby
-    --   2. During a transition  -> since the standby scheduled following the input event leading to the transtion has been unscheduled
+    --   2. During a transition  -> since the standby scheduled following the input event leading to the transition has been unscheduled
     --        to avoid going into standby during the transition, re-schedule the next standby
     AutoStandby:scheduleNextStandby()
 end


### PR DESCRIPTION
This PR attempts to fix #12814.

Following [this suggestion](https://github.com/koreader/koreader/discussions/12791#discussioncomment-11381336) and [that one](https://github.com/koreader/koreader/issues/12814#issuecomment-2506749839), I tested the fix vs. standard plugin settings and the plugin appears to work as expected, even with a never-opened-before complex EPUB. To be clear, this is not an attempt to fix the other issues reported for this plugin, c.f. #9493.

### Current approach

Based off of [this suggestion](https://github.com/koreader/koreader/discussions/12791#discussioncomment-11381336), schedule the next standby when the plugin is initialized, either:
1. When KOReader starts
    - To prevent the device from instantly going into standby
2. During a view transition
    - The standby scheduled by the input event leading to the transition has been unscheduled in order to avoid going into standby during the transition
    - Therefore, re-schedule the next standby

Since calling `AutoStandby:onInputEvent()` on `init` would actually likely result in [filtering out](https://github.com/koreader/koreader/blob/f5c6b5689942b3e6c3ced1b33dcfc98ba482df22/plugins/autostandby.koplugin/main.lua#L76-L80) the call (because the view transition happens right after pressing the screen), I isolated [this section](https://github.com/koreader/koreader/blob/f5c6b5689942b3e6c3ced1b33dcfc98ba482df22/plugins/autostandby.koplugin/main.lua#L82-L114) in a separate function which is now also called in `AutoStandby:init()`.

### Undesirable side-effect of the current approach

Since the standby previously scheduled has just been unscheduled by `AutoStandby:onCloseWidget()` and another one is scheduled pretty much right away by `AutoStandby:init()`, this results in increasing the standby delay because of the multiplier effect.

### Important note regarding the current approach

The approach is to schedule the next standby on `init` because it has been unscheduled in `AutoStandby:onCloseWidget()`. [It seems](https://github.com/koreader/koreader/discussions/12791#discussioncomment-11381336) the original purpose of unscheduling the standby is to "prevent standby during a view transition". However, with the proposed fix, when opening a never-opened-before complex EPUB and/or in case the plugin is set to its aggressive mode (e.g. battery below the _Always standby if battery below_ threshold), `AutoStandby:allow()` will actually be invoked on `init`, i.e. during the transition.
I've tested this use-case (e.g. set _Always standby if battery below_ to `100` and open/close a book) with the patch. And it works fine, i.e. the device instantly goes into standby but only **after** the view transition is fully over.

As far as I understand, it's because **the role of the plugin is not to put the device into standby, it's actually to prevent the device from going into standby**. Indeed, when `forbidden == false` (i.e. _Allow auto-standby_ is unchecked), the device always goes into standby instantly after every event. But only **after everything this event has triggered has been fully executed**.
If I understand correctly, the plugin has been created precisely to prevent the device from going into standby right away, so that some automatic events scheduled in the future (such as auto page turning, frontlight dim, etc.) will be able to be triggered before the device goes into standby.

If the above is correct, a better approach would probably be to simply not unschedule the next standby in `AutoStandby:onCloseWidget()` anymore, since there's no risk for the device to go into standby during the view transition. This would have the benefit to avoid the undesirable side-effect mentioned in the previous section.
However, to fix the other bug mentioned in #12814 (device goes into standby instantly when KOReader starts), it would still be necessary to invoke `AutoStandby:scheduleNextStandby()` on `init`. But only if the plugin is initialized for the first time, e.g. probably inside [this block](https://github.com/koreader/koreader/blob/f5c6b5689942b3e6c3ced1b33dcfc98ba482df22/plugins/autostandby.koplugin/main.lua#L29-L41).

I'd be quite interested to further discuss this point.

### Disclaimer

Not only this is my first experience with KOReader, its code-base and the PocketBook InkPad platform, this is also my first experience with Lua. I struggled quite a bit with variable visibility and function arguments and I'd really appreciate some extra guidance. In particular:

1. I tried the following signature for the function I created: `AutoStandby:scheduleNextStandby(t, config)`
    - Indeed, these variables are already available in `AutoStandby:onInputEvent()` and `config` is also already available in `AutoStandby:init()`, so I only would've needed to add `os.time()` in that case
    - However, I was unable to figure the right syntax to pass those arguments to the function when calling it from both functions
2. Similarly, I couldn't keep the references to `self` in the code I extracted from `AutoStandby:onInputEvent()`
    - Apparently, `self` couldn't be recognized when `AutoStandby:scheduleNextStandby()` was invoked from `AutoStandby:onInputEvent()` (e.g. `attempt to index local 'self' (a nil value) `), event though it would be fine when invoked from `AutoStandby:init()`
    - I found it quite weird since `self` was actually recognized in `AutoStandby:onInputEvent()`

CC:
- @NiLuJe, @pazos and @Frenzie as you've been previously involved in #12791 
- @rjd22 since you're also working on PB standby issues in the context of #9493

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12815)
<!-- Reviewable:end -->
