### PR TITLE
Dispatcher: ignore order for single-action gesture

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -616,8 +616,9 @@ function Dispatcher:removeAction(name)
 end
 
 local function iter_func(settings)
-    if settings and settings.settings and settings.settings.order then
-        return ipairs(settings.settings.order)
+    local order = util.tableGetValue(settings, "settings", "order")
+    if order and #order > 1 then
+        return ipairs(order)
     else
         return pairs(settings)
     end


### PR DESCRIPTION
Currently new single-action gesture/profile doesn't have `order` setting.
Let's ignore order for old single-action gestures.
Fixes https://github.com/koreader/koreader/pull/11072#issuecomment-2746366874.

Doesn't fix rtl inverting of multi-actions gestures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13450)
<!-- Reviewable:end -->
