### PR TITLE
OPDS: fix calling "file downloaded" dialog

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -638,7 +638,7 @@ function OPDSBrowser:showDownloads(item)
                     callback = function()
                         UIManager:close(self.download_dialog)
                         local local_path = self:getLocalDownloadPath(filename, filetype, acquisition.href)
-                        self:downloadFile(local_path, acquisition.href, self._manager.file_downloaded_callback)
+                        self:downloadFile(local_path, acquisition.href, self.file_downloaded_callback)
                     end,
                     hold_callback = function()
                         UIManager:close(self.download_dialog)


### PR DESCRIPTION
Recent bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13443)
<!-- Reviewable:end -->
