### PR TITLE
[DoubleSpinWidget, SpinWidget] change values with page-turn buttons

### DIFF
--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -368,9 +368,14 @@ step value to either the left or right widget component.
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget
-    local step = target_widget.value_step or 1
     -- Use the target_widget's changeValue method but don't update the stored value directly
-    local new_value = target_widget:changeValue(target_widget:getValue(), direction * step, target_widget.value_max, target_widget.value_min, false)
+    local new_value = target_widget:changeValue(
+        target_widget:getValue(),
+        target_widget.value_step * direction,
+        target_widget.value_max,
+        target_widget.value_min,
+        false
+    )
     target_widget.value = new_value
     target_widget:update()
     return true

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -68,6 +68,10 @@ function DoubleSpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.LeftWidgetUp = { { "LPgFwd" }, event = "ButtonSpinAdjust", args = { "left_widget", 1 } }
+        self.key_events.LeftWidgetDown = { { "LPgBack" }, event = "ButtonSpinAdjust", args = { "left_widget", -1 } }
+        self.key_events.RightWidgetUp = { { "RPgFwd" }, event = "ButtonSpinAdjust", args = { "right_widget", 1 } }
+        self.key_events.RightWidgetDown = { { "RPgBack" }, event = "ButtonSpinAdjust", args = { "right_widget", -1 } }
     end
     if Device:isTouchDevice() then
         self.ges_events.TapClose = {
@@ -347,6 +351,22 @@ function DoubleSpinWidget:onClose()
     if self.close_callback then
         self.close_callback()
     end
+    return true
+end
+
+function DoubleSpinWidget:onButtonSpinAdjust(args)
+    local which_widget, direction = unpack(args)
+    local current_value = which_widget == "left_widget" and self.left_value or self.right_value
+    local step = (which_widget == "left_widget" and self.left_step or self.right_step) or 1
+    local min_val = which_widget == "left_widget" and self.left_min or self.right_min
+    local max_val = which_widget == "left_widget" and self.left_max or self.right_max
+    local new_value = NumberPickerWidget:changeValue(current_value, direction * step, max_val, min_val, false)
+    if which_widget == "left_widget" then
+        self.left_value = new_value
+    else
+        self.right_value = new_value
+    end
+    self:update(self.left_value, self.right_value)
     return true
 end
 

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -55,13 +55,13 @@ local DoubleSpinWidget = FocusManager:extend{
     extra_callback = nil,
     is_range = false, -- show a range separator in default button and between the spinners
     unit = nil,
-    _left_widget = nil,  -- Instance variable to store left widget reference
-    _right_widget = nil, -- Instance variable to store right widget reference
 }
 
 function DoubleSpinWidget:init()
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
+    self._left_widget = nil  -- Instance variable to store left widget reference
+    self._right_widget = nil -- Instance variable to store right widget reference
     if not self.width then
         if not self.width_factor then
             self.width_factor = 0.8 -- default if no width specified

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -369,14 +369,13 @@ function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget
     -- Use the target_widget's changeValue method but don't update the stored value directly
-    local new_value = target_widget:changeValue(
+    target_widget.value = target_widget:changeValue(
         target_widget:getValue(),
         target_widget.value_step * direction,
         target_widget.value_max,
         target_widget.value_min,
         false
     )
-    target_widget.value = new_value
     target_widget:update()
     return true
 end

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -368,9 +368,9 @@ step value to either the left or right widget component.
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget
-    local step = (target_side == "left_widget" and self.left_step or self.right_step) or 1
+    local step = target_widget.value_step or 1
     -- Use the target_widget's changeValue method but don't update the stored value directly
-    local new_value = NumberPickerWidget:changeValue(target_widget:getValue(), direction * step, target_widget.value_max, target_widget.value_min, false)
+    local new_value = target_widget:changeValue(target_widget:getValue(), direction * step, target_widget.value_max, target_widget.value_min, false)
     target_widget.value = new_value
     target_widget:update()
     return true

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -127,7 +127,6 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         unit = self.unit,
     }
     self:mergeLayoutInHorizontal(right_widget)
-
     left_widget.picker_updated_callback = function(value)
         self:update(value, right_widget:getValue())
     end

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -57,12 +57,11 @@ local DoubleSpinWidget = FocusManager:extend{
     unit = nil,
 }
 
-local left_widget
-local right_widget
-
 function DoubleSpinWidget:init()
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
+    local left_widget
+    local right_widget
     if not self.width then
         if not self.width_factor then
             self.width_factor = 0.8 -- default if no width specified

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -380,6 +380,7 @@ step value to either the left or right widget component.
 @param args {table} A table containing:
     - is_left_widget {boolean}. True for self.left_widget or False for self.right_widget
     - direction {int}. The direction of change (1 for increase, -1 for decrease)
+    - is_hold_event {boolean}. True if the event is a hold event, false otherwise
 @return {boolean} Returns true to indicate the event was handled
 ]]
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -369,13 +369,7 @@ function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget
     -- Use the target_widget's changeValue method but don't update the stored value directly
