### PR TITLE
[plugin] NewsDownloader: switch default to download_full_article=false

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -14,8 +14,8 @@ return {--do NOT change this line
  -- set 'limit' to "0" means no limit.
 
  -- 'download_full_article=true' - means download full article (may not always work correctly)
- -- 'download_full_article=false' - means use only feed description to create feeds (usually only beginning of the article)
- -- default value is 'true' (if no 'download_full_article' entry)
+ -- 'download_full_article=false' - means use only feed description to create feeds. Ssmetimes this is only a summary or the first few lines, sometimes it's the full article.
+ -- default value is 'false' (if no 'download_full_article' entry)
 
  -- 'include_images=true' - means download any images on the page and include them in the article
  -- 'include_images=false' - means ignore any images, only download the text (faster download, smaller file sizes)
@@ -38,7 +38,7 @@ return {--do NOT change this line
 
  -- LIST YOUR FEEDS HERE:
 
- { "https://github.com/koreader/koreader/releases.atom", limit = 3, download_full_article=true, include_images=false, enable_filter=true, filter_element = "div.release-main-section"},
+ { "https://github.com/koreader/koreader/releases.atom", limit = 3, download_full_article=false, include_images=false, enable_filter=true, filter_element = "div.release-main-section"},
  { "https://ourworldindata.org/atom.xml", limit = 5 , download_full_article=true, include_images=true, enable_filter=false, filter_element = ""},
 
 }--do NOT change this line

--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -14,7 +14,7 @@ return {--do NOT change this line
  -- set 'limit' to "0" means no limit.
 
  -- 'download_full_article=true' - means download full article (may not always work correctly)
- -- 'download_full_article=false' - means use only feed description to create feeds. Ssmetimes this is only a summary or the first few lines, sometimes it's the full article.
+ -- 'download_full_article=false' - means use only feed description to create feeds. Sometimes this is only a summary or the first few lines, sometimes it's the full article.
  -- default value is 'false' (if no 'download_full_article' entry)
 
  -- 'include_images=true' - means download any images on the page and include them in the article

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -63,7 +63,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
     end
 
     -- Collect this stuff for later, with the single view.
-    local download_full_article = feed.download_full_article ~= false
+    local download_full_article = feed.download_full_article or false
     local include_images = feed.include_images ~= false
     local enable_filter = feed.enable_filter ~= false
     local filter_element = feed.filter_element

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -36,7 +36,7 @@ local NewsDownloader = WidgetContainer:extend{
     empty_feed = {
         [1] = "https://",
         limit = 5,
-        download_full_article = true,
+        download_full_article = false,
         include_images = true,
         enable_filter = false,
         filter_element = ""
@@ -249,7 +249,7 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
     for idx, feed in ipairs(feed_config) do
         local url = feed[1]
         local limit = feed.limit
-        local download_full_article = feed.download_full_article == nil or feed.download_full_article
+        local download_full_article = feed.download_full_article or false
         local include_images = not never_download_images and feed.include_images
         local enable_filter = feed.enable_filter or feed.enable_filter == nil
         local filter_element = feed.filter_element or feed.filter_element == nil


### PR DESCRIPTION
It's a saner default. Much of the time it won't just work but it'll work *significantly better* than `download_full_article=true`.

Additionally it should reduce the chance of being seen as abuse, cf. <https://github.com/koreader/koreader/issues/12953#issuecomment-2565973079>.

Also see #3172.

Since both the UI and the default config include the value, impact may be surprisingly limited.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12965)
<!-- Reviewable:end -->
