### PR TITLE
Reduce sleep screen message's font size to fit one line

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -650,6 +650,7 @@ function Screensaver:show()
                 text = screensaver_message,
                 readonly = true,
                 dismissable = false,
+                shrink_to_fit = true,
             }
         else
             local face = Font:getFace("infofont")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -650,7 +650,7 @@ function Screensaver:show()
                 text = screensaver_message,
                 readonly = true,
                 dismissable = false,
-                shrink_to_fit = true,
+                cap_height_to_one_line = true,
             }
         else
             local face = Font:getFace("infofont")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -650,7 +650,7 @@ function Screensaver:show()
                 text = screensaver_message,
                 readonly = true,
                 dismissable = false,
-                cap_height_to_one_line = true,
+                force_one_line = true,
             }
         else
             local face = Font:getFace("infofont")

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -181,7 +181,7 @@ function InfoMessage:init()
     end
 
     if self.shrink_to_fit then
-        self:shrinkFontToFit(frame, text_widget, 0.07) 
+        self:shrinkFontToFit(frame, text_widget, 0.07)
     end
 
     if self.show_delay then
@@ -262,7 +262,7 @@ end
 function InfoMessage:shrinkFontToFit(frame, text_widget, height_threshold)
     local cur_size = frame:getSize()
     if cur_size and cur_size.h > height_threshold * Screen:getHeight() then
-        local orig_font = text_widget.face.orig_font 
+        local orig_font = text_widget.face.orig_font
         local orig_size = text_widget.face.orig_size
         local real_size = text_widget.face.size
         if orig_size > 10 then -- don't go too small

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -180,23 +180,8 @@ function InfoMessage:init()
     if not self.height then
         local max_height
         if self.cap_height_to_one_line then
-            -- Create a dummy text widget to get single line height
-            local dummy_widget = TextBoxWidget:new{
-            text = "XdgfhTipqy",
-            face = self.face,
-            width = text_width,
-            }
-            local dummy_frame = FrameContainer:new{
-                HorizontalGroup:new{
-                    align = "center",
-                    image_widget,
-                    HorizontalSpan:new{ width = (self.show_icon and Size.span.horizontal_default or 0) },
-                    dummy_widget,
-                }
-            }
-            max_height = dummy_frame:getSize().h + 3 -- 3 is a magic number to give it some wiggle room
-            dummy_widget:free()
-            dummy_frame:free()
+            local icon_height = self.show_icon and image_widget:getSize().h or 0
+            max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding + 3 -- 3 is a magic number to give it some wiggle room
         else
             max_height = Screen:getHeight() * 0.95
         end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -176,12 +176,10 @@ function InfoMessage:init()
         dimen = Screen:getSize(),
         self.movable,
     }
-    if not self.height then
-        self:shrinkFontToFit(frame, text_widget, 0.95)
-    end
-
     if self.shrink_to_fit then
         self:shrinkFontToFit(frame, text_widget, 0.07)
+    elseif not self.height then
+        self:shrinkFontToFit(frame, text_widget, 0.95)
     end
 
     if self.show_delay then

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -179,7 +179,7 @@ function InfoMessage:init()
 
     if not self.height then
         local max_height
-        if self.force_one_line then
+        if self.force_one_line and not self.text:find("\n") then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
             -- Calculate the size of the frame container when it's only displaying one line.
             max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -181,7 +181,8 @@ function InfoMessage:init()
         local max_height
         if self.cap_height_to_one_line then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
-            max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding + 3 -- 3 is a magic number to give it some wiggle room
+            -- calculate the size of the frame container when it's only displaying one line, and add a magic number (3) to give it some wiggle room
+            max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding + 3
         else
             max_height = Screen:getHeight() * 0.95
         end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -76,6 +76,7 @@ local InfoMessage = InputContainer:extend{
     show_delay = nil,
     -- Set to true when it might be displayed after some processing, to avoid accidental dismissal
     flush_events_on_show = false,
+    shrink_to_fit = false,
 }
 
 function InfoMessage:init()
@@ -176,28 +177,11 @@ function InfoMessage:init()
         self.movable,
     }
     if not self.height then