-    target_widget.value = target_widget:changeValue(
-        target_widget:getValue(),
-        target_widget.value_step * direction,
-        target_widget.value_max,
-        target_widget.value_min,
-        target_widget.wrap
-    )
+    target_widget.value = target_widget:changeValue(target_widget.value_step * direction)
     target_widget:update()
     return true
 end

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -94,6 +94,15 @@ function DoubleSpinWidget:init()
 
     -- Actually the widget layout
     self:update()
+
+    -- Move focus to OK button on devices which have key_events, saves time for users
+    if Device:hasDPad() and Device:useDPadAsActionKeys() and not Device:isTouchDevice() then
+        -- Since button table is the last row in our layout, and OK is the last button
+        -- We need to set focus to both last row, and last column
+        local last_row = #self.layout
+        local last_col = #self.layout[last_row]
+        self:moveFocusTo(last_col, last_row)
+    end
 end
 
 function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_value)

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -73,6 +73,14 @@ function DoubleSpinWidget:init()
             self.key_events.LeftWidgetValueDown  = { { "LPgBack" }, event = "DoubleSpinButtonPressed", args = { true,  -1 } }
             self.key_events.RightWidgetValueUp   = { { "RPgFwd"  }, event = "DoubleSpinButtonPressed", args = { false,  1 } }
             self.key_events.RightWidgetValueDown = { { "RPgBack" }, event = "DoubleSpinButtonPressed", args = { false, -1 } }
+            if Device:hasScreenKB() or Device:hasKeyboard() then
+                local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+                local HOLD = true -- use hold step value
+                self.key_events.LeftWidgetHoldValueUp    = { { modifier, "LPgFwd"  }, event = "DoubleSpinButtonPressed", args = { true,   1, HOLD } }
+                self.key_events.LeftWidgetHoldValueDown  = { { modifier, "LPgBack" }, event = "DoubleSpinButtonPressed", args = { true,  -1, HOLD } }
+                self.key_events.RightWidgetHoldValueUp   = { { modifier, "RPgFwd"  }, event = "DoubleSpinButtonPressed", args = { false,  1, HOLD } }
+                self.key_events.RightWidgetHoldValueDown = { { modifier, "RPgBack" }, event = "DoubleSpinButtonPressed", args = { false, -1, HOLD } }
+            end
         end
     end
     if Device:isTouchDevice() then
@@ -375,9 +383,10 @@ step value to either the left or right widget component.
 @return {boolean} Returns true to indicate the event was handled
 ]]
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
-    local is_left_widget, direction = unpack(args)
+    local is_left_widget, direction, is_hold_event = unpack(args)
     local target_widget = is_left_widget and self.left_widget or self.right_widget
-    target_widget.value = target_widget:changeValue(target_widget.value_step * direction)
+    local step = is_hold_event and target_widget.value_hold_step or target_widget.value_step
+    target_widget.value = target_widget:changeValue(step * direction)
     target_widget:update()
     return true
 end

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -357,14 +357,14 @@ function DoubleSpinWidget:onClose()
 end
 
 --[[
-This method processes value changes when physical buttons are pressed, applying the appropriate
+This method processes value changes based on the direction of the spin, applying the appropriate
 step value to either the left or right widget component.
 
 @param args {table} A table containing:
     - target_side {string}. Either "left_widget" or "right_widget" indicating which side to modify
     - direction {number}. The direction of change (1 for increase, -1 for decrease)
 @return {boolean} Returns true to indicate the event was handled
---]]
+]]
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -69,10 +69,10 @@ function DoubleSpinWidget:init()
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
         if Device:hasDPad() and Device:useDPadAsActionKeys() then
