### PR TITLE
[plugin] NewsDownloader: don't try to strip <script> tags

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -333,9 +333,6 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local cre = require("libs/libkoreader-cre")
     html = cre.getBalancedHTML(html, 0x0)
 
-    -- Remove all script tags to save a few bytes.
-    html = html:gsub("<script.->.-</script>", "")
-
 --    local sections = html.sections -- Wikipedia provided TOC
     local bookid = "bookid_placeholder" --string.format("wikipedia_%s_%s_%s", lang, phtml.pageid, phtml.revid)
     -- Not sure if this bookid may ever be used by indexing software/calibre, but if it is,


### PR DESCRIPTION
`<script src="etc"></script>` is turned into `<script/>`, which can cause far too much to be stripped.

While that could be dealt with a bit better, for example by first stripping self-closing and then regular, it feels hacky to do so.

See <https://github.com/koreader/koreader/pull/13188#issuecomment-2660362639>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13260)
<!-- Reviewable:end -->
