### PR TITLE
[Hotkeys] override self.ui.fonts key_events

### DIFF
--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -203,11 +203,7 @@ function HotKeys:genMenu(hotkey)
                     self.updated = true
                     touchmenu_instance:updateItems()
                 end
-                if self.hotkeys[hotkey] and next(self.hotkeys[hotkey]) then
-                    Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
-                else -- If no actions are selected, just update the defaults
-                    do_remove()
-                end
+                Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
             end,
         })
     end
@@ -225,11 +221,7 @@ function HotKeys:genMenu(hotkey)
                 self.updated = true
                 touchmenu_instance:updateItems()
             end
-            if self.hotkeys[hotkey] and next(self.hotkeys[hotkey]) then
-                Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
-            else
-                do_remove()
-            end
+            Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
         end,
     })
     Dispatcher:addSubMenu(self, sub_items, self.hotkeys, hotkey)
@@ -428,6 +420,9 @@ function HotKeys:overrideConflictingKeyEvents()
     if not self.is_docless then
         self.ui.bookmark.key_events = {} -- reset it.
         logger.dbg("Hotkey ReaderBookmark:registerKeyEvents() overridden.")
+
+        self.ui.font.key_events = {} -- reset it.
+        logger.dbg("Hotkey ReaderFont:registerKeyEvents() overridden.")
 
         if Device:hasScreenKB() or Device:hasSymKey() then
             local readerconfig = self.ui.config


### PR DESCRIPTION
### what's new

* Removed [now] unnecessary conditions when removing actions for hotkeys in the `HotKeys:genMenu` function. No longer needed as of #13227

* Added code to reset key events for the overlooked `font` UI component in the `HotKeys:overrideConflictingKeyEvents` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13257)
<!-- Reviewable:end -->
