### PR TITLE
[News Downloader UI] Fix missing elements in the Add feeds window

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -169,7 +169,7 @@ end
 --
 function FeedView:flattenArray(base_array, source_array)
     for _, value in pairs(source_array) do
-        if not value[2] then
+        if value[2] == nil then
             -- If the value is empty, then it's probably supposed to be a line
             table.insert(base_array, "---")
         else


### PR DESCRIPTION
In the News downloader, on the "Edit news feed" screen. Each field to display is stored in a table.
 
The current code will replace "empty" UI elements with a line (separator). However it is relying on the truthiness of the value of the field. If the value is False, for instance for the "download image" item, then the UI element for that field will be replaced with a line in the UI.

This PR just makes sure that we check for explicit "nil" value instead of truthiness.

We could also check `value` (and not `value[2]`) against a constant like `SEPARATOR="---"`, and use that constant elsewhere in the code, but that would require larger code change.

# Screenshots
This PR
![good](https://github.com/user-attachments/assets/94ad986b-fb5b-4fe4-b621-468645a5e35a)
Master
![master](https://github.com/user-attachments/assets/da700384-b03a-47b0-bc8c-50f79d438701)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13415)
<!-- Reviewable:end -->
