### PR TITLE
reMarkable Paper Pro support

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -122,7 +122,7 @@ local RemarkablePaperPro = Remarkable:extend{
     input_buttons = "/dev/input/event2",
     battery_path = "/sys/class/power_supply/max1726x_battery/capacity",
     status_path = "/sys/class/power_supply/max1726x_battery/status",
-    hasFrontlight = yes, -- Paper Pro has frontlight and color display
+    hasFrontlight = yes,
     canTurnFrontlightOff = yes,
     hasColorScreen = yes,
 }
@@ -335,16 +335,16 @@ function Remarkable:setEventHandlers(UIManager)
     end
 end
 
-if isRmPaperPro then
-    if not os.getenv("LD_PRELOAD") then
-        error("reMarkable Paper Pro requires qtfb and qtfb-rmpp-shim to work")
-    end
-    return RemarkablePaperPro
-elseif isRm2 then
+if isRm2 then
     if not os.getenv("RM2FB_SHIM") then
         error("reMarkable2 requires RM2FB to work (https://github.com/ddvk/remarkable2-framebuffer)")
     end
     return Remarkable2
+elseif isRmPaperPro then
+    if not os.getenv("LD_PRELOAD") then
+        error("reMarkable Paper Pro requires qtfb and qtfb-rmpp-shim to work")
+    end
+    return RemarkablePaperPro
 else
     return Remarkable1
 end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -127,6 +127,9 @@ local RemarkablePaperPro = Remarkable:extend{
     hasFrontlight = yes,
     canTurnFrontlightOff = yes,
     hasColorScreen = yes,
+    frontlight_settings = {
+        frontlight_white = "/sys/class/backlight/rm_frontlight",
+    }
 }
 
 function RemarkablePaperPro:adjustTouchEvent(ev, by)
@@ -286,6 +289,10 @@ function Remarkable:setDateTime(year, month, day, hour, min, sec)
         command = string.format("timedatectl set-time '%d:%d'",hour, min)
     end
     return os.execute(command) == 0
+end
+
+function Remarkable:saveSettings()
+    self.powerd:saveSettings()
 end
 
 function Remarkable:resume()

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -124,6 +124,8 @@ local RemarkablePaperPro = Remarkable:extend{
     input_buttons = "/dev/input/event0",
     battery_path = "/sys/class/power_supply/max1726x_battery/capacity",
     status_path = "/sys/class/power_supply/max1726x_battery/status",
+    canSuspend = no, -- Suspend and Standby should be handled by xochitl with KO_DONT_GRAB_INPUT=1 set, otherwise bad things will happen
+    canStandby = no,
     hasFrontlight = yes,
     canTurnFrontlightOff = yes,
     hasColorScreen = yes,

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -208,7 +208,7 @@ function Remarkable:init()
         std_out:close()
         release = release:match("^(%d+%.%d+)%.%d+.*$")
         release = tonumber(release)
-        if release and release >= 6.2 then
+        if release and release >= 6.2 and not isRmPaperPro then -- seems like it triggers on rMPP 3.19+ so just disable it on rMPP
             is_mainline = true
         end
     end
@@ -272,12 +272,20 @@ function Remarkable:supportsScreensaver() return true end
 
 function Remarkable:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback, interactive)
-        os.execute("./enable-wifi.sh")
+        if isRmPaperPro then
+            os.execute("/usr/bin/csl wifi -p on")
+        else
+            os.execute("./enable-wifi.sh")
+        end
         return self:reconnectOrShowNetworkMenu(complete_callback, interactive)
     end
 
     function NetworkMgr:turnOffWifi(complete_callback)
-        os.execute("./disable-wifi.sh")
+        if isRmPaperPro then
+            os.execute("/usr/bin/csl wifi -p off")
+        else
+            os.execute("./disable-wifi.sh")
+        end
         if complete_callback then
             complete_callback()
         end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -376,7 +376,7 @@ elseif isRmPaperPro then
     if not os.getenv("LD_PRELOAD") then
         error("reMarkable Paper Pro requires qtfb and qtfb-rmpp-shim to work")
     end
-    if os.getenv("QTFB_SHIM_INPUT") ~= "false" or os.getenv("QTFB_SHIM_MODEL") ~= "false" then
+    if (os.getenv("QTFB_SHIM_INPUT") ~= "false") or (os.getenv("QTFB_SHIM_MODEL") ~= "false") then
         error("You must set both QTFB_SHIM_INPUT and QTFB_SHIM_MODEL to false")
     end
     if os.getenv("QTFB_SHIM_MODE") ~= "RGB565" then

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -17,7 +17,7 @@ local function getModel()
     end
     local model = f:read("*line")
     f:close()
