### PR TITLE
Support Kindle Oasis (KOA) charging cover "soda"

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1322,7 +1322,7 @@ function KindleOasis:init()
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
         fl_intensity_file = "/sys/class/backlight/max77696-bl/brightness",
-        -- NOTE: Points to the embedded battery. The one in the cover is codenamed "soda".
+        -- NOTE: Points to the embedded battery. The one in the cover is codenamed "soda", see aux_batt_capacity_file below.
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
         aux_batt_capacity_file = "/sys/devices/platform/soda/power_supply/soda_fg/capacity",

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -923,6 +923,7 @@ local KindleOasis = Kindle:extend{
     hasKeys = yes,
     hasGSensor = yes,
     display_dpi = 300,
+    hasAuxBattery = yes,
     --[[
     -- NOTE: Points to event3 on Wi-Fi devices, event4 on 3G devices...
     --       3G devices apparently have an extra SX9500 Proximity/Capacitive controller for mysterious purposes...
@@ -1324,6 +1325,8 @@ function KindleOasis:init()
         -- NOTE: Points to the embedded battery. The one in the cover is codenamed "soda".
         batt_capacity_file = "/sys/devices/system/wario_battery/wario_battery0/battery_capacity",
         is_charging_file = "/sys/devices/system/wario_charger/wario_charger0/charging",
+        aux_batt_capacity_file = "/sys/devices/platform/soda/power_supply/soda_fg/capacity",
+        aux_batt_status_file = "/sys/devices/platform/soda/power_supply/soda_fg/status",
         hall_file = "/sys/devices/system/wario_hall/wario_hall0/hall_enable",
     }
 

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -24,6 +24,33 @@ function KindlePowerD:init()
         self.fl_max = self.fl_max + 1
     end
 
+    if self.device:hasAuxBattery() then
+        self.getAuxCapacityHW = function(this)
+            return this:unchecked_read_int_file(self.aux_batt_capacity_file)
+        end
+
+        self.isAuxBatteryConnectedHW = function(this)
+            local status = this:read_str_file(self.aux_batt_status_file)
+            if status == nil then
+                -- File could not be read, assume not connected
+                return false
+            end
+            -- File was read, assume aux battery is connected
+            return true
+        end
+
+        self.isAuxChargingHW = function(this)
+            -- "Discharging" when discharging
+            -- "Full" when full
+            -- "Charging" when charging via DCP
+            return this:read_str_file(this.aux_batt_status_file) ~= "Discharging"
+        end
+
+        self.isAuxChargedHW = function(this)
+            return this:read_str_file(this.aux_batt_status_file) == "Full"
+        end
+    end
+
     self:initWakeupMgr()
 end
 


### PR DESCRIPTION
Adds support for the Kindle Oasis (KOA) charging cover, codename "soda". 

Much of this code was taken from the Kobo implementation of an auxiliary battery. The biggest difference between the Kobo and Kindle implementation is that the status file for the charging cover is not present when the cover is detached, so the check for status there will result in the file failing to read.

Tested on two Kindles running koreader 2024.11.

![IMG_2332](https://github.com/user-attachments/assets/740d843e-fa4f-46c5-b058-7e96818b3f30)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13133)
<!-- Reviewable:end -->
