### PR TITLE
ReaderView: fix resetting screen boxes cache

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1149,7 +1149,7 @@ function ReaderView:onSetViewMode(new_mode)
 end
 
 function ReaderView:resetHighlightBoxesCache(items)
-    if items == nil then
+    if type(items) ~= "table" then
         self.highlight.page_boxes = {}
     else
         for _, item in ipairs(items) do


### PR DESCRIPTION
`resetHighlightBoxesCache()` can get different types of args because of 
https://github.com/koreader/koreader/blob/9911ef71d10c3e824ef6e8a9069654ec724dbdae/frontend/apps/reader/modules/readerview.lua#L1173-L1175
Closes https://github.com/koreader/koreader/issues/13162.
