### PR TITLE
Dictionary, footnotes: highlight the selected text

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -356,16 +356,16 @@ function ReaderWikipedia:initLanguages(word)
     end
 end
 
-function ReaderWikipedia:onLookupWikipedia(word, is_sane, box, get_fullpage, forced_lang)
+function ReaderWikipedia:onLookupWikipedia(word, is_sane, box, get_fullpage, forced_lang, dict_close_callback)
     -- Wrapped through Trapper, as we may be using Trapper:dismissableRunInSubprocess() in it
     Trapper:wrap(function()
-        self:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang)
+        self:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang, dict_close_callback)
     end)
     return true
 end
 
-function ReaderWikipedia:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang)
-    if NetworkMgr:willRerunWhenOnline(function() self:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang) end) then
+function ReaderWikipedia:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang, dict_close_callback)
+    if NetworkMgr:willRerunWhenOnline(function() self:lookupWikipedia(word, is_sane, box, get_fullpage, forced_lang, dict_close_callback) end) then
         -- Not online yet, nothing more to do here, NetworkMgr will forward the callback and run it once connected!
         return
     end
@@ -497,7 +497,7 @@ function ReaderWikipedia:lookupWikipedia(word, is_sane, box, get_fullpage, force
         results.no_result = true
         logger.dbg("dummy result table:", word, results)
     end
-    self:showDict(word, results, box)
+    self:showDict(word, results, box, nil, dict_close_callback)
 end
 
 function ReaderWikipedia:getWikiLanguages(first_lang)

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -60,6 +60,8 @@ local DictQuickLookup = InputContainer:extend{
     refresh_callback = nil,
     html_dictionary_link_tapped_callback = nil,
 
+    dict_close_callback = nil, -- called when closing DictQuickLookup
+
     -- Static class member, holds a ref to the currently opened widgets (in instantiation order).
     window_list = {},
     -- Static class member, used by ReaderWiktionary to communicate state from a closed widget to the next opened one.
@@ -126,6 +128,12 @@ function DictQuickLookup:init()
             w = Screen:getWidth(),
             h = Screen:getHeight(),
         }
+
+        local hold_pan_rate = G_reader_settings:readSetting("hold_pan_rate")
+        if not hold_pan_rate then
+            hold_pan_rate = Screen.low_pan_rate and 5.0 or 30.0
+        end
+
         self.ges_events = {
             Tap = {
                 GestureRange:new{
@@ -165,8 +173,9 @@ function DictQuickLookup:init()
             },
             HoldPanText = {
                 GestureRange:new{
-                    ges = "hold",
+                    ges = "hold_pan",
                     range = range,
+                    rate = hold_pan_rate,
                 },
             },
             HoldReleaseText = {
@@ -182,12 +191,17 @@ function DictQuickLookup:init()
                         -- but allow switching domain with a long hold
                         lookup_wikipedia = not lookup_wikipedia
                     end
+
+                    local new_dict_close_callback = function()
+                        self:clearDictionaryHighlight()
+                    end
+
                     -- We don't pass self.highlight to subsequent lookup, we want the
                     -- first to be the only one to unhighlight selection when closed
                     if lookup_wikipedia then
-                        self:lookupWikipedia(false, text)
+                        self:lookupWikipedia(false, text, nil, nil, new_dict_close_callback)
                     else
-                        self.ui:handleEvent(Event:new("LookupWord", text))
+                        self.ui:handleEvent(Event:new("LookupWord", text, nil, nil, nil, nil, new_dict_close_callback))
                     end
                 end
             },
@@ -832,6 +846,7 @@ function DictQuickLookup:_instantiateScrollWidget()
             auto_para_direction = not self.is_wiki, -- only for dict results (we don't know their lang)
             image_alt_face = self.image_alt_face,
             images = self.images,
+            display_highlight = true,
         }
         self.text_widget = self.stw_widget
     end
@@ -1166,6 +1181,11 @@ function DictQuickLookup:onClose(no_clear)
             end)
         end
     end
+
+    if self.dict_close_callback then
+        self.dict_close_callback()
+    end
+
     return true
 end
 
@@ -1321,7 +1341,7 @@ function DictQuickLookup:onLookupInputWord(hint)
     self.input_dialog:onShowKeyboard()
 end
 
-function DictQuickLookup:lookupWikipedia(get_fullpage, word, is_sane, lang)
+function DictQuickLookup:lookupWikipedia(get_fullpage, word, is_sane, lang, dict_close_callback)
     if not lang then
         -- Use the lang of the current or nearest is_wiki DictQuickLookup.
         -- Otherwise, first lang in ReaderWikipedia.wiki_languages will be used.
@@ -1346,7 +1366,7 @@ function DictQuickLookup:lookupWikipedia(get_fullpage, word, is_sane, lang)
         end
     end
     -- Keep providing self.word_boxes so new windows keep being positioned to not hide it
-    self.ui:handleEvent(Event:new("LookupWikipedia", word, is_sane, self.word_boxes, get_fullpage, lang))
+    self.ui:handleEvent(Event:new("LookupWikipedia", word, is_sane, self.word_boxes, get_fullpage, lang, dict_close_callback))
 end
 
 function DictQuickLookup:onShowResultsMenu()
@@ -1591,6 +1611,14 @@ function DictQuickLookup:showWikiResultsMenu()
     button_dialog:setScrolledOffset(self.menu_scrolled_offsets["wiki"])
     self.menu_opened[button_dialog] = true
     UIManager:show(button_dialog)
+end
+
+function DictQuickLookup:clearDictionaryHighlight()
+    if self.shw_widget then
+        self.shw_widget.htmlbox_widget:scheduleClearHighlightAndRedraw()
+    elseif self.stw_widget then
+        self.stw_widget.text_widget:scheduleClearHighlightAndRedraw()
+    end
 end
 
 return DictQuickLookup

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -828,6 +828,7 @@ function DictQuickLookup:_instantiateScrollWidget()
             width = self.content_width,
             height = self.definition_height,
             dialog = self,
+            highlight_text_selection = true,
             html_link_tapped_callback = function(link)
                 self.html_dictionary_link_tapped_callback(self.dictionary, link)
             end,
@@ -846,7 +847,7 @@ function DictQuickLookup:_instantiateScrollWidget()
             auto_para_direction = not self.is_wiki, -- only for dict results (we don't know their lang)
             image_alt_face = self.image_alt_face,
             images = self.images,
-            display_highlight = true,
+            highlight_text_selection = true,
         }
         self.text_widget = self.stw_widget
     end

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -321,6 +321,7 @@ function FootnoteWidget:init()
         scroll_bar_width = scroll_bar_width,
         text_scroll_span = text_scroll_span,
         dialog = self.dialog,
+        highlight_text_selection = true,
     }
 
     -- We only want a top border, so use a LineWidget for that

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -149,6 +149,12 @@ function FootnoteWidget:init()
             w = Screen:getWidth(),
             h = Screen:getHeight(),
         }
