### PR TITLE
[UnderlineContainer] "fix" focus underline for RTL UI

### DIFF
--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -4,6 +4,7 @@ a line under its child node.
 --]]
 
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Geom = require("ui/geometry")
 local Size = require("ui/size")
@@ -15,6 +16,7 @@ local UnderlineContainer = WidgetContainer:extend{
     -- We default to white to be invisible by default for FocusManager use-cases (only switching to black @ onFocus)
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
+    line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
 }
 
 function UnderlineContainer:getSize()
@@ -37,6 +39,13 @@ function UnderlineContainer:paintTo(bb, x, y)
         self.dimen.x = x
         self.dimen.y = y
     end
+
+    local line_width = self.line_width or self.dimen.w
+    local line_x = x
+    if BD.mirroredUILayout() then
+        line_x = line_x + self.dimen.w - line_width
+    end
+
     local content_size = self[1]:getSize()
     local p_y = y
     if self.vertical_align == "center" then
@@ -45,8 +54,8 @@ function UnderlineContainer:paintTo(bb, x, y)
         p_y = (container_size.h - content_size.h) + y
     end
     self[1]:paintTo(bb, x, p_y)
-    bb:paintRect(x, y + container_size.h - self.linesize,
-        container_size.w, self.linesize, self.color)
+    bb:paintRect(line_x, y + container_size.h - self.linesize,
+        line_width, self.linesize, self.color)
 end
 
 return UnderlineContainer

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -146,6 +146,7 @@ function TouchMenuItem:init()
     self._underline_container = UnderlineContainer:new{
         vertical_align = "center",
         dimen = self.dimen:copy(),
+        line_width = self.item_frame:getSize().w, -- we'll draw a shorter line
         self.item_frame,
     }
 


### PR DESCRIPTION
### what's new

* fix touch menu's focus underline (non-touch) when using RTL languages

see #13362 generally and https://github.com/koreader/koreader/pull/13362#issuecomment-2749434009

@poire-z

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13454)
<!-- Reviewable:end -->
