### PR TITLE
[ReaderLink, Dispatcher] add toggle for tap-to-follow links

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -703,6 +703,16 @@ function ReaderLink:onTap(_, ges)
     end
 end
 
+-- Toggle tap to follow links functionality
+function ReaderLink:onToggleTapLinks()
+    G_reader_settings:flipNilOrTrue("tap_to_follow_links")
+    local tap_links_status = isTapToFollowLinksOn() and _("on") or _("off")
+    UIManager:show(Notification:new{
+        text = T(_("Tap to follow links: %1"), tap_links_status),
+    })
+    return true
+end
+
 function ReaderLink:getCurrentLocation()
     return self.ui.paging and self.ui.paging:getBookLocation()
                            or {xpointer = self.ui.rolling:getBookLocation()}

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -699,7 +699,7 @@ function ReaderLink:onToggleTapLinks()
     G_reader_settings:flipNilOrTrue("tap_to_follow_links")
     local tap_links_status = isTapToFollowLinksOn() and _("on") or _("off")
     UIManager:show(Notification:new{
-        text = T(_("Tap-to-follow links: %1"), tap_links_status),
+        text = T(_("Tap to follow links: %1"), tap_links_status),
     })
     return true
 end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -460,15 +460,15 @@ From the footnote popup, you can jump to the footnote location in the book by sw
         local footnote_popup_settings_items = {}
         table.insert(menu_items.follow_links.sub_item_table, 5, {
             text = _("Footnote popup settings"),
+            enabled_func = function()
+                return isFootnoteLinkInPopupEnabled() and
+                    (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
+            end,
             sub_item_table = footnote_popup_settings_items,
             separator = true,
         })
         table.insert(footnote_popup_settings_items, {
             text = _("Show more links as footnotes"),
-            enabled_func = function()
-                return isFootnoteLinkInPopupEnabled() and
-                    (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
-            end,
             checked_func = isPreferFootnoteEnabled,
             callback = function()
                 G_reader_settings:saveSetting("link_prefer_footnote",
@@ -479,10 +479,6 @@ From the footnote popup, you can jump to the footnote location in the book by sw
         })
         table.insert(footnote_popup_settings_items, {
             text = _("Use book font as popup font"),
-            enabled_func = function()
-                return isFootnoteLinkInPopupEnabled() and
-                    (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
-            end,
             checked_func = function()
                 return G_reader_settings:isTrue("footnote_popup_use_book_font")
             end,
@@ -493,10 +489,6 @@ From the footnote popup, you can jump to the footnote location in the book by sw
         })
         table.insert(footnote_popup_settings_items, {
             text = _("Set footnote popup font size"),
-            enabled_func = function()
-                return isFootnoteLinkInPopupEnabled() and
-                    (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
-            end,
             keep_menu_open = true,
             callback = function()
                 local spin_widget
@@ -703,12 +695,11 @@ function ReaderLink:onTap(_, ges)
     end
 end
 
--- Toggle tap to follow links functionality
 function ReaderLink:onToggleTapLinks()
     G_reader_settings:flipNilOrTrue("tap_to_follow_links")
     local tap_links_status = isTapToFollowLinksOn() and _("on") or _("off")
     UIManager:show(Notification:new{
-        text = T(_("Tap to follow links: %1"), tap_links_status),
+        text = T(_("Tap-to-follow links: %1"), tap_links_status),
     })
     return true
 end

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -172,6 +172,7 @@ local settingsList = {
     follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), reader=true},
     select_prev_page_link = { category="none", event = "SelectPrevPageLink", title=_("Select previous link in current page"), reader=true, condition=not Device:isTouchDevice()},
     select_next_page_link = { category="none", event = "SelectNextPageLink", title=_("Select next link in current page"), reader=true, condition=not Device:isTouchDevice()},
+    toggle_tap_links = {category="none", event="ToggleTapLinks", title=_("Toggle tap to follow links"), reader=true, condition=Device:isTouchDevice()},
     add_location_to_history = {category="none", event="AddCurrentLocationToStack", arg=true, title=_("Add current location to history"), reader=true},
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
     ----
@@ -407,6 +408,7 @@ local dispatcher_menu_order = {
     "follow_nearest_internal_link",
     "select_prev_page_link",
     "select_next_page_link",
+    "toggle_tap_links",
     "add_location_to_history",
     "clear_location_history",
     ----

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -172,7 +172,7 @@ local settingsList = {
     follow_nearest_internal_link = {category="arg", event="GoToInternalPageLink", arg={pos={x=0,y=0}}, title=_("Follow nearest internal link"), reader=true},
     select_prev_page_link = { category="none", event = "SelectPrevPageLink", title=_("Select previous link in current page"), reader=true, condition=not Device:isTouchDevice()},
     select_next_page_link = { category="none", event = "SelectNextPageLink", title=_("Select next link in current page"), reader=true, condition=not Device:isTouchDevice()},
-    toggle_tap_links = {category="none", event="ToggleTapLinks", title=_("Toggle tap to follow links"), reader=true, condition=Device:isTouchDevice()},
+    toggle_tap_links = {category="none", event="ToggleTapLinks", title=_("Toggle tap-to-follow links"), reader=true, condition=Device:isTouchDevice()},
     add_location_to_history = {category="none", event="AddCurrentLocationToStack", arg=true, title=_("Add current location to history"), reader=true},
     clear_location_history = {category="none", event="ClearLocationStack", arg=true, title=_("Clear location history"), reader=true, separator=true},
     ----


### PR DESCRIPTION
### what's new

* Consolidated the `enabled_func` for footnote popup settings into a single location to avoid redundancy in `frontend/apps/reader/modules/readerlink.lua`. 
* Added a new function `onToggleTapLinks` to toggle the tap-to-follow links setting and display a notification of the current status in `frontend/apps/reader/modules/readerlink.lua`.
* Included the new `toggle_tap_links` event in the settings list and dispatcher menu order in `frontend/dispatcher.lua`. 

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/174c52de-6930-4579-8144-f38347c264b8" width=40% height=40%> 
<img src="https://github.com/user-attachments/assets/cfafc38f-4d36-4060-846a-7f616c09a062" width=40% height=40%> 
</p>

closes #13381

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13469)
<!-- Reviewable:end -->
