### PR TITLE
 css_tweaks: Reimplement smaller inpage footnotes 

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -24,8 +24,9 @@ local T = require("ffi/util").template
 -- Default globally enabled style tweaks, for new installations
 local DEFAULT_GLOBAL_STYLE_TWEAKS = {}
 -- Display in-page per-specs footnotes for EPUB and FB2:
-DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_epub_smaller"] = true
+DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_epub"] = true
 DEFAULT_GLOBAL_STYLE_TWEAKS["footnote-inpage_fb2"] = true
+DEFAULT_GLOBAL_STYLE_TWEAKS["inpage_footnote_font-size_80"] = true
 
 local CssTweaks = {
     DEFAULT_GLOBAL_STYLE_TWEAKS = DEFAULT_GLOBAL_STYLE_TWEAKS,
@@ -845,10 +846,6 @@ body[name="notes"] section {
         -cr-hint: footnote-inpage;
         margin: 0 !important;
 }
-body[name="notes"] > section {
-    -cr-only-if: fb2-document;
-        font-size: 0.75rem;
-}
 body[name="notes"] > title {
     -cr-only-if: fb2-document;
         margin-bottom: 0;
@@ -867,10 +864,6 @@ body[name="comments"] section {
         -cr-hint: footnote-inpage;
         margin: 0 !important;
 }
-body[name="comments"] > section {
-    -cr-only-if: fb2-document;
-        font-size: 0.85rem;
-}
 body[name="comments"] > title {
     -cr-only-if: fb2-document;
         margin-bottom: 0;
@@ -879,26 +872,11 @@ body[name="comments"] > title {
                 ]],
                 separator = true,
             },
-            {
-                id = "fb2_footnotes_regular_font_size",
-                title = _("Keep regular font size"),
-                description = _([[
-FB2 footnotes and endnotes get a smaller font size when displayed in-page. This allows them to be shown with the normal font size.]]),
-                css = [[
-body[name="notes"] > section,
-body[name="comments"] > section
-{
-    -cr-only-if: fb2-document;
-        font-size: 1rem !important;
-}
-                ]],
-            },
             separator = true,
         },
         {
             id = "footnote-inpage_epub",
             conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_epub") end,
             title = _("In-page EPUB footnotes"),
             description = _([[
 Show EPUB footnote text at the bottom of pages that contain links to them.
@@ -921,37 +899,8 @@ This only works with footnotes that have specific attributes set by the publishe
             ]],
         },
         {
-            id = "footnote-inpage_epub_smaller",
-            conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_epub") end,
-            title = _("In-page EPUB footnotes (smaller)"),
-            description = _([[
-Show EPUB footnote text at the bottom of pages that contain links to them.
-This only works with footnotes that have specific attributes set by the publisher.]]),
-            -- Restrict this to non-FB2 documents, as FB2 can have <a type="note">
-            -- and we don't want to have them smaller
-            css = [[
-*[type~="note"],
-*[type~="endnote"],
-*[type~="footnote"],
-*[type~="rearnote"],
-*[role~="doc-note"],
-*[role~="doc-endnote"],
-*[role~="doc-footnote"],
-*[role~="doc-rearnote"]
-{
-    -cr-only-if: -fb2-document;
-        -cr-hint: footnote-inpage;
-        margin: 0 !important;
-        font-size: 0.8rem !important;
-}
-            ]],
-            separator = true,
-        },
-        {
             id = "footnote-inpage_wikipedia",
             conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_wikipedia") end,
             title = _("In-page Wikipedia footnotes"),
             description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
             css = [[
@@ -965,32 +914,12 @@ ol.references > li > .noprint { display: none; }
 ol.references > li > .mw-cite-backlink { display: none; }
             ]],
         },
-        {
-            id = "footnote-inpage_wikipedia_smaller",
-            conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_wikipedia") end,
-            title = _("In-page Wikipedia footnotes (smaller)"),
-            description = _([[Show footnotes at the bottom of pages in Wikipedia EPUBs.]]),
-            css = [[
-ol.references > li {
-    -cr-hint: footnote-inpage;
-    list-style-position: -cr-outside;
-    margin: 0 !important;
-    font-size: 0.8rem !important;
-}
-/* hide backlinks */
-ol.references > li > .noprint { display: none; }
-ol.references > li > .mw-cite-backlink { display: none; }
-            ]],
-            separator = true,
-        },
-        -- We can add other classic classnames to the 2 following
-        -- tweaks (except when named 'calibreN', as the N number is
+        -- We can add other classic classnames to the following
+        -- tweak (except when named 'calibreN', as the N number is
         -- usually random across books).
         {
             id = "footnote-inpage_classic_classnames",
             conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_classic_classnames") end,
             title = _("In-page classic classname footnotes"),
             description = _([[
 Show footnotes with classic classnames at the bottom of pages.
@@ -1006,27 +935,6 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
 {
     -cr-hint: footnote-inpage;
     margin: 0 !important;
-}
-            ]],
-        },
-        {
-            id = "footnote-inpage_classic_classnames_smaller",
-            conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_") end,
-            global_conflicts_with = function(id) return util.stringStartsWith(id, "footnote-inpage_classic_classnames") end,
-            title = _("In-page classic classname footnotes (smaller)"),
-            description = _([[
-Show footnotes with classic classnames at the bottom of pages.
-This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
-            css = [[
-.footnote, .footnotes, .fn,
-.note, .note1, .note2, .note3,
-.ntb, .ntb-txt, .ntb-txt-j,
-.przypis, .przypis1, /* Polish footnotes */
-.voetnoten /* Dutch footnotes */
-{
-    -cr-hint: footnote-inpage;
-    margin: 0 !important;
-    font-size: 0.8rem !important;
 }
             ]],
             separator = true,
@@ -1052,19 +960,43 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
                     id = T("inpage_footnote_font-size_%1", pct),
                     conflicts_with = function(id) return util.stringStartsWith(id, "inpage_footnote_font-size_") end,
                     title = T(_("Footnote font size: %1 %"), pct),
-                    css = T([[
+                    css_func = (
+                        function(tweaks)
+                            for _, tweak in ipairs(tweaks) do
+                                if tweak.id == "inpage_footnote_text_force_size" then
+                                    return T([[
 *, autoBoxing {
     -cr-hint: late;
     -cr-only-if: inside-inpage-footnote -inline;
         font-size: %1rem !important;
 }
-                    ]], rem),
+                                    ]], rem)
+                                end
+                            end
+                            return T([[
+*, autoBoxing {
+    -cr-hint: late;
+    -cr-only-if: inpage-footnote;
+        font-size: %1rem !important;
+}
+                            ]], rem)
+                        end
+                    ),
                 })
             end
             return sub_table
         end)(),
         {
             title = _("In-page footnote fix-up"),
+            {
+                id = "inpage_footnote_text_force_size",
+                title = _("Override publisher footnote size"),
+                description = _([[
+Force footnote text to use the specified font size.]]),
+                css = [[
+/* Footnote font size style tweak changed by override */
+                    ]],
+            },
             {
                 id = "inpage_footnote_text-indent_0",
                 title = _("No footnote indentation"),

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -956,6 +956,8 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
             }
             for __, rem in ipairs( { 1.0, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65 } ) do
                 local pct = rem * 100
+                local fb2_notes_rem = 0.75 * rem / 0.8
+                local fb2_comments_rem = 0.85 * rem / 0.8
                 table.insert(sub_table, {
                     id = T("inpage_footnote_font-size_%1", pct),
                     conflicts_with = function(id) return util.stringStartsWith(id, "inpage_footnote_font-size_") end,
@@ -965,21 +967,45 @@ This tweak can be duplicated as a user style tweak when books contain footnotes 
                             for _, tweak in ipairs(tweaks) do
                                 if tweak.id == "inpage_footnote_text_force_size" then
                                     return T([[
+body[name="notes"] > section,
+body[name="notes"] > section *,
+body[name="notes"] > section autoBoxing
+{
+    -cr-hint: late;
+    -cr-only-if: fb2-document inside-inpage-footnote -inline;
+        font-size: %2rem !important;
+}
+body[name="comments"] > section,
+body[name="comments"] > section *,
+body[name="comments"] > section autoBoxing
+{
+    -cr-hint: late;
+    -cr-only-if: fb2-document inside-inpage-footnote -inline;
+        font-size: %3rem !important;
+}
 *, autoBoxing {
     -cr-hint: late;
-    -cr-only-if: inside-inpage-footnote -inline;
+    -cr-only-if: -fb2-document inside-inpage-footnote -inline;
         font-size: %1rem !important;
 }
-                                    ]], rem)
+                                    ]], rem, fb2_notes_rem, fb2_comments_rem)
                                 end
                             end
                             return T([[
+body[name="notes"] > section {
+    -cr-only-if: fb2-document inpage-footnote;
+        font-size: %2rem;
+}
+body[name="comments"] > section {
+    -cr-only-if: fb2-document inpage-footnote;
+        font-size: %3rem;
+}
 *, autoBoxing {
     -cr-hint: late;
-    -cr-only-if: inpage-footnote;
+    -cr-only-if: -fb2-document inpage-footnote;
         font-size: %1rem !important;
 }
-                            ]], rem)
+                            ]], rem, fb2_notes_rem, fb2_comments_rem)
                         end
                     ),
                 })

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20250405
+local CURRENT_MIGRATION_DATE = 20250420
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -884,6 +884,43 @@ if last_migration_date < 20250405 then
         })
     end
     G_reader_settings:delSetting("show_finished")
