### PR TITLE
Annotations: fix matchFunc

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -350,8 +350,7 @@ function ReaderAnnotation:getMatchFunc()
     if self.ui.rolling then
         doesMatch = function(a, b)
             if (a.datetime ~= nil and b.datetime ~= nil and a.datetime ~= b.datetime)
-                    or (not a.drawer) ~= (not b.drawer)
-                    or a.page ~= b.page
+                    or a.pos0 ~= b.pos0
                     or a.pos1 ~= b.pos1 then
                 return false
             end
@@ -360,7 +359,6 @@ function ReaderAnnotation:getMatchFunc()
     else
         doesMatch = function(a, b)
             if (a.datetime ~= nil and b.datetime ~= nil and a.datetime ~= b.datetime)
-                    or (not a.drawer) ~= (not b.drawer)
                     or a.page ~= b.page
                     or (a.pos0 and (a.pos0.x ~= b.pos0.x or a.pos1.x ~= b.pos1.x
                                  or a.pos0.y ~= b.pos0.y or a.pos1.y ~= b.pos1.y)) then


### PR DESCRIPTION
Compare only datetime and start/end positions, it's enough.
Closes https://github.com/koreader/koreader/issues/13030.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13037)
<!-- Reviewable:end -->
