### PR TITLE
Add notification when toggling 'Ignore long-press on corners' via Dispatcher

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -280,7 +280,7 @@ if Device:isTouchDevice() then
             return G_reader_settings:isTrue("ignore_hold_corners")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("IgnoreHoldCorners"))
+            UIManager:broadcastEvent(Event:new("IgnoreHoldCorners", nil, true)) -- skip notification
         end,
     }
     common_settings.screen_disable_double_tap = {

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -280,7 +280,7 @@ if Device:isTouchDevice() then
             return G_reader_settings:isTrue("ignore_hold_corners")
         end,
         callback = function()
-            UIManager:broadcastEvent(Event:new("IgnoreHoldCorners", nil, true)) -- skip notification
+            UIManager:broadcastEvent(Event:new("IgnoreHoldCorners", nil, true)) -- no notification
         end,
     }
     common_settings.screen_disable_double_tap = {

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1202,9 +1202,9 @@ function Gestures:onIgnoreHoldCorners(ignore_hold_corners, no_notification)
         G_reader_settings:saveSetting("ignore_hold_corners", ignore_hold_corners)
     end
     self.ignore_hold_corners = G_reader_settings:isTrue("ignore_hold_corners")
-    
+
     if no_notification then return true end -- when toggled from menu
-    
+
     local Notification = require("ui/widget/notification")
     if G_reader_settings:readSetting("ignore_hold_corners") then
         Notification:notify(_("Ignore long-press on corners: on"))

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1195,13 +1195,22 @@ function Gestures:multiswipeAction(multiswipe_directions, ges)
     end
 end
 
-function Gestures:onIgnoreHoldCorners(ignore_hold_corners)
+function Gestures:onIgnoreHoldCorners(ignore_hold_corners, no_notification)
     if ignore_hold_corners == nil then
         G_reader_settings:flipNilOrFalse("ignore_hold_corners")
     else
         G_reader_settings:saveSetting("ignore_hold_corners", ignore_hold_corners)
     end
     self.ignore_hold_corners = G_reader_settings:isTrue("ignore_hold_corners")
+    
+    if no_notification then return true end -- when toggled from menu
+    
+    local Notification = require("ui/widget/notification")
+    if G_reader_settings:readSetting("ignore_hold_corners") then
+        Notification:notify(_("Ignore long-press on corners: on"))
+    else
+        Notification:notify(_("Ignore long-press on corners: off"))
+    end
     return true
 end
 

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1203,7 +1203,7 @@ function Gestures:onIgnoreHoldCorners(ignore_hold_corners, no_notification)
     end
     self.ignore_hold_corners = G_reader_settings:isTrue("ignore_hold_corners")
 
-    if no_notification then return true end -- when toggled from menu
+    if no_notification then return true end
 
     local Notification = require("ui/widget/notification")
     if G_reader_settings:readSetting("ignore_hold_corners") then


### PR DESCRIPTION
As discussed in #13578: adds notifications when toggling `Ignore long-press on corners` via Dispatcher.
(Skips notification when toggled via menu.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13605)
<!-- Reviewable:end -->
