### PR TITLE
Gesture manager and Profiles: improve Dispatcher actions menu

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -976,6 +976,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         end,
         callback = function(touchmenu_instance)
             local function do_remove()
+                local actions = location[settings]
                 local name = actions and actions.settings and actions.settings.name
                 location[settings] = name and { settings = { name = name } } or {}
                 caller.updated = true

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -83,10 +83,17 @@ function SortItemWidget:init()
                     dimen = Geom:new{ w = checked_widget:getSize().w },
                     self.checkmark_widget,
                 },
-                TextWidget:new{
-                    text = self.item.text,
-                    max_width = text_max_width,
-                    face = self.item.face or self.face,
+                VerticalGroup:new{
+                    align = "left",
+                    TextWidget:new{
+                        text = self.item.text,
+                        max_width = text_max_width,
+                        face = self.item.face or self.face,
+                    },
+                    self.show_parent.underscore_checked_item and item_checked and LineWidget:new{
+                        dimen = Geom:new{ w = text_max_width, h = Size.line.thick },
+                        background = Blitbuffer.COLOR_DARK_GRAY,
+                    },
                 },
             },
         },

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -921,7 +921,9 @@ function TouchMenu:onMenuSelect(item, tap_on_checkmark)
                 -- must set keep_menu_open=true if that is wished)
                 callback(self)
                 if refresh then
-                    self:updateItems()
+                    if not item.no_refresh_on_check then
+                        self:updateItems()
+                    end
                 elseif not item.keep_menu_open then
                     self:closeMenu()
                 end

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -207,7 +207,7 @@ function Profiles:getSubMenuItems()
             },
             {
                 text_func = function()
-                    return T(_("Edit actions: (%1)"), Dispatcher:menuTextFunc(v))
+                    return T(_("Edit actions: (%1)"), Dispatcher:menuTextFunc(self.data[k]))
                 end,
                 sub_item_table_func = function()
                     local edit_actions_sub_items = {}
@@ -259,7 +259,6 @@ function Profiles:getSubMenuItems()
             {
                 text = _("Delete"),
                 keep_menu_open = true,
-                separator = true,
                 callback = function(touchmenu_instance)
                     UIManager:show(ConfirmBox:new{
                         text = _("Do you want to delete this profile?"),
@@ -278,6 +277,7 @@ function Profiles:getSubMenuItems()
                         end,
                     })
                 end,
+                separator = true,
             },
         }
         table.insert(sub_item_table, {
@@ -545,6 +545,7 @@ function Profiles:genAutoExecPathChangedMenuItem(text, event, profile_name, sepa
                         local value = util.tableGetValue(self.autoexec, event, profile_name, conditions[i][2])
                         return value and txt .. ": " .. value or txt
                     end,
+                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[i][2])
                     end,
@@ -672,6 +673,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                                     local txt = util.tableGetValue(self.autoexec, event, profile_name, condition, prop)
                                     return txt and title .. " " .. txt or title:sub(1, -2)
                                 end,
+                                no_refresh_on_check = true,
                                 checked_func = function()
                                     return util.tableGetValue(self.autoexec, event, profile_name, condition, prop) and true
                                 end,
@@ -741,6 +743,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     enabled_func = function()
                         return not util.tableGetValue(self.autoexec, event_always, profile_name)
                     end,
+                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[3][2]) and true
                     end,
@@ -805,6 +808,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     enabled_func = function()
                         return not util.tableGetValue(self.autoexec, event_always, profile_name)
                     end,
+                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[4][2]) and true
                     end,


### PR DESCRIPTION
**(1)** Actions menu: ask to remove several actions when choosing Default, Pass through or Nothing. Closes https://github.com/koreader/koreader/issues/10534.

![01](https://github.com/user-attachments/assets/8522ca29-7275-4d64-bc56-65e51c5b037b)

**(2)** "Arrange actions" is available iff number of actions is greater than 1.
Actions are always ordered, in the order of adding until manual sorting, hence no checkbox in the menu.

![02](https://github.com/user-attachments/assets/010c38ba-65b9-49bb-bea1-e6f213ed7714)

**(3)** Remove "QuickMenu" header for gestures. Closes https://github.com/koreader/koreader/issues/12827.

![03](https://github.com/user-attachments/assets/9135551b-058e-41a3-aeac-429b1ac22543)

**(4)** QuickMenu separators can be set in the Sorting widget (via SortWidget checkboxes). Closes https://github.com/koreader/koreader/issues/13056.

![04](https://github.com/user-attachments/assets/e88db83c-cd97-4161-b641-0a27852953ab)

![05](https://github.com/user-attachments/assets/edbb79b3-0fb7-4ec7-835a-9a87e1617288)

![06](https://github.com/user-attachments/assets/150646b4-8b12-4848-bcff-1c1a7f396b84)

**(5)** Other minor fixes in actions menu appearance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13078)
<!-- Reviewable:end -->
