### PR TITLE
Opds-pse v1.2 [LastRead]

### DIFF
--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -194,19 +194,6 @@ function ImageViewer:init()
                 end,
             },
             {
-                id = "scale_width",
-                text = _("Fit to Width"),
-                callback = function()
-                    if self.image:getWidth() and self.width then
-                        self.scale_factor = self.width / self.image:getWidth()
-                        self._center_x_ratio = 0.5
-                        self._center_y_ratio = 0.0
-                        self._scale_to_fit = false
-                        self:update()
-                    end
-                end,
-            },
-            {
                 id = "rotate",
                 text = self.rotated and _("No rotation") or _("Rotate"),
                 callback = function()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -566,7 +566,7 @@ function OPDSBrowser:searchCatalog(item_url)
 end
 
 -- Show the Page Stream Dialog
-function createPageStreamDialog(acquisition, self)
+function OPDSBrowser:createPageStreamDialog(acquisition, self)
     local page_stream_dialog
 
     local buttons = {
@@ -596,7 +596,7 @@ function createPageStreamDialog(acquisition, self)
                 text = _("\u{25B6} Resume from Page ") .. acquisition.lastRead,
                 callback = function()
                     OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password, acquisition.lastRead)
-                    UIManager:close(stream_dialog)
+                    UIManager:close(page_stream_dialog)
                     UIManager:close(self.download_dialog)
                 end,
             },
@@ -639,7 +639,7 @@ function OPDSBrowser:showDownloads(item)
                 {
                     text = _("Page stream"),
                     callback = function()
-                        createPageStreamDialog(acquisition, self)
+                        OPDSBrowser:createPageStreamDialog(acquisition, self)
                     end,
                 },
             }

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -566,7 +566,7 @@ function OPDSBrowser:searchCatalog(item_url)
 end
 
 -- Show the Page Stream Dialog
-function OPDSBrowser:createPageStreamDialog(acquisition, self)
+function OPDSBrowser:createPageStreamDialog(acquisition)
     local page_stream_dialog
 
     local buttons = {
@@ -639,7 +639,7 @@ function OPDSBrowser:showDownloads(item)
                 {
                     text = _("Page stream"),
                     callback = function()
-                        OPDSBrowser:createPageStreamDialog(acquisition, self)
+                        self:createPageStreamDialog(acquisition, self)
                     end,
                 },
             }

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -418,12 +418,12 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                         -- https://vaemendis.net/opds-pse/
                         -- «count» MUST provide the number of pages of the document
                         -- namespace may be not "pse"
-                        local count, lastRead
+                        local count, last_read
                         for k, v in pairs(link) do
                             if k:sub(-6) == ":count" then
                                 count = tonumber(v)
                             elseif k:sub(-9) == ":lastRead" then
-                                lastRead = tonumber(v)
+                                last_read = tonumber(v)
                             end
                         end
                         if count then
@@ -433,8 +433,8 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                                 title = link.title,
                                 count = count,
                             }
-                            if lastRead and lastRead > 0 then
-                                acquisition.lastRead = lastRead -- Only add if lastRead > 0
+                            if last_read and last_read > 0 then
+                                acquisition.last_read = last_read
                             end
                             table.insert(item.acquisitions, acquisition)
                         end
@@ -565,8 +565,7 @@ function OPDSBrowser:searchCatalog(item_url)
     dialog:onShowKeyboard()
 end
 
--- Show the Page Stream Dialog
-function OPDSBrowser:createPageStreamDialog(acquisition)
+function OPDSBrowser:showPageStreamDialog(acquisition)
     local page_stream_dialog
 
     local buttons = {
@@ -590,12 +589,12 @@ function OPDSBrowser:createPageStreamDialog(acquisition)
         },
     }
 
