### PR TITLE
[plugin] Gestures, Hotkeys: attempt to work around corrupted gestures file

### DIFF
--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -147,7 +147,7 @@ function Gestures:init()
     if not self.settings_data then
         self.settings_data = LuaSettings:open(gestures_path)
         if not next(self.settings_data.data) then
-            logger.dbg("No gestures file or invalid gestures file found, copying defaults")
+            logger.warn("No gestures file or invalid gestures file found, copying defaults")
             self.settings_data:purge()
             FFIUtil.copyFile(defaults_path, gestures_path)
             self.settings_data = LuaSettings:open(gestures_path)

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -16,7 +16,6 @@ local Screen = require("device").screen
 local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
 local T = FFIUtil.template
@@ -140,9 +139,6 @@ end
 
 function Gestures:init()
     local defaults_path = FFIUtil.joinPath(self.path, "defaults.lua")
-    if not lfs.attributes(gestures_path, "mode") then
-        FFIUtil.copyFile(defaults_path, gestures_path)
-    end
     self.ignore_hold_corners = G_reader_settings:isTrue("ignore_hold_corners")
     self.multiswipes_enabled = G_reader_settings:isTrue("multiswipes_enabled")
     self.is_docless = self.ui == nil or self.ui.document == nil
@@ -150,6 +146,12 @@ function Gestures:init()
     self.defaults = LuaSettings:open(defaults_path).data[self.ges_mode]
     if not self.settings_data then
         self.settings_data = LuaSettings:open(gestures_path)
+        if not next(self.settings_data.data) then
+            logger.dbg("No gestures file or invalid gestures file found, copying defaults")
+            self.settings_data:purge()
+            FFIUtil.copyFile(defaults_path, gestures_path)
+            self.settings_data = LuaSettings:open(gestures_path)
+        end
     end
     self.gestures = self.settings_data.data[self.ges_mode]
     self.custom_multiswipes = self.settings_data.data["custom_multiswipes"]

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -104,7 +104,7 @@ function HotKeys:init()
     if not self.settings_data then
         self.settings_data = LuaSettings:open(hotkeys_path)
         if not next(self.settings_data.data) then
-            logger.dbg("No hotkeys file or invalid hotkeys file found, copying defaults")
+            logger.warn("No hotkeys file or invalid hotkeys file found, copying defaults")
             self.settings_data:purge()
             FFIUtil.copyFile(defaults_path, hotkeys_path)
             self.settings_data = LuaSettings:open(hotkeys_path)

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -5,7 +5,6 @@ local FFIUtil = require("ffi/util")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LuaSettings = require("luasettings")
 local UIManager = require("ui/uimanager")
-local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
 local T = FFIUtil.template
@@ -99,14 +98,17 @@ end
 
 function HotKeys:init()
     local defaults_path = FFIUtil.joinPath(self.path, "defaults.lua")
-    if not lfs.attributes(hotkeys_path, "mode") then
-        FFIUtil.copyFile(defaults_path, hotkeys_path)
-    end
     self.is_docless = self.ui == nil or self.ui.document == nil
     self.hotkey_mode = self.is_docless and "hotkeys_fm" or "hotkeys_reader"
     self.defaults = LuaSettings:open(defaults_path).data[self.hotkey_mode]
     if not self.settings_data then
         self.settings_data = LuaSettings:open(hotkeys_path)
+        if not next(self.settings_data.data) then
+            logger.dbg("No hotkeys file or invalid hotkeys file found, copying defaults")
+            self.settings_data:purge()
+            FFIUtil.copyFile(defaults_path, hotkeys_path)
+            self.settings_data = LuaSettings:open(hotkeys_path)
+        end
     end
     self.hotkeys = self.settings_data.data[self.hotkey_mode]
     self.type_to_search = self.settings_data.data["type_to_search"] or false


### PR DESCRIPTION
See #13009 for details.

LuaSettings attempts to read a backup if the main doesn't work. If that doesn't work it returns an empty `data` table. But gestures expects there to be defaults inside.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13054)
<!-- Reviewable:end -->
