### PR TITLE
CoverBrowser list mode: fix shortcut icon position

### DIFF
--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -433,11 +433,7 @@ function MenuItem:init()
         HorizontalSpan:new{ width = self.items_padding or Size.padding.fullscreen },
     }
     if self.shortcut then
-        table.insert(hgroup, ItemShortCutIcon:new{
-            dimen = shortcut_icon_dimen,
-            key = self.shortcut,
-            style = self.shortcut_style,
-        })
+        table.insert(hgroup, self.menu:getItemShortCutIcon(shortcut_icon_dimen, self.shortcut, self.shortcut_style))
         table.insert(hgroup, HorizontalSpan:new{ width = Size.span.horizontal_default })
     end
     table.insert(hgroup, self._underline_container)
@@ -624,6 +620,14 @@ local Menu = FocusManager:extend{
     linesize = Size.line.medium,
     line_color = Blitbuffer.COLOR_DARK_GRAY,
 }
+
+function Menu:getItemShortCutIcon(dimen, key, style)
+    return ItemShortCutIcon:new{
+        dimen = dimen,
+        key = key,
+        style = style,
+    }
+end
 
 function Menu:_recalculateDimen(no_recalculate_dimen)
     local perpage = self.items_per_page or G_reader_settings:readSetting("items_per_page") or self.items_per_page_default

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -22,7 +22,6 @@ local TextWidget = require("ui/widget/textwidget")
 local UnderlineContainer = require("ui/widget/container/underlinecontainer")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
-local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
 local logger = require("logger")
 local util = require("util")
@@ -45,50 +44,6 @@ local corner_mark_size = -1
 local corner_mark
 
 local scale_by_size = Screen:scaleBySize(1000000) * (1/1000000)
-
--- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
--- so we need to redefine it
-local ItemShortCutIcon = WidgetContainer:extend{
-    dimen = Geom:new{ x = 0, y = 0, w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
-    key = nil,
-    bordersize = Size.border.default,
-    radius = 0,
-    style = "square",
-}
-
-function ItemShortCutIcon:init()
-    if not self.key then
-        return
-    end
-    local radius = 0
-    local background = Blitbuffer.COLOR_WHITE
-    if self.style == "rounded_corner" then
-        radius = math.floor(self.width/2)
-    elseif self.style == "grey_square" then
-        background = Blitbuffer.COLOR_LIGHT_GRAY
-    end
-    local sc_face
-    if self.key:len() > 1 then
-        sc_face = Font:getFace("ffont", 14)
-    else
-        sc_face = Font:getFace("scfont", 22)
-    end
-    self[1] = FrameContainer:new{
-        padding = 0,
-        bordersize = self.bordersize,
-        radius = radius,
-        background = background,
-        dimen = self.dimen:copy(),
-        CenterContainer:new{
-            dimen = self.dimen,
-            TextWidget:new{
-                text = self.key,
-                face = sc_face,
-            },
-        },
-    }
-end
-
 
 -- Based on menu.lua's MenuItem
 local ListMenuItem = InputContainer:extend{
@@ -126,11 +81,7 @@ function ListMenuItem:init()
         }
         -- To keep a simpler widget structure, this shortcut icon will not
         -- be part of it, but will be painted over the widget in our paintTo
-        self.shortcut_icon = ItemShortCutIcon:new{
-            dimen = shortcut_icon_dimen,
-            key = self.shortcut,
-            style = self.shortcut_style,
-        }
+        self.shortcut_icon = self.menu:getItemShortCutIcon(shortcut_icon_dimen, self.shortcut, self.shortcut_style)
     end
 
     -- we need this table per-instance, so we declare it here
@@ -790,11 +741,11 @@ function ListMenuItem:paintTo(bb, x, y)
         local target = self[1][1][2]
         local ix
         if BD.mirroredUILayout() then
-            ix = target.dimen.w - self.shortcut_icon.dimen.w
+            ix = target.dimen.w - self.shortcut_icon.dimen.w - 2 * self.shortcut_icon.bordersize
         else
             ix = 0
         end
-        local iy = target.dimen.h - self.shortcut_icon.dimen.h
+        local iy = target.dimen.h - self.shortcut_icon.dimen.h - self.shortcut_icon.bordersize
         self.shortcut_icon:paintTo(bb, x+ix, y+iy)
     end
 

--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -18,11 +18,9 @@ local ProgressWidget = require("ui/widget/progresswidget")
 local ReadCollection = require("readcollection")
 local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
-local TextWidget = require("ui/widget/textwidget")
 local UnderlineContainer = require("ui/widget/container/underlinecontainer")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
-local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
@@ -46,49 +44,6 @@ local abandoned_mark
 local complete_mark
 local collection_mark
 local progress_widget
-
--- ItemShortCutIcon (for keyboard navigation) is private to menu.lua and can't be accessed,
--- so we need to redefine it
-local ItemShortCutIcon = WidgetContainer:extend{
-    dimen = Geom:new{ x = 0, y = 0, w = Screen:scaleBySize(22), h = Screen:scaleBySize(22) },
-    key = nil,
-    bordersize = Size.border.default,
-    radius = 0,
-    style = "square",
-}
-
-function ItemShortCutIcon:init()
-    if not self.key then
-        return
-    end
-    local radius = 0
-    local background = Blitbuffer.COLOR_WHITE
-    if self.style == "rounded_corner" then
-        radius = math.floor(self.width/2)
-    elseif self.style == "grey_square" then
-        background = Blitbuffer.COLOR_LIGHT_GRAY
-    end
-    local sc_face
-    if self.key:len() > 1 then
-        sc_face = Font:getFace("ffont", 14)
-    else
-        sc_face = Font:getFace("scfont", 22)
-    end
-    self[1] = FrameContainer:new{
-        padding = 0,
-        bordersize = self.bordersize,
-        radius = radius,
-        background = background,
-        dimen = self.dimen:copy(),
-        CenterContainer:new{
-            dimen = self.dimen,
-            TextWidget:new{
-                text = self.key,
-                face = sc_face,
-            },
-        },
-    }
-end
 
 -- We may find a better algorithm, or just a set of
 -- nice looking combinations of 3 sizes to iterate thru
@@ -375,11 +330,7 @@ function MosaicMenuItem:init()
         }
         -- To keep a simpler widget structure, this shortcut icon will not
         -- be part of it, but will be painted over the widget in our paintTo
-        self.shortcut_icon = ItemShortCutIcon:new{
-            dimen = shortcut_icon_dimen,
-            key = self.shortcut,
-            style = self.shortcut_style,
-        }
+        self.shortcut_icon = self.menu:getItemShortCutIcon(shortcut_icon_dimen, self.shortcut, self.shortcut_style)
     end
 
     self.percent_finished = nil


### PR DESCRIPTION
**Before**

![0](https://github.com/user-attachments/assets/520a3279-ea87-4250-af00-a0f061348d8d)

![1](https://github.com/user-attachments/assets/7488dbfd-ebd6-4e62-867c-e859fd76d240)

Mirrored layout, the icon in the right
![3](https://github.com/user-attachments/assets/9d0e3c70-ed79-43f5-88b1-2724dd9b6310)

**After**

![2](https://github.com/user-attachments/assets/cb2af959-d89e-4028-8454-109670566941)

![4](https://github.com/user-attachments/assets/55059a38-8c33-4976-bbf3-a115bab6428f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13429)
<!-- Reviewable:end -->
