### PR TITLE
[Dispatcher] add enable_func to Dispatcher:addSubMenu

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -67,10 +67,6 @@ local settingsList = {
     notebook_file = {category="none", event="ShowNotebookFile", title=_("Notebook file"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
     ----
-    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), general=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), general=true},
-    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), general=true},
-    ----
 
     -- Device
     exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit sleep screen"), device=true, condition=Device:isTouchDevice()},
@@ -139,6 +135,9 @@ local settingsList = {
     show_plus_menu = {category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
     toggle_select_mode = {category="none", event="ToggleSelectMode", title=_("Toggle select mode"), filemanager=true},
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
+    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, reader=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true, reader=true},
+    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true, reader=true},
     ----
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     -- go_to
@@ -301,10 +300,6 @@ local dispatcher_menu_order = {
     "notebook_file",
     "screenshot",
     ----
-    "folder_shortcuts",
-    "file_search",
-    "file_search_results",
-    ----
 
     -- Device
     "exit_screensaver",
@@ -374,6 +369,9 @@ local dispatcher_menu_order = {
     "show_plus_menu",
     "toggle_select_mode",
     "refresh_content",
+    "folder_shortcuts",
+    "file_search",
+    "file_search_results",
     ----
     "folder_up",
     -- "go_to"
@@ -980,6 +978,15 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                     end
                 end
             end,
+            enabled_func = function()
+                local ui = require("apps/reader/readerui").instance
+                local context = ui and (ui.paging and "ReaderPaging" or "ReaderRolling") or "FileManager"
+                if context == "FileManager" then
+                    return section[1] ~= "reader" and section[1] ~= "rolling" and section[1] ~= "paging"
+                else
+                    return section[1] ~= "filemanager"
+                end
+            end,
             hold_callback = function(touchmenu_instance)
                 if location[settings] ~= nil then
                     for k, _ in pairs(location[settings]) do
@@ -993,15 +1000,6 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                 end
             end,
             sub_item_table = submenu,
-            enabled_func = function()
-                local ui = require("apps/reader/readerui").instance
-                local context = ui and (ui.paging and "ReaderPaging" or "ReaderRolling") or "FileManager"
-                if context == "FileManager" then
-                    return section[1] ~= "reader" and section[1] ~= "rolling" and section[1] ~= "paging"
-                else
-                    return section[1] ~= "filemanager"
-                end
-            end,
         })
     end
     menu.max_per_page = #menu -- next items in page 2

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -991,6 +991,19 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                 end
             end,
             sub_item_table = submenu,
+            enabled_func = function()
+                local ui = require("apps/reader/readerui").instance
+                local context = ui and (ui.paging and "ReaderPaging" or "ReaderRolling") or "FileManager"
+                if context == "FileManager" then
+                    return section[1] ~= "reader" and section[1] ~= "rolling" and section[1] ~= "paging"
+                elseif context == "ReaderPaging" then
+                    return section[1] ~= "filemanager" and section[1] ~= "rolling"
+                elseif context == "ReaderRolling" then
+                    return section[1] ~= "filemanager" and section[1] ~= "paging"
+                else
+                    return section[1] ~= "filemanager"
+                end
+            end,
         })
     end
     menu.max_per_page = #menu -- next items in page 2

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -135,9 +135,9 @@ local settingsList = {
     show_plus_menu = {category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
     toggle_select_mode = {category="none", event="ToggleSelectMode", title=_("Toggle select mode"), filemanager=true},
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
-    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, reader=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true, reader=true},
-    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true, reader=true},
+    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true, general=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true, general=true},
+    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true, general=true},
     ----
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     -- go_to

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -67,9 +67,9 @@ local settingsList = {
     notebook_file = {category="none", event="ShowNotebookFile", title=_("Notebook file"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
     ----
-    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true},
-    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true},
+    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), general=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), general=true},
+    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), general=true},
     ----
 
     -- Device

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -67,6 +67,10 @@ local settingsList = {
     notebook_file = {category="none", event="ShowNotebookFile", title=_("Notebook file"), general=true},
     screenshot = {category="none", event="Screenshot", title=_("Screenshot"), general=true, separator=true},
     ----
+    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true},
+    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true},
+    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true},
+    ----
 
     -- Device
     exit_screensaver = {category="none", event="ExitScreensaver", title=_("Exit sleep screen"), device=true, condition=Device:isTouchDevice()},
@@ -135,9 +139,6 @@ local settingsList = {
     show_plus_menu = {category="none", event="ShowPlusMenu", title=_("Show plus menu"), filemanager=true},
     toggle_select_mode = {category="none", event="ToggleSelectMode", title=_("Toggle select mode"), filemanager=true},
     refresh_content = {category="none", event="RefreshContent", title=_("Refresh content"), filemanager=true},
-    folder_shortcuts = {category="none", event="ShowFolderShortcutsDialog", title=_("Folder shortcuts"), filemanager=true},
-    file_search = {category="none", event="ShowFileSearch", title=_("File search"), filemanager=true},
-    file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true},
     ----
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
     -- go_to