-            self.key_events.LeftWidgetUp    = { { "LPgFwd"  }, event = "SpinButtonPressed", args = { "left_widget",   1 } }
-            self.key_events.LeftWidgetDown  = { { "LPgBack" }, event = "SpinButtonPressed", args = { "left_widget",  -1 } }
-            self.key_events.RightWidgetUp   = { { "RPgFwd"  }, event = "SpinButtonPressed", args = { "right_widget",  1 } }
-            self.key_events.RightWidgetDown = { { "RPgBack" }, event = "SpinButtonPressed", args = { "right_widget", -1 } }
+            self.key_events.LeftWidgetValueUp    = { { "LPgFwd"  }, event = "DoubleSpinButtonPressed", args = { "left_widget",   1 } }
+            self.key_events.LeftWidgetValueDown  = { { "LPgBack" }, event = "DoubleSpinButtonPressed", args = { "left_widget",  -1 } }
+            self.key_events.RightWidgetValueUp   = { { "RPgFwd"  }, event = "DoubleSpinButtonPressed", args = { "right_widget",  1 } }
+            self.key_events.RightWidgetValueDown = { { "RPgBack" }, event = "DoubleSpinButtonPressed", args = { "right_widget", -1 } }
         end
     end
     if Device:isTouchDevice() then
@@ -356,7 +356,7 @@ function DoubleSpinWidget:onClose()
     return true
 end
 
-function DoubleSpinWidget:onSpinButtonPressed(args)
+function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget
     local step = (target_side == "left_widget" and self.left_step or self.right_step) or 1

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -60,8 +60,6 @@ local DoubleSpinWidget = FocusManager:extend{
 function DoubleSpinWidget:init()
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
-    local left_widget
-    local right_widget
     if not self.width then
         if not self.width_factor then
             self.width_factor = 0.8 -- default if no width specified
@@ -71,10 +69,10 @@ function DoubleSpinWidget:init()
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
         if Device:hasDPad() and Device:useDPadAsActionKeys() then
-            self.key_events.LeftWidgetValueUp    = { { "LPgFwd"  }, event = "DoubleSpinButtonPressed", args = { "left_widget",   1 } }
-            self.key_events.LeftWidgetValueDown  = { { "LPgBack" }, event = "DoubleSpinButtonPressed", args = { "left_widget",  -1 } }
-            self.key_events.RightWidgetValueUp   = { { "RPgFwd"  }, event = "DoubleSpinButtonPressed", args = { "right_widget",  1 } }
-            self.key_events.RightWidgetValueDown = { { "RPgBack" }, event = "DoubleSpinButtonPressed", args = { "right_widget", -1 } }
+            self.key_events.LeftWidgetValueUp    = { { "LPgFwd"  }, event = "DoubleSpinButtonPressed", args = { true,   1 } }
+            self.key_events.LeftWidgetValueDown  = { { "LPgBack" }, event = "DoubleSpinButtonPressed", args = { true,  -1 } }
+            self.key_events.RightWidgetValueUp   = { { "RPgFwd"  }, event = "DoubleSpinButtonPressed", args = { false,  1 } }
+            self.key_events.RightWidgetValueDown = { { "RPgBack" }, event = "DoubleSpinButtonPressed", args = { false, -1 } }
         end
     end
     if Device:isTouchDevice() then
@@ -102,7 +100,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     local prev_movable_offset = self.movable and self.movable:getMovedOffset()
     local prev_movable_alpha = self.movable and self.movable.alpha
     self.layout = {}
-    left_widget = NumberPickerWidget:new{
+    self.left_widget = NumberPickerWidget:new{
         show_parent = self,
         value = numberpicker_left_value or self.left_value,
         value_min = self.left_min,
@@ -113,8 +111,8 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         wrap = self.left_wrap,
         unit = self.unit,
     }
-    self:mergeLayoutInHorizontal(left_widget)
-    right_widget = NumberPickerWidget:new{
+    self:mergeLayoutInHorizontal(self.left_widget)
+    self.right_widget = NumberPickerWidget:new{
         show_parent = self,
         value = numberpicker_right_value or self.right_value,
         value_min = self.right_min,
@@ -125,12 +123,12 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         wrap = self.right_wrap,
         unit = self.unit,
     }
-    self:mergeLayoutInHorizontal(right_widget)
-    left_widget.picker_updated_callback = function(value)
-        self:update(value, right_widget:getValue())
+    self:mergeLayoutInHorizontal(self.right_widget)
+    self.left_widget.picker_updated_callback = function(value)
+        self:update(value, self.right_widget:getValue())
     end
-    right_widget.picker_updated_callback = function(value)
-        self:update(left_widget:getValue(), value)
+    self.right_widget.picker_updated_callback = function(value)
+        self:update(self.left_widget:getValue(), value)
     end
     local separator_widget = TextWidget:new{
         text = self.is_range and "–" or "",
@@ -141,7 +139,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     local text_max_width = math.floor(0.95 * self.width / 2)
     local left_vertical_group = VerticalGroup:new{
         align = "center",
-        left_widget,
+        self.left_widget,
     }
     local separator_vertical_group = VerticalGroup:new{
         align = "center",
@@ -149,7 +147,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
     }
     local right_vertical_group = VerticalGroup:new{
         align = "center",
-        right_widget,
+        self.right_widget,
     }
 
     if self.left_text ~= "" or self.right_text ~= "" then
@@ -219,10 +217,10 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
                     self.right_precision and string.format(self.right_precision, self.right_default) or self.right_default,
                     unit, separator),
                 callback = function()
-                    left_widget.value = self.left_default
-                    right_widget.value = self.right_default
-                    left_widget:update()
-                    right_widget:update()
+                    self.left_widget.value = self.left_default
+                    self.right_widget.value = self.right_default
+                    self.left_widget:update()
+                    self.right_widget:update()
                 end,
             }
         })
