### PR TITLE
Update en_popup.lua

### DIFF
--- a/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
+++ b/frontend/ui/data/keyboardlayouts/keypopup/en_popup.lua
@@ -513,6 +513,7 @@ return {
         southwest = "Ů",
         "Ū",
         "ɒ", -- turned alpha, open back rounded vowel IPA
+        "Ŭ", -- U with breve from Belarusan Latin alphabet
     },
     _u_ = {
         "u",
@@ -526,6 +527,7 @@ return {
         southwest = "ů",
         "ū",
         "ɒ", -- turned alpha, open back rounded vowel IPA
+        "ŭ", -- u with breve from Belarusan Latin alphabet
     },
     _V_ = {
         "V",


### PR DESCRIPTION
EN layout: Added 'u with breve' (ŭ, Ŭ) from Belarusan Latin alphabet in popup under 'u' and 'U'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13425)
<!-- Reviewable:end -->
