### PR TITLE
[DictQuickLookup] make the widget's width user patchable

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -218,7 +218,7 @@ function DictQuickLookup:init()
     if is_large_window then
         self.width = Screen:getWidth() - 2*Size.margin.default
     else
-        self.width = self.width or Screen:getWidth() - Screen:scaleBySize(80) --user patchable
+        self.width = self.width or Screen:getWidth() - Screen:scaleBySize(80) -- user patchable
     end
     local frame_bordersize = Size.border.window
     local inner_width = self.width - 2*frame_bordersize

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -218,7 +218,7 @@ function DictQuickLookup:init()
     if is_large_window then
         self.width = Screen:getWidth() - 2*Size.margin.default
     else
-        self.width = Screen:getWidth() - Screen:scaleBySize(80)
+        self.width = self.width or Screen:getWidth() - Screen:scaleBySize(80) --user patchable
     end
     local frame_bordersize = Size.border.window
     local inner_width = self.width - 2*frame_bordersize


### PR DESCRIPTION
### what's new

* [`frontend/ui/widget/dictquicklookup.lua`](diffhunk://#diff-f250b2c70dbfef162af814861c9c2f8cc36c8c7c7f9628ce75286dee13a8e5edL221-R221): Modified the `width` assignment to be user-patchable in the `DictQuickLookup:init()` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13497)
<!-- Reviewable:end -->
