### PR TITLE
Profiles: add "on exiting sleep screen" auto-exec trigger

### DIFF
--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -527,6 +527,13 @@ function Profiles:genAutoExecMenuItem(text, event, profile_name, separator)
     end
     return {
         text = text,
+        enabled_func = function()
+            if event == "Resume" then
+                local screensaver_delay = G_reader_settings:readSetting("screensaver_delay")
+                return screensaver_delay == nil or screensaver_delay == "disable"
+            end
+            return true
+        end,
         checked_func = function()
             return util.tableGetValue(self.autoexec, event, profile_name)
         end,


### PR DESCRIPTION
Useful for delayed or "with a gesture" sleep screen exiting.
Fixes https://github.com/koreader/koreader/pull/13399#issuecomment-2723139521.

![1](https://github.com/user-attachments/assets/8af197e4-60a5-4c56-a032-27c7624e0311)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13430)
<!-- Reviewable:end -->