-    return model == "reMarkable 2.0", model == "reMarkable Ferrari", model
+    return model
 end
 
 -- Resolutions from libremarkable src/framebuffer/common.rs
@@ -25,7 +25,9 @@ local screen_width = 1404 -- unscaled_size_check: ignore
 local screen_height = 1872 -- unscaled_size_check: ignore
 local wacom_width = 15725 -- unscaled_size_check: ignore
 local wacom_height = 20967 -- unscaled_size_check: ignore
-local isRm2, isRmPaperPro, rm_model = getModel()
+local rm_model = getModel()
+local isRm2 = rm_model == "reMarkable 2.0"
+local isRmPaperPro = rm_model == "reMarkable Ferrari"
 
 if isRmPaperPro then
     screen_width = 1620 -- unscaled_size_check: ignore

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -138,10 +138,10 @@ function RemarkablePaperPro:adjustTouchEvent(ev, by)
     if ev.type == C.EV_ABS then
         -- Mirror X and Y and scale up both X & Y as touch input is different res from display
         if ev.code == C.ABS_MT_POSITION_X then
-            ev.value = (ev.value) * by.mt_scale_x
+            ev.value = ev.value * by.mt_scale_x
         end
         if ev.code == C.ABS_MT_POSITION_Y then
-            ev.value = (ev.value) * by.mt_scale_y
+            ev.value = ev.value * by.mt_scale_y
         end
     end
 end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -376,10 +376,10 @@ elseif isRmPaperPro then
     if not os.getenv("LD_PRELOAD") then
         error("reMarkable Paper Pro requires qtfb and qtfb-rmpp-shim to work")
     end