-    if acquisition.lastRead then
+    if acquisition.last_read then
         table.insert(buttons, {
             {
-                text = _("\u{25B6} Resume from Page ") .. acquisition.lastRead,
+                text = _("\u{25B6} Resume from Page ") .. acquisition.last_read,
                 callback = function()
-                    OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password, acquisition.lastRead)
+                    OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password, acquisition.last_read)
                     UIManager:close(page_stream_dialog)
                     UIManager:close(self.download_dialog)
                 end,
@@ -604,7 +603,6 @@ function OPDSBrowser:createPageStreamDialog(acquisition)
     end
 
     page_stream_dialog = ButtonDialog:new{
-        -- @translators "Stream" here refers to being able to read documents from an OPDS server without downloading them completely, on a page by page basis.
         title = _("Select Page Stream Option \u{2B0C}\n"),
         title_align = "center",
         buttons = buttons,
@@ -637,9 +635,9 @@ function OPDSBrowser:showDownloads(item)
         if acquisition.count then
             stream_buttons = {
                 {
-                    text = _("Page stream"),
+                    text = _("Page stream \u{2B0C}"),
                     callback = function()
-                        self:createPageStreamDialog(acquisition)
+                        self:showPageStreamDialog(acquisition)
                     end,
                 },
             }
@@ -790,9 +788,8 @@ function OPDSBrowser:getLocalDownloadPath(filename, filetype, remote_url, filena
     local filename_from_server
     if self.root_catalog_raw_names then
         filename_from_server = self:getServerFileName(remote_url)
-        -- if fileNameFromServer is not found and use filename_orig instead
         if not filename_from_server or filename_from_server == "" then
-            logger.warn("No fileName found: falling back to default name")
+            logger.warn("No filename found: falling back to default name")
             filename_from_server = filename_orig .. "." .. filetype:lower()
         end
     end

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -639,7 +639,7 @@ function OPDSBrowser:showDownloads(item)
                 {
                     text = _("Page stream"),
                     callback = function()
-                        self:createPageStreamDialog(acquisition, self)
+                        self:createPageStreamDialog(acquisition)
                     end,
                 },
             }

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -571,7 +571,7 @@ function OPDSBrowser:showPageStreamDialog(acquisition)
     local buttons = {
         {
             {
-                text = _("\u{23EE} Beginning"),
+                text = "\u{23EE} " .. _("Beginning"),
                 callback = function()
                     OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password)
                     UIManager:close(page_stream_dialog)
@@ -579,7 +579,7 @@ function OPDSBrowser:showPageStreamDialog(acquisition)
                 end,
             },
             {
-                text = _("\u{23E9} Go to Page"),
+                text = _("Go to page") .. " \u{23E9}",
                 callback = function()
                     OPDSPSE:streamPages(acquisition.href, acquisition.count, true, self.root_catalog_username, self.root_catalog_password)
                     UIManager:close(page_stream_dialog)
@@ -592,7 +592,7 @@ function OPDSBrowser:showPageStreamDialog(acquisition)
     if acquisition.last_read then
         table.insert(buttons, {
             {
-                text = _("\u{25B6} Resume from Page ") .. acquisition.last_read,
+                text = "\u{25B6} " .. _("Resume from page") .. " " .. acquisition.last_read,
                 callback = function()
                     OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password, acquisition.last_read)
                     UIManager:close(page_stream_dialog)
@@ -603,7 +603,7 @@ function OPDSBrowser:showPageStreamDialog(acquisition)
     end
 
     page_stream_dialog = ButtonDialog:new{
-        title = _("Select Page Stream Option \u{2B0C}\n"),
+        title = _("Select page stream option") .. " \u{2B0C}\n",
         title_align = "center",
         buttons = buttons,
     }
@@ -635,7 +635,8 @@ function OPDSBrowser:showDownloads(item)
         if acquisition.count then
             stream_buttons = {
                 {
-                    text = _("Page stream \u{2B0C}"),
+                    -- @translators "Stream" here refers to being able to read documents from an OPDS server without downloading them completely, on a page by page basis.
+                    text = _("Page stream") .. "\u{2B0C}", -- append LEFT RIGHT BLACK ARROW
                     callback = function()
                         self:showPageStreamDialog(acquisition)
                     end,

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -427,16 +427,13 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                             end
                         end
                         if count then
-                            local acquisition = {
+                            table.insert(item.acquisitions, {
                                 type  = link.type,
                                 href  = link_href,
                                 title = link.title,
                                 count = count,
-                            }
-                            if last_read and last_read > 0 then
-                                acquisition.last_read = last_read
-                            end
-                            table.insert(item.acquisitions, acquisition)
+                                last_read = last_read and last_read > 0 and last_read or nil
+                            })
                         end
                     elseif link.rel == self.thumbnail_rel or link.rel == self.thumbnail_rel_alt then
                         item.thumbnail = link_href

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -588,7 +588,7 @@ function OPDSBrowser:showDownloads(item)
                 {
                     {
                         -- @translators "Stream" here refers to being able to read documents from an OPDS server without downloading them completely, on a page by page basis.
-                        text = "\u{23EE} " .. _("Page stream"),
+                        text = "\u{23EE} " .. _("Page stream"), -- prepend BLACK LEFT-POINTING DOUBLE TRIANGLE WITH BAR
                         callback = function()
                             OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password)
                             UIManager:close(self.download_dialog)
@@ -596,7 +596,7 @@ function OPDSBrowser:showDownloads(item)
                     },
                     {
                         -- @translators "Stream" here refers to being able to read documents from an OPDS server without downloading them completely, on a page by page basis.
-                        text = _("Stream from page") .. " \u{23E9}",
+                        text = _("Stream from page") .. " \u{23E9}", -- append BLACK RIGHT-POINTING DOUBLE TRIANGLE
                         callback = function()
                             OPDSPSE:streamPages(acquisition.href, acquisition.count, true, self.root_catalog_username, self.root_catalog_password)
                             UIManager:close(self.download_dialog)
@@ -609,7 +609,7 @@ function OPDSBrowser:showDownloads(item)
                 table.insert(stream_buttons, {
                     {
                         -- @translators "Stream" here refers to being able to read documents from an OPDS server without downloading them completely, on a page by page basis.
-                        text = "\u{25B6} " .. _("Resume stream from page") .. " " .. acquisition.last_read,
+                        text = "\u{25B6} " .. _("Resume stream from page") .. " " .. acquisition.last_read, -- prepend BLACK RIGHT-POINTING TRIANGLE
                         callback = function()
                             OPDSPSE:streamPages(acquisition.href, acquisition.count, false, self.root_catalog_username, self.root_catalog_password, acquisition.last_read)
                             UIManager:close(self.download_dialog)

--- a/plugins/opds.koplugin/opdspse.lua
+++ b/plugins/opds.koplugin/opdspse.lua
@@ -92,7 +92,7 @@ function OPDSPSE:getLastPage(remote_url, username, password)
     return last_page;
 end
 
-function OPDSPSE:streamPages(remote_url, count, continue, username, password, lastPageRead)
+function OPDSPSE:streamPages(remote_url, count, continue, username, password, last_page_read)
     -- attempt to pull chapter progress from Kavita if user pressed
     -- "Page Stream" button.
     -- We have to pull the progress here, otherwise the creation of the page_table
@@ -159,9 +159,8 @@ function OPDSPSE:streamPages(remote_url, count, continue, username, password, la
     UIManager:show(viewer)
     if continue then
         self:jumpToPage(viewer, count)
-    elseif lastPageRead then
-        -- Switch to the last page that was read
-        viewer:switchToImageNum(lastPageRead)
+    elseif last_page_read then
+        viewer:switchToImageNum(last_page_read)
     else
         -- add 1 since Kavita's Page count is zero based
         -- and ImageViewer is not.


### PR DESCRIPTION
**_Still pretty new to Lua & KOReader, so might’ve missed something. Open to any suggestions..._**
### Changes
- Added [OPDS-PSE v1.2](https://github.com/anansi-project/opds-pse/blob/master/v1.2.md) [lastRead] support in the download dialog whenever pse:lastRead is present.
    - Since the Page Stream option now has three buttons, I added a sub-dialog—clicking "Page Stream" now opens another dialog with all three options.
    - Clicking "Resume From Page N" directs the ImageViewer to open that page image.
- Fix for serverFileName issues: If the endpoint doesn’t return proper headers on a HEAD request, the filename was set as empty, causing an error saying "Is a directory". Now, it falls back to the original/default filename, and if the filename is modified, it correctly retains that change. Relates to https://github.com/koreader/koreader/issues/13007

### Screenshots
<details>
<summary> Page Stream Button & Dialog </summary>

![Page Stream Button](https://github.com/user-attachments/assets/728a1f3c-28bb-4442-bdc4-869e9ed27e92)
![Page Stream Dialog](https://github.com/user-attachments/assets/931b12c8-b219-4b1d-af97-fd0dc94b718e)

</details>
<details>
<summary> Raw File name enabled (existing) </summary>

https://github.com/user-attachments/assets/743a597d-0cba-44c6-948d-23f3048aeddb
</details>

<details>
<summary> Raw File name enabled (this change) | last one returns filename in header</summary>

https://github.com/user-attachments/assets/dbf7cee2-ed29-480d-9abc-74cabf9856b7
</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13357)
<!-- Reviewable:end -->