@@ -233,7 +231,7 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
                 text = self.extra_text,
                 callback = function()
                     if self.extra_callback then
-                        self.extra_callback(left_widget:getValue(), right_widget:getValue())
+                        self.extra_callback(self.left_widget:getValue(), self.right_widget:getValue())
                     end
                     if not self.keep_shown_on_apply then -- assume extra wants it same as ok
                         self:onClose()
@@ -254,11 +252,11 @@ function DoubleSpinWidget:update(numberpicker_left_value, numberpicker_right_val
         },
         {
             text = self.ok_text,
-            enabled = self.ok_always_enabled or self.left_value ~= left_widget:getValue()
-                or self.right_value ~= right_widget:getValue(),
+            enabled = self.ok_always_enabled or self.left_value ~= self.left_widget:getValue()
+                or self.right_value ~= self.right_widget:getValue(),
             callback = function()
-                self.left_value = left_widget:getValue()
-                self.right_value = right_widget:getValue()
+                self.left_value = self.left_widget:getValue()
+                self.right_value = self.right_widget:getValue()
                 if self.callback then
                     self.callback(self.left_value, self.right_value)
                 end
@@ -363,13 +361,13 @@ This method processes value changes based on the direction of the spin, applying
 step value to either the left or right widget component.
 
 @param args {table} A table containing:
-    - target_side {string}. Either "left_widget" or "right_widget" indicating which side to modify
-    - direction {number}. The direction of change (1 for increase, -1 for decrease)
+    - is_left_widget {boolean}. True for self.left_widget or False for self.right_widget
+    - direction {int}. The direction of change (1 for increase, -1 for decrease)
 @return {boolean} Returns true to indicate the event was handled
 ]]
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
-    local target_side, direction = unpack(args)
-    local target_widget = target_side == "left_widget" and left_widget or right_widget
+    local is_left_widget, direction = unpack(args)
+    local target_widget = is_left_widget and self.left_widget or self.right_widget
     target_widget.value = target_widget:changeValue(target_widget.value_step * direction)
     target_widget:update()
     return true

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -374,7 +374,7 @@ function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
         target_widget.value_step * direction,
         target_widget.value_max,
         target_widget.value_min,
-        false
+        target_widget.wrap
     )
     target_widget:update()
     return true

--- a/frontend/ui/widget/doublespinwidget.lua
+++ b/frontend/ui/widget/doublespinwidget.lua
@@ -356,6 +356,15 @@ function DoubleSpinWidget:onClose()
     return true
 end
 
+--[[
+This method processes value changes when physical buttons are pressed, applying the appropriate
+step value to either the left or right widget component.
+
+@param args {table} A table containing:
+    - target_side {string}. Either "left_widget" or "right_widget" indicating which side to modify
+    - direction {number}. The direction of change (1 for increase, -1 for decrease)
+@return {boolean} Returns true to indicate the event was handled
+--]]
 function DoubleSpinWidget:onDoubleSpinButtonPressed(args)
     local target_side, direction = unpack(args)
     local target_widget = target_side == "left_widget" and self.left_widget or self.right_widget

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -78,14 +78,14 @@ function NumberPickerWidget:init()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value, self.value_step, self.value_max, self.value_min, self.wrap)
+            self.value = self:changeValue(self.value_step)
             self:update()
         end,
         hold_callback = function()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value, self.value_hold_step, self.value_max, self.value_min, self.wrap)
+            self.value = self:changeValue(self.value_hold_step)
             self:update()
         end
     }
@@ -102,14 +102,14 @@ function NumberPickerWidget:init()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value, self.value_step * -1, self.value_max, self.value_min, self.wrap)
+            self.value = self:changeValue(self.value_step * -1)
             self:update()
         end,
         hold_callback = function()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value, self.value_hold_step * -1, self.value_max, self.value_min, self.wrap)