+
+        local hold_pan_rate = G_reader_settings:readSetting("hold_pan_rate")
+        if not hold_pan_rate then
+            hold_pan_rate = Screen.low_pan_rate and 5.0 or 30.0
+        end
+
         self.ges_events = {
             TapClose = {
                 GestureRange:new{
@@ -170,8 +176,9 @@ function FootnoteWidget:init()
             },
             HoldPanText = {
                 GestureRange:new{
-                    ges = "hold",
+                    ges = "hold_pan",
                     range = range,
+                    rate = hold_pan_rate,
                 },
             },
             HoldReleaseText = {
@@ -182,9 +189,13 @@ function FootnoteWidget:init()
                 -- callback function when HoldReleaseText is handled as args
                 args = function(text, hold_duration)
                     if self.dialog then
+                        local dict_close_callback = function()
+                            self.htmlwidget.htmlbox_widget:scheduleClearHighlightAndRedraw()
+                        end
+
                         local lookup_target = hold_duration < time.s(3) and "LookupWord" or "LookupWikipedia"
                         self.dialog:handleEvent(
-                            Event:new(lookup_target, text)
+                            Event:new(lookup_target, text, nil, nil, nil, nil, dict_close_callback)
                         )
                     end
                 end

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -202,10 +202,8 @@ function HtmlBoxWidget:onHoldStartText(_, ges)
 
     self.hold_start_time = UIManager:getTime()
 
-    if self.highlight_text_selection then
-        if self:updateHighlight() then
-            self:redrawHighlight()
-        end
+    if self:updateHighlight() then
+        self:redrawHighlight()
     end
 
     return true
@@ -223,11 +221,9 @@ function HtmlBoxWidget:onHoldPanText(_, ges)
         y = ges.pos.y - self.dimen.y,
     }
 
-    if self.highlight_text_selection then
-        if self:updateHighlight() then
-            self.hold_start_time = UIManager:getTime()
-            self:redrawHighlight()
-        end
+    if self:updateHighlight() then
+        self.hold_start_time = UIManager:getTime()
+        self:redrawHighlight()
     end
 
     return true
@@ -400,12 +396,8 @@ function HtmlBoxWidget:onHoldReleaseText(callback, ges)
         y = ges.pos.y - self.dimen.y,
     }
 
-    -- Unlike to onHoldStartText and onHoldPanText we must call updateHighlight here even if highlight
-    -- displaying is disabled to be able to query the higlighted word.
     if self:updateHighlight() then
-        if self.highlight_text_selection then
-            self:redrawHighlight()
-        end
+        self:redrawHighlight()
     end
 
     if not self.highlight_text then
@@ -512,14 +504,16 @@ function HtmlBoxWidget:updateHighlight()
 end
 
 function HtmlBoxWidget:redrawHighlight()
-    self:freeBb()
-    UIManager:setDirty(self.dialog or "all", function()
-        return "ui", self.dimen
-    end)
+    if self.highlight_text_selection then
+        self:freeBb()
+        UIManager:setDirty(self.dialog or "all", function()
+            return "ui", self.dimen
+        end)
+    end
 end
 
 function HtmlBoxWidget:scheduleClearHighlightAndRedraw()
-    if self.highlight_clear_and_redraw_function or not self.highlight_text_selection then
+    if self.highlight_clear_and_redraw_function then
         return
     end
 

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -23,7 +23,6 @@ local function getLineTextDirection(line)
 
     local ltr = true
     local rtl = true
-
     for i = 2, word_count do
         if line[i].x0 > line[i - 1].x0 then
             rtl = false
@@ -31,7 +30,6 @@ local function getLineTextDirection(line)
             ltr = false
         end
     end
-
     if ltr and not rtl then
         return 1
     elseif rtl and not ltr then
@@ -43,12 +41,10 @@ end
 
 local function getWordIndices(lines, pos)
     local last_checked_line_index = nil
-
     for line_index, line in ipairs(lines) do
         if pos.y >= line.y0 then -- check if pos in on or below the line
             if pos.y < line.y1 then -- check if pos is within the line vertically
                 local rtl_line = getLineTextDirection(line) < 0
-
                 if pos.x >= line.x0 and pos.x < line.x1 then -- check if pos is within the line horizontally
                     if #line >= 1 then -- if line is not empty then check for exact word hit
                         local word_start_index = 1
@@ -116,18 +112,15 @@ local function getSelectedText(lines, start_pos, end_pos)
     local found_start = false
     local words = {}
     local rects = {}
-
     for line_index = start_line_index, end_line_index do
         local line = lines[line_index]
         local line_last_rect = nil
         local line_text_direction = getLineTextDirection(line)
-
         for word_index, word in ipairs(line) do
             if type(word) == 'table' then
                 if line_index == start_line_index and word_index == start_word_index then
                     found_start = true
                 end
-
                 if found_start then
                     table.insert(words, word.word)
 
@@ -139,7 +132,6 @@ local function getSelectedText(lines, start_pos, end_pos)
                             w = word.x1 - word.x0,
                             h = line.y1 - line.y0,
                         }
