### PR TITLE
[InfoMessage] stop force_one_line if font is too small

### DIFF
--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -208,10 +208,9 @@ function InfoMessage:init()
                         break
                     end
                 end
-                if self.force_one_line and orig_size < self._initial_orig_size * 0.7 then
-                    -- Do not reduce the font size by more than 30 percent, at around orig_size 15 or 16 (30% of default font size), our font is too small
-                    -- for the max_height check to be useful anymore (when icon_height), at those sizes (or lower) two lines fit inside the max_height so,
-                    -- simply disable it.
+                if self.force_one_line and orig_font == "xx_smallinfofont" and orig_size < 16 then
+                    -- Do not reduce the font size any longer, at around this point, our font is too small for the max_height check to be useful
+                    -- anymore (when icon_height), at those sizes (or lower) two lines fit inside the max_height so, simply disable it.
                     self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)
                     self.force_one_line = false
                 end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -208,7 +208,7 @@ function InfoMessage:init()
                         break
                     end
                 end
-                if self.force_one_line and orig_font == "xx_smallinfofont" and orig_size < 16 then
+                if self.force_one_line and orig_size < 16 then
                     -- Do not reduce the font size any longer, at around this point, our font is too small for the max_height check to be useful
                     -- anymore (when icon_height), at those sizes (or lower) two lines fit inside the max_height so, simply disable it.
                     self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -179,7 +179,7 @@ function InfoMessage:init()
 
     if not self.height then
         local max_height
-        if self.force_one_line then
+        if self.force_one_line and not self.text:find("\n") then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
             -- Calculate the size of the frame container when it's only displaying one line.
             max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding
@@ -209,8 +209,9 @@ function InfoMessage:init()
                     end
                 end
                 if self.force_one_line and orig_size < self._initial_orig_size * 0.7 then
-                    -- do not reduce font size by more than 30 percent, at around orig_size 15 or 16 (30% of defualt font size), our font is too small
-                    -- for the max_height check to be useful anymore, at those sizes (or lower) two lines fit inside the max_height so, disable it.
+                    -- Do not reduce the font size by more than 30 percent, at around orig_size 15 or 16 (30% of defualt font size), our font is too small
+                    -- for the max_height check to be useful anymore (when icon_height), at those sizes (or lower) two lines fit inside the max_height so,
+                    -- simply disable it.
                     self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)
                     self.force_one_line = false
                 end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -179,7 +179,7 @@ function InfoMessage:init()
 
     if not self.height then
         local max_height
-        if self.force_one_line and not self.text:find("\n") then
+        if self.force_one_line then
             local icon_height = self.show_icon and image_widget:getSize().h or 0
             -- Calculate the size of the frame container when it's only displaying one line.
             max_height = math.max(text_widget:getLineHeight(), icon_height) + 2*frame.bordersize + 2*frame.padding
@@ -189,6 +189,10 @@ function InfoMessage:init()
 
         -- Reduce font size if the text is too long
         local cur_size = frame:getSize()
+        if self.force_one_line and not (self._initial_orig_font and self._initial_orig_size) then
+            self._initial_orig_font = text_widget.face.orig_font
+            self._initial_orig_size = text_widget.face.orig_size
+        end
         if cur_size and cur_size.h > max_height then
             local orig_font = text_widget.face.orig_font
             local orig_size = text_widget.face.orig_size
@@ -203,6 +207,11 @@ function InfoMessage:init()
                     if self.face.size < real_size then
                         break
                     end
+                end
+                if self.force_one_line and orig_size == 11 then
+                    -- we reached the smallest font size, we are likely not going to fit in one line so disable it
+                    self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)
+                    self.force_one_line = false
                 end
                 -- re-init this widget
                 self:free()

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -208,8 +208,9 @@ function InfoMessage:init()
                         break
                     end
                 end
-                if self.force_one_line and orig_size == 11 then
-                    -- we reached the smallest font size, we are likely not going to fit in one line so disable it
+                if self.force_one_line and orig_size < self._initial_orig_size * 0.7 then
+                    -- do not reduce font size by more than 30 percent, at around orig_size 15 or 16 (30% of defualt font size), our font is too small
+                    -- for the max_height check to be useful anymore, at those sizes (or lower) two lines fit inside the max_height so, disable it.
                     self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)
                     self.force_one_line = false
                 end

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -209,7 +209,7 @@ function InfoMessage:init()
                     end
                 end
                 if self.force_one_line and orig_size < self._initial_orig_size * 0.7 then
-                    -- Do not reduce the font size by more than 30 percent, at around orig_size 15 or 16 (30% of defualt font size), our font is too small
+                    -- Do not reduce the font size by more than 30 percent, at around orig_size 15 or 16 (30% of default font size), our font is too small
                     -- for the max_height check to be useful anymore (when icon_height), at those sizes (or lower) two lines fit inside the max_height so,
                     -- simply disable it.
                     self.face = Font:getFace(self._initial_orig_font, self._initial_orig_size)


### PR DESCRIPTION
### what's new

* `frontend/ui/widget/infomessage.lua`: Added logic to store the original font and size when `force_one_line` is enabled, preventing excessive font size reduction.
* `frontend/ui/widget/infomessage.lua`: Implemented a condition to stop reducing the font size by more than 30 percent and reset to the original font and size if necessary.

related to #13107

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13337)
<!-- Reviewable:end -->
