### PR TITLE
Statistics: revert erroneous nextTick in onReaderReady()

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2840,15 +2840,13 @@ function ReaderStatistics:onReadingResumed()
 end
 
 function ReaderStatistics:onReaderReady(config)
-    UIManager:nextTick(function()
-        if self.settings and self.settings.is_enabled then
-            self.data = config:readSetting("stats", { performance_in_pages = {} })
-            self.doc_md5 = config:readSetting("partial_md5_checksum")
-            -- we have correct page count now, do the actual initialization work
-            self:initData()
-            self.view.footer:maybeUpdateFooter()
-        end
-    end)
+    if self.settings.is_enabled then
+        self.data = config:readSetting("stats", { performance_in_pages = {} })
+        self.doc_md5 = config:readSetting("partial_md5_checksum")
+        -- we have correct page count now, do the actual initialization work
+        self:initData()
+        self.view.footer:maybeUpdateFooter()
+    end
 end
 
 function ReaderStatistics:onShowCalendarView()


### PR DESCRIPTION
https://github.com/koreader/koreader/pull/13387#discussion_r1986246214
Closes https://github.com/koreader/koreader/issues/13579.

@mergen3107 unfortunately disabling statistics in a profile auto-exec on book opening doesn't work anymore until a workaround is found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13592)
<!-- Reviewable:end -->
