### PR TITLE
ReaderUI: fix BookList cache

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -824,7 +824,7 @@ function ReaderUI:onClose(full_refresh)
     end
     UIManager:close(self.dialog, full_refresh ~= false and "full")
     if file then
-        BookList.resetBookInfoCache(file, self.doc_settings)
+        BookList.setBookInfoCache(file, self.doc_settings)
     end
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -814,7 +814,7 @@ function ReaderUI:onClose(full_refresh)
         file = self.document.file
         require("readhistory"):updateLastBookTime(self.tearing_down)
         -- Serialize the most recently displayed page for later launch
-        DocCache:serialize(self.document.file)
+        DocCache:serialize(file)
         logger.dbg("closing document")
         self:handleEvent(Event:new("CloseDocument"))
         if self.document:isEdited() and not self.highlight.highlight_write_into_pdf then

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -810,7 +810,6 @@ function ReaderUI:onClose(full_refresh)
         self:saveSettings()
     end
     if self.document ~= nil then
-        BookList.setBookInfoCache(self.document.file, self.doc_settings)
         require("readhistory"):updateLastBookTime(self.tearing_down)
         -- Serialize the most recently displayed page for later launch
         DocCache:serialize(self.document.file)
@@ -819,6 +818,7 @@ function ReaderUI:onClose(full_refresh)
         if self.document:isEdited() and not self.highlight.highlight_write_into_pdf then
             self.document:discardChange()
         end
+        BookList.setBookInfoCache(self.document.file, self.doc_settings)
         self:closeDocument()
     end
     UIManager:close(self.dialog, full_refresh ~= false and "full")

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -809,7 +809,9 @@ function ReaderUI:onClose(full_refresh)
     if self.dialog ~= self then
         self:saveSettings()
     end
+    local file
     if self.document ~= nil then
+        file = self.document.file
         require("readhistory"):updateLastBookTime(self.tearing_down)
         -- Serialize the most recently displayed page for later launch
         DocCache:serialize(self.document.file)
@@ -818,10 +820,12 @@ function ReaderUI:onClose(full_refresh)
         if self.document:isEdited() and not self.highlight.highlight_write_into_pdf then
             self.document:discardChange()
         end
-        BookList.setBookInfoCache(self.document.file, self.doc_settings)
         self:closeDocument()
     end
     UIManager:close(self.dialog, full_refresh ~= false and "full")
+    if file then
+        BookList.resetBookInfoCache(file, self.doc_settings)
+    end
 end
 
 function ReaderUI:onCloseWidget()


### PR DESCRIPTION
Updating of `percent_finished` for `rolling` is triggered by the `CloseDocument` event, so refresh the cache after it.
Closes https://github.com/koreader/koreader/issues/13244.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13245)
<!-- Reviewable:end -->
