### PR TITLE
Collections: filter by metadata

### DIFF
--- a/frontend/apps/filemanager/filemanagercollection.lua
+++ b/frontend/apps/filemanager/filemanagercollection.lua
@@ -258,23 +258,23 @@ end
 
 function FileManagerCollection:showCollDialog()
     local coll_dialog
-    local function genFilterByMetadataButton(text_, prop_)
+    local function genFilterByMetadataButton(button_text, button_prop)
         return {
-            text = text_,
+            text = button_text,
             callback = function()
                 UIManager:close(coll_dialog)
                 local prop_values = {}
                 for idx, item in ipairs(self.coll_menu.item_table) do
-                    local doc_prop = self.ui.bookinfo:getDocProps(item.file, nil, true)[prop_]
+                    local doc_prop = self.ui.bookinfo:getDocProps(item.file, nil, true)[button_prop]
                     if doc_prop == nil then
                         doc_prop = self.empty_prop
-                    elseif prop_ == "language" then
+                    elseif button_prop == "language" then
                         doc_prop = doc_prop:lower()
                     end
                     prop_values[doc_prop] = prop_values[doc_prop] or {}
                     table.insert(prop_values[doc_prop], idx)
                 end
-                self:showPropValueList(prop_, prop_values)
+                self:showPropValueList(button_prop, prop_values)
             end,
         }
     end


### PR DESCRIPTION
"Filter by ..." buttons in the popup menu:

![01](https://github.com/user-attachments/assets/a5c3d324-ccb9-4ac3-bc41-fe06c2e235c3)

On pressing, say, "Filter by language" we get the list of unique "language" props in the collection, showing number of books for each value:

![02](https://github.com/user-attachments/assets/bdb8bc4b-5b2a-4043-a1e8-83521663554d)

On pressing an item we get the list of books with the prop matching.

Filtered by one prop:

![03](https://github.com/user-attachments/assets/367832c0-d60d-47fc-954a-2d496c237696)

We can apply another filter to the filtered list. Filtered by two props:

![04](https://github.com/user-attachments/assets/0b1298a0-ec99-4179-8705-94bba9fa1aa2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12981)
<!-- Reviewable:end -->