-
                         table.insert(rects, rect)
                         line_last_rect = rect
                     else
@@ -170,18 +162,15 @@ local function areTextBoxesEqual(boxes1, text1, boxes2, text2)
     if text1 ~= text2 then
         return false
     end
-
     if boxes1 and boxes2 then
         if #boxes1 ~= #boxes2 then
             return false
         end
-
         for i = 1, #boxes1, 1 do
             if boxes1[i] ~= boxes2[i] then
                 return false
             end
         end
-
         return true
     else
         return (boxes1 == nil) == (boxes2 == nil)
@@ -462,7 +451,6 @@ function HtmlBoxWidget:setPageNumber(page_number)
     if page_number == self.page_number then
         return
     end
-
     self.page_number = page_number
     self.page_boxes = nil
     self:clearHighlight()

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -201,13 +201,10 @@ local HtmlBoxWidget = InputContainer:extend{
     hold_start_time = nil,
     html_link_tapped_callback = nil,
 
-    -- If highlight_text_selection is true then text selection will be highlighted.
-    -- If false then text selection will work as it did originally: no highlighting, and the
-    -- text selection will be updated only on hold release (so hold time might be incorrect).
-    highlight_text_selection = false,
+    highlight_text_selection = false, -- if true then the selected text will be highlighted
     highlight_rects = nil,
     highlight_text = nil,
-    highlight_clear_and_redraw_function = nil,
+    highlight_clear_and_redraw_action = nil,
 }
 
 function HtmlBoxWidget:init()
