### PR TITLE
Readerlink: add notification when following internal links on pdf

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -790,7 +790,9 @@ function ReaderLink:onGotoLink(link, neglect_current_location, allow_footnote_po
             if not neglect_current_location then
                 self:addCurrentLocationToStack()
             end
+            local originating_page = self.ui:getCurrentPage()
             self.ui:handleEvent(Event:new("GotoPage", link.page + 1, link.pos))
+            Notification:notify(_("Link from page " .. originating_page), Notification.SOURCE_OTHER)
             return true
         end
         link_url = link.uri -- external link


### PR DESCRIPTION
**Changes:** Adds notification when following an internal link on a pdf in the form of, "Link from page 123". 

(The notification can be disabled by unchecking notifications 'from all other sources'. 

**Purpose:** Alert the user that a link was followed. Links on pdf documents are often not clearly marked, which makes it easy to inadvertently tap a link while just trying to turn the page, and land on a completely different page in the book without realizing. (On cre-docs this is solved by showing the flashing indicator; there, a notification would only distract from it.) 