### PR TITLE
Annotations: add datetime_updated property

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -60,20 +60,21 @@ function ReaderAnnotation:buildAnnotation(bm, highlights, init)
         end
     end
     return { -- annotation
-        datetime    = bm.datetime, -- creation time, not changeable
-        drawer      = hl.drawer,   -- highlight drawer
-        color       = hl.color,    -- highlight color
-        text        = bm.notes,    -- highlighted text, editable
-        text_edited = hl.edited,   -- true if highlighted text has been edited
-        note        = note,        -- user's note, editable
-        chapter     = chapter,     -- book chapter title
-        pageno      = pageno,      -- book page number (continuous numbering, used by KOHighlights)
-        pageref     = pageref,     -- book page number (iff: reference pages or hidden flows)
-        page        = bm.page,     -- highlight location, xPointer or number (pdf)
-        pos0        = bm.pos0,     -- highlight start position, xPointer (== page) or table (pdf)
-        pos1        = bm.pos1,     -- highlight end position, xPointer or table (pdf)
-        pboxes      = hl.pboxes,   -- pdf pboxes, used only and changeable by addMarkupAnnotation
-        ext         = hl.ext,      -- pdf multi-page highlight
+        datetime         = bm.datetime, -- creation time, not changeable
+        datetime_updated = nil,         -- last modification time
+        drawer           = hl.drawer,   -- highlight drawer
+        color            = hl.color,    -- highlight color
+        text             = bm.notes,    -- highlighted text, editable
+        text_edited      = hl.edited,   -- true if highlighted text has been edited
+        note             = note,        -- user's note, editable
+        chapter          = chapter,     -- book chapter title
+        pageno           = pageno,      -- book page number (continuous numbering, used by KOHighlights)
+        pageref          = pageref,     -- book page number (iff: reference pages or hidden flows)
+        page             = bm.page,     -- highlight location, xPointer or number (pdf)
+        pos0             = bm.pos0,     -- highlight start position, xPointer (== page) or table (pdf)
+        pos1             = bm.pos1,     -- highlight end position, xPointer or table (pdf)
+        pboxes           = hl.pboxes,   -- pdf pboxes, used only and changeable by addMarkupAnnotation
+        ext              = hl.ext,      -- pdf multi-page highlight
     }
 end
 
@@ -418,6 +419,10 @@ function ReaderAnnotation:addItem(item)
     local index = self:getInsertionIndex(item)
     table.insert(self.annotations, index, item)
     return index
+end
+
+function ReaderAnnotation:onAnnotationsModified(items)
+    items[1].datetime_updated = os.date("%Y-%m-%d %H:%M:%S")
 end
 
 -- info


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/12957.

(1) `datetime_updated` is not exposed to UI.
(2) `datetime_updated` is not exported.
(3) There is no sorting by date modified.
(4) "Latest bookmark" still means the last **created** bookmark.

(5) @noembryo I do not add `datetime_updated` to new annotations.
Old annotations don't have this field, in any case you need to do something like
```Lua
local datetime = item.datetime_updated or item.datetime
```
so no difference whether it is `nil` or equals to `datetime`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12963)
<!-- Reviewable:end -->
