### PR TITLE
Quote directory in util.diskUsage

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -920,7 +920,7 @@ end
 function util.diskUsage(dir)
     -- safe way of testing df & awk
     local function doCommand(d)
-        local handle = io.popen("df -k " .. d .. " 2>/dev/null | awk '$3 ~ /[0-9]+/ { print $2,$3,$4 }' 2>/dev/null || echo ::ERROR::")
+        local handle = io.popen("df -k " .. util.shell_escape({d}) .. " 2>/dev/null | awk '$3 ~ /[0-9]+/ { print $2,$3,$4 }' 2>/dev/null || echo ::ERROR::")
         if not handle then return end
         local output = handle:read("*all")
         handle:close()


### PR DESCRIPTION
If not quoted, this function does not work with directories that include a space in their name.

I noticed this when using calibre wirelessly. It reports the disk space as 1GB as this is the default if util.diskUsage doesn't work. Adding quotes around the directory fixes it on my Kobo Libra Color.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13448)
<!-- Reviewable:end -->
