### PR TITLE
CoverBrowser BookInfoManager: lite getDocProps()

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -99,7 +99,7 @@ function BookInfo:show(doc_settings_or_file, book_props)
     -- book_props may be provided if caller already has them available
     -- but it may lack "pages", that we may get from sidecar file
     if not book_props or not book_props.pages then
-        book_props = BookInfo.getDocProps(file, book_props)
+        book_props = self:getDocProps(file, book_props)
     end
     -- cover image
     self.custom_book_cover = DocSettings:findCustomCoverFile(file)
@@ -238,7 +238,15 @@ function BookInfo.extendProps(original_props, filepath)
 end
 
 -- Returns customized document metadata, including number of pages.
-function BookInfo.getDocProps(file, book_props, no_open_document)
+function BookInfo:getDocProps(file, book_props, no_open_document)
+    if self.ui.coverbrowser then
+        book_props = self.ui.coverbrowser.getDocProps(file)
+        if book_props ~= nil then -- already customized
+            book_props.display_title = book_props.title or filemanagerutil.splitFileNameType(file)
+            return book_props
+        end
+    end
+
     if DocSettings:hasSidecarFile(file) then
         local doc_settings = DocSettings:open(file)
         if not book_props then
@@ -340,7 +348,7 @@ end
 function BookInfo:onShowBookDescription(description, file)
     if not description then
         if file then
-            description = BookInfo.getDocProps(file).description
+            description = self:getDocProps(file).description
         elseif self.document then -- currently opened document
             description = self.ui.doc_props.description
         end

--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -708,8 +708,7 @@ function FileManagerCollection:searchCollections()
         if util.stringSearch(file:gsub(".*/", ""), self.search_str, self.case_sensitive) ~= 0 then
             return true
         end
-        local book_props = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file) or
-                           self.ui.bookinfo.getDocProps(file, nil, true) -- do not open the document
+        local book_props = self.ui.bookinfo:getDocProps(file, nil, true) -- do not open the document
         if next(book_props) ~= nil and self.ui.bookinfo:findInProps(book_props, self.search_str, self.case_sensitive) then
             return true
         end

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -215,12 +215,9 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
         return true
     end
     if self.include_metadata and is_file and DocumentRegistry:hasProvider(fullpath) then
-        local book_props = self.ui.coverbrowser:getBookInfo(fullpath) or
-                           self.ui.bookinfo.getDocProps(fullpath, nil, true) -- do not open the document
+        local book_props = self.ui.bookinfo:getDocProps(fullpath, nil, true) -- do not open the document
         if next(book_props) ~= nil then
-            if self.ui.bookinfo:findInProps(book_props, search_string, self.case_sensitive) then
-                return true
-            end
+            return self.ui.bookinfo:findInProps(book_props, search_string, self.case_sensitive)
         else
             self.no_metadata_count = self.no_metadata_count + 1
         end
@@ -330,7 +327,7 @@ function FileSearcher:showFileDialog(item)
         local doc_settings_or_file = is_currently_opened and self.ui.doc_settings
             or (has_sidecar and DocSettings:open(file) or file)
         if has_provider or has_sidecar then
-            bookinfo = self.ui.coverbrowser and self.ui.coverbrowser:getBookInfo(file)
+            bookinfo = self.ui.bookinfo:getDocProps(file, nil, true)
             table.insert(buttons, filemanagerutil.genStatusButtonsRow(doc_settings_or_file, close_dialog_callback))
             table.insert(buttons, {}) -- separator
             table.insert(buttons, {

--- a/frontend/apps/filemanager/filemanagerhistory.lua
+++ b/frontend/apps/filemanager/filemanagerhistory.lua
@@ -96,13 +96,7 @@ function FileManagerHistory:isItemMatch(item)
     if self.search_string then
         local filename = self.case_sensitive and item.text or Utf8Proc.lowercase(util.fixUtf8(item.text, "?"))
         if not filename:find(self.search_string) then
-            local book_props
-            if self.ui.coverbrowser then
-                book_props = self.ui.coverbrowser:getBookInfo(item.file)
-            end
-            if not book_props then
-                book_props = self.ui.bookinfo.getDocProps(item.file, nil, true) -- do not open the document
-            end
+            local book_props = self.ui.bookinfo:getDocProps(item.file, nil, true) -- do not open the document
             if not self.ui.bookinfo:findInProps(book_props, self.search_string, self.case_sensitive) then
                 return false
             end

--- a/frontend/ui/widget/iconbutton.lua
+++ b/frontend/ui/widget/iconbutton.lua
@@ -136,6 +136,8 @@ function IconButton:onTapIconButton()
         --
         self.callback()
 
+        -- Enqueue the actual refresh request for the unhighlight post-callback, otherwise, it's lost.
+        UIManager:setDirty(nil, "fast", self.dimen)
         UIManager:forceRePaint()
     end
     return true

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -87,14 +87,14 @@ local BOOKINFO_COLS_SET = {
         "cover_sizetag",
         "ignore_meta",
         "ignore_cover",
-        "pages",
+        "pages", -- 13: start index for getDocProps()
         "title",
         "authors",
         "series",
         "series_index",
         "language",
         "keywords",
-        "description",
+        "description", -- 20: end index for getDocProps()
         "cover_w",
         "cover_h",
         "cover_bb_type",
@@ -400,6 +400,22 @@ function BookInfoManager:getBookInfo(filepath, get_cover)
     end
 
     self.get_stmt:clearbind():reset() -- get ready for next query
+    return bookinfo
+end
+
+function BookInfoManager:getDocProps(filepath)
+    local bookinfo
+    local directory, filename = util.splitFilePathName(filepath)
+    self:openDbConnection()
+    local row = self.get_stmt:bind(directory, filename):step()
+    if row ~= nil then
+        bookinfo = {}
+        for i = 13, 20 do
+            bookinfo[BOOKINFO_COLS_SET[i]] = row[i]
+        end
+        bookinfo.pages = tonumber(bookinfo.pages)
+    end
+    self.get_stmt:clearbind():reset()
     return bookinfo
 end
 

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -832,6 +832,10 @@ function CoverBrowser:getBookInfo(file)
     return BookInfoManager:getBookInfo(file)
 end
 
+function CoverBrowser.getDocProps(file)
+    return BookInfoManager:getDocProps(file)
+end
+
 function CoverBrowser:onInvalidateMetadataCache(file)
     BookInfoManager:deleteBookInfo(file)
     return true


### PR DESCRIPTION
When available, use CoverBrowser sql base to get (already customized) doc props.
Should be faster than `DocSettings:open()`.

(Also revert my erroneous change to IconButton)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12936)
<!-- Reviewable:end -->
