### PR TITLE
PL keyboard layout: move "ó" and "Ó" to east on keypopup

### DIFF
--- a/frontend/ui/data/keyboardlayouts/pl_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/pl_keyboard.lua
@@ -11,8 +11,8 @@ keys[2][3][2].east, keys[2][3][2].south = keys[2][3][2].south, keys[2][3][2].eas
 
 -- keys[2][9][1].east = 'Ó'; keys[1][9][1].northeast = 'Ô'
 -- keys[2][9][2].east = 'ó'; keys[1][9][2].northeast = 'ô'
-keys[2][9][1].east, keys[2][9][1].south = keys[2][9][1].south, keys[2][9][1].east
-keys[2][9][2].east, keys[2][9][2].south = keys[2][9][2].south, keys[2][9][2].east
+keys[2][9][1].east, keys[2][9][1].northeast = keys[2][9][1].northeast, keys[2][9][1].east
+keys[2][9][2].east, keys[2][9][2].northeast = keys[2][9][2].northeast, keys[2][9][2].east
 
 -- keys[3][1][1].east = 'Ą'; keys[2][1][1].south = 'Â'
 -- keys[3][1][2].east = 'ą'; keys[2][1][2].south = 'â'


### PR DESCRIPTION
... in order to keep it consistent with other Polish characters. Looks like a copyedit bug to me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13347)
<!-- Reviewable:end -->
