### PR TITLE
[plugin] NewsDownloader: reduce HTML idiosyncracies

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -610,11 +610,18 @@ function NewsDownloader:createFromDescription(feed, title, content, feed_output_
         logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
         local article_message = T(_("%1\n%2"), message, title_with_date)
         local footer = _("If this is only a summary, the full article can be downloaded by going to the News Downloader settings and changing 'Download full article' to 'true'.")
-        local html = string.format([[<!DOCTYPE html>
+        local html = string.format([[
+<!DOCTYPE html>
 <html>
-<head><meta charset='UTF-8'><title>%s</title></head>
-<body><header><h2>%s</h2></header><article>%s</article>
-<br><footer><small>%s</small></footer>
+<head>
+<meta charset="UTF-8">
+<title>%s</title>
+</head>
+<body>
+<header><h1>%s</h1></header>
+<article>%s</article>
+<br>
+<footer><small>%s</small></footer>
 </body>
 </html>]], title, title, content, footer)
         local link = getFeedLink(feed.link)


### PR DESCRIPTION
Noticed in https://github.com/koreader/koreader/pull/12969#discussion_r1900122593

This merely makes it a touch friendlier to future changes. Fixing it up as "proper" XHTML is likely to do more harm than good, since the content will typically be regular HTML encapsulated in `<![CDATA[`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12976)
<!-- Reviewable:end -->
