### PR TITLE
[screensaver] Add option to cycle through folder images

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -70,28 +70,6 @@ function filemanagerutil.getRandomFile(dir, match_func)
     end
 end
 
--- This function is almost the same as getRandomFile, but returns a list of files instead of a single file
-function filemanagerutil.getFiles(dir, match_func)
-    if not dir:match("/$") then
-        dir = dir .. "/"
-    end
-    local files = {}
-    local ok, iter, dir_obj = pcall(lfs.dir, dir)
-    if ok then
-        for entry in iter, dir_obj do
-            local file = dir .. entry
-            if lfs.attributes(file, "mode") == "file" and match_func(file) then
-                table.insert(files, file)
-            end
-        end
-        if #files == 0 then
-            -- return nil if no files found, to distinguish from an empty list
-            return nil
-        end
-    end
-    return files
-end
-
 -- Purge doc settings except kept
 function filemanagerutil.resetDocumentSettings(file)
     local settings_to_keep = {

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -70,6 +70,28 @@ function filemanagerutil.getRandomFile(dir, match_func)
     end
 end
 
+-- This function is almost the same as getRandomFile, but returns a list of files instead of a single file
+function filemanagerutil.getFiles(dir, match_func)
+    if not dir:match("/$") then
+        dir = dir .. "/"
+    end
+    local files = {}
+    local ok, iter, dir_obj = pcall(lfs.dir, dir)
+    if ok then
+        for entry in iter, dir_obj do
+            local file = dir .. entry
+            if lfs.attributes(file, "mode") == "file" and match_func(file) then
+                table.insert(files, file)
+            end
+        end
+        if #files == 0 then
+            -- return nil if no files found, to distinguish from an empty list
+            return nil
+        end
+    end
+    return files
+end
+
 -- Purge doc settings except kept
 function filemanagerutil.resetDocumentSettings(file)
     local settings_to_keep = {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -162,7 +162,7 @@ return {
                         separator = true,
                     },
                     {
-                        text = _("Cycle through images in order rather than randomly"),
+                        text = _("Cycle through images in order"),
                         help_text = _("When enabled, all images (up to 128) will be displayed at least once on the sleep screen in sequence before repeating the cycle."),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -162,8 +162,8 @@ return {
                         separator = true,
                     },
                     {
-                        text = _("Show images in alphabetical order"),
-                        help_text = _("When enabled, images will be shown in alphabetical order rather than in random order."),
+                        text = _("Show images in sequence instead of randomly"),
+                        help_text = _("When enabled, all images (up to 128) will be displayed at least once on the sleep screen in sequence before repeating the cycle."),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"
                         end,

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -34,7 +34,8 @@ return {
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image or cover on sleep screen"), "screensaver_type", "document_cover"),
-            genMenuItem(_("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
+            genMenuItem(G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") and _("Show cycled images on sleep screen")
+                or _("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -34,8 +34,7 @@ return {
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image or cover on sleep screen"), "screensaver_type", "document_cover"),
-            genMenuItem(G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") and _("Show cycled images from folder on sleep screen")
-                or _("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
+            genMenuItem(_("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),
             genMenuItem(_("Leave screen as-is"), "screensaver_type", "disable", nil, true),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -34,7 +34,7 @@ return {
         sub_item_table = {
             genMenuItem(_("Show book cover on sleep screen"), "screensaver_type", "cover", hasLastFile),
             genMenuItem(_("Show custom image or cover on sleep screen"), "screensaver_type", "document_cover"),
-            genMenuItem(G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") and _("Show cycled images on sleep screen")
+            genMenuItem(G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") and _("Show cycled images from folder on sleep screen")
                 or _("Show random image from folder on sleep screen"), "screensaver_type", "random_image"),
             genMenuItem(_("Show reading progress on sleep screen"), "screensaver_type", "readingprogress", isReaderProgressEnabled),
             genMenuItem(_("Show book status on sleep screen"), "screensaver_type", "bookstatus", hasLastFile),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -162,7 +162,7 @@ return {
                         separator = true,
                     },
                     {
-                        text = _("Show images in sequence instead of randomly"),
+                        text = _("Cycle through images in order rather than randomly"),
                         help_text = _("When enabled, all images (up to 128) will be displayed at least once on the sleep screen in sequence before repeating the cycle."),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -159,6 +159,20 @@ return {
                         callback = function()
                             Screensaver:chooseFolder()
                         end,
+                        separator = true,
+                    },
+                    {
+                        text = _("Show images in alphabetical order"),
+                        help_text = _("When enabled, images will be shown in alphabetical order rather than random order. Please note that numbers are sorted lexicographically, so they will be sorted like this: 1, 10, 11, 2, 20, 21, ..."),
+                        enabled_func = function()
+                            return G_reader_settings:readSetting("screensaver_type") == "random_image"
+                        end,
+                        checked_func = function()
+                            return G_reader_settings:isTrue("screensaver_cycle_images_alphabetically")
+                        end,
+                        callback = function()
+                            G_reader_settings:flipNilOrFalse("screensaver_cycle_images_alphabetically")
+                        end,
                     },
                 },
             },

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -163,7 +163,7 @@ return {
                     },
                     {
                         text = _("Show images in alphabetical order"),
-                        help_text = _("When enabled, images will be shown in alphabetical order rather than random order. Please note that numbers are sorted lexicographically, so they will be sorted like this: 1, 10, 11, 2, 20, 21, ..."),
+                        help_text = _("When enabled, images will be shown in alphabetical order rather than in random order."),
                         enabled_func = function()
                             return G_reader_settings:readSetting("screensaver_type") == "random_image"
                         end,

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -91,8 +91,7 @@ local function _getRandomImage(dir)
         if not files then return end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
         local sort = require("frontend/sort")
-        local natsort, cache
-        natsort, cache = sort.natsort_cmp()
+        local natsort, cache = sort.natsort_cmp()
         table.sort(files, function(a, b)
             return natsort(a, b)
         end)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -96,6 +96,10 @@ local function _getRandomImage(dir)
             end
         end, false)
         if #files == 0 then return end
+        -- Slippery slope detected! Ensure the number of files does not exceed 128 to prevent performance issues.
+        if #files > 128 then -- this seems like a reasonable [arbitrary] limit
+            files = {table.unpack(files, 1, 128)}
+        end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
         local sort = require("frontend/sort")
         local natsort = sort.natsort_cmp()

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -103,14 +103,13 @@ local function _getRandomImage(dir)
         end)
         local elapsed_time = os.clock() - start_time
         if elapsed_time > 0.5 then -- threshold in seconds
-            logger.warn("Screensaver, finding and sorting files took: " .. elapsed_time .. " seconds")
+            logger.warn("Screensaver: finding and sorting files alphabetically took " .. elapsed_time .. " seconds")
         end
-        local index = G_reader_settings:readSetting("screensaver_cycle_index", 1)
+        local index = G_reader_settings:readSetting("screensaver_cycle_index", 0) + 1
         if index > #files then -- wrap around
             index = 1
         end
         local file = files[index]
-        index = (index % #files) + 1
         G_reader_settings:saveSetting("screensaver_cycle_index", index)
         return file
     else -- Pick a random file (default behavior)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -89,8 +89,17 @@ local function _getRandomImage(dir)
     if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
         local files = filemanagerutil.getFiles(dir, match_func)
         if not files then return end
-        table.sort(files) -- Sort files alphabetically (numbers go: 1, 10, 11, 2, 20, 21, ...)
+        -- we have files, sort them in natural order, i.e z2 < z11 < z20
+        local sort = require("frontend/sort")
+        local natsort
+        natsort, cache = sort.natsort_cmp()
+        table.sort(files, function(a, b)
+            return natsort(a, b)
+        end)
         local index = G_reader_settings:readSetting("screensaver_cycle_index", 1)
+        if index > #files then -- wrap around
+            index = 1
+        end
         local file = files[index]
         index = (index % #files) + 1
         G_reader_settings:saveSetting("screensaver_cycle_index", index)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -87,11 +87,16 @@ local function _getRandomImage(dir)
     end
     -- If the user has set the option to cycle images alphabetically, we sort the files instead of picking a random one.
     if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
-        local files = filemanagerutil.getFiles(dir, match_func)
-        if not files then return end
+        local files = {}
+        util.findFiles(dir, function(file)
+            if match_func(file) then
+                table.insert(files, file)
+            end
+        end, false)
+        if #files == 0 then return end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
         local sort = require("frontend/sort")
-        local natsort, cache = sort.natsort_cmp()
+        local natsort = sort.natsort_cmp()
         table.sort(files, function(a, b)
             return natsort(a, b)
         end)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -98,6 +98,7 @@ local function _getRandomImage(dir)
         if #files == 0 then return end
         -- Slippery slope detected! Ensure the number of files does not exceed 128 to prevent performance issues.
         if #files > 128 then -- this seems like a reasonable [arbitrary] limit
+            logger.warn("Screensaver: found", #files, "files, dropping", #files - 128)
             files = {table.unpack(files, 1, 128)}
         end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
@@ -107,7 +108,7 @@ local function _getRandomImage(dir)
             return natsort(a, b)
         end)
         local elapsed_time = time.to_s(time.since(start_time))
-        logger.info("Screensaver: finding and sorting", #files, "files took ", elapsed_time, " seconds")
+        logger.info("Screensaver: found and sorted", #files, "files in", elapsed_time, "seconds")
         local index = G_reader_settings:readSetting("screensaver_cycle_index", 0) + 1
         if index > #files then -- wrap around
             index = 1

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -85,7 +85,19 @@ local function _getRandomImage(dir)
     local match_func = function(file) -- images, ignore macOS resource forks
         return not util.stringStartsWith(ffiUtil.basename(file), "._") and DocumentRegistry:isImageFile(file)
     end
-    return filemanagerutil.getRandomFile(dir, match_func)
+    -- If the user has set the option to cycle images alphabetically, we sort the files instead of picking a random one.
+    if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
+        local files = filemanagerutil.getFiles(dir, match_func)
+        if not files then return end
+        table.sort(files) -- Sort files alphabetically (numbers go: 1, 10, 11, 2, 20, 21, ...)
+        local index = G_reader_settings:readSetting("screensaver_cycle_index", 1)
+        local file = files[index]
+        index = (index % #files) + 1
+        G_reader_settings:saveSetting("screensaver_cycle_index", index)
+        return file
+    else -- Pick a random file (default behavior)
+        return filemanagerutil.getRandomFile(dir, match_func)
+    end
 end
 
 -- This is implemented by the Statistics plugin

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -87,6 +87,7 @@ local function _getRandomImage(dir)
     end
     -- If the user has set the option to cycle images alphabetically, we sort the files instead of picking a random one.
     if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
+        local start_time = os.clock()
         local files = {}
         util.findFiles(dir, function(file)
             if match_func(file) then
@@ -100,6 +101,10 @@ local function _getRandomImage(dir)
         table.sort(files, function(a, b)
             return natsort(a, b)
         end)
+        local elapsed_time = os.clock() - start_time
+        if elapsed_time > 0.5 then -- threshold in seconds
+            logger.warn("Screensaver, finding and sorting files took: " .. elapsed_time .. " seconds")
+        end
         local index = G_reader_settings:readSetting("screensaver_cycle_index", 1)
         if index > #files then -- wrap around
             index = 1

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -90,19 +90,19 @@ local function _getRandomImage(dir)
     if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
         local start_time = time.now()
         local files = {}
+        local num_files = 0
         util.findFiles(dir, function(file)
+            -- Slippery slope ahead! Ensure the number of files does not become unmanageable, otherwise we'll have performance issues.
+            -- NOTE: empirically, a kindle 4 found and sorted 128 files in 0.274828 seconds.
+            if num_files > 128 then return end -- this seems like a reasonable [yet arbitrary] limit
             if match_func(file) then
                 table.insert(files, file)
+                num_files = num_files + 1
             end
         end, false)
         if #files == 0 then return end
-        -- Slippery slope detected! Ensure the number of files does not exceed 128 to prevent performance issues.
-        if #files > 128 then -- this seems like a reasonable [arbitrary] limit
-            logger.warn("Screensaver: found", #files, "files, dropping", #files - 128)
-            files = {table.unpack(files, 1, 128)}
-        end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
-        local sort = require("frontend/sort")
+        local sort = require("sort")
         local natsort = sort.natsort_cmp()
         table.sort(files, function(a, b)
             return natsort(a, b)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -103,7 +103,7 @@ local function _getRandomImage(dir)
         end)
         local elapsed_time = os.clock() - start_time
         if elapsed_time > 0.5 then -- threshold in seconds
-            logger.warn("Screensaver: finding and sorting files alphabetically took " .. elapsed_time .. " seconds")
+            logger.warn("Screensaver: finding and sorting", #files, "files alphabetically took ", elapsed_time, " seconds")
         end
         local index = G_reader_settings:readSetting("screensaver_cycle_index", 0) + 1
         if index > #files then -- wrap around

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -25,6 +25,7 @@ local ffiUtil = require("ffi/util")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local time = require("ui/time")
 local util = require("util")
 local _ = require("gettext")
 local Screen = Device.screen
@@ -87,7 +88,7 @@ local function _getRandomImage(dir)
     end
     -- If the user has set the option to cycle images alphabetically, we sort the files instead of picking a random one.
     if G_reader_settings:isTrue("screensaver_cycle_images_alphabetically") then
-        local start_time = os.clock()
+        local start_time = time.now()
         local files = {}
         util.findFiles(dir, function(file)
             if match_func(file) then
@@ -101,10 +102,8 @@ local function _getRandomImage(dir)
         table.sort(files, function(a, b)
             return natsort(a, b)
         end)
-        local elapsed_time = os.clock() - start_time
-        if elapsed_time > 0.5 then -- threshold in seconds
-            logger.warn("Screensaver: finding and sorting", #files, "files alphabetically took ", elapsed_time, " seconds")
-        end
+        local elapsed_time = time.to_s(time.since(start_time))
+        logger.info("Screensaver: finding and sorting", #files, "files took ", elapsed_time, " seconds")
         local index = G_reader_settings:readSetting("screensaver_cycle_index", 0) + 1
         if index > #files then -- wrap around
             index = 1

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -94,7 +94,7 @@ local function _getRandomImage(dir)
         util.findFiles(dir, function(file)
             -- Slippery slope ahead! Ensure the number of files does not become unmanageable, otherwise we'll have performance issues.
             -- NOTE: empirically, a kindle 4 found and sorted 128 files in 0.274828 seconds.
-            if num_files > 128 then return end -- this seems like a reasonable [yet arbitrary] limit
+            if num_files >= 128 then return end -- this seems like a reasonable [yet arbitrary] limit
             if match_func(file) then
                 table.insert(files, file)
                 num_files = num_files + 1

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -91,7 +91,7 @@ local function _getRandomImage(dir)
         if not files then return end
         -- we have files, sort them in natural order, i.e z2 < z11 < z20
         local sort = require("frontend/sort")
-        local natsort
+        local natsort, cache
         natsort, cache = sort.natsort_cmp()
         table.sort(files, function(a, b)
             return natsort(a, b)

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -113,9 +113,8 @@ local function _getRandomImage(dir)
         if index > #files then -- wrap around
             index = 1
         end
-        local file = files[index]
         G_reader_settings:saveSetting("screensaver_cycle_index", index)
-        return file
+        return files[index]
     else -- Pick a random file (default behavior)
         return filemanagerutil.getRandomFile(dir, match_func)
     end


### PR DESCRIPTION
### what's new

* [`frontend/ui/elements/screensaver_menu.lua`](diffhunk://#diff-3982e81823bb1df13fdf234b0087be5bef2fb5f744be693b20fce2d8f833692cR162-R175): Added a new menu item to toggle the display of images in alphabetical order.

* [`frontend/ui/screensaver.lua`](diffhunk://#diff-ca0df032a2d2a54f0d1c18b7372a594335ef10c6fb9ecd1042b2a710cdc1f327R88-R101): Modified the `_getRandomImage` function to support the new alphabetical order option by sorting files and cycling through them. Wasn't sure whether to create a brand new one or just adapt this one, alas the latter was chosen. 

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/f1b27413-553e-416b-85f1-aef780db2474" width=40% height=40%> 
</p> 

* fix #11179

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13094)
<!-- Reviewable:end -->