@@ -300,6 +301,10 @@ local dispatcher_menu_order = {
     "notebook_file",
     "screenshot",
     ----
+    "folder_shortcuts",
+    "file_search",
+    "file_search_results",
+    ----
 
     -- Device
     "exit_screensaver",
@@ -369,9 +374,6 @@ local dispatcher_menu_order = {
     "show_plus_menu",
     "toggle_select_mode",
     "refresh_content",
-    "folder_shortcuts",
-    "file_search",
-    "file_search_results",
     ----
     "folder_up",
     -- "go_to"
@@ -996,10 +998,6 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                 local context = ui and (ui.paging and "ReaderPaging" or "ReaderRolling") or "FileManager"
                 if context == "FileManager" then
                     return section[1] ~= "reader" and section[1] ~= "rolling" and section[1] ~= "paging"
-                elseif context == "ReaderPaging" then
-                    return section[1] ~= "filemanager" and section[1] ~= "rolling"
-                elseif context == "ReaderRolling" then
-                    return section[1] ~= "filemanager" and section[1] ~= "paging"
                 else
                     return section[1] ~= "filemanager"
                 end

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -220,7 +220,7 @@ The following methods are available for accessing your books and articles:
 
 You can assign hotkeys for quick access to each of these dialogs.
 
-Note, our hotkeys plugin works independently for both our reader and file manager modules. 
+Note, our hotkeys plugin works independently for both our reader and file manager modules.
 You will need to set up the hotkeys for both modules separately.
 
 You can also set KOReader to open with any of these dialogs on startup via:
@@ -239,7 +239,7 @@ The following methods are available for accessing your books and articles:
 
 You can assign gestures for quick access to each of these dialogs.
 
-Note, our gestures plugin works independently for both our reader and file manager modules. 
+Note, our gestures plugin works independently for both our reader and file manager modules.
 You will need to set up the gestures for both modules separately.
 
 You can also set KOReader to open with any of these dialogs on startup via:

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -218,6 +218,11 @@ The following methods are available for accessing your books and articles:
 * Favorites
 * History
 
+You can assign hotkeys for quick access to each of these dialogs.
+
+Note, our hotkeys plugin works independently for both our reader and file manager modules. 
+You will need to set up the hotkeys for both modules separately.
+
 You can also set KOReader to open with any of these dialogs on startup via:
 
 > **Menu (in File Browser) ➔ ![Filebrowser](resources/icons/mdlight/appbar.filebrowser.svg) ➔ Start with**
@@ -233,6 +238,9 @@ The following methods are available for accessing your books and articles:
 * History
 
 You can assign gestures for quick access to each of these dialogs.
+
+Note, our gestures plugin works independently for both our reader and file manager modules. 
+You will need to set up the gestures for both modules separately.
 
 You can also set KOReader to open with any of these dialogs on startup via:
 

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -10,7 +10,7 @@ local OPDS = WidgetContainer:extend{
 
 function OPDS:onDispatcherRegisterActions()
     Dispatcher:registerAction("opds_show_catalog",
-        {category="none", event="ShowOPDSCatalog", title=_("OPDS Catalog"), filemanager=true,}
+        {category="none", event="ShowOPDSCatalog", title=_("OPDS Catalog"), filemanager=true, reader=true})
     )
 end
 

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -10,7 +10,7 @@ local OPDS = WidgetContainer:extend{
 
 function OPDS:onDispatcherRegisterActions()
     Dispatcher:registerAction("opds_show_catalog",
-        {category="none", event="ShowOPDSCatalog", title=_("OPDS Catalog"), filemanager=true, reader=true})
+        {category="none", event="ShowOPDSCatalog", title=_("OPDS Catalog"), filemanager=true, reader=true}
     )
 end
 

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -212,8 +212,9 @@ function Profiles:getSubMenuItems()
                 sub_item_table_func = function()
                     local edit_actions_sub_items = {}
                     Dispatcher:addSubMenu(self, edit_actions_sub_items, self.data, k)
+                    local function always_enabled() return true end
                     for _, item in ipairs(edit_actions_sub_items) do
-                        item.enabled_func = function() return true end
+                        item.enabled_func = always_enabled
                     end
                     return edit_actions_sub_items
                 end,

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -212,6 +212,9 @@ function Profiles:getSubMenuItems()
                 sub_item_table_func = function()
                     local edit_actions_sub_items = {}
                     Dispatcher:addSubMenu(self, edit_actions_sub_items, self.data, k)
+                    for _, item in ipairs(edit_actions_sub_items) do
+                        item.enabled_func = function() return true end
+                    end
                     return edit_actions_sub_items
                 end,
                 separator = true,


### PR DESCRIPTION
### what's new

* [`frontend/dispatcher.lua`](diffhunk://#diff-73231974e9f228d37b8cd3abe7abf22d9d75e4d04e378c5c6de575e0fc8396bfR994-R1006): Added an `enabled_func` to the `Dispatcher:addSubMenu` function to check the current UI context and determine if various dispatcher submenus should be enabled. This function considers different contexts such as `FileManager`, `ReaderPaging`, and `ReaderRolling` to ensure appropriate submenu visibility.

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/b5f11e25-215b-4770-b0c5-89b753a7ca17" width=40% height=40%> 
<img src="https://github.com/user-attachments/assets/90149c38-12e2-4b6e-8260-87adf0f085e7" width=40% height=40%>
</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12929)
<!-- Reviewable:end -->
