### PR TITLE
"Invert page turn taps and swipes" fix

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -988,7 +988,11 @@ function ReaderView:onReadSettings(config)
     end
     self:resetLayout()
     self.page_scroll = (config:readSetting("kopt_page_scroll") or self.document.configurable.page_scroll) == 1
-    self.inverse_reading_order = config:isTrue("inverse_reading_order") or G_reader_settings:isTrue("inverse_reading_order")
+    if config:has("inverse_reading_order") then
+        self.inverse_reading_order = config:isTrue("inverse_reading_order")
+    else
+        self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
+    end
     self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or G_defaults:readSetting("DSHOWOVERLAP")
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height")
@@ -1279,11 +1283,16 @@ function ReaderView:setupTouchZones()
     (self.ui.rolling or self.ui.paging):setupTouchZones()
 end
 
-function ReaderView:onToggleReadingOrder()
-    self.inverse_reading_order = not self.inverse_reading_order
-    self:setupTouchZones()
-    local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
-    Notification:notify(is_rtl and _("RTL page turning.") or _("LTR page turning."))
+function ReaderView:onToggleReadingOrder(toggle)
+    if toggle == nil then
+        toggle = not self.inverse_reading_order
+    end
+    if self.inverse_reading_order ~= toggle then
+        self.inverse_reading_order = toggle
+        self:setupTouchZones()
+        local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
+        Notification:notify(is_rtl and _("RTL page turning.") or _("LTR page turning."))
+    end
     return true
 end
 

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -187,12 +187,13 @@ local settingsList = {
     book_status = {category="none", event="ShowBookStatus", title=_("Book status"), reader=true},
     book_info = {category="none", event="ShowBookInfo", title=_("Book information"), reader=true},
     book_description = {category="none", event="ShowBookDescription", title=_("Book description"), reader=true},
-    book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), reader=true},
+    book_cover = {category="none", event="ShowBookCover", title=_("Book cover"), reader=true, separator=true},
     ----
     translate_page = {category="none", event="TranslateCurrentPage", title=_("Translate current page"), reader=true, separator=true},
     ----
-    toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
+    set_inverse_reading_order = {category="string", event="ToggleReadingOrder", title=_("Invert page turn taps and swipes"), reader=true, condition=Device:isTouchDevice(), args={true, false}, toggle={_("on"), _("off")}},
     toggle_inverse_reading_order = {category="none", event="ToggleReadingOrder", title=_("Toggle page turn direction"), reader=true, condition=Device:isTouchDevice()},
+    toggle_page_change_animation = {category="none", event="TogglePageChangeAnimation", title=_("Toggle page turn animations"), reader=true, condition=Device:canDoSwipeAnimation()},
     toggle_handmade_toc = {category="none", event="ToggleHandmadeToc", title=_("Toggle custom TOC"), reader=true, condition=Device:isTouchDevice()},
     toggle_handmade_flows = {category="none", event="ToggleHandmadeFlows", title=_("Toggle custom hidden flows"), reader=true, separator=true, condition=Device:isTouchDevice()},
     ----
@@ -425,8 +426,9 @@ local dispatcher_menu_order = {
     ----
     "translate_page",
     ----
-    "toggle_page_change_animation",
+    "set_inverse_reading_order",
     "toggle_inverse_reading_order",
+    "toggle_page_change_animation",
     "toggle_handmade_toc",
     "toggle_handmade_flows",
     ----


### PR DESCRIPTION
(1) Fix "Invert page turn taps and swipes" per document setting (it was impossible to set `false`).
(2) Add action to set the inverted direction on/off (in addition to toggle). See https://github.com/koreader/koreader/issues/13010.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13155)
<!-- Reviewable:end -->
