### PR TITLE
PDF: single-word search with leading and trailing spaces

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -1443,6 +1443,10 @@ local function get_pattern_list(pattern, case_insensitive)
             table.insert(plist, case_insensitive and Utf8Proc.lowercase(util.fixUtf8(word, "?")) or word)
         end
     end
+    if #plist == 1 then
+        plist.from_start = pattern:sub(1, 1) == " "
+        plist.from_end = pattern:sub(-1) == " "
+    end
     return plist
 end
 
@@ -1464,7 +1468,17 @@ local function all_matches(boxes, plist, case_insensitive)
             local pword = plist[pindex]
             local matched
             if pnb == 1 then -- single word in plist
-                matched = word:find(pword, 1, true)
+                if plist.from_start or plist.from_end then
+                    if plist.from_start and plist.from_end then
+                        matched = word == pword
+                    elseif plist.from_start then
+                        matched = word:sub(1, #pword) == pword
+                    else -- plist.from_end
+                        matched = word:sub(-#pword) == pword
+                    end
+                else
+                    matched = word:find(pword, 1, true)
+                end
             else -- multiple words in plist
                 if pindex == 1 then
                     -- first word of query should match at end of a word from the document


### PR DESCRIPTION
Leading space in the pattern: to search for words starting with the pattern.
Trailing space in the pattern: to search for words ending with the pattern.
Leading and trailing spaces in the pattern: to search for the exact word.
Closes https://github.com/koreader/koreader/issues/11029.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13414)
<!-- Reviewable:end -->
