### PR TITLE
[plugin] HttpInspector: fix crash when starting server

### DIFF
--- a/frontend/ui/message/simpletcpserver.lua
+++ b/frontend/ui/message/simpletcpserver.lua
@@ -32,6 +32,7 @@ function SimpleTCPServer:start()
     self.server = server
     self.server:settimeout(0.01) -- set timeout (10ms)
     logger.dbg("SimpleTCPServer: Server listening on port " .. self.port)
+    return true
 end
 
 function SimpleTCPServer:stop()


### PR DESCRIPTION
The http inspector expects `http_socket:start()` to return `true` on success
https://github.com/koreader/koreader/blob/b58fc372abfb8545262330ee38553d6dc7872da9/plugins/httpinspector.koplugin/main.lua#L103-L107

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13541)
<!-- Reviewable:end -->
