### PR TITLE
Better dictionary results sorting when fuzzy searching

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -99,6 +99,69 @@ local function getDictionaryFixHtmlFunc(path)
     end
 end
 
+local function calculateStringSimilarity(str1, str2, prefix_weight)
+    str1, str2 = str1:lower(), str2:lower()
+    if str1 == str2 then
+        return 1.0
+    end
+
+    local len1, len2 = #str1, #str2
+    local str1_matches, str2_matches = {}, {}
+
+    local match_distance = math.floor(math.max(len1, len2) / 2) - 1
+    local matches = 0
+
+    -- Count the number of matching characters
+    for i = 1, len1 do
+        local start = math.max(1, i - match_distance)
+        local ends = math.min(i + match_distance, len2)
+
+        for j = start, ends do
+            if str2:sub(j,j) == str1:sub(i,i) and not str2_matches[j] then
+                str1_matches[i] = true
+                str2_matches[j] = true
+                matches = matches + 1
+                break
+            end
+        end
+    end
+
+    -- Count how many characters needed to change str1 into str2
+    local k = 1
+    local transpositions = 0
+    for i = 1, len1 do
+        if str1_matches[i] then
+            while not str2_matches[k] do
+                k = k + 1
+            end
+            if str1:sub(i,i) ~= str2:sub(k,k) then
+                transpositions = transpositions + 1
+            end
+            k = k + 1
+        end
+    end
+
+    -- With those two numbers, calculate the similary
+    -- score with Jaro string comparison formula
+    local distance = (
+        matches / len1 +
+        matches / len2 +
+        (matches - transpositions/2) / matches
+    ) / 3
+
+    -- Set up for adjusting the score by prefix weight
+    local prefix_length = 0
+    for i = 1, math.min(4, math.min(len1, len2)) do
+        if str1:sub(i,i) == str2:sub(i,i) then
+            prefix_length = prefix_length + 1
+        else
+            break
+        end
+    end
+
+    return distance + (prefix_length * prefix_weight * (1 - distance))
+end
+
 function ReaderDictionary:init()
     self:registerKeyEvents()
 
@@ -106,6 +169,13 @@ function ReaderDictionary:init()
     self.dicts_order = G_reader_settings:readSetting("dicts_order", {})
     self.dicts_disabled = G_reader_settings:readSetting("dicts_disabled", {})
     self.disable_fuzzy_search_fm = G_reader_settings:isTrue("disable_fuzzy_search")
+    -- Set a threshold to filter out low quality fuzzy results
+    -- 0.7 = loose, 0.8 = medium, 0.9 = strict
+    self.fuzzy_threshold = 0.8
+    -- Adjust this to weight the characters at the beginning of the
+    -- word more heavily when ranking results (good for dictionaries)
+    -- 0.05 = loose, 0.1 = medium, 0.2 = strict
+    self.prefix_weight = 0.1
 
     if self.ui then
         self.ui.menu:registerToMainMenu(self)
@@ -926,8 +996,17 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             for _, r in ipairs(term_results) do
                 h = r.dict .. r.word .. r.definition
                 if seen_results[h] == nil then
-                    table.insert(flat_results, r)
-                    seen_results[h] = true
+                    if fuzzy_search then
+                        r.similarity = calculateStringSimilarity(word, r.word, self.prefix_weight)
+                        if r.similarity > self.fuzzy_threshold then
+                            r.preferred_order = #flat_results
+                            table.insert(flat_results, r)
+                            seen_results[h] = true
+                        end
+                    else
+                        table.insert(flat_results, r)
+                        seen_results[h] = true
+                    end
                 end
             end
         end
@@ -950,6 +1029,18 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         -- we may get results from the 1st lookup, and have interrupted the 2nd.
         results.lookup_cancelled = true
     end
+
+    -- Sort results by similarity first, then by user's preferred order if words match
+    if fuzzy_search then
+        table.sort(results, function(a, b)
+            if a.similarity ~= b.similarity then
+                return a.similarity > b.similarity
+            else
+                return a.preferred_order < b.preferred_order
+            end
+        end)
+    end
+
     return results
 end
 


### PR DESCRIPTION
Satisfies the KOReader FR: Smarter dictionary result ordering on fuzzy search #13248 

Orders dictionary search results by similarity first and preferred dictionary order second, and filters out low quality results. Seems to work well in my testing, I get better results and no noticeable slowdown when testing with 20 dictionaries enabled at once.

### Issues:
* **Suboptimal ordering of results**: When searching 'goldsmiths', 'gold' is ranked before 'goldsmith' despite being a less relevant result.
![IMG_0224](https://github.com/user-attachments/assets/7dea2338-4e83-44e0-a803-3e41259a66f8)
![IMG_0225](https://github.com/user-attachments/assets/6cad7dbf-095f-4c9a-9e63-ff39629f73c2)
* **Fuzzy search sometimes gives bad results**: Searching the word 'Eata' on my device gives dictionary results for 'Batak' (similarity = 0.73) and 'Datum' (similarity = 0.63) which are far away.

### Solution:
1. Add a string comparison function.
2. Add some tinkerable settings so we can easily adjust how it works (could make these user settable, but I think it's too in depth).
3. If fuzzy searching, give the dictionary results a similarity score.
4. Filter out the low-quality results. A threshold of ~0.75-0.8 seems to be good.
5. Order by the similarity score first, and then our preferred dictionary order second on matching results.

### Threshold/prefix weight tests
| Test Word | Base Similarity (Jaro) | p=0.05 | **p=0.1** | p=0.15 | Notes |
|-----------|----------------------|---------|------------|---------|-------|
| goldsmith | 1.000 | 1.000 | **1.000** | 1.000 | Exact match |
| goldsmiths | 0.965 | 0.973 | **0.982** | 0.991 | Common plural form |
| goldsmit | 0.949 | 0.957 | **0.965** | 0.973 | Missing last letter |
| goldsmyth | 0.944 | 0.952 | **0.959** | 0.967 | Historical spelling |
| goldsmithing | 0.909 | 0.918 | **0.927** | 0.936 | Verb form |
| goldsmythe | 0.889 | 0.898 | **0.907** | 0.916 | Archaic variant |
| goldsmits | 0.859 | 0.867 | **0.875** | 0.883 | Misspelling |
| goldsmyths | 0.843 | 0.851 | **0.859** | 0.867 | Historical plural |
| goldsmythe's | 0.810 | 0.818 | **0.826** | 0.834 | Possessive form |
| goldsmithed | 0.798 | 0.806 | **0.814** | 0.822 | Past tense |
| goldsmyths' | 0.785 | 0.793 | **0.801** | 0.809 | Plural possessive |
| goldsmittery | 0.778 | 0.786 | **0.794** | 0.802 | Related noun |
| goldsmyther | 0.772 | 0.780 | **0.788** | 0.796 | Made-up variant |
| goldsmith's shop | 0.765 | 0.773 | **0.781** | 0.789 | Compound phrase |
| goldworker | 0.705 | 0.713 | **0.721** | 0.729 | Related occupation |
| gold | 0.667 | 0.700 | **0.722** | 0.744 | Root word |
| smith | 0.444 | 0.444 | **0.444** | 0.444 | Second root word |
