### PR TITLE
KeyValuePage: lanscape and portrait items per page

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -2,6 +2,7 @@ local BD = require("ui/bidi")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local KeyValuePage = require("ui/widget/keyvaluepage")
 local PluginLoader = require("pluginloader")
@@ -394,9 +395,8 @@ To:
             },
             {
                 text_func = function()
-                    local default_value = KeyValuePage.getDefaultItemsPerPage()
-                    local current_value = G_reader_settings:readSetting("keyvalues_per_page") or default_value
-                    return T(_("Info lists items per page: %1"), current_value)
+                    local nb_items_landscape, nb_items_portrait = KeyValuePage.getCurrentItemsPerPage()
+                    return T(_("Info lists items per page: %1 / %2"), nb_items_landscape, nb_items_portrait)
                 end,
                 help_text = _([[This sets the number of items per page in:
 - Book information
@@ -405,25 +405,38 @@ To:
 - A few other plugins]]),
                 keep_menu_open = true,
                 callback = function(touchmenu_instance)
-                    local default_value = KeyValuePage.getDefaultItemsPerPage()
-                    local current_value = G_reader_settings:readSetting("keyvalues_per_page") or default_value
-                    local widget = SpinWidget:new{
-                        value = current_value,
-                        value_min = 10,
-                        value_max = 30,
-                        default_value = default_value,
+                    local nb_items_landscape_default, nb_items_portrait_default = KeyValuePage.getDefaultItemsPerPage()
+                    local nb_items_landscape, nb_items_portrait =
+                        KeyValuePage.getCurrentItemsPerPage(nb_items_landscape_default, nb_items_portrait_default)
+                    local widget = DoubleSpinWidget:new{
                         title_text =  _("Info lists items per page"),
-                        callback = function(spin)
-                            if spin.value == default_value then
-                                -- We can't know if the user has set a value or hit "Use default", but
-                                -- assume that if it is the default, he will prefer to stay with our
-                                -- default if he later changes screen DPI
+                        width_factor = 0.6,
+                        left_text = _("Landscape"),
+                        left_value = nb_items_landscape,
+                        left_min = 10,
+                        left_max = 30,
+                        left_default = nb_items_landscape_default,
+                        right_text = _("Portrait"),
+                        right_value = nb_items_portrait,
+                        right_min = 10,
+                        right_max = 30,
+                        right_default = nb_items_portrait_default,
+                        callback = function(left_value, right_value)
+                            -- We can't know if the user has set a value or hit "Use default", but
+                            -- assume that if it is the default, he will prefer to stay with our
+                            -- default if he later changes screen DPI
+                            if left_value == nb_items_landscape_default then
+                                G_reader_settings:delSetting("keyvalues_per_page_landscape")
+                            else
+                                G_reader_settings:saveSetting("keyvalues_per_page_landscape", left_value)
+                            end
+                            if right_value == nb_items_portrait_default then
                                 G_reader_settings:delSetting("keyvalues_per_page")
                             else
-                                G_reader_settings:saveSetting("keyvalues_per_page", spin.value)
+                                G_reader_settings:saveSetting("keyvalues_per_page", right_value)
                             end
                             touchmenu_instance:updateItems()
-                        end
+                        end,
                     }
                     UIManager:show(widget)
                 end,

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -396,7 +396,7 @@ To:
             {
                 text_func = function()
                     local nb_items_landscape, nb_items_portrait = KeyValuePage.getCurrentItemsPerPage()
-                    return T(_("Info lists items per page: %1 / %2"), nb_items_landscape, nb_items_portrait)
+                    return T(_("Info lists items per page: %1 / %2"), nb_items_portrait, nb_items_landscape)
                 end,
                 help_text = _([[This sets the number of items per page in:
 - Book information
@@ -411,29 +411,29 @@ To:
                     local widget = DoubleSpinWidget:new{
                         title_text =  _("Info lists items per page"),
                         width_factor = 0.6,
-                        left_text = _("Landscape"),
-                        left_value = nb_items_landscape,
+                        left_text = _("Portrait"),
+                        left_value = nb_items_portrait,
                         left_min = 10,
                         left_max = 30,
-                        left_default = nb_items_landscape_default,
-                        right_text = _("Portrait"),
-                        right_value = nb_items_portrait,
+                        left_default = nb_items_portrait_default,
+                        right_text = _("Landscape"),
+                        right_value = nb_items_landscape,
                         right_min = 10,
                         right_max = 30,
-                        right_default = nb_items_portrait_default,
+                        right_default = nb_items_landscape_default,
                         callback = function(left_value, right_value)
                             -- We can't know if the user has set a value or hit "Use default", but
                             -- assume that if it is the default, he will prefer to stay with our
                             -- default if he later changes screen DPI
-                            if left_value == nb_items_landscape_default then
-                                G_reader_settings:delSetting("keyvalues_per_page_landscape")
-                            else
-                                G_reader_settings:saveSetting("keyvalues_per_page_landscape", left_value)
-                            end
-                            if right_value == nb_items_portrait_default then
+                            if left_value == nb_items_portrait_default then
                                 G_reader_settings:delSetting("keyvalues_per_page")
                             else
-                                G_reader_settings:saveSetting("keyvalues_per_page", right_value)
+                                G_reader_settings:saveSetting("keyvalues_per_page", left_value)
+                            end
+                            if right_value == nb_items_landscape_default then
+                                G_reader_settings:delSetting("keyvalues_per_page_landscape")
+                            else
+                                G_reader_settings:saveSetting("keyvalues_per_page_landscape", right_value)
                             end
                             touchmenu_instance:updateItems()
                         end,


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/ee63ea87-e7a2-4402-ab0b-5fde99f41aaa)

![2](https://github.com/user-attachments/assets/ea84c802-777b-439b-8842-4a7cd978f87c)

Closes https://github.com/koreader/koreader/issues/12640.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13377)
<!-- Reviewable:end -->
