### PR TITLE
Dictionary: fix missing images

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -641,16 +641,21 @@ local function tidyMarkup(results)
             result.ifo_lang = ifo.lang
         end
         if ifo and ifo.is_html then
+            local dict_path = util.splitFilePathName(ifo.file)
             result.is_html = ifo.is_html
             result.css = ifo.css
             if ifo.fix_html_func then
-                local dict_path = util.splitFilePathName(ifo.file)
                 local ok, fixed_definition = pcall(ifo.fix_html_func, result.definition, dict_path)
                 if ok then
                     result.definition = fixed_definition
                 else
                     logger.warn("Dict's user provided function failed:", fixed_definition)
                 end
+            end
+
+            local res_dir = dict_path .. "res"
+            if lfs.attributes(res_dir, "mode") == "directory" then
+                result.dictionary_resource_directory = res_dir
             end
         else
             local def = result.definition

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -43,6 +43,7 @@ local DictQuickLookup = InputContainer:extend{
     results = nil,
     lookupword = nil,
     dictionary = nil,
+    dictionary_resource_directory = nil, -- relative path to the dictionary's res folder if it exists
     definition = nil,
     displayword = nil,
     images = nil,
@@ -807,6 +808,7 @@ function DictQuickLookup:_instantiateScrollWidget()
     if self.is_html then
         self.shw_widget = ScrollHtmlWidget:new{
             html_body = self.definition,
+            html_resource_directory = self.dictionary_resource_directory,
             css = self:getHtmlDictionaryCss(),
             default_font_size = Screen:scaleBySize(self.dict_font_size),
             width = self.content_width,
@@ -865,7 +867,7 @@ function DictQuickLookup:update()
     if self.is_html and self.shw_widget then
         -- Reuse our ScrollHtmlWidget (self.shw_widget)
         -- NOTE: The recursive free via our WidgetContainer (self[1]) above already released the previous MµPDF document instance ;)
-        self.text_widget.htmlbox_widget:setContent(self.definition, self:getHtmlDictionaryCss(), Screen:scaleBySize(self.dict_font_size))
+        self.text_widget.htmlbox_widget:setContent(self.definition, self:getHtmlDictionaryCss(), Screen:scaleBySize(self.dict_font_size), nil, nil, self.dictionary_resource_directory)
         -- Scroll back to top
         self.text_widget:resetScroll()
     elseif not self.is_html and self.stw_widget then
@@ -1004,6 +1006,7 @@ function DictQuickLookup:changeDictionary(index, skip_update)
     if not self.results[index] then return end
     self.dict_index = index
     self.dictionary = self.results[index].dict
+    self.dictionary_resource_directory = self.results[index].dictionary_resource_directory
     self.lookupword = self.results[index].word
     self.definition = self.results[index].definition
     self.is_wiki_fullpage = self.results[index].is_wiki_fullpage

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -50,7 +50,7 @@ plaintext, search, select, summary, template, textarea, video, xmp {
 }
 ]]
 
-function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css_fixes)
+function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css_fixes, html_resource_directory)
     -- fz_set_user_css is tied to the context instead of the document so to easily support multiple
     -- HTML dictionaries with different CSS, we embed the stylesheet into the HTML instead of using
     -- that function.
@@ -72,7 +72,7 @@ function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css
     -- rules to trigger (ie. <title><p>123</p></title>, which is valid in FB2 snippets, parsed
     -- as title>p, while gumbo-parse would consider "<p>123</p>" as being plain text).
     local ok
-    ok, self.document = pcall(Mupdf.openDocumentFromText, html, is_xhtml and "xhtml" or "html")
+    ok, self.document = pcall(Mupdf.openDocumentFromText, html, is_xhtml and "xhtml" or "html", html_resource_directory)
     if not ok then
         -- self.document contains the error
         logger.warn("HTML loading error:", self.document)
@@ -83,7 +83,7 @@ function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css
         body = body:gsub("\n", "&nbsp;<div></div>")
         html = string.format("<html>%s<body>%s</body></html>", head, body)
 
-        ok, self.document = pcall(Mupdf.openDocumentFromText, html, "html")
+        ok, self.document = pcall(Mupdf.openDocumentFromText, html, "html", html_resource_directory)
         if not ok then
             error(self.document)
         end

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -40,7 +40,7 @@ function ScrollHtmlWidget:init()
         html_link_tapped_callback = self.html_link_tapped_callback,
     }
 
-    self.htmlbox_widget:setContent(self.html_body, self.css, self.default_font_size, self.is_xhtml)
+    self.htmlbox_widget:setContent(self.html_body, self.css, self.default_font_size, self.is_xhtml, nil, self.html_resource_directory)
 
     self.v_scroll_bar = VerticalScrollBar:new{
         enable = self.htmlbox_widget.page_count > 1,


### PR DESCRIPTION
Pass the directory that contains the dictionary's ifo file to Mupdf.openDocumentFromText to allow MuPDF to display images referenced by HTML dictionaries.

Depends on: https://github.com/koreader/koreader-base/pull/2002
Fixes: https://github.com/koreader/koreader/issues/12628

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12877)
<!-- Reviewable:end -->
