### PR TITLE
CoverBrowser: minor fix and remove unused

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -681,21 +681,6 @@ dbg:guard(UIManager, 'setDirty',
     end)
 --]]
 
---[[--
-Clear the full repaint & refresh queues.
-
-NOTE: Beware! This doesn't take any prisonners!
-You shouldn't have to resort to this unless in very specific circumstances!
-plugins/coverbrowser.koplugin/covermenu.lua building a franken-menu out of buttondialog
-and wanting to avoid inheriting their original paint/refresh cycle being a prime example.
---]]
-function UIManager:clearRenderStack()
-    logger.dbg("clearRenderStack: Clearing the full render stack!")
-    self._dirty = {}
-    self._refresh_func_stack = {}
-    self._refresh_stack = {}
-end
-
 function UIManager:insertZMQ(zeromq)
     table.insert(self._zeromqs, zeromq)
     return zeromq

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -136,12 +136,6 @@ function IconButton:onTapIconButton()
         --
         self.callback()
 
-        -- NOTE: plugins/coverbrowser.koplugin/covermenu (ab)uses UIManager:clearRenderStack,
-        --       so we need to enqueue the actual refresh request for the unhighlight post-callback,
-        --       otherwise, it's lost.
-        --       This changes nothing in practice, since we follow by explicitly requesting to drain the refresh queue ;).
-        UIManager:setDirty(nil, "fast", self.dimen)
-
         UIManager:forceRePaint()
     end
     return true

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -672,7 +672,7 @@ function CoverBrowser:setupFileManagerDisplayMode(display_mode)
     end
 end
 
-local function _FileManagerHistory_updateItemTable(self)
+local function _FileManagerHistory_updateItemTable(self, ...)
     -- 'self' here is the single FileManagerHistory instance
     -- FileManagerHistory has just created a new instance of Menu as 'hist_menu'
     -- at each display of History. Soon after instantiation, this method
@@ -714,7 +714,7 @@ local function _FileManagerHistory_updateItemTable(self)
     end
 
     -- And do now what the original does
-    _FileManagerHistory_updateItemTable_orig(self)
+    _FileManagerHistory_updateItemTable_orig(self, ...)
 end
 
 function CoverBrowser:setupHistoryDisplayMode(display_mode)
@@ -750,7 +750,7 @@ function CoverBrowser:setupHistoryDisplayMode(display_mode)
     end
 end
 
-local function _FileManagerCollections_updateItemTable(self)
+local function _FileManagerCollections_updateItemTable(self, ...)
     -- 'self' here is the single FileManagerCollections instance
     -- FileManagerCollections has just created a new instance of Menu as 'coll_menu'
     -- at each display of Collection/Favorites. Soon after instantiation, this method
@@ -792,7 +792,7 @@ local function _FileManagerCollections_updateItemTable(self)
     end
 
     -- And do now what the original does
-    _FileManagerCollection_updateItemTable_orig(self)
+    _FileManagerCollection_updateItemTable_orig(self, ...)
 end
 
 function CoverBrowser:setupCollectionDisplayMode(display_mode)


### PR DESCRIPTION
`updateItemTable()` can get args.
`clearRenderStack()` is not used anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12895)
<!-- Reviewable:end -->
