### PR TITLE
[Hotkeys] refactor hotkey list and update callbacks

### DIFF
--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -23,76 +23,37 @@ local HotKeys = InputContainer:extend{
 }
 local hotkeys_path = FFIUtil.joinPath(DataStorage:getSettingsDir(), "hotkeys.lua")
 
--- mofifier *here* refers to either screenkb or shift
-local hotkeys_list = {
-    -- cursor keys
-    modifier_plus_up                 = Device:hasScreenKB() and _("ScreenKB + Up")      or _("Shift + Up"),
-    modifier_plus_down               = Device:hasScreenKB() and _("ScreenKB + Down")    or _("Shift + Down"),
-    modifier_plus_left               = Device:hasScreenKB() and _("ScreenKB + Left")    or _("Shift + Left"),
-    modifier_plus_right              = Device:hasScreenKB() and _("ScreenKB + Right")   or _("Shift + Right"),
-    -- page turn buttons
-    modifier_plus_left_page_back     = Device:hasScreenKB() and _("ScreenKB + LPgBack") or _("Shift + LPgBack"),
-    modifier_plus_left_page_forward  = Device:hasScreenKB() and _("ScreenKB + LPgFwd")  or _("Shift + LPgFwd"),
-    modifier_plus_right_page_back    = Device:hasScreenKB() and _("ScreenKB + RPgBack") or _("Shift + RPgBack"),
-    modifier_plus_right_page_forward = Device:hasScreenKB() and _("ScreenKB + RPgFwd")  or _("Shift + RPgFwd"),
-    -- function keys
-    modifier_plus_back               = Device:hasScreenKB() and _("ScreenKB + Back")    or _("Shift + Back"),
-    modifier_plus_home               = Device:hasScreenKB() and _("ScreenKB + Home")    or _("Shift + Home"),
-    modifier_plus_press              = Device:hasScreenKB() and _("ScreenKB + Press")   or _("Shift + Press"),
-    -- modifier_plus_menu (screenkb+menu) is already used globally for screenshots (on k4), don't add it here.
+-- Define hotkeys_list
+local hotkeys_list = {}
+local base_keys = {
+    up = "Up", down = "Down", left = "Left", right = "Right",
+    left_page_back = "LPgBack", left_page_forward = "LPgFwd",
+    right_page_back = "RPgBack", right_page_forward = "RPgFwd",
+    back = "Back", home = "Home", press = "Press"
 }
+-- modifier *here* refers to either screenkb or shift
+local modifier_one = Device:hasScreenKB() and "ScreenKB + " or "Shift + "
+-- screenkb/shift + base_keys
+for key, label in pairs(base_keys) do
+    hotkeys_list["modifier_plus_" .. key] = _(modifier_one .. label)
+    -- modifier_plus_menu (screenkb+menu) is already used globally for screenshots (on k4), don't add it here.
+end
 if LuaSettings:open(hotkeys_path).data["press_key_does_hotkeys"] then
-    local hotkeys_list_press = { press = _("Press") }
-    util.tableMerge(hotkeys_list, hotkeys_list_press)
+    util.tableMerge(hotkeys_list, { press = _("Press") })
 end
 if Device:hasKeyboard() then
-    local hotkeys_list_haskeyboard = {
-        modifier_plus_menu          = _("Shift + Menu"),
-        -- NOTE: we will use 'alt' for kindles and 'ctrl' for other devices with keyboards
-        --       but for simplicity we will use in code 'alt+keys' as the array's key for all.
-        -- alt+cursor
-        alt_plus_up                 = Device:hasSymKey() and _("Alt + Up")      or _("Ctrl + Up"),
-        alt_plus_down               = Device:hasSymKey() and _("Alt + Down")    or _("Ctrl + Down"),
-        alt_plus_left               = Device:hasSymKey() and _("Alt + Left")    or _("Ctrl + Left"),
-        alt_plus_right              = Device:hasSymKey() and _("Alt + Right")   or _("Ctrl + Right"),
-        -- alt+page_turn
-        alt_plus_left_page_back     = Device:hasSymKey() and _("Alt + LPgBack") or _("Ctrl + LPgBack"),
-        alt_plus_left_page_forward  = Device:hasSymKey() and _("Alt + LPgFwd")  or _("Ctrl + LPgFwd"),
-        alt_plus_right_page_back    = Device:hasSymKey() and _("Alt + RPgBack") or _("Ctrl + RPgBack"),
-        alt_plus_right_page_forward = Device:hasSymKey() and _("Alt + RPgFwd")  or _("Ctrl + RPgFwd"),
-        -- alt+fn_keys
-        alt_plus_back               = Device:hasSymKey() and _("Alt + Back")    or _("Ctrl + Back"),
-        alt_plus_home               = Device:hasSymKey() and _("Alt + Home")    or _("Ctrl + Home"),
-        alt_plus_press              = Device:hasSymKey() and _("Alt + Press")   or _("Ctrl + Press"),
-        alt_plus_menu               = Device:hasSymKey() and _("Alt + Menu")    or _("Ctrl + Menu"),
-        -- alt+alphabet
-        alt_plus_a = Device:hasSymKey() and _("Alt + A") or _("Ctrl + A"),
-        alt_plus_b = Device:hasSymKey() and _("Alt + B") or _("Ctrl + B"),
-        alt_plus_c = Device:hasSymKey() and _("Alt + C") or _("Ctrl + C"),
-        alt_plus_d = Device:hasSymKey() and _("Alt + D") or _("Ctrl + D"),
-        alt_plus_e = Device:hasSymKey() and _("Alt + E") or _("Ctrl + E"),
-        alt_plus_f = Device:hasSymKey() and _("Alt + F") or _("Ctrl + F"),
-        alt_plus_g = Device:hasSymKey() and _("Alt + G") or _("Ctrl + G"),
-        alt_plus_h = Device:hasSymKey() and _("Alt + H") or _("Ctrl + H"),
-        alt_plus_i = Device:hasSymKey() and _("Alt + I") or _("Ctrl + I"),
-        alt_plus_j = Device:hasSymKey() and _("Alt + J") or _("Ctrl + J"),
-        alt_plus_k = Device:hasSymKey() and _("Alt + K") or _("Ctrl + K"),
-        alt_plus_l = Device:hasSymKey() and _("Alt + L") or _("Ctrl + L"),
-        alt_plus_m = Device:hasSymKey() and _("Alt + M") or _("Ctrl + M"),
-        alt_plus_n = Device:hasSymKey() and _("Alt + N") or _("Ctrl + N"),
-        alt_plus_o = Device:hasSymKey() and _("Alt + O") or _("Ctrl + O"),
-        alt_plus_p = Device:hasSymKey() and _("Alt + P") or _("Ctrl + P"),
-        alt_plus_q = Device:hasSymKey() and _("Alt + Q") or _("Ctrl + Q"),
-        alt_plus_r = Device:hasSymKey() and _("Alt + R") or _("Ctrl + R"),
-        alt_plus_s = Device:hasSymKey() and _("Alt + S") or _("Ctrl + S"),
-        alt_plus_t = Device:hasSymKey() and _("Alt + T") or _("Ctrl + T"),
-        alt_plus_u = Device:hasSymKey() and _("Alt + U") or _("Ctrl + U"),
-        alt_plus_v = Device:hasSymKey() and _("Alt + V") or _("Ctrl + V"),
-        alt_plus_w = Device:hasSymKey() and _("Alt + W") or _("Ctrl + W"),
-        alt_plus_x = Device:hasSymKey() and _("Alt + X") or _("Ctrl + X"),
-        alt_plus_y = Device:hasSymKey() and _("Alt + Y") or _("Ctrl + Y"),
-        alt_plus_z = Device:hasSymKey() and _("Alt + Z") or _("Ctrl + Z"),
-    }
+    local hotkeys_list_haskeyboard = { modifier_plus_menu = _("Shift + Menu") }
+    -- NOTE: we will use 'alt' for kindles and 'ctrl' for other devices with keyboards
+    --       but for simplicity we will use in code 'alt+keys' as the array's key for all.
+    local modifier_two = Device:hasSymKey() and "Alt + " or "Ctrl + "
+    -- Alt/Ctrl + base_keys
+    for key, label in pairs(base_keys) do
+        hotkeys_list_haskeyboard["alt_plus_" .. key] = _(modifier_two .. label)
+    end
+    -- Alt/Ctrl + alphabet keys
+    for _, char in ipairs(Device.input.group.Alphabet) do
+        hotkeys_list_haskeyboard["alt_plus_" .. char:lower()] = _(modifier_two .. char)
+    end
     util.tableMerge(hotkeys_list, hotkeys_list_haskeyboard)
 end
 

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -217,7 +217,6 @@ function HotKeys:genMenu(hotkey)
         no_refresh_on_check = true,
         separator = true,
         checked_func = function()
-            -- Return true if no hotkey exists, or if the hotkey exists but has no dispatcher settings
             return self.hotkeys[hotkey] == nil or next(self.hotkeys[hotkey]) == nil
         end,
         callback = function(touchmenu_instance)
@@ -228,7 +227,7 @@ function HotKeys:genMenu(hotkey)
             end
             if self.hotkeys[hotkey] and next(self.hotkeys[hotkey]) then
                 Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
-            else -- If no actions are selected, just update the defaults
+            else
                 do_remove()
             end
         end,


### PR DESCRIPTION
### what's new

* Renamed `FFIUtil` to `ffiUtil` to maintain a consistent naming convention across the code base.
* Refactored the hotkeys list generation by defining a base keys table and iterating over it to create the hotkeys list dynamically. This change simplifies the code and makes it more maintainable.
* Added `no_refresh_on_check` property to menu items to prevent unnecessary refreshes when checking the items.
* Updated the `callback` functions in the hotkeys menu to include a `touchmenu_instance` parameter and handle the removal of actions more gracefully. This ensures the menu items are updated correctly after changes.

### bug report

there is a problem with the callbacks introduced (in the gestures plugin) in #13078, I believe the solution is doing exactly what I am doing here (the if/else bit), but await instructions to see if I should do it here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13219)
<!-- Reviewable:end -->
