### PR TITLE
[Dispatcher] remove gesture mentions from NT

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -869,7 +869,7 @@ function Dispatcher:_addItem(caller, menu, location, settings, section)
                             callback = function(spin)
                                 setValue(k, spin.value, touchmenu_instance)
                             end,
-                            option_text = caller.profiles == nil and _("Use gesture distance"), -- Gesture manager only
+                            option_text = Device:isTouchDevice() and caller.profiles == nil and _("Use gesture distance"), -- Gesture manager only
                             option_callback = function()
                                 setValue(k, 0, touchmenu_instance)
                             end,


### PR DESCRIPTION
### what's new

* [`frontend/dispatcher.lua`](diffhunk://#diff-73231974e9f228d37b8cd3abe7abf22d9d75e4d04e378c5c6de575e0fc8396bfL872-R872): Modified the `Dispatcher:_addItem` function to check if the device is a touch device before setting the option text for gesture distance.

### screenshots 

<p align="center"> before/after  </p>

<p align="center">
<img src="https://github.com/user-attachments/assets/2b4da672-36c1-46b8-8245-5c685711223d" width=40% height=40%>
<img src="https://github.com/user-attachments/assets/e6eaffec-3240-4dc4-b3c9-697d67c5c071" width=40% height=40%>

</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12889)
<!-- Reviewable:end -->
