### PR TITLE
[plugin] HttpInspector: avoid crash when port can't be bound

### DIFF
--- a/frontend/ui/message/simpletcpserver.lua
+++ b/frontend/ui/message/simpletcpserver.lua
@@ -1,5 +1,7 @@
 local socket = require("socket")
 local logger = require("logger")
+local _ = require("gettext")
+local T = require("ffi/util").template
 
 -- Reference:
 -- https://lunarmodules.github.io/luasocket/tcp.html
@@ -25,7 +27,7 @@ end
 function SimpleTCPServer:start()
     local server, err = socket.bind(self.host, self.port)
     if not server then
-        return false, err or ""
+        return false, (err and T(_("Failed to bind socket: %1"), err) or "Failed to bind socket")
     end
     self.server = server
     self.server:settimeout(0.01) -- set timeout (10ms)

--- a/frontend/ui/message/simpletcpserver.lua
+++ b/frontend/ui/message/simpletcpserver.lua
@@ -23,7 +23,11 @@ function SimpleTCPServer:new(o)
 end
 
 function SimpleTCPServer:start()
-    self.server = socket.bind(self.host, self.port)
+    local server, err = socket.bind(self.host, self.port)
+    if not server then
+        return false, err or ""
+    end
+    self.server = server
     self.server:settimeout(0.01) -- set timeout (10ms)
     logger.dbg("SimpleTCPServer: Server listening on port " .. self.port)
 end

--- a/frontend/ui/message/simpletcpserver.lua
+++ b/frontend/ui/message/simpletcpserver.lua
@@ -27,7 +27,7 @@ end
 function SimpleTCPServer:start()
     local server, err = socket.bind(self.host, self.port)
     if not server then
-        return false, (err and T(_("Failed to bind socket: %1"), err) or "Failed to bind socket")
+        return false, (err and T(_("Failed to bind socket: %1"), err) or _("Failed to bind socket"))
     end
     self.server = server
     self.server:settimeout(0.01) -- set timeout (10ms)

--- a/plugins/httpinspector.koplugin/main.lua
+++ b/plugins/httpinspector.koplugin/main.lua
@@ -100,10 +100,18 @@ function HttpInspector:start()
         port = self.port,
         receiveCallback = function(data, id) return self:onRequest(data, id) end,
     }
-    self.http_socket:start()
-    self.http_messagequeue = UIManager:insertZMQ(self.http_socket)
-
-    logger.dbg("HttpInspector: Server listening on port " .. self.port)
+    local ok, err = self.http_socket:start()
+    if ok then
+        self.http_messagequeue = UIManager:insertZMQ(self.http_socket)
+        logger.dbg("HttpInspector: Server listening on port " .. self.port)
+    else
+        logger.err("HttpInspector: Failed to start server:", err)
+        self.http_socket = nil
+        local InfoMessage = require("ui/widget/infomessage")
+        UIManager:show(InfoMessage:new{
+            text = T(_("Failed to start HTTP inspector on port %1."), self.port) .. "\n" .. err,
+        })
+    end
 end
 
 function HttpInspector:stop()

--- a/plugins/httpinspector.koplugin/main.lua
+++ b/plugins/httpinspector.koplugin/main.lua
@@ -109,7 +109,7 @@ function HttpInspector:start()
         self.http_socket = nil
         local InfoMessage = require("ui/widget/infomessage")
         UIManager:show(InfoMessage:new{
-            text = T(_("Failed to start HTTP inspector on port %1."), self.port) .. "\n" .. err,
+            text = T(_("Failed to start HTTP inspector on port %1."), self.port) .. "\n\n" .. err,
         })
     end
 end


### PR DESCRIPTION
See <https://github.com/koreader/koreader/issues/13420#issuecomment-2726311224>.

<img src=https://github.com/user-attachments/assets/9090788f-19cf-4965-a680-4c09cfb84e3d width=45%>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13421)
<!-- Reviewable:end -->
