### PR TITLE
Statistics: do not read settings for pic documents

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2841,7 +2841,7 @@ end
 
 function ReaderStatistics:onReaderReady(config)
     UIManager:nextTick(function()
-        if self.settings.is_enabled then
+        if self.settings and self.settings.is_enabled then
             self.data = config:readSetting("stats", { performance_in_pages = {} })
             self.doc_md5 = config:readSetting("partial_md5_checksum")
             -- we have correct page count now, do the actual initialization work


### PR DESCRIPTION
Statistics is disabled for pic documents.
Thanks https://github.com/koreader/koreader-base/pull/2050#issuecomment-2795276910.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13561)
<!-- Reviewable:end -->
