### PR TITLE
[HotKeys] adds 'type to search' setting to hasKeyboard devices

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -319,7 +319,6 @@ function ReaderSearch:onShowFulltextSearchInput(search_string)
 
     UIManager:show(self.input_dialog)
     self.input_dialog:onShowKeyboard()
-    return true
 end
 
 function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitive)

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -431,7 +431,7 @@ end
         - ReaderBookmark
         - ReaderConfig
         - ReaderLink
-        - ReaderSearch; also includes a new type to search feature.
+        - ReaderSearch; also adds a type to search feature.
         - ReaderToc
         - ReaderThumbnail
         - ReaderUI
@@ -487,7 +487,6 @@ function HotKeys:overrideConflictingKeyEvents()
                 event = "ShowFulltextSearchInput",
                 args = ""
             }
-            -- This is an entirely new feature, we don't want to add it to self.key_events as we are harcoding it.
             if self.type_to_search then
                 self.ui.highlight.key_events.StartHighlightIndicator = nil -- remove 'H' shortcut used for highlight indicator
                 readersearch.key_events.Alphabet = {

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -109,6 +109,7 @@ function HotKeys:init()
         self.settings_data = LuaSettings:open(hotkeys_path)
     end
     self.hotkeys = self.settings_data.data[self.hotkey_mode]
+    self.type_to_search = self.settings_data.data["type_to_search"] or false
 
     self.ui.menu:registerToMainMenu(self)
     Dispatcher:init()
@@ -354,7 +355,24 @@ function HotKeys:addToMainMenu(menu_items)
         }
         attachNewTableToExistingTable(fn_keys, fn_keys_haskeyboard)
     end
-    -- 4. Adds a menu item for enabling/disabling the use of the press key for shortcuts.
+    -- 4a. Adds a menu item for enabling/disabling the type-to-search feature
+    if Device:hasKeyboard() and not self.is_docless then
+        menu_items.a_type_to_search = {
+            sorting_hint = "physical_buttons_setup",
+            text = _("Type to launch full text search"),
+            checked_func = function()
+                return self.type_to_search
+            end,
+            callback = function()
+                self.type_to_search = not self.type_to_search
+                self.settings_data.data["type_to_search"] = self.type_to_search
+                self.updated = true
+                self:onFlushSettings()
+                UIManager:askForRestart()
+            end,
+        }
+    end
+    -- 4b. Adds a menu item for enabling/disabling the use of the press key for shortcuts.
     if Device:hasScreenKB() or Device:hasSymKey() then
         menu_items.button_press_does_hotkeys = {
             sorting_hint = "physical_buttons_setup",
@@ -413,7 +431,7 @@ end
         - ReaderBookmark
         - ReaderConfig
         - ReaderLink
-        - ReaderSearch
+        - ReaderSearch; also includes a new type to search feature.
         - ReaderToc
         - ReaderThumbnail
         - ReaderUI
@@ -469,6 +487,15 @@ function HotKeys:overrideConflictingKeyEvents()
                 event = "ShowFulltextSearchInput",
                 args = ""
             }
+            -- This is an entirely new feature, we don't want to add it to self.key_events as we are harcoding it.
+            if self.type_to_search then
+                self.ui.highlight.key_events.StartHighlightIndicator = nil -- remove 'H' shortcut used for highlight indicator
+                readersearch.key_events.Alphabet = {
+                    { Device.input.group.Alphabet }, { "Shift", Device.input.group.Alphabet },
+                    event = "ShowFulltextSearchInput",
+                    args = ""
+                }
+            end
             logger.dbg("Hotkey ReaderSearch:registerKeyEvents() overridden.")
         end
 


### PR DESCRIPTION
### what's new

This pull request introduces a new "type-to-search" feature to the `plugins/hotkeys.koplugin` module.

### adjustments

* Modified `HotKeys:overrideConflictingKeyEvents()` to handle the new type-to-search feature by adjusting key events and removing conflicting shortcuts.
* Reverts a previous addition of a now unnecessary return statement from the `ReaderSearch:onShowFulltextSearchInput(search_string)` function in `frontend/apps/reader/modules/readersearch.lua`.

### screenshots 

<p align="center">
<img src="https://github.com/user-attachments/assets/39cd25ff-0d19-4dbf-9011-1810a5e641b7" width=40% height=40%> 
</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12860)
<!-- Reviewable:end -->
