### PR TITLE
NewsDownloader: process HTML with cre.getBalancedHTML() to ensure self-closing tags like <hr> are closed like <hr/>

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -331,7 +331,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
 
     -- Rejigger HTML into XHTML to avoid unclosed elements. See <https://github.com/koreader/crengine/pull/370#issuecomment-910156921>.
     local cre = require("libs/libkoreader-cre")
-    html = cre.getBalancedHTML(html, 0x50)
+    html = cre.getBalancedHTML(html, 0x0)
 
     -- Remove all script tags to save a few bytes.
     html = html:gsub("<script.->.-</script>", "")

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -328,6 +328,26 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local cancelled = false
     local page_htmltitle = html:match([[<title[^>]*>(.-)</title>]])
     logger.dbg("page_htmltitle is ", page_htmltitle)
+
+    -- Make sure self-closing tags like <br> and <hr> are closed like <br/>.
+    html = html:gsub("<(%w+)(.-)>", function(tag, attrs)
+        local self_closing_tags = {
+            br = true, hr = true, img = true,
+            input = true, meta = true, link = true,
+            area = true, base = true, col = true,
+            embed = true, param = true, source = true,
+            track = true, wbr = true
+        }
+        if self_closing_tags[tag] then
+            return string.format("<%s%s/>", tag, attrs)
+        else
+            return string.format("<%s%s>", tag, attrs)
+        end
+    end)
+
+    -- Remove all script tags to save a few bytes.
+    html = html:gsub("<script.->.-</script>", "")
+
 --    local sections = html.sections -- Wikipedia provided TOC
     local bookid = "bookid_placeholder" --string.format("wikipedia_%s_%s_%s", lang, phtml.pageid, phtml.revid)
     -- Not sure if this bookid may ever be used by indexing software/calibre, but if it is,

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -329,21 +329,9 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local page_htmltitle = html:match([[<title[^>]*>(.-)</title>]])
     logger.dbg("page_htmltitle is ", page_htmltitle)
 
-    -- Make sure self-closing tags like <br> and <hr> are closed like <br/>.
-    html = html:gsub("<(%w+)(.-)>", function(tag, attrs)
-        local self_closing_tags = {
-            br = true, hr = true, img = true,
-            input = true, meta = true, link = true,
-            area = true, base = true, col = true,
-            embed = true, param = true, source = true,
-            track = true, wbr = true
-        }
-        if self_closing_tags[tag] then
-            return string.format("<%s%s/>", tag, attrs)
-        else
-            return string.format("<%s%s>", tag, attrs)
-        end
-    end)
+    -- Rejigger HTML into XHTML to avoid unclosed elements. See <https://github.com/koreader/crengine/pull/370#issuecomment-910156921>.
+    local cre = require("libs/libkoreader-cre")
+    html = cre.getBalancedHTML(html, 0x50)
 
     -- Remove all script tags to save a few bytes.
     html = html:gsub("<script.->.-</script>", "")


### PR DESCRIPTION
Works around the issue in <https://github.com/koreader/koreader/issues/13173#issuecomment-2628027654>.

---

It's not a proper solution, since traditional HTML like the following would still cause issues, but it catches the low-hanging fruit of self-closing tags. Other than `<hr>` with its gray color I'm not sure if any of the other elements matter much in practice, but you might sometimes see some slightly curious indentation due to nesting.
```html
<p>Paragraph one
<p>Paragraph two
```
The simplest solution would be to revert to plain HTML files, but EPUB does offer some advantages. (And I don't know if I want to put in the work required for that. :-)

A better solution might be to leverage crengine or MuPDF's HTML parsing, to output normalized HTML. Or perhaps to put in the mimetype text/html to signal that it's to be parsed differently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13188)
<!-- Reviewable:end -->
