### PR TITLE
Hide sleep screen covers for finished books

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -1,4 +1,5 @@
 local Device = require("device")
+local DocSettings = require("docsettings")
 local Screensaver = require("ui/screensaver")
 local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
@@ -38,6 +39,19 @@ return {
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),
+            {
+                text = _("Hide sleep screen covers for finished books"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == "cover"
+                end,
+                checked_func = function()
+                    return G_reader_settings:isTrue("screensaver_exclude_finished_books")
+                end,
+                callback = function()
+                    G_reader_settings:toggle("screensaver_exclude_finished_books")
+                end,
+                separator = true,
+            },
             {
                 text = _("Border fill, rotation, and fit"),
                 enabled_func = function()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -58,6 +58,9 @@ end
 if G_reader_settings:hasNot("screensaver_hide_fallback_msg") then
     G_reader_settings:makeFalse("screensaver_hide_fallback_msg")
 end
+if G_reader_settings:hasNot("screensaver_exclude_finished_books") then
+    G_reader_settings:makeFalse("screensaver_exclude_finished_books")
+end
 
 local Screensaver = {
     default_screensaver_message = _("Sleeping"),

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -449,6 +449,15 @@ function Screensaver:setup(event, event_message)
             else
                 doc_settings = DocSettings:open(lastfile)
             end
+            if G_reader_settings:isTrue("screensaver_exclude_finished_books") then
+                local book_summary = doc_settings:readSetting("summary")
+                if book_summary and book_summary.status == "complete" then
+                    doc_settings:makeTrue("exclude_screensaver")
+                    self.show_message = false
+                else
+                    doc_settings:makeFalse("exclude_screensaver")
+                end
+            end
             excluded = doc_settings:isTrue("exclude_screensaver")
         else
             -- No DocSetting, not excluded

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -453,20 +453,17 @@ function Screensaver:setup(event, event_message)
                 doc_settings = DocSettings:open(lastfile)
             end
             local book_summary = doc_settings:readSetting("summary")
-            if G_reader_settings:isTrue("screensaver_exclude_finished_books") then
-                if book_summary and book_summary.status == "complete" then
-                    doc_settings:makeTrue("exclude_screensaver")
+            local exclude_finished_books = G_reader_settings:isTrue("screensaver_exclude_finished_books")
+            local book_finished = book_summary and book_summary.status == "complete"
+            if exclude_finished_books and book_finished then
+                doc_settings:makeTrue("exclude_screensaver_finished")
+                if self.show_message then
                     self.show_message = false
                 end
             else
-                if book_summary and book_summary.status == "complete" then
-                    doc_settings:makeFalse("exclude_screensaver")
-                    if G_reader_settings:isTrue("screensaver_show_message") then
-                        self.show_message = true
-                    end
-                end
+                doc_settings:makeFalse("exclude_screensaver_finished")
             end
-            excluded = doc_settings:isTrue("exclude_screensaver")
+            excluded = doc_settings:isTrue("exclude_screensaver") or doc_settings:isTrue("exclude_screensaver_finished")
         else
             -- No DocSetting, not excluded
             excluded = false

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -449,13 +449,18 @@ function Screensaver:setup(event, event_message)
             else
                 doc_settings = DocSettings:open(lastfile)
             end
+            local book_summary = doc_settings:readSetting("summary")
             if G_reader_settings:isTrue("screensaver_exclude_finished_books") then
-                local book_summary = doc_settings:readSetting("summary")
                 if book_summary and book_summary.status == "complete" then
                     doc_settings:makeTrue("exclude_screensaver")
                     self.show_message = false
-                else
+                end
+            else
+                if book_summary and book_summary.status == "complete" then
                     doc_settings:makeFalse("exclude_screensaver")
+                    if G_reader_settings:isTrue("screensaver_show_message") then
+                        self.show_message = true
+                    end
                 end
             end
             excluded = doc_settings:isTrue("exclude_screensaver")


### PR DESCRIPTION
### what's new

This pull request introduces a new feature to allow users to hide sleep screen covers for finished books.

* [`frontend/ui/elements/screensaver_menu.lua`](diffhunk://#diff-3982e81823bb1df13fdf234b0087be5bef2fb5f744be693b20fce2d8f833692cR42-R54): Added a new menu item "Hide sleep screen covers for finished books" with corresponding functions to check and toggle the setting.
* [`frontend/ui/screensaver.lua`](diffhunk://#diff-ca0df032a2d2a54f0d1c18b7372a594335ef10c6fb9ecd1042b2a710cdc1f327R452-R460): Modified the `setup` function to check if the new setting is enabled and to exclude finished books from the screensaver if applicable.

### screenshots

<p align="center">
hide cover off / hide cover on
</p> 
<p align="center">
<img src="https://github.com/user-attachments/assets/9080e964-0799-430c-b41b-f90c6937d32d" width=40% height=40%> 
<img src="https://github.com/user-attachments/assets/a3959ba5-53c9-4d15-9e20-445989293ada" width=40% height=40%>
</p>

<p align="center">
<img src="https://github.com/user-attachments/assets/e5b3e012-88a4-4bfb-95fe-689b021f9a35" width=40% height=40%> 
</p>

* fix #11080