### PR TITLE
socketutil: use Device.model directly

### DIFF
--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -17,7 +17,7 @@ local socketutil = {
 
 --- Builds a sensible UserAgent that fits Wikipedia's UA policy <https://meta.wikimedia.org/wiki/User-Agent_policy>
 local socket_ua = http.USERAGENT
-socketutil.USER_AGENT = "KOReader/" .. Version:getShortVersion() .. " (" .. Device:info() .. "; " .. jit.os .. "; " .. jit.arch .. ") " .. socket_ua:gsub(" ", "/")
+socketutil.USER_AGENT = "KOReader/" .. Version:getShortVersion() .. " (" .. Device.model .. "; " .. jit.os .. "; " .. jit.arch .. ") " .. socket_ua:gsub(" ", "/")
 -- Monkey-patch it in LuaSocket, as it already takes care of inserting the appropriate header to its requests.
 http.USERAGENT = socketutil.USER_AGENT
 


### PR DESCRIPTION
Device:info() is multiline on Android, see https://github.com/koreader/koreader/pull/12977#issuecomment-2568355984

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12992)
<!-- Reviewable:end -->
