### PR TITLE
[Common settings] remove screenshot setting from unsupported devices

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -750,13 +750,15 @@ common_settings.units = {
     }
 }
 
-common_settings.screenshot = {
-    text = _("Screenshot folder"),
-    callback = function()
-        local Screenshoter = require("ui/widget/screenshoter")
-        Screenshoter:chooseFolder()
-    end,
-    keep_menu_open = true,
-}
+if Device:isTouchDevice() or Device:hasKeyboard() or Device:hasScreenKB() then
+    common_settings.screenshot = {
+        text = _("Screenshot folder"),
+        callback = function()
+            local Screenshoter = require("ui/widget/screenshoter")
+            Screenshoter:chooseFolder()
+        end,
+        keep_menu_open = true,
+    }
+end
 
 return common_settings


### PR DESCRIPTION
#12293

* [`frontend/ui/elements/common_settings_menu_table.lua`](diffhunk://#diff-cb989447e34bc5b8a0e9f2f4c10ec368720cb0b7e6d99181a9c935371d057d60R753): Added a conditional check to include the `screenshot` setting only if the device meets certain criteria.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13221)
<!-- Reviewable:end -->
