### PR TITLE
Satisfy FR #13163: Option to hide the "night mode changed" warning

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -66,7 +66,7 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
-    self.hide_nightmode_warning = G_reader_settings:isTrue("hide_nightmode_warning") or false
+    self.hide_nightmode_warning = G_reader_settings:isTrue("autowarmth_hide_nightmode_warning") or false
     self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -225,7 +225,7 @@ function AutoWarmth:_onToggleNightMode()
             {{
                 text = _("Hide this warning permanently"),
                 provider = function()
-                self.hide_nightmode_warning = true
+                    self.hide_nightmode_warning = true
                     G_reader_settings:saveSetting("hide_nightmode_warning", true)
                 end
             }},

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -66,6 +66,7 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
+	self.hide_nightmode_warning = G_reader_settings:isTrue("hide_nightmode_warning") or false
     self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
@@ -221,6 +222,13 @@ function AutoWarmth:_onToggleNightMode()
                     self.hide_nightmode_warning = true
                 end,
             }},
+			{{
+				text = _("Hide this warning permanently"),
+				provider = function()
+					self.hide_nightmode_warning = true
+					G_reader_settings:saveSetting("hide_nightmode_warning", true)
+				end
+			}},
             {{
                 text = _("Disable AutoWarmth's nightmode control"),
                 provider = function()
@@ -602,6 +610,16 @@ function AutoWarmth:getSubMenuItems()
             end,
             sub_item_table = self:getActivateMenu(),
         },
+		{
+			text = _("Enable night mode warning"),
+			checked_func = function()
+				return not self.hide_nightmode_warning
+			end,
+			callback = function()
+				self.hide_nightmode_warning = not self.hide_nightmode_warning
+				G_reader_settings:saveSetting("hide_nightmode_warning", self.hide_nightmode_warning)
+			end
+		},
         {
             text = _("Expert mode"),
             checked_func = function()

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -66,7 +66,6 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
-    self.hide_nightmode_warning = G_reader_settings:isTrue("autowarmth_hide_nightmode_warning")
     self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
@@ -80,6 +79,7 @@ function AutoWarmth:init()
 
     self.control_warmth = G_reader_settings:nilOrTrue("autowarmth_control_warmth")
     self.control_nightmode = G_reader_settings:nilOrTrue("autowarmth_control_nightmode")
+    self.hide_nightmode_warning = G_reader_settings:isTrue("autowarmth_hide_nightmode_warning")
     if not Device:hasNaturalLight() then
         self.control_nightmode = true
     elseif not self.control_warmth and not self.control_nightmode then
@@ -226,8 +226,8 @@ function AutoWarmth:_onToggleNightMode()
                 text = _("Hide this warning permanently"),
                 provider = function()
                     self.hide_nightmode_warning = true
-                    G_reader_settings:makeTrue("hide_nightmode_warning")
-                end
+                    G_reader_settings:makeTrue("autowarmth_hide_nightmode_warning")
+                end,
             }},
             {{
                 text = _("Disable AutoWarmth's nightmode control"),
@@ -360,7 +360,7 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
         self.current_times_h[1] = nil   -- Solar midnight prev. day
         self.current_times_h[2] = nil   -- Astronomical dawn
         self.current_times_h[3] = nil   -- Nautical dawn
-        self.current_times_h[6] = nil   -- Solar noon
+        -- self.current_times_h[6] = nil   -- Solar noon
         self.current_times_h[9] = nil   -- Nautical dusk
         self.current_times_h[10] = nil  -- Astronomical dusk
         self.current_times_h[11] = nil  -- Solar midnight
@@ -611,21 +611,12 @@ function AutoWarmth:getSubMenuItems()
             sub_item_table = self:getActivateMenu(),
         },
         {
-            text = _("Enable night mode warning"),
-            checked_func = function()
-                return not self.hide_nightmode_warning
-            end,
-            callback = function()
-                self.hide_nightmode_warning = not self.hide_nightmode_warning
-                G_reader_settings:saveSetting("hide_nightmode_warning", self.hide_nightmode_warning)
-            end
-        },
-        {
             text = _("Expert mode"),
             checked_func = function()
                 return not self.easy_mode
             end,
             help_text = _("In the expert mode, different types of twilight can be used in addition to civil twilight."),
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 self.easy_mode = not self.easy_mode
                 G_reader_settings:saveSetting("autowarmth_easy_mode", self.easy_mode)
@@ -659,9 +650,20 @@ function AutoWarmth:getSubMenuItems()
                 return self.activate ~= 0
             end,
             text = Device:hasNaturalLight() and _("Warmth and night mode settings") or _("Night mode settings"),
-            sub_item_table = self:getWarmthMenu(),
+            sub_item_table_func = function() return self:getWarmthMenu() end,
         },
         self:getFlOffDuringDayMenu(),
+        {
+            text = _("Enable night mode warning"),
+            checked_func = function()
+                return not self.hide_nightmode_warning
+            end,
+            callback = function()
+                self.hide_nightmode_warning = not self.hide_nightmode_warning
+                G_reader_settings:saveSetting("autowarmth_hide_nightmode_warning", self.hide_nightmode_warning)
+            end,
+            separator = true,
+        },
         self:getTimesMenu(_("Currently active parameters")),
         self:getTimesMenu(_("Sun position information for"), true, activate_sun),
         self:getTimesMenu(_("Fixed schedule information"), false, activate_schedule),
@@ -680,6 +682,7 @@ function AutoWarmth:getFlOffDuringDayMenu()
                 return _("Frontlight off during day")
             end
         end,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             if self.easy_mode then
                 self.fl_off_during_day = not self.fl_off_during_day
@@ -738,7 +741,6 @@ For cloudy autumn days, the switch-on/off time can be shifted by an offset.]]),
             })
         end,
         keep_menu_open = true,
