### PR TITLE
Issue template: add log instructions for desktop

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,12 +17,14 @@ assignees: ''
 ##### `crash.log` (if applicable)
 `crash.log` is a file that is automatically created when KOReader crashes. It can normally be found in the KOReader directory:
 
-* `/mnt/private/koreader` for Cervantes
-* `koreader/` directory for Kindle
-* `.adds/koreader/` directory for Kobo
-* `applications/koreader/` directory for Pocketbook
-
-Android logs are kept in memory. Please go to [Menu] → Help → Bug Report to save these logs to a file.
+| Device      | Path                        |
+|-------------|-----------------------------|
+| Cervantes   | `/mnt/private/koreader`      |
+| Kindle      | `koreader/`                  |
+| Kobo        | `.adds/koreader/`            |
+| Pocketbook  | `applications/koreader/`     |
+| Android | Logs are kept in memory. Please go to [Menu] → Help → Bug Report to save these logs to a file. |
+| Deb / Flatpak / AppImage | On regular desktop systems, logs can be obtained by running `koreader-20xx 2>&1 \| tee log.txt` from the terminal. |
 
 Please try to include the relevant sections in your issue description.
 You can upload the whole `crash.log` file (zipped if necessary) on GitHub by dragging and dropping it onto this textbox.


### PR DESCRIPTION
Same as for any other app. ^_^ Cf. https://github.com/koreader/koreader/pull/13619#issuecomment-2816833050

Also stuck it in a table. (Top the current bullets, bottom as changed.)

---

![image](https://github.com/user-attachments/assets/37b34d17-1978-4e46-96c0-b5cf95768532)


Edit:

I just realized I wasn't thinking straight. This requires conversion to a form. But for this one it makes sense to do so.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13632)
<!-- Reviewable:end -->
