### PR TITLE
Fix VocabularyBuilder context when adding word from dictionary

### DIFF
--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -2104,7 +2104,7 @@ function VocabBuilder:onWordLookedUp(word, title, is_manual)
     end
 
     local update = function() DB:insertOrUpdate({
-        book_title = (not word_from_dict) and title or "Dictionary",
+        book_title = not word_from_dict and title or "Dictionary",
         time = os.time(),
         word = word,
         prev_context = prev_context,

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -2093,17 +2093,18 @@ function VocabBuilder:onWordLookedUp(word, title, is_manual)
     local prev_context
     local next_context
     local highlight
+    local word_from_dict = util.cleanupSelectedText(self.ui.highlight.selected_text.text) ~= word
     -- Only get context around the highlighted word if the looked up word matches the highlighted word
     if settings.with_context and self.ui.highlight
       and self.ui.highlight.selected_text
       and self.ui.highlight.selected_text.text
-      and util.cleanupSelectedText(self.ui.highlight.selected_text.text) == word then
+      and not word_from_dict then
         prev_context, next_context = self.ui.highlight:getSelectedWordContext(15)
         highlight = util.cleanupSelectedText(self.ui.highlight.selected_text.text)
     end
 
     local update = function() DB:insertOrUpdate({
-        book_title = title,
+        book_title = (not word_from_dict) and title or "Dictionary",
         time = os.time(),
         word = word,
         prev_context = prev_context,

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -2093,11 +2093,13 @@ function VocabBuilder:onWordLookedUp(word, title, is_manual)
     local prev_context
     local next_context
     local highlight
-    if settings.with_context and self.ui.highlight then
+    -- Only get context around the highlighted word if the looked up word matches the highlighted word
+    if settings.with_context and self.ui.highlight
+      and self.ui.highlight.selected_text
+      and self.ui.highlight.selected_text.text
+      and util.cleanupSelectedText(self.ui.highlight.selected_text.text) == word then
         prev_context, next_context = self.ui.highlight:getSelectedWordContext(15)
-        if self.ui.highlight.selected_text and self.ui.highlight.selected_text.text then
-            highlight = util.cleanupSelectedText(self.ui.highlight.selected_text.text)
-        end
+        highlight = util.cleanupSelectedText(self.ui.highlight.selected_text.text)
     end
 
     local update = function() DB:insertOrUpdate({


### PR DESCRIPTION
Resolves #13252 Vocabulary Builder gets the wrong context when adding word from dictionary.

#### Issues:
* You can tap on a word in a dictionary, and get the dictionary definition for that word too. However, the context is not updated, and the old one appears in the vocab builder. See #13252 for screenshot examples.
* When manually looking up a word with the dictionary search, the title of the open book will be saved as the source of the word, even if it's totally unrelated.

#### Cause:

https://github.com/koreader/koreader/blob/435c2868a9f4ae288c313eedd2c624703319d743/plugins/vocabbuilder.koplugin/main.lua#L2089-L2099

It looks like it gets the context from `self.ui.highlight`. If you open a new dictionary definition from within the first, the `word` has changed but the text in, and around, `self.ui.highlight` is the same.

#### Simple fix for now:
Add another check to the `readerdictionary "WordLookedUp"` event and don't get the context if the highlighted word does not equal the looked up word. There's no point in getting the wrong context, so even none is better right now. Also don't give it the title of the open book if the word you are adding is not that book.

#### Better fix in the future:

- Get the context from the dictionary definition (I need to research how this works).
-  Get the dictionary title?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13256)
<!-- Reviewable:end -->
