### PR TITLE
socketutil: remove URL from user agent, add device info

### DIFF
--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -2,6 +2,7 @@
 This module contains miscellaneous helper functions specific to our usage of LuaSocket/LuaSec.
 ]]
 
+local Device = require("device")
 local Version = require("version")
 local http = require("socket.http")
 local https = require("ssl.https")
@@ -16,7 +17,7 @@ local socketutil = {
 
 --- Builds a sensible UserAgent that fits Wikipedia's UA policy <https://meta.wikimedia.org/wiki/User-Agent_policy>
 local socket_ua = http.USERAGENT
-socketutil.USER_AGENT = "KOReader/" .. Version:getShortVersion() .. " (https://koreader.rocks/) " .. socket_ua:gsub(" ", "/")
+socketutil.USER_AGENT = "KOReader/" .. Version:getShortVersion() .. " (" .. Device:info() .. "; " .. jit.os .. "; " .. jit.arch .. ") " .. socket_ua:gsub(" ", "/")
 -- Monkey-patch it in LuaSocket, as it already takes care of inserting the appropriate header to its requests.
 http.USERAGENT = socketutil.USER_AGENT
 


### PR DESCRIPTION
Closes #10186, also see <https://github.com/koreader/koreader/issues/12953#issuecomment-2565973079>

Results in:

```
KOReader/2024.11-112 (Emulator; Linux; x64) LuaSocket/3.1.0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12977)
<!-- Reviewable:end -->
