### PR TITLE
[plugin/NEWS-RSS] Handle missing description gracefully in rss feed

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -611,7 +611,7 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
             self:createFromDescription(
                 feed,
                 feed_title,
-                feed_description or "No description available",
+                feed_description or "",
                 feed_output_dir,
                 include_images,
                 article_message

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -587,8 +587,10 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
         if feed_type == FEED_TYPE_RSS then
             feed_title = feed.title
             feed.description = feed.description and feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
-            -- Spec: https://web.resource.org/rss/1.0/modules/content/
-            feed_description = feed["content:encoded"] or feed.description
+            if feed["content:encoded"] ~= nil then
+                -- Spec: https://web.resource.org/rss/1.0/modules/content/
+                feed_description = feed["content:encoded"]
+            end
         elseif feed_type == FEED_TYPE_ATOM then
             feed_title = feed.title and feed.title[1] or feed.title
             feed_description = feed.content and feed.content[1] or feed.content --- @todo This should select the one with type="html" if there is a choice.

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -586,18 +586,12 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
         local feed_description
         if feed_type == FEED_TYPE_RSS then
             feed_title = feed.title
-            if feed["description"] == nil then
-                feed_description = feed.title
-            else
-                feed.description = feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
-            end
-            if feed["content:encoded"] ~= nil then
-                -- Spec: https://web.resource.org/rss/1.0/modules/content/
-                feed_description = feed["content:encoded"]
-            end
+            feed.description = feed.description and feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
+            -- Spec: https://web.resource.org/rss/1.0/modules/content/
+            feed_description = feed["content:encoded"] or feed.description
         elseif feed_type == FEED_TYPE_ATOM then
             feed_title = feed.title and feed.title[1] or feed.title
-            feed_description = feed.content[1] or feed.content --- @todo This should select the one with type="html" if there is a choice.
+            feed_description = feed.content and feed.content[1] or feed.content --- @todo This should select the one with type="html" if there is a choice.
         else
             feed_title = feed.title and feed.title[1] or feed.title
             feed_description = feed.summary
@@ -617,7 +611,7 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
             self:createFromDescription(
                 feed,
                 feed_title,
-                feed_description,
+                feed_description or "No description available",
                 feed_output_dir,
                 include_images,
                 article_message

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -586,7 +586,11 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, limit, download_f
         local feed_description
         if feed_type == FEED_TYPE_RSS then
             feed_title = feed.title
-            feed_description = feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
+            if feed["description"] == nil then
+                feed_description = feed.title
+            else
+                feed.description = feed.description[1] or feed.description --- @todo This should select the one with type="html" if there is a choice.
+            end
             if feed["content:encoded"] ~= nil then
                 -- Spec: https://web.resource.org/rss/1.0/modules/content/
                 feed_description = feed["content:encoded"]


### PR DESCRIPTION
Hi, I couldn't find instructions on how to make PRs so I just pushed one. Feel free to tell me if the procedure isn't followed. I stumbled on KoReader 3 days ago and it is a real gem, thank you very much for your work!

I found this issue on nightly 2025-03-10, v2024.11-223-g154ec621d_2025-03-03, KindlePaperWhite5.

# Issue

Some RSS feeds contain items that don't have a description (for instance [this one](https://fabiensanglard.net/rss.xml), which is valid as per https://validator.w3.org/feed/). In that case the processing for the feed just stop abruptly and we get "Could not process some feeds. Unsupported format in: XXX (Reason: Failed to download content)".

Probably because the call `feed.description[1]` raise an exception like in this code, and the code is run on another thread (? I am not too familiar with lua), and the exception is not catched.

```
> item = {}
> item.description[1]
stdin:1: attempt to index a nil value (field 'description')
stack traceback:
        stdin:1: in main chunk
        [C]: in ?
```


# Quick Fix

I check if there is a "description" element in the feed. If that's not the case I use the title instead as a placeholder.
If `download_full_article` is not set, it means that we will have a very short document that only contain the title. However since I have no way that I can see to give the user feedback, I'd rather just generate the file and let the user come to their own conclusions (same case as with very short descriptions).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13407)
<!-- Reviewable:end -->