+            self.value = self:changeValue(self.value_hold_step * -1)
             self:update()
         end
     }
@@ -295,21 +295,22 @@ end
 --[[--
 Change value.
 --]]
-function NumberPickerWidget:changeValue(value, step, max, min, wrap)
+function NumberPickerWidget:changeValue(step)
+    local value
     if self.value_index then
         self.value_index = self.value_index + step
         if self.value_index > #self.value_table then
-            self.value_index = wrap and 1 or #self.value_table
+            self.value_index = self.wrap and 1 or #self.value_table
         elseif self.value_index < 1 then
-            self.value_index = wrap and #self.value_table or 1
+            self.value_index = self.wrap and #self.value_table or 1
         end
         value = self.value_table[self.value_index]
     else
-        value = value + step
-        if value > max then
-            value = wrap and min or max
-        elseif value < min then
-            value = wrap and max or min
+        value = self.value + step
+        if value > self.value_max then
+            value = self.wrap and self.value_min or self.value_max
+        elseif value < self.value_min then
+            value = self.wrap and self.value_max or self.value_min
         end
     end
     return value

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -300,8 +300,7 @@ function NumberPickerWidget:changeValue(value, step, max, min, wrap)
         self.value_index = self.value_index + step
         if self.value_index > #self.value_table then
             self.value_index = wrap and 1 or #self.value_table
-        elseif
-        self.value_index < 1 then
+        elseif self.value_index < 1 then
             self.value_index = wrap and #self.value_table or 1
         end
         value = self.value_table[self.value_index]

--- a/frontend/ui/widget/numberpickerwidget.lua
+++ b/frontend/ui/widget/numberpickerwidget.lua
@@ -102,14 +102,14 @@ function NumberPickerWidget:init()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value_step * -1)
+            self.value = self:changeValue(-self.value_step)
             self:update()
         end,
         hold_callback = function()
             if self.date_month and self.date_year then
                 self.value_max = self:getDaysInMonth(self.date_month:getValue(), self.date_year:getValue())
             end
-            self.value = self:changeValue(self.value_hold_step * -1)
+            self.value = self:changeValue(-self.value_hold_step)
             self:update()
         end
     }

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -340,6 +340,14 @@ function SpinWidget:onClose()
     return true
 end
 
+--[[
+This method updates the widget's value based on the direction of the spin.
+For value_table-based widgets, it cycles through indices in the table.
+For numeric widgets, it increments/decrements by the specified step value.
+
+@param direction {number}. The direction of the spin (-1 for decrease, 1 for increase)
+@return boolean Always returns true to indicate the event was handled
+]]
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
     if widget.value_table then

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -349,8 +349,7 @@ This method updates the widget's value based on the direction of the spin.
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
     -- Use the widget's changeValue method but don't update the stored value directly
-    local new_value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, false)
-    widget.value = new_value
+    widget.value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, false)
     widget:update()
     return true
 end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -68,6 +68,12 @@ function SpinWidget:init()
         self.key_events.Close = { { Device.input.group.Back } }
         self.key_events.WidgetValueUp    = { { Device.input.group.PgFwd  }, event = "SpinButtonPressed", args =  1 }
         self.key_events.WidgetValueDown  = { { Device.input.group.PgBack }, event = "SpinButtonPressed", args = -1 }
+        if Device:hasScreenKB() or Device:hasKeyboard() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            local HOLD = true -- use hold step value
+            self.key_events.WidgetHoldValueUp    = { { modifier, Device.input.group.PgFwd  },  event = "DoubleSpinButtonPressed", args = {  1, HOLD } }
+            self.key_events.WidgetHoldValueDown  = { { modifier, Device.input.group.LPgBack }, event = "DoubleSpinButtonPressed", args = { -1, HOLD } }
+        end
     end
     if Device:isTouchDevice() then
         self.ges_events.TapClose = {
@@ -355,8 +361,10 @@ This method updates the widget's value based on the direction of the spin.
 @param direction {number}. The direction of the spin (-1 for decrease, 1 for increase)
 @return boolean Always returns true to indicate the event was handled
 ]]
