### PR TITLE
fix for Add new entry show the url from the last added entry in NoewDownloader

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -34,14 +34,6 @@ local NewsDownloader = WidgetContainer:extend{
     download_dir = nil,
     file_extension = ".epub",
     config_key_custom_dl_dir = "custom_dl_dir",
-    empty_feed = {
-        [1] = "https://",
-        limit = 5,
-        download_full_article = false,
-        include_images = true,
-        enable_filter = false,
-        filter_element = ""
-    },
     kv = nil, -- KeyValuePage
 }
 
@@ -57,6 +49,18 @@ local function getFeedTitle(possible_title)
     elseif possible_title[1] and type(possible_title[1]) == "string" then
         return util.htmlEntitiesToUtf8(possible_title[1])
     end
+end
+
+--- Return a new empty field that can be modified by the caller
+local function getEmptyFeed()
+   return {
+        [1] = "https://",
+        limit = 5,
+        download_full_article = false,
+        include_images = true,
+        enable_filter = false,
+        filter_element = ""
+    }
 end
 
 -- There can be multiple links.
@@ -225,7 +229,7 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
             -- add a feed to their list.
             local feed_item_vc = FeedView:getItem(
                 1,
-                self.empty_feed,
+                getEmptyFeed(),
                 function(id, edit_key, value)
                     self:editFeedAttribute(id, edit_key, value)
                 end
@@ -796,7 +800,7 @@ function NewsDownloader:viewFeedList()
                 -- Prepare the view with all the callbacks for editing the attributes
                 local feed_item_vc = FeedView:getItem(
                     #feed_config + 1,
-                    self.empty_feed,
+                    getEmptyFeed(),
                     function(id, edit_key, value)
                         self:editFeedAttribute(id, edit_key, value)
                     end
@@ -960,7 +964,7 @@ function NewsDownloader:updateFeedConfig(id, key, value)
     if id > #feed_config then
         table.insert(
             feed_config,
-            self.empty_feed
+            getEmptyFeed()
         )
     end
 

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -51,7 +51,7 @@ local function getFeedTitle(possible_title)
     end
 end
 
---- Return a new empty field that can be modified by the caller
+-- Returns a new empty field that can be modified by the caller
 local function getEmptyFeed()
    return {
         [1] = "https://",


### PR DESCRIPTION
Fix issue #13408

> In the news plugin, when you add 2 news feed in a row from the UI, for the second item the UI is populated with the exact same data that you entered on the first item, instead of showing the default "blank" values.

The `empty_feed` data structure is mutated every time the user adds a new feed item. This result in the UI showing the previously added feed as the "default" for new feeds.

This is confusing as it _looks_ as if they were editing the previously inserted feed.

This PR just create a new empty feed item every time, so that mutations to that feed items are not an issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13411)
<!-- Reviewable:end -->
