### PR TITLE
processImg: skip data URI

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -699,7 +699,7 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
             return nil
         end
         if src:sub(1,5) == "data:" then
-            logger.dbg("NewsDownloader: skipping data URI")
+            logger.dbg("skipping data URI", src)
             return nil
         end
         if src:sub(1,2) == "//" then

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -698,6 +698,10 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
             logger.info("no src found in ", img_tag)
             return nil
         end
+        if src:sub(1,5) == "data:" then
+            logger.dbg("NewsDownloader: skipping data URI")
+            return nil
+        end
         if src:sub(1,2) == "//" then
             src = "https:" .. src -- Wikipedia redirects from http to https, so use https
         elseif src:sub(1,1) == "/" then -- non absolute url

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -339,6 +339,10 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
             logger.dbg("no src found in ", img_tag)
             return nil
         end
+        if src:sub(1,5) == "data:" then
+            logger.dbg("NewsDownloader: skipping data URI")
+            return nil
+        end
         if src:sub(1,2) == "//" then
             src = "https:" .. src -- Wikipedia redirects from http to https, so use https
         elseif src:sub(1,1) == "/" then -- non absolute url

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -340,7 +340,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
             return nil
         end
         if src:sub(1,5) == "data:" then
-            logger.dbg("NewsDownloader: skipping data URI")
+            logger.dbg("skipping data URI", src)
             return nil
         end
         if src:sub(1,2) == "//" then


### PR DESCRIPTION
This is the underlying reason that The Verge + download full article fails, see <https://github.com/koreader/koreader/issues/12953#issuecomment-2580784621>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13034)
<!-- Reviewable:end -->
