### PR TITLE
kosync: Make sure there are no leading or trailing whitespaces.

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -139,7 +139,7 @@ end
 local function validate(entry)
     if not entry then return false end
     if type(entry) == "string" then
-        if entry == "" or not entry:match("%S") then return false end
+        if entry == "" or not entry:match("^%S+$") then return false end
     end
     return true
 end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -136,10 +136,6 @@ local function showSyncError()
     })
 end
 
-local function trim(entry)
-    return entry:match("^%s*(.-)%s*$")
-end
-
 local function validate(entry)
     if not entry then return false end
     if type(entry) == "string" then
@@ -451,7 +447,7 @@ function KOSync:login(menu)
                     text = _("Login"),
                     callback = function()
                         local username, password = unpack(dialog:getFields())
-                        username = trim(username)
+                        username = util.trim(username)
                         local ok, err = validateUser(username, password)
                         if not ok then
                             UIManager:show(InfoMessage:new{
@@ -474,7 +470,7 @@ function KOSync:login(menu)
                     text = _("Register"),
                     callback = function()
                         local username, password = unpack(dialog:getFields())
-                        username = trim(username)
+                        username = util.trim(username)
                         local ok, err = validateUser(username, password)
                         if not ok then
                             UIManager:show(InfoMessage:new{

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -143,7 +143,7 @@ end
 local function validate(entry)
     if not entry then return false end
     if type(entry) == "string" then
-        if entry == "" or not entry:match("^%S+$") then return false end
+        if entry == "" or not entry:match("%S") then return false end
     end
     return true
 end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -136,6 +136,10 @@ local function showSyncError()
     })
 end
 
+local function trim(entry)
+    return entry:match("^%s*(.-)%s*$")
+end
+
 local function validate(entry)
     if not entry then return false end
     if type(entry) == "string" then
@@ -447,6 +451,7 @@ function KOSync:login(menu)
                     text = _("Login"),
                     callback = function()
                         local username, password = unpack(dialog:getFields())
+                        username = trim(username)
                         local ok, err = validateUser(username, password)
                         if not ok then
                             UIManager:show(InfoMessage:new{
@@ -469,6 +474,7 @@ function KOSync:login(menu)
                     text = _("Register"),
                     callback = function()
                         local username, password = unpack(dialog:getFields())
+                        username = trim(username)
                         local ok, err = validateUser(username, password)
                         if not ok then
                             UIManager:show(InfoMessage:new{


### PR DESCRIPTION
This should fix #13076 (if desired).

As said in the issue, one disadvantage is that existing (in my opinion incorrect) user names would become invalid.
(Another one is that since validate() is also used for passwords, it won't be possible to have whitespaces in passwords.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13077)
<!-- Reviewable:end -->
