### PR TITLE
ReaderSearch results: search string always in bold

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -661,7 +661,7 @@ function ReaderSearch:onShowFindAllResults(not_cached)
         item_table = self.findall_results,
         items_per_page = self.findall_results_per_page,
         items_max_lines = self.findall_results_max_lines,
-        single_line_disabled = true, -- to always have search_string in bold
+        multilines_forced = true, -- to always have search_string in bold
         covers_fullscreen = true,
         is_borderless = true,
         is_popout = false,

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -661,6 +661,7 @@ function ReaderSearch:onShowFindAllResults(not_cached)
         item_table = self.findall_results,
         items_per_page = self.findall_results_per_page,
         items_max_lines = self.findall_results_max_lines,
+        single_line_disabled = true, -- to always have search_string in bold
         covers_fullscreen = true,
         is_borderless = true,
         is_popout = false,
@@ -718,7 +719,16 @@ function ReaderSearch:showAllResultsMenuDialog()
     local buttons = {
         {
             {
-                text = _("Filter by current chapter"),
+                text = _("All results"),
+                callback = function()
+                    UIManager:close(button_dialog)
+                    self:updateAllResultsMenu(self.findall_results)
+                end,
+            },
+        },
+        {
+            {
+                text = _("Results in current chapter"),
                 callback = function()
                     UIManager:close(button_dialog)
                     local current_chapter = self.ui.toc:getTocTitleOfCurrentPage()
@@ -737,6 +747,7 @@ function ReaderSearch:showAllResultsMenuDialog()
                 end,
             },
         },
+        {}, -- separator
         {
             {
                 text_func = function()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -91,7 +91,7 @@ local MenuItem = InputContainer:extend{
     infont = "infont",
     linesize = Size.line.medium,
     single_line = false,
-    single_line_disabled = false, -- set to true to always use TextBoxWidget
+    multilines_forced = false, -- set to true to always use TextBoxWidget
     multilines_show_more_text = false,
     -- Align text & mandatory baselines (only when single_line=true)
     align_baselines = false,
@@ -140,7 +140,7 @@ function MenuItem:init()
     if self.infont_size > max_font_size then
         self.infont_size = max_font_size
     end
-    if not self.single_line and not self.single_line_disabled
+    if not self.single_line and not self.multilines_forced
             and not self.multilines_show_more_text and not self.items_max_lines then
         -- For non single line menus (File browser, Bookmarks), if the
         -- user provided font size is large and would not allow showing
@@ -1108,7 +1108,7 @@ function Menu:updateItems(select_number, no_recalculate_dimen)
             menu = self,
             linesize = self.linesize,
             single_line = self.single_line,
-            single_line_disabled = self.single_line_disabled,
+            multilines_forced = self.multilines_forced,
             multilines_show_more_text = multilines_show_more_text,
             items_max_lines = self.items_max_lines,
             truncate_left = self.truncate_left,

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -91,6 +91,7 @@ local MenuItem = InputContainer:extend{
     infont = "infont",
     linesize = Size.line.medium,
     single_line = false,
+    single_line_disabled = false, -- set to true to always use TextBoxWidget
     multilines_show_more_text = false,
     -- Align text & mandatory baselines (only when single_line=true)
     align_baselines = false,
@@ -139,7 +140,8 @@ function MenuItem:init()
     if self.infont_size > max_font_size then
         self.infont_size = max_font_size
     end
-    if not self.single_line and not self.multilines_show_more_text and not self.items_max_lines then
+    if not self.single_line and not self.single_line_disabled
+            and not self.multilines_show_more_text and not self.items_max_lines then
         -- For non single line menus (File browser, Bookmarks), if the
         -- user provided font size is large and would not allow showing
         -- more than one line in our item height, just switch to single
@@ -1106,6 +1108,7 @@ function Menu:updateItems(select_number, no_recalculate_dimen)
             menu = self,
             linesize = self.linesize,
             single_line = self.single_line,
+            single_line_disabled = self.single_line_disabled,
             multilines_show_more_text = multilines_show_more_text,
             items_max_lines = self.items_max_lines,
             truncate_left = self.truncate_left,


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/12937.

Also adds "All results" button, see (1) in https://github.com/koreader/koreader/issues/12900.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12940)
<!-- Reviewable:end -->
