### PR TITLE
Menu search fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -964,13 +964,9 @@ function FileManagerMenu:exitOrRestart(callback, force)
     end
 end
 
-function FileManagerMenu:onShowMenu(tab_index)
+function FileManagerMenu:onShowMenu(tab_index, do_not_show)
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
-    end
-
-    if not tab_index then
-        tab_index = G_reader_settings:readSetting("filemanagermenu_tab_index") or 1
     end
 
     local menu_container = CenterContainer:new{
@@ -983,9 +979,10 @@ function FileManagerMenu:onShowMenu(tab_index)
         local TouchMenu = require("ui/widget/touchmenu")
         main_menu = TouchMenu:new{
             width = Screen:getWidth(),
-            last_index = tab_index,
+            last_index = tab_index or G_reader_settings:readSetting("filemanagermenu_tab_index") or 1,
             tab_item_table = self.tab_item_table,
             show_parent = menu_container,
+            not_shown = do_not_show,
         }
     else
         local Menu = require("ui/widget/menu")
@@ -1004,7 +1001,9 @@ function FileManagerMenu:onShowMenu(tab_index)
     menu_container[1] = main_menu
     -- maintain a reference to menu_container
     self.menu_container = menu_container
-    UIManager:show(menu_container)
+    if not do_not_show then
+        UIManager:show(menu_container)
+    end
     return true
 end
 
@@ -1062,7 +1061,7 @@ function FileManagerMenu:onSetDimensions(dimen)
 end
 
 function FileManagerMenu:onMenuSearch()
-    self:onShowMenu()
+    self:onShowMenu(nil, true)
     self.menu_container[1]:onShowMenuSearch()
 end
 

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -381,13 +381,9 @@ function ReaderMenu:exitOrRestart(callback, force)
     end)
 end
 
