### PR TITLE
Do not discard RSS/Atom feed processing errors

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -340,7 +340,7 @@ function NewsDownloader:processFeedSource(url, credentials, limit, unsupported_f
     -- Check if we have a cached response first
     local cache = DownloadBackend:getCache()
     local cached_response = cache:check(url)
-    local ok, response
+    local ok, error, response
 
     local cookies = nil
     if credentials ~= nil then
@@ -475,7 +475,7 @@ function NewsDownloader:processFeedSource(url, credentials, limit, unsupported_f
 
     -- Process the feeds accordingly.
     if is_atom then
-        ok = pcall(function()
+        ok, error = pcall(function()
                 return self:processFeed(
                     FEED_TYPE_ATOM,
                     feeds,
@@ -489,7 +489,7 @@ function NewsDownloader:processFeedSource(url, credentials, limit, unsupported_f
                 )
         end)
     elseif is_rss then
-        ok = pcall(function()
+        ok, error = pcall(function()
                 return self:processFeed(
                     FEED_TYPE_RSS,
                     feeds,
@@ -509,6 +509,7 @@ function NewsDownloader:processFeedSource(url, credentials, limit, unsupported_f
     if not ok or (not is_rss and not is_atom) then
         local error_message
         if not ok then
+            logger.err("NewsDownloader: Error processing feed", error)
             error_message = _("(Reason: Failed to download content)")
         elseif not is_rss then
             error_message = _("(Reason: Couldn't process RSS)")


### PR DESCRIPTION
A small commit that helped me debug issues with weird RSS feeds, feel free to discard it if you don't think it would be useful.

The current implementation of the NewsDownloader will silently discard errors generated during the call to `processFeed`. This PR just store that error and log it as "err" to help with debugging. Given that it is a hard failure, I logged it at err instead of dbg.
(It's my last PR, I promise)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13413)
<!-- Reviewable:end -->
