### PR TITLE
Update macOS PATH shenanigans

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -101,10 +101,7 @@ You will also have to ensure Homebrew's findutils, gnu-getopt, make & util-linux
 export PATH="$(brew --prefix)/opt/findutils/libexec/gnubin:$(brew --prefix)/opt/gnu-getopt/bin:$(brew --prefix)/opt/make/libexec/gnubin:$(brew --prefix)/opt/util-linux/bin:${PATH}"
 ```
 
-In the same vein, if that's not already the case, you probably also want to make sure Homebrew's stuff takes precedence:
-```
-export PATH="/usr/local/bin:/usr/local/sbin:${PATH/:\/usr\/local\/bin/}"
-```
+This also assumes you've followed Homebrew's installation instructions properly (e.g., the `brew shellenv` stuff is in your shell's profile).
 
 *Note:* With current XCode versions, you *will* need to set a minimum deployment version higher than `10.04`. Otherwise, you'll hit various linking errors related to missing unwinding libraries/symbols.
 On Mojave, `10.09` has been known to behave with XCode 10, And `10.14` with XCode 11. When in doubt, go with your current macOS version.

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -101,8 +101,6 @@ You will also have to ensure Homebrew's findutils, gnu-getopt, make & util-linux
 export PATH="$(brew --prefix)/opt/findutils/libexec/gnubin:$(brew --prefix)/opt/gnu-getopt/bin:$(brew --prefix)/opt/make/libexec/gnubin:$(brew --prefix)/opt/util-linux/bin:${PATH}"
 ```
 
-This also assumes you've followed Homebrew's installation instructions properly (e.g., the `brew shellenv` stuff is in your shell's profile).
-
 *Note:* With current XCode versions, you *will* need to set a minimum deployment version higher than `10.04`. Otherwise, you'll hit various linking errors related to missing unwinding libraries/symbols.
 On Mojave, `10.09` has been known to behave with XCode 10, And `10.14` with XCode 11. When in doubt, go with your current macOS version.
 ```


### PR DESCRIPTION
One, the brew prefix differs on aarch64 hosts, two, this was completely nuts: the homebrew install process already handles that via an `eval $(brew shellenv)` in the shell profile.

Fix #12868

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12873)
<!-- Reviewable:end -->
