### PR TITLE
[MultiInputDialog] vertically centre multi input dialogue

### DIFF
--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -110,11 +110,9 @@ function MultiInputDialog:init()
     self:onCloseKeyboard()
     self._input_widget:onCloseWidget()
 
-    -- Initialize keyboard_visible
+    -- Update keyboard_visible
     if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:isFalse("virtual_keyboard_enabled") then
         self.keyboard_visible = false
-    else
-        self.keyboard_visible = true
     end
 
     local VerticalGroupData = VerticalGroup:new{

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -110,10 +110,14 @@ function MultiInputDialog:init()
     self:onCloseKeyboard()
     self._input_widget:onCloseWidget()
 
-    -- Update self.keyboard_visible, this is needed because InputDialog:onCloseKeyboard updates it regardless of whether
-    -- G_reader_settings("virtual_keyboard_enabled") is disabled, which can lead to an incorrect keyboard visibility state.
+    -- Reset self.keyboard_visible because InputDialog:onCloseKeyboard sets it to false, which can lead to an incorrect keyboard
+    -- visibility state since we still might want our very own virtual keyboard.
     if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:isFalse("virtual_keyboard_enabled") then
-        self.keyboard_visible = false
+        do end -- luacheck: ignore 541
+    elseif self.readonly then
+        do end -- luacheck: ignore 541
+    else
+        self.keyboard_visible = true
     end
 
     local VerticalGroupData = VerticalGroup:new{

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -110,7 +110,8 @@ function MultiInputDialog:init()
     self:onCloseKeyboard()
     self._input_widget:onCloseWidget()
 
-    -- Update keyboard_visible
+    -- Update self.keyboard_visible, this is needed because InputDialog:onCloseKeyboard updates it regardless of whether
+    -- G_reader_settings("virtual_keyboard_enabled") is disabled, which can lead to an incorrect keyboard visibility state.
     if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:isFalse("virtual_keyboard_enabled") then
         self.keyboard_visible = false
     end

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -110,6 +110,13 @@ function MultiInputDialog:init()
     self:onCloseKeyboard()
     self._input_widget:onCloseWidget()
 
+    -- Initialize keyboard_visible
+    if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:isFalse("virtual_keyboard_enabled") then
+        self.keyboard_visible = false
+    else
+        self.keyboard_visible = true
+    end
+
     local VerticalGroupData = VerticalGroup:new{
         align = "left",
         self.title_bar,
@@ -208,10 +215,11 @@ function MultiInputDialog:init()
 
     self._input_widget = self.input_fields[self.focused_field_idx]
 
+    local keyboard_height = self.keyboard_visible and self._input_widget:getKeyboardDimen().h or 0
     self[1] = CenterContainer:new{
         dimen = Geom:new{
             w = Screen:getWidth(),
-            h = Screen:getHeight() - self._input_widget:getKeyboardDimen().h,
+            h = Screen:getHeight() - keyboard_height,
         },
         ignore_if_over = "height",
         self.dialog_frame,
@@ -253,10 +261,10 @@ function MultiInputDialog:onSwitchFocus(inputbox)
     self.focused_field_idx = inputbox.idx
 
     if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:isFalse("virtual_keyboard_enabled") then
-         -- do not load virtual keyboard when user is hiding it.
-         return
-     end
-     -- Otherwise make sure we have a (new) visible keyboard
+        -- do not load virtual keyboard when user is hiding it.
+        return
+    end
+    -- Otherwise make sure we have a (new) visible keyboard
     self:onShowKeyboard()
 end
 


### PR DESCRIPTION
### what's new

* [`frontend/ui/widget/multiinputdialog.lua`](diffhunk://#diff-ec760af17116d6a9eb1ebd6cfcb2a3dd5ecf8d242af8cb2b061cdec5dbac583dR113-R119): Added initialization for the `keyboard_visible` property in the `MultiInputDialog:init()` function to determine if the keyboard should be visible based on device and reader settings.
* [`frontend/ui/widget/multiinputdialog.lua`](diffhunk://#diff-ec760af17116d6a9eb1ebd6cfcb2a3dd5ecf8d242af8cb2b061cdec5dbac583dR218-R222): Adjusted the height of the `CenterContainer` to account for the keyboard height only if the keyboard is visible.
* Removed pesky whitespaces

### screenshots

<p align="center">
before/after
</p> 
<p align="center">
<img src="https://github.com/user-attachments/assets/564e417e-f82f-4006-813d-477c07555d9f" width=40% height=40%>
<img src="https://github.com/user-attachments/assets/e617d802-96ac-48f2-8f34-14fafeded7fd" width=40% height=40%> 
</p>

* fix #12914

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12951)
<!-- Reviewable:end -->
