### PR TITLE
Dispatcher: fix action deleted arg

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -296,10 +296,15 @@ end
 
 function ReaderFont:onSetFont(face)
     if face and self.font_face ~= face then
-        self.font_face = face
-        self.ui.document:setFontFace(face)
-        -- signal readerrolling to update pos in new height
-        self.ui:handleEvent(Event:new("UpdatePos"))
+        for _, fontinfo in pairs(FontList.fontinfo) do
+            if fontinfo[1].name == face then
+                self.font_face = face
+                self.ui.document:setFontFace(face)
+                -- signal readerrolling to update pos in new height
+                self.ui:handleEvent(Event:new("UpdatePos"))
+                return
+            end
+        end
     end
 end
 

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -720,6 +720,7 @@ function ReaderStyleTweak:addToMainMenu(menu_items)
 end
 
 function ReaderStyleTweak:onToggleStyleTweak(tweak_id, item, no_notification)
+    if self.tweaks_by_id[tweak_id] == nil then return true end
     local toggle
     if type(tweak_id) == "table" then -- Dispatcher action 'Style tweak set on/off'
         tweak_id, toggle = unpack(tweak_id)

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -720,11 +720,11 @@ function ReaderStyleTweak:addToMainMenu(menu_items)
 end
 
 function ReaderStyleTweak:onToggleStyleTweak(tweak_id, item, no_notification)
-    if self.tweaks_by_id[tweak_id] == nil then return true end
     local toggle
     if type(tweak_id) == "table" then -- Dispatcher action 'Style tweak set on/off'
         tweak_id, toggle = unpack(tweak_id)
     end
+    if self.tweaks_by_id[tweak_id] == nil then return true end
     local enabled, g_enabled = self:isTweakEnabled(tweak_id)
     if enabled == toggle then return true end
     local text

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -655,7 +655,8 @@ function Dispatcher:getNameFromItem(item, settings, dont_show_value)
                 settingsList[item].args, settingsList[item].toggle = settingsList[item].args_func()
             end
             local value_num = util.arrayContains(settingsList[item].args, value)
-            display_value = settingsList[item].toggle[value_num] or string.format("%.1f", value)
+            display_value = settingsList[item].toggle[value_num]
+                or (type(value) == "number" and string.format("%.1f", value) or value)
         end
     elseif category == "absolutenumber" then
         display_value = tostring(value)


### PR DESCRIPTION
Font file or user style tweak can be deleted (outside of the program) after assigning an action with them as arg.
Fix displaying the action in Gesture manager / Profiles.
Check for font/tweak existence before executing.
Closes https://github.com/koreader/koreader/issues/13479.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13488)
<!-- Reviewable:end -->
