### PR TITLE
[plugin] Added ability for statistics plugin to use reference pages

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -1048,6 +1048,10 @@ function ReaderStatistics:getPageTimeTotalStats(id_book)
     return total_pages, total_time
 end
 
+function ReaderStatistics:usePageMapForPageNumbers()
+    return self.ui.doc_settings:isTrue("pagemap_use_page_labels") and self.document:getPageMap()
+end
+
 function ReaderStatistics:onToggleStatistics(no_notification)
     if self.settings.is_enabled then -- save data to file
         self:insertDB()
@@ -1057,7 +1061,11 @@ function ReaderStatistics:onToggleStatistics(no_notification)
         if self.settings.is_enabled then
             self:initData()
             self.start_current_period = os.time()
-            self.curr_page = self.ui:getCurrentPage()
+            if self:usePageMapForPageNumbers() then
+                self.curr_page = self.ui.document:getPageMapCurrentPageLabel()
+            else
+                self.curr_page = self.ui:getCurrentPage()
+            end
             self:resetVolatileStats(self.start_current_period)
         end
         self.view.footer:maybeUpdateFooter()
@@ -1641,7 +1649,11 @@ function ReaderStatistics:getCurrentStat()
     if first_open == nil then
         first_open = now_ts
     end
-    self.data.pages = self.document:getPageCount()
+    if self:usePageMapForPageNumbers() then
+        self.data.pages = self.document:getPageMapLastPageLabel()
+    else
+        self.data.pages = self.document:getPageCount()
+    end
     total_time_book = tonumber(total_time_book)
     total_read_pages = tonumber(total_read_pages)
 
@@ -1660,7 +1672,11 @@ function ReaderStatistics:getCurrentStat()
             page_progress_string = ("[%d / %d]%d (%d%%)"):format(current_page, total_pages, flow, percent_read)
         end
     else
-        current_page = self.ui:getCurrentPage()
+        if self:usePageMapForPageNumbers() then
+            current_page = self.document:getPageMapCurrentPageLabel()
+        else
+            current_page = self.ui:getCurrentPage()
+        end
         total_pages = self.data.pages
         percent_read = Math.round(100*current_page/total_pages)
         page_progress_string = ("%d / %d (%d%%)"):format(current_page, total_pages, percent_read)


### PR DESCRIPTION
## Changes
- Added ability for the statistics plugin to use reference page numbers instead of the digital reader based page numbers
- Added option in statistics plugin settings to either use reference pages never, when there available of the current document, or when using reference pages for current document


- Note: Reference page labels that aren't numbers (eg iv) are counted as pages read, but aren't included in the total pages value to avoid user confusion, but are still included in the percentage read.

## Screenshots
![image](https://github.com/user-attachments/assets/91b1cdcf-b624-445b-abaa-f5575cca7d0d)
![image](https://github.com/user-attachments/assets/f81a4305-dd63-4919-8b2b-395cd146ec5e)
![image](https://github.com/user-attachments/assets/bc5080c9-de67-4ec0-be10-91408b09e685)
