### PR TITLE
[screenshoter] Fix bug in ‘set as wallpaper’ setting.

### DIFF
--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -99,8 +99,8 @@ function Screenshoter:onScreenshot(screenshot_name, caller_callback)
             {
                 text = _("Set as wallpaper"),
                 callback = function()
-                    G_reader_settings:saveSetting("screensaver_type", "image_file")
-                    G_reader_settings:saveSetting("screensaver_image", screenshot_name)
+                    G_reader_settings:saveSetting("screensaver_type", "document_cover")
+                    G_reader_settings:saveSetting("screensaver_document_cover", screenshot_name)
                     dialog:onClose()
                 end,
             },


### PR DESCRIPTION
### bug

* [`frontend/ui/widget/screenshoter.lua`](diffhunk://#diff-ba47f4be979e53cfa280f177af83f1d52322ea41885213aa708392211b996a03L102-R103): Changed the saved settings from `image_file ` and `screensaver_image` to `document_cover` and `screensaver_document_cover` when setting a screenshot as a wallpaper.

this one slipped through the cracks when we removed `image_file` back in #11549

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13108)
<!-- Reviewable:end -->
