### PR TITLE
add kindle basic 5 hall file

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1701,6 +1701,7 @@ function KindleBasic5:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
+        hall_file = "/sys/devices/platform/eink_hall/hall_enable"
     }
 
     -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1701,7 +1701,7 @@ function KindleBasic5:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
-        hall_file = "/sys/devices/platform/eink_hall/hall_enable"
+        hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
 
     -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.


### PR DESCRIPTION
Added kindle basic 5 hall file. Have been using the following patch: 

```
local Device = require("device")
Device.powerd.hall_file = "/sys/devices/platform/eink_hall/hall_enable"
Device.powerd:initWakeupMgr()
```

which has been working for me, but should be updated in the project.

This allows Basic 5 users to make use of toggling "cover events"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13603)
<!-- Reviewable:end -->
