### PR TITLE
Autodetect OCR language support files

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -833,7 +833,9 @@ function KoptInterface:getNativeOCRWord(doc, pageno, rect)
             kc.getTOCRWord, kc, "src",
             0, 0, word_w, word_h,
             self.tessocr_data, self.ocr_lang, self.ocr_type, 0, 1)
-        DocCache:insert(hash, CacheItem:new{ ocrword = word, size = #word + 64 }) -- estimation
+        if word then
+            DocCache:insert(hash, CacheItem:new{ ocrword = word, size = #word + 64 }) -- estimation
+        end
         logger.dbg("word", word)
         page:close()
         kc:free()

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -1,7 +1,6 @@
 local BD = require("ui/bidi")
 local Device = require("device")
 local IsoLanguage = require("ui/data/isolanguage")
-local lfs = require("libs/libkoreader-lfs")
 local optionsutil = require("ui/data/optionsutil")
 local util = require("util")
 local _ = require("gettext")
@@ -13,16 +12,7 @@ local FONT_SCALE_FACTORS = {0.2, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.3, 1.
 -- Font sizes used for the font size widget only
 local FONT_SCALE_DISPLAY_SIZE = {12, 14, 15, 16, 17, 18, 19, 20, 22, 25, 30, 35}
 
-local DKOPTREADER_CONFIG_DOC_LANGS_CODE = {}
-local tessocr_data_dir = require("document/koptinterface").tessocr_data or os.getenv("TESSDATA_PREFIX")
-if tessocr_data_dir and lfs.attributes(tessocr_data_dir, "mode") == "directory" then
-    for file in lfs.dir(tessocr_data_dir) do
-        if file and file ~= "." and file ~= ".." and file:sub(-12) == ".traineddata" then
-            table.insert(DKOPTREADER_CONFIG_DOC_LANGS_CODE, file:sub(1, -13))
-        end
-    end
-    table.sort(DKOPTREADER_CONFIG_DOC_LANGS_CODE)
-end
+local DKOPTREADER_CONFIG_DOC_LANGS_CODE = require("ui/data/ocr").getOCRLangs()
 
 local KOPTREADER_CONFIG_DOC_LANGS_TEXT = {}
 for _, lang in ipairs(DKOPTREADER_CONFIG_DOC_LANGS_CODE) do

--- a/frontend/ui/data/ocr.lua
+++ b/frontend/ui/data/ocr.lua
@@ -1,0 +1,31 @@
+local lfs = require("libs/libkoreader-lfs")
+
+local OCR = {}
+
+-- Returns a sorted array of detected Tesseract language codes.
+function OCR.getOCRLangs()
+    local langs = {}
+    local seen = {}
+    local candidates = {}
+    local ki = require("document/koptinterface").tessocr_data
+    if ki then table.insert(candidates, ki) end
+    local env = os.getenv("TESSDATA_PREFIX")
+    if env then
+        table.insert(candidates, env)
+        table.insert(candidates, env .. "/tessdata")
+    end
+    for _, dir in ipairs(candidates) do
+        if dir and lfs.attributes(dir, "mode") == "directory" then
+            for file in lfs.dir(dir) do
+                if file and file ~= "." and file ~= ".." and file:sub(-12) == ".traineddata" then
+                    local code = file:sub(1, -13)
+                    if not seen[code] then seen[code] = true; table.insert(langs, code) end
+                end
+            end
+        end
+    end
+    table.sort(langs)
+    return langs
+end
+
+return OCR

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -347,6 +347,8 @@ function ConfigOption:init()
                     return math.abs(val1 - val2)
                 elseif type(val1) == "string" then
                     return val1 == val2 and 0 or 1
+                elseif val1 == nil then
+                    return 1
                 end
             end
             if self.options[c].name then


### PR DESCRIPTION
Messing about with advanced settings is kind of annoying, isn't it?

In reply to <https://github.com/koreader/koreader/issues/11147#issuecomment-2571602782>.

<img src=https://github.com/user-attachments/assets/033a4812-06ac-470a-b239-d477022b969e width=40%> <img src=https://github.com/user-attachments/assets/bfe0415f-e99f-4060-98bc-cf2d55f538dc width=40%>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13004)
<!-- Reviewable:end -->
