### PR TITLE
ReaderPaging: Don't alter view.page_states table on scroll

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -891,7 +891,7 @@ function ReaderPaging:onScrollPageRel(page_diff)
         return true
     elseif page_diff > 0 then
         -- page down, last page should be moved to top
-        local last_page_state = table.remove(self.view.page_states)
+        local last_page_state = self.view.page_states[#self.view.page_states]
         local last_visible_area = last_page_state.visible_area
         if self.ui.document:getNextPage(last_page_state.page) == 0 and
                 last_visible_area.y + last_visible_area.h >= last_page_state.page_area.h then
@@ -913,7 +913,7 @@ function ReaderPaging:onScrollPageRel(page_diff)
         local blank_area = Geom:new()
         blank_area:setSizeTo(self.view.visible_area)
         local overlap = self.overlap
-        local first_page_state = table.remove(self.view.page_states, 1)
+        local first_page_state = self.view.page_states[1]
         local offset = Geom:new{
             x = 0,
             y = -first_page_state.visible_area.h + overlap


### PR DESCRIPTION
Probably not perfect yet, but with this fix I could not produce any further forward/back-link crashes anymore during testing. Fixes #12869 and likely #11989.

There are still some odd behaviors involving the location stacks that need to be worked out (all involving fixed-layout docs, AFAICT), but they at least don't cause any crashes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13560)
<!-- Reviewable:end -->
