### PR TITLE
feat(readerdictionary): add ability to use kiwix standalone

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -59,6 +59,7 @@ local external = require("device/thirdparty"):new{
         { "GoldenFree", "GoldenDict Free", false, "mobi.goldendict.android.free", "send" },
         { "GoldenPro", "GoldenDict Pro", false, "mobi.goldendict.android", "send" },
         { "Kiwix", "Kiwix", false, "org.kiwix.kiwixmobile", "text" },
+        { "Kiwix (FDroid)", "Kiwix (FDroid)", false, "org.kiwix.kiwixmobile.standalone", "text" },
         { "LookUp", "Look Up", false, "gaurav.lookup", "send" },
         { "LookUpPro", "Look Up Pro", false, "gaurav.lookuppro", "send" },
         { "Mdict", "Mdict", false, "cn.mdict", "send" },


### PR DESCRIPTION
Problem: when you install Kiwix from FDroid or as a standalone apk (ergo not via
the Play Store) it installs as `org.kiwix.kiwixmobile.standalone`, which before
this commit isn't supported.

This commit simply just adds it as a seperate option :)

I know it's a one-line change but I figured I'd just submit it so you can add it if you want, other might benefit from it too.
