### PR TITLE
doc: fix / update build instructions for Alpine Linux

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -40,11 +40,14 @@ For testing:
 Install the prerequisites using apk:
 
 ```
-sudo apk add autoconf automake bash cmake coreutils curl diffutils g++ \
-    gcc gettext-dev git grep gzip libtool linux-headers lua5.1-busted \
-    luarocks5.1 make meson ninja-build ninja-is-really-ninja patch \
-    perl pkgconf procps-ng sdl2 tar unzip wget
+sudo apk add autoconf automake bash cmake coreutils curl diffutils \
+    findutils g++ gcc gettext-dev git grep gzip libtool linux-headers \
+    lua5.1-busted luarocks5.1 make meson nasm ninja-build patch perl \
+    pkgconf procps-ng sdl2 tar unzip wget
 ```
+
+**Note:** don't forget to add `/usr/lib/ninja-build/bin` to `$PATH`
+so the real ninja is used (and not the binary provided by samurai).
 
 ### Arch Linux
 


### PR DESCRIPTION
- add `findutils`: we need the real deal (for `-printf`)
- add `nasm`: for building libjpeg-turbo' SIMD support
- drop `ninja-is-really-ninja` in favor of `ninja-build`: the former now conflicts with `samurai` (required by `meson`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13319)
<!-- Reviewable:end -->
