### PR TITLE
[FocusManager] correct cursor keys in RTL

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -51,19 +51,21 @@ end
 function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
+    local nextKey = BD.mirroredUILayout() and "Left" or "Right"
+    local prevKey = BD.mirroredUILayout() and "Right" or "Left"
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", "Right", " " } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", nextKey, " " } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
         elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
-            self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
-            self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextChapter = { { nextKey }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { prevKey }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", " " } }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack" } }, event = "GotoViewRel", args = -1, }
         end
     elseif Device:hasKeys() then
-        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and "Right" } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and "Left" } }, event = "GotoViewRel", args = -1, }
+        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and nextKey } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and prevKey } }, event = "GotoViewRel", args = -1, }
         self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
         self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
     end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -116,13 +116,15 @@ end
 function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
+    local nextKey = BD.mirroredUILayout() and "Left" or "Right"
+    local prevKey = BD.mirroredUILayout() and "Right" or "Left"
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextView = { { { "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevView = { { { "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextView = { { { "LPgFwd", nextKey } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
         elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
-            self.key_events.GotoNextChapter = { { "Right" }, event = "GotoNextChapter", args = 1, }
-            self.key_events.GotoPrevChapter = { { "Left" }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextChapter = { { nextKey }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { prevKey }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextView = { { "LPgFwd" }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevView = { { "LPgBack" }, event = "GotoViewRel", args = -1, }
         end
@@ -133,8 +135,8 @@ function ReaderRolling:registerKeyEvents()
         self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
     end
     if (Device:hasDPad() and not Device:useDPadAsActionKeys()) or (Device:hasKeys() and not Device:useDPadAsActionKeys()) then
-        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Right" } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Left" } }, event = "GotoViewRel", args = -1, }
+        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", nextKey } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
     end
     if Device:hasKeyboard() and not Device.k3_alt_plus_key_kernel_translated then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -156,7 +156,7 @@ function FocusManager:onFocusHalfMove(args)
             dy = #self.layout - y -- last row
         end
     elseif direction == "left" then
-        dx = -math.floor(#row / 2)
+        dx = - math.floor(#row / 2)
         if BD.mirroredUILayout() then dx = -dx end
         if dx == 0 then
             dx = -1

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -172,8 +172,10 @@ function FocusManager:onFocusHalfMove(args)
             dx = #row - x -- last column
         end
     end
-    -- Flip horizontal direction in RTL mode
     if dx ~= 0 and BD.mirroredUILayout() then
+        -- When in RTL we mirror horizontally the elements/buttons on the screen, however we don't mirror self.layout
+        -- therefore we must account for this when moving the focus. Since we're already inverting dx in the FocusMove
+        -- method, we need to "unfix" our value here, before calling onFocusMove, where it will be flipped again.
         dx = -dx
     end
     return self:onFocusMove({dx, dy})
@@ -223,6 +225,8 @@ function FocusManager:onFocusMove(args)
 
     -- Flip horizontal direction in RTL mode
     if dx ~= 0 and BD.mirroredUILayout() then
+        -- When in RTL we mirror horizontally the elements/buttons on the screen, however we don't mirror self.layout
+        -- therefore we must account for this when moving the focus.
         dx = -dx
     end
 

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -156,14 +156,16 @@ function FocusManager:onFocusHalfMove(args)
             dy = #self.layout - y -- last row
         end
     elseif direction == "left" then
-        dx = BD.mirroredUILayout() and math.floor(#row / 2) or -math.floor(#row / 2)
+        dx = -math.floor(#row / 2)
+        if BD.mirroredUILayout() then dx = -dx end
         if dx == 0 then
             dx = -1
         elseif dx + x <= 0 then
             dx = -x + 1 -- first column
         end
     elseif direction == "right" then
-        dx = BD.mirroredUILayout() and -math.floor(#row / 2) or math.floor(#row / 2)
+        dx = math.floor(#row / 2)
+        if BD.mirroredUILayout() then dx = -dx end
         if dx == 0 then
             dx = 1
         elseif dx + x > #row then

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -1,9 +1,10 @@
-local bit = require("bit")
+local BD = require("ui/bidi")
 local Device = require("device")
 local Event = require("ui/event")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local logger = require("logger")
 local UIManager = require("ui/uimanager")
+local bit = require("bit")
+local logger = require("logger")
 local util = require("util")
 --[[
 Wrapper Widget that manages focus for a whole dialog
@@ -213,6 +214,11 @@ function FocusManager:onFocusMove(args)
         return false
     end
     local dx, dy = unpack(args)
+
+    -- Flip horizontal direction in RTL mode
+    if dx ~= 0 and BD.mirroredUILayout() then
+        dx = -dx
+    end
 
     if (dx ~= 0 and not self.movement_allowed.x)
         or (dy ~= 0 and not self.movement_allowed.y) then

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -167,7 +167,7 @@ function FocusManager:onFocusHalfMove(args)
         if dx == 0 then
             dx = 1
         elseif dx + x > #row then
-            dx = #row - y -- last column
+            dx = #row - x -- last column
         end
     end
     return self:onFocusMove({dx, dy})

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -156,19 +156,23 @@ function FocusManager:onFocusHalfMove(args)
             dy = #self.layout - y -- last row
         end
     elseif direction == "left" then
-        dx = - math.floor(#row / 2)
+        dx = BD.mirroredUILayout() and math.floor(#row / 2) or -math.floor(#row / 2)
         if dx == 0 then
             dx = -1
         elseif dx + x <= 0 then
             dx = -x + 1 -- first column
         end
     elseif direction == "right" then
-        dx = math.floor(#row / 2)
+        dx = BD.mirroredUILayout() and -math.floor(#row / 2) or math.floor(#row / 2)
         if dx == 0 then
             dx = 1
         elseif dx + x > #row then
             dx = #row - x -- last column
         end
+    end
+    -- Flip horizontal direction in RTL mode
+    if dx ~= 0 and BD.mirroredUILayout() then
+        dx = -dx
     end
     return self:onFocusMove({dx, dy})
 end


### PR DESCRIPTION
### what's new

* `frontend/ui/widget/focusmanager.lua`: Added logic in the `onFocusMove` function to flip the horizontal direction when RTL mode is enabled.
* `frontend/apps/reader/modules/readerpaging.lua`: Introduced `nextKey` and `prevKey` variables that adjust key events based on the layout direction.
* `frontend/apps/reader/modules/readerrolling.lua`: Similar changes to `readerpaging.lua`, adjusting key events based on the layout direction using `nextKey` and `prevKey`.


reported https://github.com/koreader/koreader/pull/12579#issuecomment-2692262849

okay @poire-z, this should solve the cursor key problem. But there is still another one. The focus underline sticks to the left side of the screen (touchmenu)... when it should move along with the text to the right

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13362)
<!-- Reviewable:end -->