+end
+
+-- 20250420, Remove separate "smaller footnotes" tweak
+-- https://github.com/koreader/koreader/pull/13639
+if last_migration_date < 20250420 then
+    local global_tweaks = G_reader_settings:readSetting("style_tweaks")
+
+    if global_tweaks then
+        for __, pct in ipairs( { 100, 90, 85, 80, 75, 70, 65 } ) do
+            if global_tweaks["font-size_" .. pct] then
+                global_tweaks["inpage_footnote_text_force_size"] = true
+            end
+        end
+        -- if the force flag isn't set then none of the size hints
+        -- were set before and we should keep the "small" setting
+        if not global_tweaks["inpage_footnote_text_force_size"]
+            and (global_tweaks["footnote-inpage_epub_smaller"]
+                or global_tweaks["footnote-inpage_wikipedia_smaller"]
+                or global_tweaks["footnote-inpage_classic_classnames_smaller"]
+        ) then
+            global_tweaks["inpage_footnote_font-size_80"] = true
+        end
+
+        if global_tweaks["footnote-inpage_epub_smaller"] then
+            global_tweaks["footnote-inpage_epub"] = true
+        end
+        if global_tweaks["footnote-inpage_wikipedia_smaller"] then
+            global_tweaks["footnote-inpage_wikipedia"] = true
+        end
+        if global_tweaks["footnote-inpage_classic_classnames_smaller"] then
+            global_tweaks["footnote-inpage_classic_classnames"] = true
+        end
+
+        global_tweaks["footnote-inpage_epub_smaller"] = nil
+        global_tweaks["footnote-inpage_wikipedia_smaller"] = nil
+        global_tweaks["footnote-inpage_classic_classnames_smaller"] = nil
+    end
 end
 
 -- We're done, store the current migration date


### PR DESCRIPTION
Alternative to #13613 that
- completely gets rid of the "smaller" footnote setting
- has a single set of size selection tweaks
- Should keep current default behavior as well as current font-size override behavior

This is done by introducing dynamic footnote tweaks that can change based on which other tweaks are set.

In short:
- Footnote size tweaks by default behave like "smaller" footnotes behave now (except not hard-coded to 80%)
- Footnote size tweaks keep the FB2 footnotes 0.75rem / 0.85rem distinction for footnotes vs endnotes
- A new "Override publisher footnote size" tweak enables the hard size override that the footnote size tweaks do on master

The dynamic style hint displays the current css in the popup, but there's no way to see other possible instantiations, which is a bit of a downside. I'm honestly not completely sure if it's worth the complexity compared to just keeping the "smaller" footnotes (maybe with #13613 as a small cleanup)

@poire-z I think this might address your concerns from https://github.com/koreader/koreader/pull/5863#issuecomment-1173097714 / https://github.com/koreader/koreader/pull/5863#issuecomment-1173104241, though obviously at the cost of complexity.

Note: I don't know if I got the fb2 hints right, might need someone to check or point me at a free fb2 book with footnotes & endnotes to test with.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13639)
<!-- Reviewable:end -->