-        -- Reduce font size until widget fit screen height if needed
-        local cur_size = frame:getSize()
-        if cur_size and cur_size.h > 0.95 * Screen:getHeight() then
-            local orig_font = text_widget.face.orig_font
-            local orig_size = text_widget.face.orig_size
-            local real_size = text_widget.face.size
-            if orig_size > 10 then -- don't go too small
-                while true do
-                    orig_size = orig_size - 1
-                    self.face = Font:getFace(orig_font, orig_size)
-                    -- scaleBySize() in Font:getFace() may give the same
-                    -- real font size even if we decreased orig_size,
-                    -- so check we really got a smaller real font size
-                    if self.face.size < real_size then
-                        break
-                    end
-                end
-                -- re-init this widget
-                self:free()
-                self:init()
-            end
-        end
+        self:shrinkFontToFit(frame, text_widget, 0.95)
+    end
+
+    if self.shrink_to_fit then
+        self:shrinkFontToFit(frame, text_widget, 0.07) 
     end
 
     if self.show_delay then
@@ -272,6 +256,30 @@ end
 function InfoMessage:getVisibleArea()
     if not self.invisible then
         return self.movable.dimen
+    end
+end
+
+function InfoMessage:shrinkFontToFit(frame, text_widget, height_threshold)
+    local cur_size = frame:getSize()
+    if cur_size and cur_size.h > height_threshold * Screen:getHeight() then
+        local orig_font = text_widget.face.orig_font 
+        local orig_size = text_widget.face.orig_size
+        local real_size = text_widget.face.size
+        if orig_size > 10 then -- don't go too small
+            while true do
+                orig_size = orig_size - 1
+                self.face = Font:getFace(orig_font, orig_size)
+                -- scaleBySize() in Font:getFace() may give the same
+                -- real font size even if we decreased orig_size,
+                -- so check we really got a smaller real font size
+                if self.face.size < real_size then
+                    break
+                end
+            end
+            -- re-init this widget
+            self:free()
+            self:init()
+        end
     end
 end
 

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -181,7 +181,7 @@ function InfoMessage:init()
         local max_height
         if self.force_one_line then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
-            -- calculate the size of the frame container when it's only displaying one line.
+            -- Calculate the size of the frame container when it's only displaying one line.
             max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding
         else
             max_height = Screen:getHeight() * 0.95

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -53,7 +53,7 @@ local InfoMessage = InputContainer:extend{
     _timeout_func = nil,
     width = nil,  -- The width of the InfoMessage. Keep it nil to use default value.
     height = nil,  -- The height of the InfoMessage. If this field is set, a scrollbar may be shown.
-    cap_height_to_one_line = false,  -- Attempt to show text in one single line. This setting and height are not to be used conjointly.
+    force_one_line = false,  -- Attempt to show text in one single line. This setting and height are not to be used conjointly.
     -- The image shows at the left of the InfoMessage. Image data will be freed
     -- by InfoMessage, caller should not manage its lifecycle
     image = nil,
@@ -179,10 +179,10 @@ function InfoMessage:init()
 
     if not self.height then
         local max_height
-        if self.cap_height_to_one_line then
+        if self.force_one_line then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
-            -- calculate the size of the frame container when it's only displaying one line, and add a magic number (3) to give it some wiggle room
-            max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding + 3
+            -- calculate the size of the frame container when it's only displaying one line.
+            max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding
         else
             max_height = Screen:getHeight() * 0.95
         end


### PR DESCRIPTION
### what's new


* Introduced the `force_one_line` property to the `InfoMessage` class to attempt to show text in a single line.
* Modified the `InfoMessage:init()` function to calculate the maximum height of the widget based on the `force_one_line` property, ensuring that the text fits within the specified constraints.
* Added the `force_one_line` property to the `Screensaver:show()` function to ensure the sleep screen message is displayed in a single line.



### screenshots

<p align="center">
before/after
</p> 
<p align="center">
<img src="https://github.com/koreader/koreader/assets/97603719/fa598ee9-dc49-4f9a-a9ce-8a11f1311e9e" width=40% height=40%>
<img src="https://github.com/user-attachments/assets/b9c728f9-4909-4c09-b127-ace712652fda" width=40% height=40%> 
</p>

fix #12109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13026)
<!-- Reviewable:end -->
