### PR TITLE
CreDocument: tweak when the default font is set

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -150,6 +150,10 @@ function CreDocument:engineInit()
         -- and bold text with the font_base_weight setting set to its default value of 0 (=400).
         cre.regularizeRegisteredFontsWeights(true) -- true to print what modifications were made
 
+        -- Let our default font (even if we don't have a document) be known to crengine's FontManager
+        -- (self:setFontFace(self.default_font) would need a credocument to be loaded)
+        cre.setAsPreferredFontWithBias(self.default_font, 1 + 128*5 + 256*5)
+
         -- Set up bias for some specific fonts
         self:setOtherFontBiases()
 
@@ -320,11 +324,6 @@ function CreDocument:loadDocument(full_document)
     if not self._loaded then
         local only_metadata = full_document == false
         logger.dbg("CreDocument: loading document...")
-        if only_metadata then
-            -- Setting a default font before loading document
-            -- actually do prevent some crashes
-            self:setFontFace(self.default_font)
-        end
         if self._document:loadDocument(self.file, only_metadata) then
             self._loaded = true
             logger.dbg("CreDocument: loading done.")


### PR DESCRIPTION
Reseting the default font each time we refresh metadata (ie. when refreshing a cover in History) could cause the rendering hash of the currently opened document to be messed up, with strange effects.
Hoping setting one in engineInit() is enough to avoid the crashes the removed comment talks about.

See https://github.com/koreader/koreader/pull/8613#issuecomment-2427326832 for the issue,
and https://github.com/koreader/koreader/pull/8613#issuecomment-2431194646 for the possible explanation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12846)
<!-- Reviewable:end -->