-function SpinWidget:onSpinButtonPressed(direction)
-    self.value_widget.value = self.value_widget:changeValue(self.value_step * direction)
+function SpinWidget:onSpinButtonPressed(args)
+    local direction, is_hold_event = unpack(args)
+    local step = is_hold_event and self.value_hold_step or self.value_step
+    self.value_widget.value = self.value_widget:changeValue(step * direction)
     self.value_widget:update()
     return true
 end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -358,7 +358,9 @@ end
 --[[
 This method updates the widget's value based on the direction of the spin.
 
-@param direction {number}. The direction of the spin (-1 for decrease, 1 for increase)
+@param args {table} A table containing:
+    - direction {number}. The direction of the spin (-1 for decrease, 1 for increase)
+    - is_hold_event {boolean}. True if the event is a hold event, false otherwise
 @return boolean Always returns true to indicate the event was handled
 ]]
 function SpinWidget:onSpinButtonPressed(args)

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -86,6 +86,15 @@ function SpinWidget:init()
     end
     -- Actually the widget layout
     self:update()
+
+    -- Move focus to OK button on NT devices with key_events, saves time for users
+    if Device:hasDPad() and Device:useDPadAsActionKeys() and not Device:isTouchDevice() then
+        -- Since button table is the last row in our layout, and OK is the last button
+        -- We need to set focus to both last row, and last column
+        local last_row = #self.layout
+        local last_col = #self.layout[last_row]
+        self:moveFocusTo(last_col, last_row)
+    end
 end
 
 function SpinWidget:update(numberpicker_value, numberpicker_value_index)

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -343,12 +343,9 @@ end
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
     if widget.value_table then
-        local new_index = widget.value_index + direction
-        if new_index < 1 then
-            new_index = 1
-        elseif new_index > #widget.value_table then
-            new_index = #widget.value_table
-        end
+        local value_index = widget.value_index
+        local table_lenght = #widget.value_table
+        local new_index = NumberPickerWidget:changeValue(value_index, direction, table_lenght, 1, false)
         widget.value_index = new_index
     else
         local step = self.value_step or 1

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -52,11 +52,10 @@ local SpinWidget = FocusManager:extend{
     unit = nil, -- unit to show or nil
 }
 
-local value_widget
-
 function SpinWidget:init()
     -- used to enable ok_button, self.value may be changed in extra callback
     self.original_value = self.value_table and self.value_table[self.value_index or 1] or self.value
+    local value_widget
 
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -348,9 +348,8 @@ This method updates the widget's value based on the direction of the spin.
 ]]
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
-    local step = self.value_step or 1
     -- Use the widget's changeValue method but don't update the stored value directly
-    local new_value = widget:changeValue(widget:getValue(), direction * step, widget.value_max, widget.value_min, false)
+    local new_value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, false)
     widget.value = new_value
     widget:update()
     return true

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -52,10 +52,11 @@ local SpinWidget = FocusManager:extend{
     unit = nil, -- unit to show or nil
 }
 
+local value_widget
+
 function SpinWidget:init()
     -- used to enable ok_button, self.value may be changed in extra callback
     self.original_value = self.value_table and self.value_table[self.value_index or 1] or self.value
-    self._value_widget = nil
 
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
@@ -93,7 +94,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
     local prev_movable_offset = self.movable and self.movable:getMovedOffset()
     local prev_movable_alpha = self.movable and self.movable.alpha
     self.layout = {}
-    local value_widget = NumberPickerWidget:new{
+    value_widget = NumberPickerWidget:new{
         show_parent = self,
         value = numberpicker_value or self.value,
         value_table = self.value_table,
@@ -114,7 +115,6 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         align = "center",
         value_widget,
     }
-    self._value_widget = value_widget
 
     local title_bar = TitleBar:new{
         width = self.width,
@@ -153,12 +153,12 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
             {
                 text = T(_("Default value: %1%2"), value, unit),
                 callback = function()
-                    if self._value_widget.value_table then
-                        self._value_widget.value_index = self.default_value
+                    if value_widget.value_table then
+                        value_widget.value_index = self.default_value
                     else
-                        self._value_widget.value = self.default_value
+                        value_widget.value = self.default_value
                     end
-                    self._value_widget:update()
+                    value_widget:update()
                 end,
             },
         })
@@ -168,7 +168,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         text = self.extra_text,
         callback = function()
             if self.extra_callback then
-                self.value, self.value_index = self._value_widget:getValue()
+                self.value, self.value_index = value_widget:getValue()
                 self.extra_callback(self)
             end
             if not self.keep_shown_on_apply then -- assume extra wants it same as ok
@@ -180,7 +180,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         text = self.option_text,
         callback = function()
             if self.option_callback then
-                self.value, self.value_index = self._value_widget:getValue()
+                self.value, self.value_index = value_widget:getValue()
                 self.option_callback(self)
             end
             if not self.keep_shown_on_apply then -- assume option wants it same as ok
