### PR TITLE
[plugin] NewsDownloader: make <title> match less greedy

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -321,7 +321,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local base_url = socket_url.parse(url)
 
     local cancelled = false
-    local page_htmltitle = html:match([[<title>(.*)</title>]])
+    local page_htmltitle = html:match([[<title>(.-)</title>]])
     logger.dbg("page_htmltitle is ", page_htmltitle)
 --    local sections = html.sections -- Wikipedia provided TOC
     local bookid = "bookid_placeholder" --string.format("wikipedia_%s_%s_%s", lang, phtml.pageid, phtml.revid)


### PR DESCRIPTION
On most pages it works fine, but on pages with multiple </title> it can match very large amounts of text.

Valid examples include <svg> in the HTML, where <title> is used similar to title="" in HTML, but of course there could also simply be invalid pages.