### PR TITLE
Translator: Add romanizations setting in Translation settings

### DIFF
--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -388,6 +388,17 @@ function Translator:loadPage(text, target_lang, source_lang)
     self.trans_params.sl = source_lang
     if G_reader_settings:isTrue("translator_from_romanizations") then
        table.insert(self.trans_params.dt, "rm")
+    else
+       local rmIndex = nil
+       for i, v in pairs(self.trans_params.dt) do
+          if v == "rm" then
+             rmIndex = i
+             break
+          end
+       end
+       if rmIndex then
+          table.remove(self.trans_params.dt, rmIndex)
+       end
     end
     for k,v in pairs(self.trans_params) do
         if type(v) == "table" then

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -278,6 +278,15 @@ This is useful:
                 end,
             },
             {
+                text = _("Show romanizations"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("translator_from_romanizations")
+                end,
+                callback = function()
+                    G_reader_settings:flipTrue("translator_from_romanizations")
+                end,
+            },
+            {
                 text_func = function()
                     local lang = G_reader_settings:readSetting("translator_from_language")
                     return T(_("Translate from: %1"), self:getLanguageName(lang, ""))
@@ -377,6 +386,9 @@ function Translator:loadPage(text, target_lang, source_lang)
     local query = ""
     self.trans_params.tl = target_lang
     self.trans_params.sl = source_lang
+    if G_reader_settings:isTrue("translator_from_romanizations") then
+       table.insert(self.trans_params.dt, "rm")
+    end
     for k,v in pairs(self.trans_params) do
         if type(v) == "table" then
             for _, v2 in ipairs(v) do
@@ -560,10 +572,14 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
         -- for easier quick reading
         local source = {}
         local translated = {}
+        local romanized = {}
         for i, r in ipairs(result[1]) do
             if detailed_view then
                 local s = type(r[2]) == "string" and r[2] or ""
                 table.insert(source, s)
+                if type(r[4]) == "string" then
+                    table.insert(romanized, r[4])
+                end
             end
             local t = type(r[1]) == "string" and r[1] or ""
             table.insert(translated, t)
@@ -572,6 +588,9 @@ function Translator:_showTranslation(text, detailed_view, source_lang, target_la
         if detailed_view then
             text_main = "● " .. text_main
             table.insert(output, "▣ " .. table.concat(source, " "))
+            if #romanized > 0 then
+                table.insert(output, table.concat(romanized, " "))
+            end
         end
         table.insert(output, text_main)
     end

--- a/spec/unit/translator_spec.lua
+++ b/spec/unit/translator_spec.lua
@@ -1,4 +1,5 @@
 local dutch_wikipedia_text = "Wikipedia is een meertalige encyclopedie, waarvan de inhoud vrij beschikbaar is. Iedereen kan hier kennis toevoegen!"
+local chinese_wikipedia_text = "維基百科是维基媒体基金会运营的一个多语言的線上百科全書，并以创建和维护作为开放式协同合作项目，特点是自由內容、自由编辑、自由版权。"
 local Translator
 
 describe("Translator module", function()
@@ -6,6 +7,18 @@ describe("Translator module", function()
         require("commonrequire")
         Translator = require("ui/translator")
     end)
+
+    local function getRomanizations(translation_result)
+        local translations = translation_result[1]
+        local romanizations = {}
+        for _, translation in ipairs(translations) do
+           if type(translation[4]) == "string" then
+              table.insert(romanizations, translation[4])
+           end
+        end
+        return romanizations
+    end
+
     it("should return server", function()
         assert.is.same("https://translate.googleapis.com/", Translator:getTransServer())
         G_reader_settings:saveSetting("trans_server", "http://translate.google.nl")
@@ -21,6 +34,28 @@ describe("Translator module", function()
         -- while some minor variation in the translation is possible it should
         -- be between about 100 and 130 characters
         assert.is_true(#translation_result > 50 and #translation_result < 200)
+    end)
+    it("should include romanization results when configured to be shown", function()
+        G_reader_settings:saveSetting("translator_from_romanizations", true)
+        local translation_result = Translator:loadPage(chinese_wikipedia_text, "en", "auto")
+        local romanizations = getRomanizations(translation_result)
+        assert.is.same(1, #romanizations)
+
+        -- The word free (zìyóu) appears 3 times in the romanization
+        local free_index = string.find(romanizations[1], "zìyóu")
+        assert.is.truthy(free_index)
+        free_index = string.find(romanizations[1], "zìyóu", free_index + 1)
+        assert.is.truthy(free_index)
+        free_index = string.find(romanizations[1], "zìyóu", free_index + 1)
+        assert.is.truthy(free_index)
+    end)
+    it("should not include romanization results when not configured to be shown", function()
+        G_reader_settings:saveSetting("translator_from_romanizations", false)
+        assert.is_false(G_reader_settings:isTrue("translator_from_romanizations"))
+        local translation_result = Translator:loadPage(chinese_wikipedia_text, "en", "auto")
+        local translations = translation_result[1]
+        local romanizations = getRomanizations(translation_result)
+        assert.is.same(0, #romanizations)
     end)
     it("should autodetect language #internet", function()
         local detect_result = Translator:detect(dutch_wikipedia_text)


### PR DESCRIPTION
This adds a new setting in "Translation settings" called "Show romanizations" which tells the translation popup to include in the query the parameter `dt=rm` and then extracts romanizations from the results to display.
![translator-romanizations-1](https://github.com/user-attachments/assets/935526d2-d5b5-4efd-b82c-5fb60509d2d8)
![translator-romanizations-2](https://github.com/user-attachments/assets/18902be0-085a-45ad-914d-c35b9e75c5f5)
