### PR TITLE
[FileChooser] minor correction, initialise a table not boolean

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -302,7 +302,7 @@ function FileChooser:getList(path, collate)
             if FileChooser.show_hidden or not util.stringStartsWith(f, ".") then
                 local fullpath = path.."/"..f
                 local attributes = lfs.attributes(fullpath) or {}
-                local item = true
+                local item = {}
                 if attributes.mode == "directory" and f ~= "." and f ~= ".."
                         and self:show_dir(f) then
                     if collate then -- when collate == nil count only to display in folder mandatory


### PR DESCRIPTION
### what's new

Changed the initialisation of the `item` variable from `true` to `{}` in the `FileChooser:getList` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12878)
<!-- Reviewable:end -->
