### PR TITLE
calibre.koplugin: show message when attempting to connect via dispatcher

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -54,7 +54,7 @@ function Calibre:onStartWirelessConnection()
             text = _("Connecting to calibre")
         })
     end)
-    UIManager:scheduleIn(1, function()
+    UIManager:scheduleIn(0.1, function()
         self:startWirelessConnection()
     end)
 end

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -54,7 +54,7 @@ function Calibre:onStartWirelessConnection()
             text = _("Connecting to calibre")
         })
     end)
-    UIManager:scheduleIn(0.1, function()
+    UIManager:tickAfterNext(function()
         self:startWirelessConnection()
     end)
 end

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -49,7 +49,14 @@ function Calibre:onClose()
 end
 
 function Calibre:onStartWirelessConnection()
-    self:startWirelessConnection()
+    UIManager:nextTick(function()
+        UIManager:show(InfoMessage:new{
+            text = _("Connecting to calibre")
+        })
+    end)
+    UIManager:scheduleIn(1, function()
+        self:startWirelessConnection()
+    end)
 end
 
 function Calibre:onCloseWirelessConnection()


### PR DESCRIPTION
closes #13193

Using an InfoMessage instead of a notification because another infomessage will follow with success/error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13237)
<!-- Reviewable:end -->
