### PR TITLE
[screenshoter] remove 'set as wallpaper' from devices with special offers

### DIFF
--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -96,7 +96,7 @@ function Screenshoter:onScreenshot(screenshot_name, caller_callback)
                     UIManager:show(image_viewer)
                 end,
             },
-            not (Device:isKindle() and Device.isSpecialOffers) and {
+            Device:supportsScreensaver() and {
                 text = _("Set as wallpaper"),
                 callback = function()
                     G_reader_settings:saveSetting("screensaver_type", "document_cover")

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -96,16 +96,18 @@ function Screenshoter:onScreenshot(screenshot_name, caller_callback)
                     UIManager:show(image_viewer)
                 end,
             },
-            Device:supportsScreensaver() and {
-                text = _("Set as wallpaper"),
-                callback = function()
-                    G_reader_settings:saveSetting("screensaver_type", "document_cover")
-                    G_reader_settings:saveSetting("screensaver_document_cover", screenshot_name)
-                    dialog:onClose()
-                end,
-            } or nil,
         },
     }
+    if Device:supportsScreensaver() then
+        table.insert(buttons[2], {
+            text = _("Set as wallpaper"),
+            callback = function()
+                G_reader_settings:saveSetting("screensaver_type", "document_cover")
+                G_reader_settings:saveSetting("screensaver_document_cover", screenshot_name)
+                dialog:onClose()
+            end,
+        })
+    end
     dialog = ButtonDialog:new{
         title = _("Screenshot saved to:") .. "\n\n" .. BD.filepath(screenshot_name) .. "\n",
         modal = true,

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -96,14 +96,14 @@ function Screenshoter:onScreenshot(screenshot_name, caller_callback)
                     UIManager:show(image_viewer)
                 end,
             },
-            {
+            not (Device:isKindle() and Device.isSpecialOffers) and {
                 text = _("Set as wallpaper"),
                 callback = function()
                     G_reader_settings:saveSetting("screensaver_type", "document_cover")
                     G_reader_settings:saveSetting("screensaver_document_cover", screenshot_name)
                     dialog:onClose()
                 end,
-            },
+            } or nil,
         },
     }
     dialog = ButtonDialog:new{


### PR DESCRIPTION
### what's new

* [`frontend/ui/widget/screenshoter.lua`](diffhunk://#diff-ba47f4be979e53cfa280f177af83f1d52322ea41885213aa708392211b996a03L99-R106): Modified the condition to display the "Set as wallpaper" option based on the device type and special offers status.

This only just crossed my mind, we don't show anything on sleep screen if a device has special offers (#13006) yet, this is still out there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13110)
<!-- Reviewable:end -->
