### PR TITLE
vocabbuilder.koplugin: fix selecting context bug

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1209,7 +1209,6 @@ function KoptInterface:getSelectedWordContext(word, nb_words, pos)
             end
         end
     end
-    if boxes[i][j].word ~= word then return end
     local prev_text = get_prev_text(boxes, i, j, nb_words)
     local next_text = get_next_text(boxes, i_end, j_end, nb_words)
     return prev_text, next_text


### PR DESCRIPTION
Missed one line in #12917.

Fixes #12916 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12938)
<!-- Reviewable:end -->
