### PR TITLE
Reader: inspect zip file content to choose provider

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1551,8 +1551,11 @@ end
 function FileManager:openFile(file, provider, doc_caller_callback, aux_caller_callback)
     if provider == nil then
         provider = DocumentRegistry:getProvider(file, true) -- include auxiliary
+    else
+        provider.forced = true
     end
     if provider and provider.order then -- auxiliary
+        provider.forced = nil
         if aux_caller_callback then
             aux_caller_callback()
         end

--- a/frontend/apps/reader/modules/readertypeset.lua
+++ b/frontend/apps/reader/modules/readertypeset.lua
@@ -189,16 +189,6 @@ function ReaderTypeset:genStyleSheetMenu()
                 end
                 return css_file == self.css
             end,
-            enabled_func = function()
-                if fb2_compatible == true and not self.ui.document.is_fb2 then
-                    return false
-                end
-                if fb2_compatible == false and self.ui.document.is_fb2 then
-                    return false
-                end
-                -- if fb2_compatible==nil, we don't know (user css file)
-                return true
-            end,
             separator = separator,
         }
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -67,7 +67,7 @@ local CreDocument = Document:extend{
         "Noto Sans",
     },
 
-    default_css = "./data/cr3.css",
+    default_css = nil,
     provider = "crengine",
     provider_name = "Cool Reader Engine",
 
@@ -76,20 +76,6 @@ local CreDocument = Document:extend{
     page_in_flow = nil, -- table
     last_linear_page = nil,
 }
-
--- NuPogodi, 20.05.12: inspect the zipfile content
-function CreDocument:zipContentExt(fname)
-    local std_out = io.popen("unzip ".."-qql \""..fname.."\"")
-    if std_out then
-        local size, ext
-        for line in std_out:lines() do
-            size, ext = string.match(line, "%s+(%d+)%s+.+%.([^.]+)")
-            if size and ext then break end
-        end
-        std_out:close()
-        if ext then return string.lower(ext) end
-    end
-end
 
 function CreDocument:cacheInit()
     -- remove legacy cr3cache directory
@@ -170,13 +156,6 @@ function CreDocument:init()
     self.flows = {}
     self.page_in_flow = {}
 
-    local file_type = string.lower(string.match(self.file, ".+%.([^.]+)") or "")
-    if file_type == "zip" then
-        -- NuPogodi, 20.05.12: read the content of zip-file
-        -- and return extension of the 1st file
-        file_type = self:zipContentExt(self.file) or "unknown"
-    end
-
     -- June 2018: epub.css has been cleaned to be more conforming to HTML specs
     -- and to not include class name based styles (with conditional compatibility
     -- styles for previously opened documents). It should be usable on all
@@ -184,11 +163,7 @@ function CreDocument:init()
     -- The other css files (htm.css, rtf.css...) have not been updated in the
     -- same way, and are kept as-is for when a previously opened document
     -- requests one of them.
-    self.default_css = "./data/epub.css"
-    if file_type == "fb2" or file_type == "fb3" then
-        self.default_css = "./data/fb2.css"
-        self.is_fb2 = true -- FB2 won't look good with any html-oriented stylesheet
-    end
+    self.default_css = self.is_fb2 and "./data/fb2.css" or "./data/epub.css"
 
     -- This mode must be the same as the default one set as ReaderView.view_mode
     self._view_mode = G_defaults:readSetting("DCREREADER_VIEW_MODE") == "scroll" and self.SCROLL_VIEW_MODE or self.PAGE_VIEW_MODE

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -67,24 +67,9 @@ function Document:_init()
     self.info = {
         -- whether the document is pageable
         has_pages = false,
-        -- whether words can be provided
-        has_words = false,
-        -- whether hyperlinks can be provided
-        has_hyperlinks = false,
-        -- whether (native to format) annotations can be provided
-        has_annotations = false,
-
-        -- whether pages can be rotated
-        is_rotatable = false,
-
         number_of_pages = 0,
         -- if not pageable, length of the document in pixels
         doc_height = 0,
-
-        -- other metadata
-        title = "",
-        author = "",
-        date = ""
     }
 
     -- Should be updated by a call to Document.updateColorRendering(self) in subclasses


### PR DESCRIPTION
Only for pure `zip` files (no double extension).