### PR TITLE
[Plugin] Added support for hexadecimal code points to OPDS parser

### DIFF
--- a/plugins/opds.koplugin/opdsparser.lua
+++ b/plugins/opds.koplugin/opdsparser.lua
@@ -23,7 +23,14 @@ local function unescape(str)
         if unescape_map[s] then
             return unescape_map[s]
         elseif n == "#" then  -- unescape unicode
-            return util.unicodeCodepointToUtf8(tonumber(s))
+            local codePoint
+            -- Determine if thhe code point s is written in decimal or hexidecimal
+            if string.sub(s,1,1) == "x" then
+                codePoint = tonumber(string.sub(s,2),16)
+            else
+                codePoint = tonumber(s)
+            end
+            return util.unicodeCodepointToUtf8(codePoint)
         else
             return orig
         end

--- a/plugins/opds.koplugin/opdsparser.lua
+++ b/plugins/opds.koplugin/opdsparser.lua
@@ -24,7 +24,7 @@ local function unescape(str)
             return unescape_map[s]
         elseif n == "#" then  -- unescape unicode
             local codePoint
-            -- Determine if thhe code point s is written in decimal or hexidecimal
+            -- Determine if the code point s is written as a decimal or hexidecimal number
             if string.sub(s,1,1) == "x" then
                 codePoint = tonumber(string.sub(s,2),16)
             else


### PR DESCRIPTION
Fixes a bug where OPDS parser fails when attempting to fetch from OPDS catalogue that uses hexadecimal code points, eg `&#x27`, as the parser fails to convert these to numbers.

The issue is most likely with KOReader as the OPDS catalogue that was failing to be parsed by KOReader was able to be correctly parsed by other OPDS supported software (eg thorium and moon+ reader) which correctly displayed the codepoint `&#x27` as an apostrophe `'` instead of completely failing to parse the page or displaying it as an unknown character.