### PR TITLE
battery stats - nit on wording

### DIFF
--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -213,7 +213,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = T(_("Battery statistics (now at %1%)"), self.awake_state.percentage),
+        title = T(_("Battery statistics (%1%"), self.awake_state.percentage),
         kv_pairs = kv_pairs,
         single_page = true,
     }

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -212,7 +212,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = _("Battery statistics") .. " (" .. self.awake_state.percentage .. ")",
+        title = _("Battery statistics") .. " (" .. self.awake_state.percentage .. "%)",
         kv_pairs = kv_pairs,
         single_page = true,
     }

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -205,7 +205,7 @@ function BatteryStat:showStatistics()
     self:accumulate()
     local kv_pairs = self:dump()
     kv_pairs[#kv_pairs].separator = true
-    table.insert(kv_pairs, {_("Tap to reset the data."), "",
+    table.insert(kv_pairs, {_("Tap here to reset the data"), "",
                             callback = function()
                                 UIManager:setDirty(self.kv_page, "fast")
                                 UIManager:scheduleIn(0.1, function()
@@ -213,7 +213,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = T(_("Battery statistics (now %1%)"), self.awake_state.percentage),
+        title = T(_("Battery statistics (now at %1%)"), self.awake_state.percentage),
         kv_pairs = kv_pairs,
         single_page = true,
     }

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -204,7 +204,7 @@ function BatteryStat:showStatistics()
     self:accumulate()
     local kv_pairs = self:dump()
     kv_pairs[#kv_pairs].separator = true
-    table.insert(kv_pairs, {_("Tap here to reset the data"), "",
+    table.insert(kv_pairs, {_("Tap to reset the data"), "",
                             callback = function()
                                 UIManager:setDirty(self.kv_page, "fast")
                                 UIManager:scheduleIn(0.1, function()

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -10,7 +10,6 @@ local datetime = require("datetime")
 local dbg = require("dbg")
 local time = require("ui/time")
 local _ = require("gettext")
-local T = require("ffi/util").template
 
 local State = {}
 

--- a/plugins/batterystat.koplugin/main.lua
+++ b/plugins/batterystat.koplugin/main.lua
@@ -213,7 +213,7 @@ function BatteryStat:showStatistics()
                                 end)
                             end})
     self.kv_page = KeyValuePage:new{
-        title = T(_("Battery statistics (%1%"), self.awake_state.percentage),
+        title = _("Battery statistics") .. " (" .. self.awake_state.percentage .. ")",
         kv_pairs = kv_pairs,
         single_page = true,
     }


### PR DESCRIPTION
1) Replace `Tap to reset the data.` by `Tap `**`here`**` to reset data`
This is in the same style as the recent changes for `Tap here to select current folder` in folder chooser dialog.
2) Replace `now 74%` by `now `**`at`**` 74%`
Another alternative: `74% now`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13476)
<!-- Reviewable:end -->