-function ReaderMenu:onShowMenu(tab_index)
+function ReaderMenu:onShowMenu(tab_index, do_not_show)
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
-    end
-
-    if not tab_index then
-        tab_index = self.last_tab_index
     end
 
     local menu_container = CenterContainer:new{
@@ -401,9 +397,10 @@ function ReaderMenu:onShowMenu(tab_index)
         local TouchMenu = require("ui/widget/touchmenu")
         main_menu = TouchMenu:new{
             width = Screen:getWidth(),
-            last_index = tab_index,
+            last_index = tab_index or self.last_tab_index,
             tab_item_table = self.tab_item_table,
             show_parent = menu_container,
+            not_shown = do_not_show,
         }
     else
         local Menu = require("ui/widget/menu")
@@ -426,7 +423,9 @@ function ReaderMenu:onShowMenu(tab_index)
     menu_container[1] = main_menu
     -- maintain a reference to menu_container
     self.menu_container = menu_container
-    UIManager:show(menu_container)
+    if not do_not_show then
+        UIManager:show(menu_container)
+    end
     return true
 end
 
@@ -512,7 +511,7 @@ function ReaderMenu:onSaveSettings()
 end
 
 function ReaderMenu:onMenuSearch()
-    self:onShowMenu()
+    self:onShowMenu(nil, true)
     self.menu_container[1]:onShowMenuSearch()
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -1028,8 +1028,8 @@ function TouchMenu:search(search_for)
             if type(v) == "table" and not v.ignored_by_menu_search then
                 local entry_text = v.text_func and v.text_func() or v.text
                 is_disabled = is_disabled or v.enabled == false or (v.enabled_func and v.enabled_func() == false)
-                local entry_displayed_text = is_disabled and "\u{2592} " .. entry_text or entry_text -- Medium Shade + Hair Space
-                local indent = text and ((" "):rep(math.min(depth-1, 6)) .. "→ ") or "→ " -- all spaces here are Hair Space U+200A
+                local entry_displayed_text = is_disabled and "▒ " .. entry_text or entry_text
+                local indent = text and ((" "):rep(math.min(depth-1, 6)) .. "→ ") or "→ " -- all spaces here and above are Hair Space U+200A
                 local walk_text = text and (text .. "\n" .. indent .. entry_displayed_text) or (indent .. entry_displayed_text)
                 local walk_path = path .. "." .. i
                 if Utf8Proc.lowercase(entry_text):find(search_for, 1, true) then

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -1016,7 +1016,7 @@ function TouchMenu:search(search_for)
     local found_menu_items = {}
 
     local MAX_MENU_DEPTH = 10 -- our menu max depth is currently 6
-    local function recurse(item_table, path, text, icon, depth)
+    local function recurse(item_table, path, text, icon, depth, is_disabled)
         if item_table.ignored_by_menu_search then
             return
         end
@@ -1027,8 +1027,10 @@ function TouchMenu:search(search_for)
         for i, v in ipairs(item_table) do
             if type(v) == "table" and not v.ignored_by_menu_search then
                 local entry_text = v.text_func and v.text_func() or v.text
+                is_disabled = is_disabled or v.enabled == false or (v.enabled_func and v.enabled_func() == false)
+                local entry_displayed_text = is_disabled and "\u{2592} " .. entry_text or entry_text -- Medium Shade + Hair Space
                 local indent = text and ((" "):rep(math.min(depth-1, 6)) .. "→ ") or "→ " -- all spaces here are Hair Space U+200A
-                local walk_text = text and (text .. "\n" .. indent .. entry_text) or (indent .. entry_text)
+                local walk_text = text and (text .. "\n" .. indent .. entry_displayed_text) or (indent .. entry_displayed_text)
                 local walk_path = path .. "." .. i
                 if Utf8Proc.lowercase(entry_text):find(search_for, 1, true) then
                     table.insert(found_menu_items, {entry_text, icon, walk_path, walk_text})
@@ -1038,7 +1040,7 @@ function TouchMenu:search(search_for)
                     sub_item_table = v.sub_item_table_func()
                 end
                 if sub_item_table and not sub_item_table.ignored_by_menu_search then
-                    recurse(sub_item_table, walk_path, walk_text, icon, depth)
+                    recurse(sub_item_table, walk_path, walk_text, icon, depth, is_disabled)
                 end
             end
         end
@@ -1053,6 +1055,9 @@ function TouchMenu:search(search_for)
 end
 
 function TouchMenu:openMenu(path, with_animation)
+    if self.not_shown then
+        UIManager:show(self.show_parent)
+    end
     local parts = {}
     for part in util.gsplit(path, "%.", false) do -- path is ie. "2.3.3.1"
         table.insert(parts, tonumber(part))
@@ -1157,24 +1162,30 @@ function TouchMenu:openMenu(path, with_animation)
                 end
             end
         elseif step == STEPS.MENU_ITEM_HIGHLIGHT then
-            if with_animation or #parts == 0 then
-                -- Even if no animation, highlight the final item (and don't unhighlight it)
-                local item_visible_index = (item_nb - 1) % self.perpage + 1
-                local item_widget
-                for i, w in ipairs(self.item_group) do
-                    if w.item_visible_index == item_visible_index then
-                        item_widget = w
-                        break
-                    end
-                end
-                if item_widget then
-                    highlightWidget(item_widget)
+            local item_visible_index = (item_nb - 1) % self.perpage + 1
+            local item_widget
+            for i, w in ipairs(self.item_group) do
+                if w.item_visible_index == item_visible_index then
+                    item_widget = w
+                    break
                 end
             end
-            if #parts == 0 then
-                step = STEPS.DONE
+            if item_widget then
+                local is_disabled = item_widget.item.enabled == false
+                    or (item_widget.item.enabled_func and item_widget.item.enabled_func() == false)
+                if is_disabled then
+                    -- do not go down to disabled submenu
+                    -- do not highlight, text of highlighted disabled item is not visible
+                    step = STEPS.DONE
+                else
+                    if with_animation or #parts == 0 then
+                        -- Even if no animation, highlight the final item (and don't unhighlight it)
+                        highlightWidget(item_widget)
+                    end
+                    step = #parts == 0 and STEPS.DONE or STEPS.MENU_ITEM_ENTER
+                end
             else
-                step = STEPS.MENU_ITEM_ENTER
+                step = STEPS.DONE
             end
         elseif step == STEPS.MENU_ITEM_ENTER then
             self:onMenuSelect(self.item_table[item_nb])
@@ -1290,6 +1301,7 @@ function TouchMenu:onShowMenuSearch()
         if #found_menu_items > 0 then
             local results_menu = Menu:new{
                 title = _("Search results"),
+                subtitle = T(_("Query: %1"), search_string),
                 item_table = get_current_search_results(),
                 width = math.floor(Screen:getWidth() * 0.9),
                 height = math.floor(Screen:getHeight() * 0.9),

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -1027,9 +1027,15 @@ function TouchMenu:search(search_for)
         for i, v in ipairs(item_table) do
             if type(v) == "table" and not v.ignored_by_menu_search then
                 local entry_text = v.text_func and v.text_func() or v.text
+                local entry_displayed_text = entry_text
                 is_disabled = is_disabled or v.enabled == false or (v.enabled_func and v.enabled_func() == false)
-                local entry_displayed_text = is_disabled and "▒ " .. entry_text or entry_text
-                local indent = text and ((" "):rep(math.min(depth-1, 6)) .. "→ ") or "→ " -- all spaces here and above are Hair Space U+200A
+                if is_disabled then
+                    entry_displayed_text = "\u{2592}\u{200A}" .. entry_displayed_text -- Medium Shade (▒) + Hair Space
+                end
+                local indent = "\u{2192}\u{200A}" -- Rightwards Arrow (→) + Hair Space
+                if text then
+                    indent = ("\u{200A}"):rep(2*math.min(depth-1, 6)) .. indent
+                end
                 local walk_text = text and (text .. "\n" .. indent .. entry_displayed_text) or (indent .. entry_displayed_text)
                 local walk_path = path .. "." .. i
                 if Utf8Proc.lowercase(entry_text):find(search_for, 1, true) then


### PR DESCRIPTION
(1) Do not open the upper menu when Menu search dialog is called by a gesture/profile.
(2) In search results dialog mark disabled items with "medium shade".
(3) "Open/walk" doesn't highlight disabled items (text of disabled highlighted item is not visible).
(4) "Open/walk" stops on the first disabled menu item if it has subitems.

![1](https://github.com/user-attachments/assets/49c1f82f-7ef0-4d1b-95cf-37bc7f4f480a)

"Open/walk" will show:

![2](https://github.com/user-attachments/assets/d4be5c2d-77c1-40b2-ad30-2c9fa69ffc87)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13493)
<!-- Reviewable:end -->