-        separator = true,
     }
 end
 
@@ -907,6 +909,7 @@ function AutoWarmth:getScheduleMenu()
             checked_func = function()
                 return self.scheduler_times[num] ~= nil
             end,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 local hh = 12
                 local mm = 0
@@ -1130,6 +1133,7 @@ function AutoWarmth:getWarmthMenu()
                     })
                 end
             end,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 if Device:hasNaturalLight() then
                     if self.control_warmth and self.control_nightmode then
@@ -1162,7 +1166,7 @@ function AutoWarmth:getWarmthMenu()
             text = Device:hasNaturalLight() and _("Set warmth and night mode for:") or _("Set night mode for:"),
             enabled = false,
         },
-        getWarmthMenuEntry(_("Solar noon"), 6, false),
+        getWarmthMenuEntry(_("Solar noon"), 6),
         getWarmthMenuEntry(_("Sunset and sunrise"), 5),
         getWarmthMenuEntry(_("Darkest time of civil twilight"), 4),
         getWarmthMenuEntry(_("Darkest time of nautical twilight"), 3, false),
@@ -1261,7 +1265,7 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
     local face = Font:getFace("scfont")
     UIManager:show(InfoMessage:new{
         face = face,
-        width = math.floor(Screen:getWidth() * (self.easy_mode and 0.75 or 0.90)),
+        width = math.floor(Screen:getWidth() * (self.easy_mode and 0.85 or 0.90)),
         text = title .. location_string .. ":\n\n" ..
             info_line(0, _("Solar midnight:"), times[1], 1, face, request_easy) ..
             add_line(2, _("Dawn"), request_easy) ..
@@ -1272,8 +1276,8 @@ function AutoWarmth:showTimesInfo(title, location, activator, request_easy)
             add_line(2, _("Dawn"), request_easy) ..
             info_line(0, _("Sunrise:"), times[5], 5, face) ..
             "\n" ..
-            info_line(0, _("Solar noon:"), times[6], 6, face, request_easy) ..
-            add_line(0, "", request_easy) ..
+            info_line(0, _("Solar noon:"), times[6], 6, face) ..
+            "\n" ..
             info_line(0, _("Sunset:"), times[7], 7, face) ..
             add_line(2, _("Dusk"), request_easy) ..
             info_line(request_easy and 0 or 4,

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -66,7 +66,7 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
-    self.hide_nightmode_warning = G_reader_settings:isTrue("autowarmth_hide_nightmode_warning") or false
+    self.hide_nightmode_warning = G_reader_settings:isTrue("autowarmth_hide_nightmode_warning")
     self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
@@ -226,7 +226,7 @@ function AutoWarmth:_onToggleNightMode()
                 text = _("Hide this warning permanently"),
                 provider = function()
                     self.hide_nightmode_warning = true
-                    G_reader_settings:saveSetting("hide_nightmode_warning", true)
+                    G_reader_settings:makeTrue("hide_nightmode_warning")
                 end
             }},
             {{

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -66,7 +66,7 @@ function AutoWarmth:init()
     self.longitude = G_reader_settings:readSetting("autowarmth_longitude") or -20.30
     self.altitude = G_reader_settings:readSetting("autowarmth_altitude") or 200
     self.timezone = G_reader_settings:readSetting("autowarmth_timezone") or 0
-	self.hide_nightmode_warning = G_reader_settings:isTrue("hide_nightmode_warning") or false
+    self.hide_nightmode_warning = G_reader_settings:isTrue("hide_nightmode_warning") or false
     self.scheduler_times = G_reader_settings:readSetting("autowarmth_scheduler_times")
         or {0.0, 5.5, 6.0, 6.5, 7.0, 13.0, 21.5, 22.0, 22.5, 23.0, 24.0}
     self.warmth = G_reader_settings:readSetting("autowarmth_warmth")
@@ -222,13 +222,13 @@ function AutoWarmth:_onToggleNightMode()
                     self.hide_nightmode_warning = true
                 end,
             }},
-			{{
-				text = _("Hide this warning permanently"),
-				provider = function()
-					self.hide_nightmode_warning = true
-					G_reader_settings:saveSetting("hide_nightmode_warning", true)
-				end
-			}},
+            {{
+                text = _("Hide this warning permanently"),
+                provider = function()
+                self.hide_nightmode_warning = true
+                    G_reader_settings:saveSetting("hide_nightmode_warning", true)
+                end
+            }},
             {{
                 text = _("Disable AutoWarmth's nightmode control"),
                 provider = function()
@@ -610,16 +610,16 @@ function AutoWarmth:getSubMenuItems()
             end,
             sub_item_table = self:getActivateMenu(),
         },
-		{
-			text = _("Enable night mode warning"),
-			checked_func = function()
-				return not self.hide_nightmode_warning
-			end,
-			callback = function()
-				self.hide_nightmode_warning = not self.hide_nightmode_warning
-				G_reader_settings:saveSetting("hide_nightmode_warning", self.hide_nightmode_warning)
-			end
-		},
+        {
+            text = _("Enable night mode warning"),
+            checked_func = function()
+                return not self.hide_nightmode_warning
+            end,
+            callback = function()
+                self.hide_nightmode_warning = not self.hide_nightmode_warning
+                G_reader_settings:saveSetting("hide_nightmode_warning", self.hide_nightmode_warning)
+            end
+        },
         {
             text = _("Expert mode"),
             checked_func = function()


### PR DESCRIPTION
Resolves https://github.com/koreader/koreader/issues/13163 FR: Hide the AutoWarmth Plugin "Night Mode changed" popup forever. 

It adds 3 simple things:

1. New `G_reader_settings` called `"hide_nightmode_warning"`.
2. Adds a radio button to the popup in question to disable it permanently.
3. Adds a button in the plugin sub-menu to turn it back on (or turn it off from the menu if desired).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13253)
<!-- Reviewable:end -->