@@ -513,25 +510,23 @@ function HtmlBoxWidget:redrawHighlight()
 end
 
 function HtmlBoxWidget:scheduleClearHighlightAndRedraw()
-    if self.highlight_clear_and_redraw_function then
+    if self.highlight_clear_and_redraw_action then
         return
     end
 
-    self.highlight_clear_and_redraw_function = function ()
-        self.highlight_clear_and_redraw_function = nil
-
+    self.highlight_clear_and_redraw_action = function ()
+        self.highlight_clear_and_redraw_action = nil
         if self:clearHighlight() then
             self:redrawHighlight()
         end
     end
-
-    UIManager:scheduleIn(0.5, self.highlight_clear_and_redraw_function)
+    UIManager:scheduleIn(0.5, self.highlight_clear_and_redraw_action)
 end
 
 function HtmlBoxWidget:unscheduleClearHighlightAndRedraw()
-    if self.highlight_clear_and_redraw_function then
-        UIManager:unschedule(self.highlight_clear_and_redraw_function)
-        self.highlight_clear_and_redraw_function = nil
+    if self.highlight_clear_and_redraw_action then
+        UIManager:unschedule(self.highlight_clear_and_redraw_action)
+        self.highlight_clear_and_redraw_action = nil
     end
 end
 

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -205,7 +205,6 @@ function HtmlBoxWidget:init()
             },
         }
     end
-
     self.highlight_lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2)
 end
 

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -99,7 +99,7 @@ end
 -- Reset the scrolling *state* to the top of the document, but don't actually re-render/refresh anything.
 -- (Useful when replacing a Scroll*Widget during an update call, c.f., DictQuickLookup).
 function ScrollHtmlWidget:resetScroll()
-    self.htmlbox_widget.page_number = 1
+    self.htmlbox_widget:setPageNumber(1)
     self:_updateScrollBar()
 
     self.v_scroll_bar.enable = self.htmlbox_widget.page_count > 1
@@ -114,7 +114,7 @@ function ScrollHtmlWidget:scrollToRatio(ratio)
     if page_num == self.htmlbox_widget.page_number then
         return
     end
-    self.htmlbox_widget.page_number = page_num
+    self.htmlbox_widget:setPageNumber(page_num)
     self:_updateScrollBar()
 
     self.htmlbox_widget:freeBb()
@@ -145,13 +145,13 @@ function ScrollHtmlWidget:scrollText(direction)
             return
         end
 
-        self.htmlbox_widget.page_number = self.htmlbox_widget.page_number + 1
+        self.htmlbox_widget:setPageNumber(self.htmlbox_widget.page_number + 1)
     elseif direction < 0 then
         if self.htmlbox_widget.page_number <= 1 then
             return
         end
 
-        self.htmlbox_widget.page_number = self.htmlbox_widget.page_number - 1
+        self.htmlbox_widget:setPageNumber(self.htmlbox_widget.page_number - 1)
     end
     self:_updateScrollBar()
 

--- a/frontend/ui/widget/scrollhtmlwidget.lua
+++ b/frontend/ui/widget/scrollhtmlwidget.lua
@@ -23,6 +23,7 @@ local ScrollHtmlWidget = InputContainer:extend{
     htmlbox_widget = nil,
     v_scroll_bar = nil,
     dialog = nil,
+    highlight_text_selection = false,
     html_link_tapped_callback = nil,
     dimen = nil,
     width = 0,
@@ -37,6 +38,8 @@ function ScrollHtmlWidget:init()
             w = self.width - self.scroll_bar_width - self.text_scroll_span,
             h = self.height,
         },
