### PR TITLE
File list: new display options

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -240,7 +240,7 @@ function FileManagerMenu:setUpdateItemTable()
                         end,
                         callback = function()
                             G_reader_settings:flipNilOrFalse("items_multilines_show_more_text")
-                            self.ui:onRefresh()
+                            FileChooser:refreshPath()
                         end,
                         separator = true,
                     },
@@ -255,7 +255,7 @@ function FileManagerMenu:setUpdateItemTable()
                             else
                                 G_reader_settings:saveSetting("show_file_in_bold", "opened")
                             end
-                            self.ui:onRefresh()
+                            FileChooser:refreshPath()
                         end,
                     },
                     {
@@ -269,7 +269,7 @@ function FileManagerMenu:setUpdateItemTable()
                             else
                                 G_reader_settings:delSetting("show_file_in_bold")
                             end
-                            self.ui:onRefresh()
+                            FileChooser:refreshPath()
                         end,
                     },
                 },
@@ -375,11 +375,21 @@ To:
                         end,
                         callback = function()
                             G_reader_settings:flipNilOrFalse("lock_home_folder")
-                            self.ui:onRefresh()
+                            FileChooser:refreshPath()
                         end,
                     },
                 },
                 separator = true,
+            },
+            {
+                text = _("Show collection mark"),
+                checked_func = function()
+                    return G_reader_settings:hasNot("collection_show_mark")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("collection_show_mark")
+                    FileChooser:refreshPath()
+                end,
             },
             {
                 text_func = function()

--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -88,11 +88,13 @@ function ReadCollection:isFileInCollection(file, collection_name)
     return self.coll[collection_name][file] and true or false
 end
 
-function ReadCollection:isFileInCollections(file)
-    file = ffiUtil.realpath(file) or file
-    for _, coll in pairs(self.coll) do
-        if coll[file] then
-            return true
+function ReadCollection:isFileInCollections(file, ignore_show_mark_setting)
+    if ignore_show_mark_setting or G_reader_settings:nilOrTrue("collection_show_mark") then
+        file = ffiUtil.realpath(file) or file
+        for _, coll in pairs(self.coll) do
+            if coll[file] then
+                return true
+            end
         end
     end
     return false

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -155,16 +155,16 @@ function CoverBrowser:addToMainMenu(menu_items)
     -- next to Classic mode settings
     if menu_items.filebrowser_settings == nil then return end
     local fc = self.ui.file_chooser
-    local function genSeriesSubMenuItem(_text, _value)
+    local function genSeriesSubMenuItem(text_, value_)
         return {
-            text = _text,
+            text = text_,
             radio = true,
             checked_func = function()
-                return series_mode == _value
+                return series_mode == value_
             end,
             callback = function()
-                if series_mode ~= _value then
-                    series_mode = _value
+                if series_mode ~= value_ then
+                    series_mode = value_
                     BookInfoManager:saveSetting("series_mode", series_mode)
                     fc:updateItems(1, true)
                 end

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -155,6 +155,23 @@ function CoverBrowser:addToMainMenu(menu_items)
     -- next to Classic mode settings
     if menu_items.filebrowser_settings == nil then return end
     local fc = self.ui.file_chooser
+    local function genSeriesSubMenuItem(_text, _value)
+        return {
+            text = _text,
+            radio = true,
+            checked_func = function()
+                return series_mode == _value
+            end,
+            callback = function()
+                if series_mode ~= _value then
+                    series_mode = _value
+                    BookInfoManager:saveSetting("series_mode", series_mode)
+                    fc:updateItems(1, true)
+                end
+            end,
+        }
+    end
+
     table.insert (menu_items.filebrowser_settings.sub_item_table, 5, {
         text = _("Mosaic and detailed list settings"),
         separator = true,
@@ -255,6 +272,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                     }
                     UIManager:show(widget)
                 end,
+                separator = true,
             },
             {
                 text_func = function()
@@ -291,6 +309,26 @@ function CoverBrowser:addToMainMenu(menu_items)
                         end,
                     }
                     UIManager:show(widget)
+                end,
+            },
+            {
+                text = _("Shrink item font size to fit more text"),
+                checked_func = function()
+                    return not BookInfoManager:getSetting("fixed_item_font_size")
+                end,
+                callback = function()
+                    BookInfoManager:toggleSetting("fixed_item_font_size")
+                    fc:updateItems(1, true)
+                end,
+            },
+            {
+                text = _("Show file properties"),
+                checked_func = function()
+                    return not BookInfoManager:getSetting("hide_file_info")
+                end,
+                callback = function()
+                    BookInfoManager:toggleSetting("hide_file_info")
+                    fc:updateItems(1, true)
                 end,
                 separator = true,
             },
@@ -344,6 +382,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                             BookInfoManager:toggleSetting("no_hint_description")
                             fc:updateItems(1, true)
                         end,
+                        separator = true,
                     },
                     {
                         text = _("Show hint for book status in history"),
@@ -360,62 +399,17 @@ function CoverBrowser:addToMainMenu(menu_items)
                             BookInfoManager:toggleSetting("collections_hint_opened")
                             fc:updateItems(1, true)
                         end,
-                    }
-                }
-            },
-            {
-                text = _("Series"),
-                sub_item_table = {
-                    {
-                        text = _("Append series metadata to authors"),
-                        checked_func = function() return series_mode == "append_series_to_authors" end,
-                        callback = function()
-                            if series_mode == "append_series_to_authors" then
-                                series_mode = nil
-                            else
-                                series_mode = "append_series_to_authors"
-                            end
-                            BookInfoManager:saveSetting("series_mode", series_mode)
-                            fc:updateItems(1, true)
-                        end,
-                    },
-                    {
-                        text = _("Append series metadata to title"),
-                        checked_func = function() return series_mode == "append_series_to_title" end,
-                        callback = function()
-                            if series_mode == "append_series_to_title" then
-                                series_mode = nil
-                            else
-                                series_mode = "append_series_to_title"
-                            end
-                            BookInfoManager:saveSetting("series_mode", series_mode)
-                            fc:updateItems(1, true)
-                        end,
-                    },
-                    {
-                        text = _("Show series metadata in separate line"),
-                        checked_func = function() return series_mode == "series_in_separate_line" end,
-                        callback = function()
-                            if series_mode == "series_in_separate_line" then
-                                series_mode = nil
-                            else
-                                series_mode = "series_in_separate_line"
-                            end
-                            BookInfoManager:saveSetting("series_mode", series_mode)
-                            fc:updateItems(1, true)
-                        end,
                     },
                 },
             },
             {
-                text = _("Show file properties"),
-                checked_func = function()
-                    return not BookInfoManager:getSetting("hide_file_info")
-                end,
-                callback = function()
-                    BookInfoManager:toggleSetting("hide_file_info")
-                    fc:updateItems(1, true)
-                end,
+                text = _("Series"),
+                sub_item_table = {
+                    genSeriesSubMenuItem(_("Do not show series metadata"), nil),
+                    genSeriesSubMenuItem(_("Show series metadata in separate line"), "series_in_separate_line"),
+                    genSeriesSubMenuItem(_("Append series metadata to title"), "append_series_to_title"),
+                    genSeriesSubMenuItem(_("Append series metadata to authors"), "append_series_to_authors"),
+                },
                 separator = true,
             },
             {
@@ -434,7 +428,6 @@ function CoverBrowser:addToMainMenu(menu_items)
                         keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
-                            UIManager:close(self.file_dialog)
                             UIManager:show(ConfirmBox:new{
                                 -- Checking file existences is quite fast, but deleting entries is slow.
                                 text = _("Are you sure that you want to prune cache of removed books?\n(This may take a while.)"),
@@ -446,9 +439,9 @@ function CoverBrowser:addToMainMenu(menu_items)
                                     UIManager:nextTick(function()
                                         local summary = BookInfoManager:removeNonExistantEntries()
                                         UIManager:close(msg)
-                                        UIManager:show( InfoMessage:new{ text = summary } )
+                                        UIManager:show(InfoMessage:new{ text = summary })
                                     end)
-                                end
+                                end,
                             })
                         end,
                     },
