### PR TITLE
Add Lua-specific formatting to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,15 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# https://github.com/CppCXY/EmmyLuaCodeStyle/blob/master/docs/format_config_EN.md
+[*.lua]
+quote_style = double
+call_arg_parentheses = remove_table_only
+max_line_length = 180
+trailing_table_separator = smart
+space_before_function_call_single_arg = false
+break_all_list_when_line_exceed = true
+
 [*.md]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
While working on #12949 I noticed not all of the code style used in this repository was part of `.editorconfig`, which meant auto-formatting broke some of your conventions. I tried reproducing what I saw in the code with the options from <https://github.com/CppCXY/EmmyLuaCodeStyle/blob/master/docs/format_config_EN.md>. I hope I made the correct assumptions, but am happy to make any changes you want.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12952)
<!-- Reviewable:end -->
