### PR TITLE
[ReaderFooter] keep menu open after arranging items in status bar

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1398,10 +1398,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                 callback = function()
                     local item_table = {}
                     for i=1, #self.mode_index do
-                        -- add only enabled items to the sort list
-                        if self.settings[self.mode_index[i]] then
-                            table.insert(item_table, {text = self:textOptionTitles(self.mode_index[i]), label = self.mode_index[i]})
-                        end
+                        table.insert(item_table, {text = self:textOptionTitles(self.mode_index[i]), label = self.mode_index[i]})
                     end
                     local SortWidget = require("ui/widget/sortwidget")
                     local sort_item
@@ -1409,18 +1406,9 @@ function ReaderFooter:addToMainMenu(menu_items)
                         title = _("Arrange items"),
                         item_table = item_table,
                         callback = function()
-                            -- update mode_index with only enabled items (in their new order)
-                            local new_mode_index = {}
                             for i=1, #sort_item.item_table do
-                                table.insert(new_mode_index, sort_item.item_table[i].label)
+                                self.mode_index[i] = sort_item.item_table[i].label
                             end
-                            -- append disabled items to the end of the sort list (in their original order)
-                            for _, m in ipairs(self.mode_index) do
-                                if not self.settings[m] then
-                                    table.insert(new_mode_index, m)
-                                end
-                            end
-                            self.mode_index = new_mode_index
                             self.settings.order = self.mode_index
                             self:updateFooterTextGenerator()
                             self:onUpdateFooter()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1388,6 +1388,9 @@ function ReaderFooter:addToMainMenu(menu_items)
                     for _, m in ipairs(self.mode_index) do
                         if self.settings[m] then
                             enabled_count = enabled_count + 1
+                            if enabled_count > 1 then
+                                break
+                            end
                         end
                     end
                     return enabled_count > 1


### PR DESCRIPTION
### what's new

* Added a `keep_menu_open` property to keep the menu open when arranging one's items. why was this not a thing?
* Introduced an `enabled_func` to ensure the "Arrange items in status bar" option is only enabled when there is more than one enabled item. (on par with dispatcher's)

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/5341c5f9-4acd-419f-8c87-e5f01e85a73d" > 
</p>



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13168)
<!-- Reviewable:end -->