@@ -207,9 +207,9 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         },
         {
             text = self.ok_text,
-            enabled = self.ok_always_enabled or self.original_value ~= self._value_widget:getValue(),
+            enabled = self.ok_always_enabled or self.original_value ~= value_widget:getValue(),
             callback = function()
-                self.value, self.value_index = self._value_widget:getValue()
+                self.value, self.value_index = value_widget:getValue()
                 self.original_value = self.value
                 if self.callback then
                     self.callback(self)
@@ -349,8 +349,8 @@ This method updates the widget's value based on the direction of the spin.
 @return boolean Always returns true to indicate the event was handled
 ]]
 function SpinWidget:onSpinButtonPressed(direction)
-    self._value_widget.value = self._value_widget:changeValue(self.value_step * direction)
-    self._value_widget:update()
+    value_widget.value = value_widget:changeValue(self.value_step * direction)
+    value_widget:update()
     return true
 end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -342,23 +342,16 @@ end
 
 --[[
 This method updates the widget's value based on the direction of the spin.
-For value_table-based widgets, it cycles through indices in the table.
-For numeric widgets, it increments/decrements by the specified step value.
 
 @param direction {number}. The direction of the spin (-1 for decrease, 1 for increase)
 @return boolean Always returns true to indicate the event was handled
 ]]
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
-    if widget.value_table then
-        local new_index = NumberPickerWidget:changeValue(widget.value_index, direction, #widget.value_table, 1, false)
-        widget.value_index = new_index
-    else
-        local step = self.value_step or 1
-        -- Use the widget's changeValue method but don't update the stored value directly
-        local new_value = NumberPickerWidget:changeValue(widget:getValue(), direction * step, widget.value_max, widget.value_min, false)
-        widget.value = new_value
-    end
+    local step = self.value_step or 1
+    -- Use the widget's changeValue method but don't update the stored value directly
+    local new_value = widget:changeValue(widget:getValue(), direction * step, widget.value_max, widget.value_min, false)
+    widget.value = new_value
     widget:update()
     return true
 end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -66,8 +66,8 @@ function SpinWidget:init()
     end
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
-        self.key_events.WidgetValueUp    = { { Device.input.group.PgFwd  }, event = "SpinButtonPressed", args =  1 }
-        self.key_events.WidgetValueDown  = { { Device.input.group.PgBack }, event = "SpinButtonPressed", args = -1 }
+        self.key_events.WidgetValueUp    = { { Device.input.group.PgFwd  }, event = "SpinButtonPressed", args = {  1, false } }
+        self.key_events.WidgetValueDown  = { { Device.input.group.PgBack }, event = "SpinButtonPressed", args = { -1, false } }
         if Device:hasScreenKB() or Device:hasKeyboard() then
             local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
             local HOLD = true -- use hold step value

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -55,7 +55,6 @@ local SpinWidget = FocusManager:extend{
 function SpinWidget:init()
     -- used to enable ok_button, self.value may be changed in extra callback
     self.original_value = self.value_table and self.value_table[self.value_index or 1] or self.value
-    local value_widget
 
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
@@ -93,7 +92,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
     local prev_movable_offset = self.movable and self.movable:getMovedOffset()
     local prev_movable_alpha = self.movable and self.movable.alpha
     self.layout = {}
-    value_widget = NumberPickerWidget:new{
+    self.value_widget = NumberPickerWidget:new{
         show_parent = self,
         value = numberpicker_value or self.value,
         value_table = self.value_table,
@@ -109,10 +108,10 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         end,
         unit = self.unit,
     }
-    self:mergeLayoutInVertical(value_widget)
+    self:mergeLayoutInVertical(self.value_widget)
     local value_group = HorizontalGroup:new{
         align = "center",
-        value_widget,
+        self.value_widget,
     }
 
     local title_bar = TitleBar:new{
@@ -152,12 +151,12 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
             {
                 text = T(_("Default value: %1%2"), value, unit),
                 callback = function()
-                    if value_widget.value_table then
-                        value_widget.value_index = self.default_value
+                    if self.value_widget.value_table then
+                        self.value_widget.value_index = self.default_value
                     else
-                        value_widget.value = self.default_value
+                        self.value_widget.value = self.default_value
                     end
-                    value_widget:update()
+                    self.value_widget:update()
                 end,
             },
         })
@@ -167,7 +166,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         text = self.extra_text,
         callback = function()
             if self.extra_callback then
-                self.value, self.value_index = value_widget:getValue()
+                self.value, self.value_index = self.value_widget:getValue()
                 self.extra_callback(self)
             end
             if not self.keep_shown_on_apply then -- assume extra wants it same as ok
@@ -179,7 +178,7 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         text = self.option_text,
         callback = function()
             if self.option_callback then
-                self.value, self.value_index = value_widget:getValue()
+                self.value, self.value_index = self.value_widget:getValue()
                 self.option_callback(self)
             end
             if not self.keep_shown_on_apply then -- assume option wants it same as ok
@@ -206,9 +205,9 @@ function SpinWidget:update(numberpicker_value, numberpicker_value_index)
         },
         {
             text = self.ok_text,
-            enabled = self.ok_always_enabled or self.original_value ~= value_widget:getValue(),
+            enabled = self.ok_always_enabled or self.original_value ~= self.value_widget:getValue(),
             callback = function()
-                self.value, self.value_index = value_widget:getValue()
+                self.value, self.value_index = self.value_widget:getValue()
                 self.original_value = self.value
                 if self.callback then
                     self.callback(self)
@@ -348,8 +347,8 @@ This method updates the widget's value based on the direction of the spin.
 @return boolean Always returns true to indicate the event was handled
 ]]
 function SpinWidget:onSpinButtonPressed(direction)