@@ -457,7 +450,6 @@ function CoverBrowser:addToMainMenu(menu_items)
                         keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
-                            UIManager:close(self.file_dialog)
                             UIManager:show(ConfirmBox:new{
                                 text = _("Are you sure that you want to compact cache database?\n(This may take a while.)"),
                                 ok_text = _("Compact database"),
@@ -468,9 +460,9 @@ function CoverBrowser:addToMainMenu(menu_items)
                                     UIManager:nextTick(function()
                                         local summary = BookInfoManager:compactDb()
                                         UIManager:close(msg)
-                                        UIManager:show( InfoMessage:new{ text = summary } )
+                                        UIManager:show(InfoMessage:new{ text = summary })
                                     end)
-                                end
+                                end,
                             })
                         end,
                     },
@@ -479,13 +471,12 @@ function CoverBrowser:addToMainMenu(menu_items)
                         keep_menu_open = true,
                         callback = function()
                             local ConfirmBox = require("ui/widget/confirmbox")
-                            UIManager:close(self.file_dialog)
                             UIManager:show(ConfirmBox:new{
                                 text = _("Are you sure that you want to delete cover and metadata cache?\n(This will also reset your display mode settings.)"),
                                 ok_text = _("Purge"),
                                 ok_callback = function()
                                     BookInfoManager:deleteDb()
-                                end
+                                end,
                             })
                         end,
                     },

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -155,16 +155,16 @@ function CoverBrowser:addToMainMenu(menu_items)
     -- next to Classic mode settings
     if menu_items.filebrowser_settings == nil then return end
     local fc = self.ui.file_chooser
