### PR TITLE
Dispatcher: only notify once per profile

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1157,6 +1157,12 @@ function Dispatcher:execute(settings, exec_props)
         UIManager:broadcastEvent(Event:new("BatchedUpdate"))
     end
     local gesture = exec_props and exec_props.gesture
+
+    if settings.settings and settings.settings.notify then
+        Notification:setNotifySource(Notification.SOURCE_DISPATCHER)
+        Notification:notify(T(_("Executing profile: %1"), settings.settings.name))
+    end
+
     for k, v in iter_func(settings) do
         if type(k) == "number" then
             k = v
@@ -1164,9 +1170,6 @@ function Dispatcher:execute(settings, exec_props)
         end
         if Dispatcher:isActionEnabled(settingsList[k]) then
             Notification:setNotifySource(Notification.SOURCE_DISPATCHER)
-            if settings.settings and settings.settings.notify then
-                Notification:notify(T(_("Executing profile: %1"), settings.settings.name))
-            end
             if settingsList[k].configurable then
                 local value = v
                 if type(v) ~= "number" then


### PR DESCRIPTION
When notifications are enabled for a profile, a notification is currently triggered for each action that is enabled. Instead, only send one notification by moving outside of the for loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12866)
<!-- Reviewable:end -->
