### PR TITLE
Make warmth show up in native units in status bar

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -160,7 +160,8 @@ local footerTextGeneratorMap = {
         if powerd:isFrontlightOn() then
             local warmth = powerd:frontlightWarmth()
             if warmth then
-                return (prefix .. " %d%%"):format(warmth)
+                local warmth_native = powerd:toNativeWarmth(warmth)
+                return (prefix .. " %d"):format(warmth_native)
             end
         else
             if footer.settings.all_at_once and footer.settings.hide_empty_generators then


### PR DESCRIPTION
I enabled both `frontlight` and `frontlight warmth` to show up in the status bar. The former is in device native units (out of max 24), the latter is in percentage units (100%) maximum.

This PR makes `warmth` in native units as well.
Together with https://github.com/koreader/koreader/pull/13344 , this change makes it so all the warmth is displayed in device native units (at least on Kindle).

@NiLuJe please review.

Pictures of the statusbar with frontlight and warmth, respectively.
Before:
![1_warmth_percent_OLD](https://github.com/user-attachments/assets/63b16f87-c0ed-4a03-98ca-d1f49505be09)

After:
![2_warmth_native_NEW](https://github.com/user-attachments/assets/e88abcfa-6946-4106-bda5-4ba662dc5251)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13474)
<!-- Reviewable:end -->