+        dialog = self.dialog,
+        highlight_text_selection = self.highlight_text_selection,
         html_link_tapped_callback = self.html_link_tapped_callback,
     }
 

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -68,6 +68,7 @@ function ScrollTextWidget:init()
         auto_para_direction = self.auto_para_direction,
         alignment_strict = self.alignment_strict,
         for_measurement_only = self.for_measurement_only,
+        display_highlight = self.display_highlight,
     }
     local visible_line_count = self.text_widget:getVisLineCount()
     local total_line_count = self.text_widget:getAllLineCount()

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -41,6 +41,7 @@ local ScrollTextWidget = InputContainer:extend{
     para_direction_rtl = nil,
     auto_para_direction = false,
     alignment_strict = false,
+    highlight_text_selection = false,
 
     -- for internal use
     for_measurement_only = nil, -- When the widget is a one-off used to compute text height
@@ -68,7 +69,7 @@ function ScrollTextWidget:init()
         auto_para_direction = self.auto_para_direction,
         alignment_strict = self.alignment_strict,
         for_measurement_only = self.for_measurement_only,
-        display_highlight = self.display_highlight,
+        highlight_text_selection = self.highlight_text_selection,
     }
     local visible_line_count = self.text_widget:getVisLineCount()
     local total_line_count = self.text_widget:getAllLineCount()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -2008,10 +2008,8 @@ function TextBoxWidget:onHoldStartText(_, ges)
     self.hold_end_pos = pos
     self:unscheduleClearHighlightAndRedraw()
 
-    if self.highlight_text_selection then
-        if self:updateHighlight() then
-            self:redrawHighlight()
-        end
+    if self:updateHighlight() then
+        self:redrawHighlight()
     end
 
     if not self.hold_start_pos then
@@ -2033,11 +2031,9 @@ function TextBoxWidget:onHoldPanText(_, ges)
         y = ges.pos.y - self.dimen.y,
     }
 
-    if self.highlight_text_selection then
-        if self:updateHighlight() then
-            self.hold_start_time = UIManager:getTime()
-            self:redrawHighlight()
-        end
+    if self:updateHighlight() then
+        self.hold_start_time = UIManager:getTime()
+        self:redrawHighlight()
     end
 
     -- Don't let that event be processed by other widget
@@ -2057,12 +2053,8 @@ function TextBoxWidget:onHoldReleaseText(callback, ges)
         y = ges.pos.y - self.dimen.y,
     }
 
-    -- Unlike to onHoldStartText and onHoldPanText we must call updateHighlight here even if highlight
-    -- displaying is disabled to be able to query the higlighted word.
     if self:updateHighlight() then
-        if self.highlight_text_selection then
-            self:redrawHighlight()
-        end
+        self:redrawHighlight()
     end
 
     local hold_duration = time.now() - self.hold_start_time
@@ -2384,14 +2376,16 @@ function TextBoxWidget:updateHighlight()
 end
 
 function TextBoxWidget:redrawHighlight()
-    self:_updateLayout(false)
-    UIManager:setDirty(self.dialog or "all", function()
-        return "ui", self.dimen
-    end)
+    if self.highlight_text_selection then
+        self:_updateLayout(false)
+        UIManager:setDirty(self.dialog or "all", function()
+            return "ui", self.dimen
+        end)
+    end
 end
 
 function TextBoxWidget:scheduleClearHighlightAndRedraw()
-    if self.highlight_clear_and_redraw_function or not self.highlight_text_selection then
+    if self.highlight_clear_and_redraw_function then
         return
     end
 

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -966,7 +966,6 @@ function TextBoxWidget:_updateLayout(update_highlight)
     if self.highlight_text_selection and (update_highlight == nil or update_highlight) then
         self:updateHighlight()
     end
-
     self:_renderText(self.virtual_line_num, self.virtual_line_num + self.lines_per_page - 1)
 end
 


### PR DESCRIPTION
When selecting text in the dictionary (including Wikipedia) or the pop-up footnotes highlight the selected text using an inverting rectangle. After closing the opened dictionary remove the highlight after a short delay just like in the reader.

Depends on https://github.com/koreader/koreader-base/pull/2013

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12948)
<!-- Reviewable:end -->