-    value_widget.value = value_widget:changeValue(self.value_step * direction)
-    value_widget:update()
+    self.value_widget.value = self.value_widget:changeValue(self.value_step * direction)
+    self.value_widget:update()
     return true
 end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -71,8 +71,8 @@ function SpinWidget:init()
         if Device:hasScreenKB() or Device:hasKeyboard() then
             local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
             local HOLD = true -- use hold step value
-            self.key_events.WidgetHoldValueUp    = { { modifier, Device.input.group.PgFwd  },  event = "DoubleSpinButtonPressed", args = {  1, HOLD } }
-            self.key_events.WidgetHoldValueDown  = { { modifier, Device.input.group.LPgBack }, event = "DoubleSpinButtonPressed", args = { -1, HOLD } }
+            self.key_events.WidgetHoldValueUp    = { { modifier, Device.input.group.PgFwd  },  event = "SpinButtonPressed", args = {  1, HOLD } }
+            self.key_events.WidgetHoldValueDown  = { { modifier, Device.input.group.LPgBack }, event = "SpinButtonPressed", args = { -1, HOLD } }
         end
     end
     if Device:isTouchDevice() then

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -347,10 +347,9 @@ This method updates the widget's value based on the direction of the spin.
 @return boolean Always returns true to indicate the event was handled
 ]]
 function SpinWidget:onSpinButtonPressed(direction)
-    local widget = self.value_widget
     -- Use the widget's changeValue method but don't update the stored value directly
-    widget.value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, widget.wrap)
-    widget:update()
+    self.value_widget.value = self.value_widget:changeValue(self.value_step * direction)
+    self.value_widget:update()
     return true
 end
 

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -349,7 +349,7 @@ This method updates the widget's value based on the direction of the spin.
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
     -- Use the widget's changeValue method but don't update the stored value directly
-    widget.value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, false)
+    widget.value = widget:changeValue(widget:getValue(), self.value_step * direction, widget.value_max, widget.value_min, widget.wrap)
     widget:update()
     return true
 end

--- a/frontend/ui/widget/spinwidget.lua
+++ b/frontend/ui/widget/spinwidget.lua
@@ -343,9 +343,7 @@ end
 function SpinWidget:onSpinButtonPressed(direction)
     local widget = self.value_widget
     if widget.value_table then
-        local value_index = widget.value_index
-        local table_lenght = #widget.value_table
-        local new_index = NumberPickerWidget:changeValue(value_index, direction, table_lenght, 1, false)
+        local new_index = NumberPickerWidget:changeValue(widget.value_index, direction, #widget.value_table, 1, false)
         widget.value_index = new_index
     else
         local step = self.value_step or 1


### PR DESCRIPTION
### what's new

This pull request includes changes to the `DoubleSpinWidget` and `SpinWidget` classes. The modifications enhance the functionality of these widgets by adding new key events to support value changing using the device's page-turn buttons.

#### enhancements to `DoubleSpinWidget`:

* Added key events to support adjusting widget values. 
* Replaced local variables with instance variables for `left_widget` and `right_widget`. 
* Introduced the `onDoubleSpinButtonPressed` method to handle page-turn button presses for adjusting widget values.

#### enhancements to `SpinWidget`:

* Added key events to support  adjusting widget values.
* Replaced local variables with instance variables for `value_widget`.
* Introduced the `onSpinButtonPressed` method to handle page-turn button presses for adjusting widget values. 

#### others

* Removed number of arguments needed to pass to `changeValue` method of `NumberPickerWidget`.
* closes #11821

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13208)
<!-- Reviewable:end -->
