### PR TITLE
InputDialog: Make sure keyboard_visible is never nil'ed

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -614,7 +614,6 @@ function InputDialog:onShowKeyboard(ignore_first_hold_release)
     end
     -- NOTE: There's no VirtualKeyboard widget instantiated at all when readonly,
     --       and our input widget handles that itself, so we don't need any guards here.
-    --       (In which case, isKeyboardVisible will return `nil`, same as if we had a VK instantiated but *never* shown).
     self._input_widget:onShowKeyboard(ignore_first_hold_release)
     -- There's a bit of a chicken or egg issue in init where we would like to check the actual keyboard's visibility state,
     -- but the widget might not exist or be shown yet, so we'll just have to keep this in sync...

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -777,6 +777,8 @@ function InputText:isKeyboardVisible()
     if self.keyboard then
         return self.keyboard:isVisible()
     end
+    -- NOTE: Never return `nil`, to avoid inheritance issues in (Multi)InputDialog's keyboard_visible flag.
+    return false
 end
 
 function InputText:lockKeyboard(toggle)

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -781,7 +781,7 @@ end
 
 local VirtualKeyboard = FocusManager:extend{
     name = "VirtualKeyboard",
-    visible = nil,
+    visible = false,
     lock_visibility = false,
     covers_footer = true,
     modal = true,
@@ -846,10 +846,6 @@ function VirtualKeyboard:init()
     if self.uwrap_func then
         self.uwrap_func()
         self.uwrap_func = nil
-    end
-    -- NOTE: Make sure this is never actually `nil` to avoid inheritance issues for higher level widgets relying on it for their own visibility tracking...
-    if self.visible == nil then
-        self.visible = false
     end
     local lang = self:getKeyboardLayout()
     local keyboard_layout = self.lang_to_keyboard_layout[lang] or self.lang_to_keyboard_layout["en"]

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -847,6 +847,10 @@ function VirtualKeyboard:init()
         self.uwrap_func()
         self.uwrap_func = nil
     end
+    -- NOTE: Make sure this is never actually `nil` to avoid inheritance issues for higher level widgets relying on it for their own visibility tracking...
+    if self.visible == nil then
+        self.visible = false
+    end
     local lang = self:getKeyboardLayout()
     local keyboard_layout = self.lang_to_keyboard_layout[lang] or self.lang_to_keyboard_layout["en"]
     local keyboard = require("ui/data/keyboardlayouts/" .. keyboard_layout)


### PR DESCRIPTION
InputText:isKeyboardVisible could return nil when the keyboard was
already gone, which cleared the instance variable, meaning we end up
with the static class default instead, which is true...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/12994)
<!-- Reviewable:end -->