-    if not (os.getenv("QTFB_SHIM_INPUT") == "false" and os.getenv("QTFB_SHIM_MODEL") == "false") then
+    if os.getenv("QTFB_SHIM_INPUT" ~= "false" or os.getenv("QTFB_SHIM_MODEL") ~= "false" then
         error("You must set both QTFB_SHIM_INPUT and QTFB_SHIM_MODEL to false")
     end
-    if not (os.getenv("QTFB_SHIM_MODE") == "RGB565") then
+    if os.getenv("QTFB_SHIM_MODE") ~= "RGB565" then
         error("You must set QTFB_SHIM_MODE to RGB565")
     end
     return RemarkablePaperPro

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -376,7 +376,7 @@ elseif isRmPaperPro then
     if not os.getenv("LD_PRELOAD") then
         error("reMarkable Paper Pro requires qtfb and qtfb-rmpp-shim to work")
     end
-    if (os.getenv("QTFB_SHIM_INPUT") ~= "false") or (os.getenv("QTFB_SHIM_MODEL") ~= "false") then
+    if os.getenv("QTFB_SHIM_INPUT") ~= "false" or os.getenv("QTFB_SHIM_MODEL") ~= "false" then
         error("You must set both QTFB_SHIM_INPUT and QTFB_SHIM_MODEL to false")
     end
     if os.getenv("QTFB_SHIM_MODE") ~= "RGB565" then

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -116,8 +116,8 @@ function Remarkable2:adjustTouchEvent(ev, by)
 end
 
 local RemarkablePaperPro = Remarkable:extend{
-    mt_width = 2064,
-    mt_height = 2832,
+    mt_width = 2064, -- unscaled_size_check: ignore
+    mt_height = 2832, -- unscaled_size_check: ignore
     display_dpi = 229,
     input_wacom = "/dev/input/event2",
     input_ts = "/dev/input/event3",

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -379,7 +379,7 @@ elseif isRmPaperPro then
     if not (os.getenv("QTFB_SHIM_INPUT") == "false" and os.getenv("QTFB_SHIM_MODEL") == "false") then
         error("You must set both QTFB_SHIM_INPUT and QTFB_SHIM_MODEL to false")
     end
-    if not os.getenv("QTFB_SHIM_MODE") == "RGB565" then
+    if not (os.getenv("QTFB_SHIM_MODE") == "RGB565") then
         error("You must set QTFB_SHIM_MODE to RGB565")
     end
     return RemarkablePaperPro

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -1,17 +1,69 @@
 local BasePowerD = require("device/generic/powerd")
+local SysfsLight = require("device/sysfs_light")
+local ffiUtil = require("ffi/util")
 
 local Remarkable_PowerD = BasePowerD:new{
     is_charging = nil,
+    fl = nil,
+    fl_min = 0, fl_max = 2047,
 }
 
+function Remarkable_PowerD:_syncLightOnStart()
+    local new_intensity = G_reader_settings:readSetting("frontlight_intensity") or nil
+    local is_frontlight_on = G_reader_settings:readSetting("is_frontlight_on") or nil
+
+    if new_intensity ~= nil then
+        self.hw_intensity = new_intensity
+    end
+
+    if is_frontlight_on ~= nil then
+        self.initial_is_fl_on = is_frontlight_on
+    end
+
+    if self.initial_is_fl_on == false and self.hw_intensity == 0 then
+        self.hw_intensity = 1
+    end
+end
+
+
 function Remarkable_PowerD:init()
+    self.hw_intensity = 20
+    self.initial_is_fl_on = true
+
+    if self.device:hasFrontlight() then
+        self.fl = SysfsLight:new(self.device.frontlight_settings)
+        self:_syncLightOnStart()
+    end
+end
+
+function Remarkable_PowerD:saveSettings()
+    if self.device:hasFrontlight() then
+        local cur_intensity = self.fl_intensity
+        local cur_is_fl_on = self.is_fl_on
+        G_reader_settings:saveSetting("frontlight_intensity", cur_intensity)
+        G_reader_settings:saveSetting("is_frontlight_on", cur_is_fl_on)
+    end
 end
 
 function Remarkable_PowerD:frontlightIntensityHW()
-    return 0
+    if not self.device:hasFrontlight() then return 0 end
+    return self.hw_intensity
+end
+
+function Remarkable_PowerD:isFrontlightOnHW()
+    if self.initial_is_fl_on ~= nil then
+        local ret = self.initial_is_fl_on
+        self.initial_is_fl_on = nil
+        return ret
+    end
+    return self.hw_intensity > 0
 end
 
 function Remarkable_PowerD:setIntensityHW(intensity)
+    if not self.device:hasFrontlight() then return end
+    self:setBrightness(intensity)
+    self.hw_intensity = intensity
+    self:_decideFrontlightState()
 end
 
 function Remarkable_PowerD:getCapacityHW()
@@ -25,13 +77,36 @@ end
 function Remarkable_PowerD:beforeSuspend()
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()
+
+    if self.fl then
+        self:setBrightness(0)
+    end
 end
 
 function Remarkable_PowerD:afterResume()
+    if self.fl then
+        self:setBrightness(self.hw_intensity)
+    end
+
     self:invalidateCapacityCache()
 
     -- Restore user input and emit the Resume event.
     self.device:_afterResume()
+end
+
+function Remarkable_PowerD:setBrightness(brightness)
+    self:_set_light_value(self.fl.frontlight_white, brightness)
+end
+
+function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
+    if not sysfs_directory then return end
+    -- for rMPP '0' is on and '4' is off
+    if (value > 0) then
+        ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
+    else
+        ffiUtil.writeToSysfs(4, sysfs_directory .. "/bl_power")
+    end
+    ffiUtil.writeToSysfs(value, sysfs_directory .. "/brightness")
 end
 
 return Remarkable_PowerD

--- a/kodev
+++ b/kodev
@@ -147,6 +147,7 @@ TARGET:
     macos                     MacOS app bundle
     pocketbook
     remarkable
+    remarkable-aarch64
     sony-prstux
     ubuntu-touch
     win32
@@ -179,6 +180,7 @@ function setup_target() {
         kobo | kobov4 | kobov5) ;;
         pocketbook) ;;
         remarkable) ;;
+        remarkable-aarch64) ;;
         sony-prstux) ;;
         ubuntu-touch) ;;
         # Invalid.


### PR DESCRIPTION
What works:
- Everything except restarting KOReader

What's janky:
- Shutdown: rmpp-qtfb-shim and qtfb dies before it can display shutdown screen, resulting in whatever was displayed before staying
- Refresh: controlled by xochitl, (reMarkable's proprietary UI/UX and controls screen) will change in future after qtfb and shim gets ability to control it.

What doesn't work:
- restart KOReader: it doesn't even try to lol

Dependencies required to run:
- [XOVI](https://github.com/asivery/rm-xovi-extensions)
- [QTFB](https://github.com/asivery/qtfb)
- [rmpp-qtfb-shim](https://github.com/asivery/rmpp-qtfb-shim)

You need to set a few environmental variables when launching, like this:
`LD_PRELOAD=(path to your qtfb-shim.so) QTFB_SHIM_INPUT=false QTFB_SHIM_MODEL=false QTFB_SHIM_MODE=RGB565 KO_DONT_GRAB_INPUT=1 ./reader.lua`

Closes #12856

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13620)
<!-- Reviewable:end -->
