### PR TITLE
NewsDownloader: deal with 404 and other error statuses better

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -193,21 +193,7 @@ local function getUrlContent(url, cookies, timeout, maxtime, redirectCount)
     end
     if code >= 400 and code < 500 then
         logger.warn("socket error:", status or code)
-        if code == 400 then
-            return false, "Bad request - invalid URL or parameters"
-        elseif code == 401 then
-            return false, "Unauthorized - authentication required"
-        elseif code == 403 then
-            return false, "Access forbidden by server"
-        elseif code == 404 then
-            return false, "Resource not found at this URL"
-        elseif code == 408 then
-            return false, "Request timed out"
-        elseif code == 429 then
-            return false, "Too many requests - please try again later"
-        else
-            return false, string.format("HTTP error %d occurred", code)
-        end
+        return false, status or code
     end
     if headers == nil then
         logger.warn("No HTTP headers:", status or code or "network unreachable")
@@ -228,7 +214,7 @@ local function getUrlContent(url, cookies, timeout, maxtime, redirectCount)
            error("EpubDownloadBackend: Don't know how to handle HTTP response status:", status or code)
         end
         logger.warn("HTTP status not okay:", status or code)
-        return false, "Remote server error or unavailable"
+        return false, status or code
     end
     if headers and headers["content-length"] then
         -- Check we really got the announced content size

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -191,6 +191,24 @@ local function getUrlContent(url, cookies, timeout, maxtime, redirectCount)
         logger.warn("request interrupted:", status or code)
         return false, code
     end
+    if code >= 400 and code < 500 then
+        logger.warn("socket error:", status or code)
+        if code == 400 then
+            return false, "Bad request - invalid URL or parameters"
+        elseif code == 401 then
+            return false, "Unauthorized - authentication required"
+        elseif code == 403 then
+            return false, "Access forbidden by server"
+        elseif code == 404 then
+            return false, "Resource not found at this URL"
+        elseif code == 408 then
+            return false, "Request timed out"
+        elseif code == 429 then
+            return false, "Too many requests - please try again later"
+        else
+            return false, string.format("HTTP error %d occurred", code)
+        end
+    end
     if headers == nil then
         logger.warn("No HTTP headers:", status or code or "network unreachable")
         return false, "Network or remote server unavailable"

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -192,7 +192,7 @@ local function getUrlContent(url, cookies, timeout, maxtime, redirectCount)
         return false, code
     end
     if code >= 400 and code < 500 then
-        logger.warn("socket error:", status or code)
+        logger.warn("HTTP error:", status or code)
         return false, status or code
     end
     if headers == nil then


### PR DESCRIPTION
May be relevant to #9363. In any case one of the most typical kind of failure wasn't treated properly, so a 404 would mess up everything instead of popping up a dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13165)
<!-- Reviewable:end -->
