### PR TITLE
[plugin] NewsDownloader: use first feed description if it's a table in RSS

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -523,7 +523,7 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
         local feed_description
         if feed_type == FEED_TYPE_RSS then
             feed_title = feed.title
-            feed_description = feed.description
+            feed_description = feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
             if feed["content:encoded"] ~= nil then
                 -- Spec: https://web.resource.org/rss/1.0/modules/content/
                 feed_description = feed["content:encoded"]


### PR DESCRIPTION
Similar to the logic for Atom in #12959.

Reported in https://github.com/koreader/koreader/issues/12953#issuecomment-2580784621

Sample feed https://www.engadget.com/rss.xml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13032)
<!-- Reviewable:end -->
