### PR TITLE
feat(cloudstorage/webdav): Show 'file size' property in WebDAV

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -231,7 +231,7 @@ function CloudStorage:downloadFile(item)
     local function createTitle(filename_orig, filesize, filename, path) -- title for ButtonDialog
         local filesize_str = filesize and util.getFriendlySize(filesize) or _("N/A")
 
-        return T(_("Filename:\n%1\n\nFile size:\n%2\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
+        return T(_("Filename (Filesize):\n%1 (%2)\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
             filename_orig, filesize_str, filename, BD.dirpath(path))
     end
 

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -19,6 +19,7 @@ local logger = require("logger")
 local _ = require("gettext")
 local N_ = _.ngettext
 local T = require("ffi/util").template
+local util = require("util")
 
 local CloudStorage = Menu:extend{
     no_title = false,
@@ -228,15 +229,17 @@ function CloudStorage:downloadFile(item)
     end
 
     local function createTitle(filename_orig, filesize, filename, path) -- title for ButtonDialog
+        local filesize_str = filesize and util.getFriendlySize(filesize) or _("N/A")
+
         return T(_("Filename:\n%1\n\nFile size:\n%2\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
-            filename_orig, filesize, filename, BD.dirpath(path))
+            filename_orig, filesize_str, filename, BD.dirpath(path))
     end
 
     local cs_settings = self:readSettings()
     local download_dir = cs_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
     local filename_orig = item.text
     local filename = filename_orig
-    local filesize = item.filesize or "N/A"
+    local filesize = item.filesize
 
     local buttons = {
         {

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -231,7 +231,7 @@ function CloudStorage:downloadFile(item)
     local function createTitle(filename_orig, filesize, filename, path) -- title for ButtonDialog
         local filesize_str = filesize and util.getFriendlySize(filesize) or _("N/A")
 
-        return T(_("Filename (Filesize):\n%1 (%2)\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
+        return T(_("Filename:\n%1\n\nFile size:\n%2\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
             filename_orig, filesize_str, filename, BD.dirpath(path))
     end
 

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -227,15 +227,16 @@ function CloudStorage:downloadFile(item)
         })
     end
 
-    local function createTitle(filename_orig, filename, path) -- title for ButtonDialog
-        return T(_("Filename:\n%1\n\nDownload filename:\n%2\n\nDownload folder:\n%3"),
-            filename_orig, filename, BD.dirpath(path))
+    local function createTitle(filename_orig, filesize, filename, path) -- title for ButtonDialog
+        return T(_("Filename:\n%1\n\nFile size:\n%2\n\nDownload filename:\n%3\n\nDownload folder:\n%4"),
+            filename_orig, filesize, filename, BD.dirpath(path))
     end
 
     local cs_settings = self:readSettings()
     local download_dir = cs_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
     local filename_orig = item.text
     local filename = filename_orig
+    local filesize = item.filesize or "N/A"
 
     local buttons = {
         {
@@ -247,7 +248,7 @@ function CloudStorage:downloadFile(item)
                             self.cs_settings:saveSetting("download_dir", path)
                             self.cs_settings:flush()
                             download_dir = path
-                            self.download_dialog:setTitle(createTitle(filename_orig, filename, download_dir))
+                            self.download_dialog:setTitle(createTitle(filename_orig, filesize, filename, download_dir))
                         end,
                     }:chooseDir(download_dir)
                 end,
@@ -278,7 +279,7 @@ function CloudStorage:downloadFile(item)
                                             filename = filename_orig
                                         end
                                         UIManager:close(input_dialog)
-                                        self.download_dialog:setTitle(createTitle(filename_orig, filename, download_dir))
+                                        self.download_dialog:setTitle(createTitle(filename_orig, filesize, filename, download_dir))
                                     end,
                                 },
                             }
@@ -318,7 +319,7 @@ function CloudStorage:downloadFile(item)
     }
 
     self.download_dialog = ButtonDialog:new{
-        title = createTitle(filename_orig, filename, download_dir),
+        title = createTitle(filename_orig, filesize, filename, download_dir),
         buttons = buttons,
     }
     UIManager:show(self.download_dialog)
@@ -388,7 +389,6 @@ function CloudStorage:onMenuHold(item)
                     callback = function()
                         UIManager:close(cs_server_dialog)
                         self:editCloudServer(item)
-
                     end
                 },
                 {

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -114,7 +114,6 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local item_content_length_match = item:match("<[^:]*:getcontentlength[^>]*>(%d+)</[^:]*:getcontentlength>")
             if item_content_length_match then
                 item_filesize = tonumber(item_content_length_match)
-                item_filesize = util.getFriendlySize(item_filesize)
             end
 
             if item:find("<[^:]*:collection[^<]*/>") then
@@ -152,7 +151,8 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             text = files.text,
             url = files.url,
             type = files.type,
-            filesize = files.filesize or nil
+            filesize = files.filesize or nil,
+            mandatory = util.getFriendlySize(files.filesize) or nil
         })
     end
     if folder_mode then

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -110,11 +110,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local item_path = path .. "/" .. item_name
 
             -- only available for files, not directories/collections
-            local item_filesize = nil
-            local item_content_length_match = item:match("<[^:]*:getcontentlength[^>]*>(%d+)</[^:]*:getcontentlength>")
-            if item_content_length_match then
-                item_filesize = tonumber(item_content_length_match)
-            end
+            local item_filesize = item:match("<[^:]*:getcontentlength[^>]*>(%d+)</[^:]*:getcontentlength>")
 
             if item:find("<[^:]*:collection[^<]*/>") then
                 item_name = item_name .. "/"
@@ -131,7 +127,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
                     text = item_name,
                     url = item_path,
                     type = "file",
-                    filesize = item_filesize
+                    filesize = tonumber(item_filesize)
                 })
             end
         end


### PR DESCRIPTION
This PR adds a 'file size' property  to the item dialog when selecting an item using Webdav Cloudstorage (see picture).

- [ ] 1) I sadly don't have an FTP/Dropbox/etc. setup to test/implement the other providers, so if someone else could at least make sure it does not cause crashes/other issues I would appreciate it, although the new field should not really affect these providers.

- [ ] 2) I was not sure what to show if the file size can't be queried (also not entirely sure when this would even be the case) so I'm just showing "N/A". If this causes problems with translations I'm happy to adjust it.

Default menu when file size is available:
<img src="https://github.com/user-attachments/assets/45b65676-31b8-456a-bfc8-6cb73b7f2ba5" width="400">

Forcing the 'item.filesize' to be nil to display 'N/A':
<img src="https://github.com/user-attachments/assets/88ddbbd1-f125-48f9-9335-6977eaa28a70" width="400">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13371)
<!-- Reviewable:end -->