-    local function genSeriesSubMenuItem(text_, value_)
+    local function genSeriesSubMenuItem(item_text, item_series_mode)
         return {
-            text = text_,
+            text = item_text,
             radio = true,
             checked_func = function()
-                return series_mode == value_
+                return series_mode == item_series_mode
             end,
             callback = function()
-                if series_mode ~= value_ then
-                    series_mode = value_
+                if series_mode ~= item_series_mode then
+                    series_mode = item_series_mode
                     BookInfoManager:saveSetting("series_mode", series_mode)
                     fc:updateItems(1, true)
                 end

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -613,31 +613,18 @@ function MosaicMenuItem:update()
                 self._has_cover_image = true
             else
                 -- add Series metadata if requested
-                local series_mode = BookInfoManager:getSetting("series_mode")
                 local title_add, authors_add
-                if bookinfo.series then
-                    if bookinfo.series_index then
-                        bookinfo.series = BD.auto(bookinfo.series .. " #" .. bookinfo.series_index)
-                    else
-                        bookinfo.series = BD.auto(bookinfo.series)
-                    end
+                local series_mode = BookInfoManager:getSetting("series_mode")
+                if series_mode and bookinfo.series then
+                    local series = bookinfo.series_index and bookinfo.series .. " #" .. bookinfo.series_index
+                        or bookinfo.series
+                    series = BD.auto(series)
                     if series_mode == "append_series_to_title" then
-                        if bookinfo.title then
-                            title_add = " - " .. bookinfo.series
-                        else
-                            title_add = bookinfo.series
-                        end
-                    end
-                    if not bookinfo.authors then
-                        if series_mode == "append_series_to_authors" or series_mode == "series_in_separate_line" then
-                            authors_add = bookinfo.series
-                        end
-                    else
-                        if series_mode == "append_series_to_authors" then
-                            authors_add = " - " .. bookinfo.series
-                        elseif series_mode == "series_in_separate_line" then
-                            authors_add = "\n \n" .. bookinfo.series
-                        end
+                        title_add = bookinfo.title and " - " .. series or series
+                    elseif series_mode == "append_series_to_authors" then
+                        authors_add = bookinfo.authors and " - " .. series or series
+                    else -- "series_in_separate_line"
+                        authors_add = bookinfo.authors and "\n \n" .. series or series
                     end
                 end
                 local bottom_pad = Size.padding.default


### PR DESCRIPTION
(1) Option to show/hide collection mark.
(Now I have **all** my books in one flat collection. "Collections search" allows to build a collection for, say, a certain author quickly.)

![01](https://github.com/user-attachments/assets/82f43c5a-40be-4e32-ba81-c95a6edd8631)

(2) Option to have fixed font size in List display mode, taken from https://github.com/koreader/koreader/issues/9094#issuecomment-2040834603.

![02](https://github.com/user-attachments/assets/3861cf65-5e50-403a-9f7c-55576af5be02)

(3) Radio buttons in the "Series" submenu. To avoid confusion comparing to adjacent "Progress" and "Display hints" menues.

![03](https://github.com/user-attachments/assets/79a70061-f196-423c-b535-d3bd6cfbb068)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12954)
<!-- Reviewable:end -->
