### PR TITLE
Dispatcher: action list fixes

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -688,7 +688,9 @@ function Dispatcher._addToOrder(location, settings, item)
     elseif count > 2 then
         local order = util.tableGetValue(actions, "settings", "order")
         if order then
-            table.insert(location[settings].settings.order, item)
+            if not util.arrayContains(order, item) then
+                table.insert(location[settings].settings.order, item)
+            end
         else -- old unordered actions
             util.tableSetValue(actions, {}, "settings", "order")
             for k in pairs(actions) do

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -276,7 +276,7 @@ local settingsList = {
     kopt_defect_size = {category="string", paging=true}, -- not shown in the bottom menu
     kopt_max_columns = {category="configurable", paging=true},
     kopt_auto_straighten = {category="absolutenumber", paging=true},
-    
+
     settings = nil, -- reserved for per instance dispatcher settings
 }
 

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -51,7 +51,6 @@ local Dispatcher = {
 local settingsList = {
     -- General
     filemanager = {category="none", event="Home", title=_("File browser"), general=true},
-    reading_progress = {category="none", event="ShowReaderProgress", title=_("Reading progress"), general=true},
     open_previous_document = {category="none", event="OpenLastDoc", title=_("Open previous document"), general=true},
     history = {category="none", event="ShowHist", title=_("History"), general=true},
     history_search = {category="none", event="SearchHistory", title=_("History search"), general=true},
@@ -90,6 +89,7 @@ local settingsList = {
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     temp_gsensor_on = {category="none", event="TempGSensorOn", title=_("Enable accelerometer for 5 seconds"), device=true, condition=Device:hasGSensor()},
     lock_gsensor = {category="none", event="LockGSensor", title=_("Lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
+    rotation_mode = {category="string", device=true}, -- title=_("Rotation"), parsed from CreOptions
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
     iterate_rotation = {category="none", event="IterateRotation", title=_("Rotate by 90° CW"), device=true},
@@ -140,8 +140,9 @@ local settingsList = {
     file_search_results = {category="none", event="ShowSearchResults", title=_("Last file search results"), filemanager=true},
     ----
     folder_up = {category="none", event="FolderUp", title=_("Folder up"), filemanager=true},
-    -- go_to
-    -- back
+    fm_go_to = {category="none", event="ShowGotoDialog", title=_("Go to page"), filemanager=true},
+    fm_back = {category="none", event="Back", title=_("Back"), filemanager=true, separator=true},
+    ----
 
     -- Reader
     open_next_document_in_folder = {category="none", event="OpenNextDocumentInFolder", title=_("Open next document in folder"), reader=true, separator=true},
@@ -156,7 +157,7 @@ local settingsList = {
     last_page = {category="none", event="GoToEnd", title=_("Last page"), reader=true},
     random_page = {category="none", event="GoToRandomPage", title=_("Random page"), reader=true},
     page_jmp = {category="absolutenumber", event="GotoViewRel", min=-100, max=100, title=_("Turn pages"), reader=true},
-    go_to = {category="none", event="ShowGotoDialog", title=_("Go to page"), filemanager=true, reader=true},
+    go_to = {category="none", event="ShowGotoDialog", title=_("Go to page"), reader=true},
     skim = {category="none", event="ShowSkimtoDialog", title=_("Skim document"), reader=true},
     prev_bookmark = {category="none", event="GotoPreviousBookmarkFromPage", title=_("Previous bookmark"), reader=true},
     next_bookmark = {category="none", event="GotoNextBookmarkFromPage", title=_("Next bookmark"), reader=true},
@@ -164,7 +165,7 @@ local settingsList = {
     last_bookmark = {category="none", event="GotoLastBookmark", title=_("Last bookmark"), reader=true},
     latest_bookmark = {category="none", event="GoToLatestBookmark", title=_("Latest bookmark"), reader=true, separator=true},
     ----
-    back = {category="none", event="Back", title=_("Back"), filemanager=true, reader=true},
+    back = {category="none", event="Back", title=_("Back"), reader=true},
     previous_location = {category="none", event="GoBackLink", arg=true, title=_("Back to previous location"), reader=true},
     next_location = {category="none", event="GoForwardLink", arg=true, title=_("Forward to next location"), reader=true},
     follow_nearest_link = {category="arg", event="GoToPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest link"), reader=true},
@@ -220,7 +221,6 @@ local settingsList = {
     ----
 
     -- parsed from CreOptions
-    rotation_mode = {category="string", device=true},
     font_size = {category="absolutenumber", rolling=true, title=_("Font size"), step=0.5},
     word_spacing = {category="string", rolling=true},
     word_expansion = {category="string", rolling=true},
@@ -253,7 +253,6 @@ local settingsList = {
     kopt_zoom_overlap_h = {category="absolutenumber", paging=true},
     kopt_zoom_overlap_v = {category="absolutenumber", paging=true},
     kopt_zoom_mode_type = {category="string", paging=true},
-    -- kopt_zoom_range_number = {category="string", paging=true},
     kopt_zoom_factor = {category="string", paging=true},
     kopt_zoom_mode_genus = {category="string", paging=true},
     kopt_zoom_direction = {category="string", paging=true},
@@ -273,19 +272,14 @@ local settingsList = {
     kopt_doc_language = {category="string", paging=true},
     kopt_forced_ocr = {category="configurable", paging=true},
     kopt_writing_direction = {category="configurable", paging=true},
-    kopt_defect_size = {category="string", paging=true},
-    kopt_detect_indent = {category="configurable", paging=true},
     kopt_max_columns = {category="configurable", paging=true},
     kopt_auto_straighten = {category="absolutenumber", paging=true},
-
-    settings = nil, -- reserved for per instance dispatcher settings
 }
 
 -- array for item order in menu
 local dispatcher_menu_order = {
     -- General
     "filemanager",
-    "reading_progress",
     "open_previous_document",
     "history",
     "history_search",
@@ -375,8 +369,9 @@ local dispatcher_menu_order = {
     "file_search_results",
     ----
     "folder_up",
-    -- "go_to"
-    -- "back"
+    "fm_go_to",
+    "fm_back",
+    ----
 
     -- Reader
     "open_next_document_in_folder",
@@ -483,7 +478,6 @@ local dispatcher_menu_order = {
     "kopt_zoom_overlap_h",
     "kopt_zoom_overlap_v",
     "kopt_zoom_mode_type",
-    -- "kopt_zoom_range_number", -- can't figure out how this name text func works
     "kopt_zoom_factor",
     "kopt_zoom_mode_genus",
     "kopt_zoom_direction",
@@ -503,8 +497,6 @@ local dispatcher_menu_order = {
     "kopt_doc_language",
     "kopt_forced_ocr",
     "kopt_writing_direction",
-    "kopt_defect_size",
-    "kopt_detect_indent",
     "kopt_max_columns",
     "kopt_auto_straighten",
 }
@@ -514,9 +506,8 @@ local dispatcher_menu_order = {
 --]]--
 function Dispatcher:init()
     if Dispatcher.initialized then return end
-    local parseoptions = function(base, i, prefix)
-        for y=1, #base[i].options do
-            local option = base[i].options[y]
+    local parseoptions = function(options, prefix)
+        for _, option in ipairs(options) do
             local name = prefix and prefix .. option.name or option.name
             if settingsList[name] ~= nil then
                 if option.name ~= nil and option.values ~= nil then
@@ -568,10 +559,10 @@ function Dispatcher:init()
         end
     end
     for i=1,#CreOptions do
-        parseoptions(CreOptions, i)
+        parseoptions(CreOptions[i].options)
     end
-    for i=1,#KoptOptions do
-        parseoptions(KoptOptions, i, "kopt_")
+    for i=2,#KoptOptions do -- #1 "Rotation" parsed from CreOptions
+        parseoptions(KoptOptions[i].options, "kopt_")
     end
     UIManager:broadcastEvent(Event:new("DispatcherRegisterActions"))
     Dispatcher.initialized = true
@@ -1094,7 +1085,7 @@ function Dispatcher:isActionEnabled(action)
         elseif context == "rolling" then
             disabled = action["paging"]
         else -- FM
-            disabled = (action["reader"] or action["rolling"] or action["paging"]) and not action["filemanager"]
+            disabled = action["reader"] or action["rolling"] or action["paging"]
         end
     end
     return not disabled

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -272,6 +272,7 @@ local settingsList = {
     kopt_doc_language = {category="string", paging=true},
     kopt_forced_ocr = {category="configurable", paging=true},
     kopt_writing_direction = {category="configurable", paging=true},
+    kopt_defect_size = {category="string", paging=true}, -- not shown in the bottom menu
     kopt_max_columns = {category="configurable", paging=true},
     kopt_auto_straighten = {category="absolutenumber", paging=true},
 }
@@ -497,6 +498,7 @@ local dispatcher_menu_order = {
     "kopt_doc_language",
     "kopt_forced_ocr",
     "kopt_writing_direction",
+    "kopt_defect_size",
     "kopt_max_columns",
     "kopt_auto_straighten",
 }

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -254,7 +254,7 @@ local settingsList = {
     kopt_zoom_overlap_v = {category="absolutenumber", paging=true},
     kopt_zoom_mode_type = {category="string", paging=true},
     kopt_zoom_mode_genus = {category="string", paging=true},
-    kopt_zoom_range_number = {category="string", paging=true, title=_("Number of columns/rows to split the page")},
+    kopt_zoom_range_number = {category="string", paging=true, title=_("Number of columns/rows to split page")},
     kopt_zoom_factor = {category="string", paging=true},
     kopt_zoom_direction = {category="string", paging=true},
     kopt_page_scroll = {category="string", paging=true},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -253,8 +253,9 @@ local settingsList = {
     kopt_zoom_overlap_h = {category="absolutenumber", paging=true},
     kopt_zoom_overlap_v = {category="absolutenumber", paging=true},
     kopt_zoom_mode_type = {category="string", paging=true},
-    kopt_zoom_factor = {category="string", paging=true},
     kopt_zoom_mode_genus = {category="string", paging=true},
+    kopt_zoom_range_number = {category="string", paging=true, title=_("Number of columns/rows to split the page")},
+    kopt_zoom_factor = {category="string", paging=true},
     kopt_zoom_direction = {category="string", paging=true},
     kopt_page_scroll = {category="string", paging=true},
     kopt_page_gap_height = {category="string", paging=true},
@@ -275,6 +276,8 @@ local settingsList = {
     kopt_defect_size = {category="string", paging=true}, -- not shown in the bottom menu
     kopt_max_columns = {category="configurable", paging=true},
     kopt_auto_straighten = {category="absolutenumber", paging=true},
+    
+    settings = nil, -- reserved for per instance dispatcher settings
 }
 
 -- array for item order in menu
@@ -479,8 +482,9 @@ local dispatcher_menu_order = {
     "kopt_zoom_overlap_h",
     "kopt_zoom_overlap_v",
     "kopt_zoom_mode_type",
-    "kopt_zoom_factor",
     "kopt_zoom_mode_genus",
+    "kopt_zoom_range_number",
+    "kopt_zoom_factor",
     "kopt_zoom_direction",
     "kopt_page_scroll",
     "kopt_page_gap_height",

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20241228
+local CURRENT_MIGRATION_DATE = 20250131
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -809,6 +809,36 @@ if last_migration_date < 20241228 then
 
         wb_settings:saveSetting("wallabag", new_settings)
         wb_settings:flush()
+    end
+end
+
+-- 20250131, Separate GoTo and Back actions for Reader and FileManager.
+-- https://github.com/koreader/koreader/pull/13167
+if last_migration_date < 20250131 then
+    logger.info("Performing one-time migration for 20250131")
+
+    local gestures_path = ffiUtil.joinPath(DataStorage:getSettingsDir(), "gestures.lua")
+    if lfs.attributes(gestures_path, "mode") == "file" then
+        local gestures = LuaSettings:open(gestures_path)
+        if next(gestures.data) and next(gestures.data.gesture_fm) then
+            local updated
+            for _, gesture in pairs(gestures.data.gesture_fm) do
+                for action in pairs(gesture) do
+                    if action == "go_to" then
+                        gesture.go_to = nil
+                        gesture.fm_go_to = true
+                        updated = true
+                    elseif action == "back" then
+                        gesture.back = nil
+                        gesture.fm_back = true
+                        updated = true
+                    end
+                end
+            end
+            if updated then
+                gestures:flush()
+            end
+        end
     end
 end
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20250131
+local CURRENT_MIGRATION_DATE = 20250207
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -812,10 +812,10 @@ if last_migration_date < 20241228 then
     end
 end
 
--- 20250131, Separate GoTo and Back actions for Reader and FileManager.
+-- 20250207, Separate GoTo and Back actions for Reader and FileManager.
 -- https://github.com/koreader/koreader/pull/13167
-if last_migration_date < 20250131 then
-    logger.info("Performing one-time migration for 20250131")
+if last_migration_date < 20250207 then
+    logger.info("Performing one-time migration for 20250207")
 
     local gestures_path = ffiUtil.joinPath(DataStorage:getSettingsDir(), "gestures.lua")
     if lfs.attributes(gestures_path, "mode") == "file" then

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -368,9 +368,9 @@ function Profiles:getProfileFromCurrentBookSettings(new_name)
             "kopt_page_margin",
             "kopt_zoom_overlap_h",
             "kopt_zoom_overlap_v",
-            "kopt_max_columns",
-            "kopt_zoom_mode_genus",
             "kopt_zoom_mode_type",
+            "kopt_zoom_mode_genus",
+            "kopt_zoom_range_number",
             "kopt_zoom_factor",
             "kopt_zoom_direction",
             "kopt_page_scroll",
@@ -378,6 +378,7 @@ function Profiles:getProfileFromCurrentBookSettings(new_name)
             "kopt_font_size",
             "kopt_contrast",
             "kopt_quality",
+            "kopt_max_columns",
         }
     end
     local setting_needs_arg = {

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -95,6 +95,8 @@ ReaderStatistics.default_settings = {
 
 function ReaderStatistics:onDispatcherRegisterActions()
     Dispatcher:registerAction("toggle_statistics", {category="none", event="ToggleStatistics", title=_("Toggle statistics"), general=true})
+    Dispatcher:registerAction("reading_progress", {category="none", event="ShowReaderProgress", title=_("Reading progress"), general=true})
+    Dispatcher:registerAction("stats_time_range", {category="none", event="ShowTimeRange", title=_("Statistics time range"), general=true})
     Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), general=true})
     Dispatcher:registerAction("stats_calendar_day_view", {category="none", event="ShowCalendarDayView", title=_("Statistics today's timeline"), general=true})
     Dispatcher:registerAction("stats_sync", {category="none", event="SyncBookStats", title=_("Synchronize book statistics"), general=true, separator=true})
@@ -1369,7 +1371,7 @@ Time is in hours and minutes.]]),
                 text = _("Time range"),
                 keep_menu_open = true,
                 callback = function()
-                    self:statMenu()
+                    self:onShowTimeRange()
                 end
             },
             {
@@ -1390,7 +1392,7 @@ Time is in hours and minutes.]]),
     }
 end
 
-function ReaderStatistics:statMenu()
+function ReaderStatistics:onShowTimeRange()
     self.kv = KeyValuePage:new{
         title = _("Time range statistics"),
         return_button = true,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -94,13 +94,13 @@ ReaderStatistics.default_settings = {
 }
 
 function ReaderStatistics:onDispatcherRegisterActions()
-    Dispatcher:registerAction("toggle_statistics", {category="none", event="ToggleStatistics", title=_("Toggle statistics"), general=true})
-    Dispatcher:registerAction("reading_progress", {category="none", event="ShowReaderProgress", title=_("Reading progress"), general=true})
-    Dispatcher:registerAction("stats_time_range", {category="none", event="ShowTimeRange", title=_("Statistics time range"), general=true})
-    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Statistics calendar view"), general=true})
-    Dispatcher:registerAction("stats_calendar_day_view", {category="none", event="ShowCalendarDayView", title=_("Statistics today's timeline"), general=true})
-    Dispatcher:registerAction("stats_sync", {category="none", event="SyncBookStats", title=_("Synchronize book statistics"), general=true, separator=true})
-    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Book statistics"), reader=true})
+    Dispatcher:registerAction("toggle_statistics", {category="none", event="ToggleStatistics", title=_("Reading statistics: toggle"), general=true})
+    Dispatcher:registerAction("reading_progress", {category="none", event="ShowReaderProgress", title=_("Reading statistics: show progress"), general=true})
+    Dispatcher:registerAction("stats_time_range", {category="none", event="ShowTimeRange", title=_("Reading statistics: show time range"), general=true})
+    Dispatcher:registerAction("stats_calendar_view", {category="none", event="ShowCalendarView", title=_("Reading statistics: show calendar view"), general=true})
+    Dispatcher:registerAction("stats_calendar_day_view", {category="none", event="ShowCalendarDayView", title=_("Reading statistics: show today's timeline"), general=true})
+    Dispatcher:registerAction("stats_sync", {category="none", event="SyncBookStats", title=_("Reading statistics: synchronize"), general=true, separator=true})
+    Dispatcher:registerAction("book_statistics", {category="none", event="ShowBookStats", title=_("Reading statistics: current book"), reader=true})
 end
 
 function ReaderStatistics:init()


### PR DESCRIPTION
(1) Remove unused kopt actions that are not shown in the bottom menu.

(2) Separate GoTo and Back actions for Reader and FileManager.

(3) Statistics:
-add "Time range" action
-group all actions together in the General section, except "Book statistics" in Reader section.
Closes https://github.com/koreader/koreader/issues/12690.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13167)
<!-- Reviewable:end -->
