### PR TITLE
feat: Adds progress bar to cloud storage downloads

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -20,15 +20,7 @@ local _ = require("gettext")
 local N_ = _.ngettext
 local T = require("ffi/util").template
 local util = require("util")
-local Device = require("device")
-local Screen          = Device.screen
-local VerticalGroup   = require("ui/widget/verticalgroup")
-local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local Size            = require("ui/size")
-local FrameContainer  = require("ui/widget/container/framecontainer")
-local Blitbuffer      = require("ffi/blitbuffer")
-local ProgressWidget = require("ui/widget/progresswidget")
-local TitleBar        = require("ui/widget/titlebar")
+local ProgressbarDialog = require("ui/widget/progressbardialog")
 
 local CloudStorage = Menu:extend{
     no_title = false,
@@ -222,90 +214,29 @@ end
 
 function CloudStorage:downloadFile(item)
     local function startDownloadFile(unit_item, address, username, password, path_dir, callback_close)
-        local filesize_available = unit_item.filesize ~= nil and unit_item.filesize > 0
-
-        -- TODO: convert into into custom progress window widget
-        local progress_bar_width = Screen:scaleBySize(360)
-        local progress_bar_height = Screen:scaleBySize(18)
-        local frame_width = Screen:scaleBySize(400)
-
-        local progress_bar = ProgressWidget:new {
-            width = progress_bar_width,
-            height = progress_bar_height,
-            padding = Size.padding.large,
-            margin = Size.margin.tiny,
-            percentage = 0,
-        }
-
-        local title_bar = TitleBar:new {
-            title = _("Downloading file"),
+        local progressbar_dialog = ProgressbarDialog:new {
+            title = _("Downloading..."),
             subtitle = unit_item.text,
-            align = "left",
-            width = frame_width,
-            with_bottom_line = false,
-            bottom_v_padding = Screen:scaleBySize(15),
-            padding = Size.padding.tiny,
-        };
-
-        local frame = WidgetContainer:new {
-            align = "center",
-            dimen = Screen:getSize(),
-            FrameContainer:new {
-                radius = Size.radius.window,
-                bordersize = Size.border.window,
-                padding = Size.padding.large,
-                background = Blitbuffer.COLOR_WHITE,
-                VerticalGroup:new {
-                    title_bar,
-                    filesize_available and progress_bar or nil
-                }
-            }
+            progress_max = unit_item.filesize,
+            refresh_mode = "time",
+            refresh_time_seconds = 3,
         }
-
-        -- only update the UI every 10%
-        local last_percent = 0
-        local percent_steps = 0.2
-
-        local reportProgress = function(percent)
-            -- logger.dbg("CloudStorage:downloadFile - progress report:", percent)
-
-            -- set percentage
-            progress_bar:setPercentage(percent)
-
-            -- only update if we have a significant change or are finished downloading
-            if (percent == 1) or (percent >= last_percent + percent_steps) then
-                last_percent = percent
-
-                --UI is not updating during file download so force an update
-                UIManager:setDirty(frame, function() return "fast", progress_bar.dimen end)
-                UIManager:forceRePaint()
-            end
-        end
 
         UIManager:scheduleIn(1, function()
+            local progress_callback = progressbar_dialog:getProgressCallback()
             -- rename progressReporter to a more fitting name
-            local progressReporter = nil
-            if filesize_available then
-                progressReporter = {
-                    reportProgressCallback = reportProgress,
-                    expected_size_bytes = unit_item.filesize,
-                }
-            end
-
             if self.type == "dropbox" then
-                DropBox:downloadFile(unit_item, password, path_dir, callback_close, progressReporter)
+                DropBox:downloadFile( unit_item, password, path_dir, callback_close, progress_callback)
             elseif self.type == "ftp" then
                 Ftp:downloadFile(unit_item, address, username, password, path_dir, callback_close, nil)
             elseif self.type == "webdav" then
-                WebDav:downloadFile(unit_item, address, username, password, path_dir, callback_close, progressReporter)
+                WebDav:downloadFile( unit_item, address, username, password, path_dir, callback_close, progress_callback)
             end
 
-            -- full flash to make sure the whole window gets closed
-            UIManager:close(frame, "flashui", Screen:getSize())
+            progressbar_dialog:close()
         end)
 
-        -- open menu
-        UIManager:show(frame)
+        progressbar_dialog:show()
     end
 
     local function createTitle(filename_orig, filesize, filename, path) -- title for ButtonDialog

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -222,7 +222,10 @@ function CloudStorage:downloadFile(item)
         }
 
         UIManager:scheduleIn(1, function()
-            local progress_callback = progressbar_dialog:getProgressCallback()
+            local progress_callback = function(progress)
+                progressbar_dialog:reportProgress(progress)
+            end
+
             if self.type == "dropbox" then
                 DropBox:downloadFile(unit_item, password, path_dir, callback_close, progress_callback)
             elseif self.type == "ftp" then

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -12,6 +12,7 @@ local LuaSettings = require("luasettings")
 local Menu = require("ui/widget/menu")
 local NetworkMgr = require("ui/network/manager")
 local PathChooser = require("ui/widget/pathchooser")
+local ProgressbarDialog = require("ui/widget/progressbardialog")
 local UIManager = require("ui/uimanager")
 local WebDav = require("apps/cloudstorage/webdav")
 local lfs = require("libs/libkoreader-lfs")
@@ -20,7 +21,6 @@ local _ = require("gettext")
 local N_ = _.ngettext
 local T = require("ffi/util").template
 local util = require("util")
-local ProgressbarDialog = require("ui/widget/progressbardialog")
 
 local CloudStorage = Menu:extend{
     no_title = false,

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -215,16 +215,14 @@ end
 function CloudStorage:downloadFile(item)
     local function startDownloadFile(unit_item, address, username, password, path_dir, callback_close)
         local progressbar_dialog = ProgressbarDialog:new {
-            title = _("Downloading..."),
+            title = _("Downloading…"),
             subtitle = unit_item.text,
             progress_max = unit_item.filesize,
-            refresh_mode = "time",
             refresh_time_seconds = 3,
         }
 
         UIManager:scheduleIn(1, function()
             local progress_callback = progressbar_dialog:getProgressCallback()
-            -- rename progressReporter to a more fitting name
             if self.type == "dropbox" then
                 DropBox:downloadFile( unit_item, password, path_dir, callback_close, progress_callback)
             elseif self.type == "ftp" then

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -218,7 +218,6 @@ function CloudStorage:downloadFile(item)
             title = _("Downloading…"),
             subtitle = unit_item.text,
             progress_max = unit_item.filesize,
-            refresh_time_seconds = 3,
         }
 
         UIManager:scheduleIn(1, function()

--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -224,11 +224,11 @@ function CloudStorage:downloadFile(item)
         UIManager:scheduleIn(1, function()
             local progress_callback = progressbar_dialog:getProgressCallback()
             if self.type == "dropbox" then
-                DropBox:downloadFile( unit_item, password, path_dir, callback_close, progress_callback)
+                DropBox:downloadFile(unit_item, password, path_dir, callback_close, progress_callback)
             elseif self.type == "ftp" then
                 Ftp:downloadFile(unit_item, address, username, password, path_dir, callback_close, nil)
             elseif self.type == "webdav" then
-                WebDav:downloadFile( unit_item, address, username, password, path_dir, callback_close, progress_callback)
+                WebDav:downloadFile(unit_item, address, username, password, path_dir, callback_close, progress_callback)
             end
 
             progressbar_dialog:close()

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -24,8 +24,8 @@ function DropBox:showFiles(url, password)
     return DropBoxApi:showFiles(url, password)
 end
 
-function DropBox:downloadFile(item, password, path, callback_close, reportProgressCallback)
-    local code_response = DropBoxApi:downloadFile(item.url, password, path, reportProgressCallback)
+function DropBox:downloadFile(item, password, path, callback_close, progress_callback)
+    local code_response = DropBoxApi:downloadFile(item.url, password, path, progress_callback)
     if code_response == 200 then
         local __, filename = util.splitFilePathName(path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then

--- a/frontend/apps/cloudstorage/dropbox.lua
+++ b/frontend/apps/cloudstorage/dropbox.lua
@@ -24,8 +24,8 @@ function DropBox:showFiles(url, password)
     return DropBoxApi:showFiles(url, password)
 end
 
-function DropBox:downloadFile(item, password, path, callback_close)
-    local code_response = DropBoxApi:downloadFile(item.url, password, path)
+function DropBox:downloadFile(item, password, path, callback_close, reportProgressCallback)
+    local code_response = DropBoxApi:downloadFile(item.url, password, path, reportProgressCallback)
     if code_response == 200 then
         local __, filename = util.splitFilePathName(path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -111,7 +111,7 @@ function DropBoxApi:downloadFile(path, token, local_path, progress_callback)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
 
     local handle = ltn12.sink.file(io.open(local_path, "w"))
-    handle = socketutil.wrapProgressReporterAroundSink(handle, progressReporter)
+    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
 
     local code, headers, status = socket.skip(1, http.request{
         url     = API_DOWNLOAD_FILE,

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -106,7 +106,7 @@ function DropBoxApi:fetchListFolders(path, token)
     logger.warn("DropBoxApi: error:", result_response)
 end
 
-function DropBoxApi:downloadFile(path, token, local_path, progressReporter)
+function DropBoxApi:downloadFile(path, token, local_path, progress_callback)
     local data1 = "{\"path\": \"" .. path .. "\"}"
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
 

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -111,7 +111,7 @@ function DropBoxApi:downloadFile(path, token, local_path, progress_callback)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
 
     local handle = ltn12.sink.file(io.open(local_path, "w"))
-    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
+    handle = socketutil.chainSinkWithProgressCallback(handle, progress_callback)
 
     local code, headers, status = socket.skip(1, http.request{
         url     = API_DOWNLOAD_FILE,

--- a/frontend/apps/cloudstorage/dropboxapi.lua
+++ b/frontend/apps/cloudstorage/dropboxapi.lua
@@ -106,9 +106,13 @@ function DropBoxApi:fetchListFolders(path, token)
     logger.warn("DropBoxApi: error:", result_response)
 end
 
-function DropBoxApi:downloadFile(path, token, local_path)
+function DropBoxApi:downloadFile(path, token, local_path, progressReporter)
     local data1 = "{\"path\": \"" .. path .. "\"}"
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+
+    local handle = ltn12.sink.file(io.open(local_path, "w"))
+    handle = socketutil.wrapProgressReporterAroundSink(handle, progressReporter)
+
     local code, headers, status = socket.skip(1, http.request{
         url     = API_DOWNLOAD_FILE,
         method  = "GET",
@@ -116,7 +120,7 @@ function DropBoxApi:downloadFile(path, token, local_path)
             ["Authorization"]   = "Bearer ".. token,
             ["Dropbox-API-Arg"] = data1,
         },
-        sink    = ltn12.sink.file(io.open(local_path, "w")),
+        sink    = handle,
     })
     socketutil:reset_timeout()
     if code ~= 200 then
@@ -195,6 +199,7 @@ function DropBoxApi:listFolder(path, token, folder_mode)
             table.insert(dropbox_file, {
                 text = text,
                 mandatory = util.getFriendlySize(files.size),
+                filesize = files.size,
                 url = files.path_display,
                 type = tag,
             })
@@ -221,6 +226,7 @@ function DropBoxApi:listFolder(path, token, folder_mode)
             mandatory = files.mandatory,
             url = files.url,
             type = files.type,
+            filesize = files.filesize,
         })
     end
     return dropbox_list

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -35,7 +35,7 @@ function Ftp:downloadFile(item, address, user, pass, path, callback_close, progr
     local handle = ltn12.sink.file(file)
     handle = socketutil.chainSinkWithProgressCallback(handle, progress_callback)
 
-    local response = FtpApi:ftpGet(url, "retr", handle )
+    local response = FtpApi:ftpGet(url, "retr", handle)
     if response ~= nil then
         local __, filename = util.splitFilePathName(path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -33,7 +33,7 @@ function Ftp:downloadFile(item, address, user, pass, path, callback_close, progr
     end
 
     local handle = ltn12.sink.file(file)
-    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
+    handle = socketutil.chainSinkWithProgressCallback(handle, progress_callback)
 
     local response = FtpApi:ftpGet(url, "retr", handle )
     if response ~= nil then

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -20,7 +20,7 @@ function Ftp:run(address, user, pass, path)
     return FtpApi:listFolder(url, path)
 end
 
-function Ftp:downloadFile(item, address, user, pass, path, callback_close, progressReporter)
+function Ftp:downloadFile(item, address, user, pass, path, callback_close, progress_callback)
     local url = FtpApi:generateUrl(address, util.urlEncode(user), util.urlEncode(pass)) .. item.url
     logger.dbg("downloadFile url", url)
     path = util.fixUtf8(path, "_")
@@ -33,7 +33,7 @@ function Ftp:downloadFile(item, address, user, pass, path, callback_close, progr
     end
 
     local handle = ltn12.sink.file(file)
-    handle = socketutil.wrapProgressReporterAroundSink(handle, progressReporter)
+    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
 
     local response = FtpApi:ftpGet(url, "retr", handle )
     if response ~= nil then

--- a/frontend/apps/cloudstorage/ftp.lua
+++ b/frontend/apps/cloudstorage/ftp.lua
@@ -8,10 +8,10 @@ local ReaderUI = require("apps/reader/readerui")
 local UIManager = require("ui/uimanager")
 local ltn12 = require("ltn12")
 local logger = require("logger")
+local socketutil = require("socketutil")
 local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
-local socketutil = require("socketutil")
 
 local Ftp = {}
 

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -17,13 +17,13 @@ function WebDav:run(address, user, pass, path, folder_mode)
     return WebDavApi:listFolder(address, user, pass, path, folder_mode)
 end
 
-function WebDav:downloadFile(item, address, username, password, local_path, callback_close, progressReporter)
+function WebDav:downloadFile(item, address, username, password, local_path, callback_close, progress_callback)
     local code_response = WebDavApi:downloadFile(
         WebDavApi:getJoinedPath(address, item.url),
         username,
         password,
         local_path,
-        progressReporter
+        progress_callback
     )
 
     if code_response == 200 then

--- a/frontend/apps/cloudstorage/webdav.lua
+++ b/frontend/apps/cloudstorage/webdav.lua
@@ -17,8 +17,15 @@ function WebDav:run(address, user, pass, path, folder_mode)
     return WebDavApi:listFolder(address, user, pass, path, folder_mode)
 end
 
-function WebDav:downloadFile(item, address, username, password, local_path, callback_close)
-    local code_response = WebDavApi:downloadFile(WebDavApi:getJoinedPath(address, item.url), username, password, local_path)
+function WebDav:downloadFile(item, address, username, password, local_path, callback_close, progressReporter)
+    local code_response = WebDavApi:downloadFile(
+        WebDavApi:getJoinedPath(address, item.url),
+        username,
+        password,
+        local_path,
+        progressReporter
+    )
+
     if code_response == 200 then
         local __, filename = util.splitFilePathName(local_path)
         if G_reader_settings:isTrue("show_unsupported") and not DocumentRegistry:hasProvider(filename) then

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -167,7 +167,7 @@ function WebDavApi:downloadFile(file_url, user, pass, local_path, progress_callb
     logger.dbg("WebDavApi: downloading file: ", file_url)
 
     local handle = ltn12.sink.file(io.open(local_path, "w"))
-    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
+    handle = socketutil.chainSinkWithProgressCallback(handle, progress_callback)
 
     local code, headers, status = socket.skip(1, http.request {
         url      = file_url,

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -186,13 +186,13 @@ end
 
 function WebDavApi:uploadFile(file_url, user, pass, local_path, etag)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-    local code, _, status = socket.skip(1, http.request {
+    local code, _, status = socket.skip(1, http.request{
         url      = file_url,
         method   = "PUT",
         source   = ltn12.source.file(io.open(local_path, "r")),
         user     = user,
         password = pass,
-        headers  = {
+        headers = {
             ["Content-Length"] = lfs.attributes(local_path, "size"),
             ["If-Match"] = etag,
         }
@@ -206,7 +206,7 @@ end
 
 function WebDavApi:createFolder(folder_url, user, pass, folder_name)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-    local code, _, status = socket.skip(1, http.request {
+    local code, _, status = socket.skip(1, http.request{
         url      = folder_url,
         method   = "MKCOL",
         user     = user,
@@ -218,5 +218,6 @@ function WebDavApi:createFolder(folder_url, user, pass, folder_name)
     end
     return code
 end
+
 
 return WebDavApi

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -162,12 +162,12 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
     return webdav_list
 end
 
-function WebDavApi:downloadFile(file_url, user, pass, local_path, progressReporter)
+function WebDavApi:downloadFile(file_url, user, pass, local_path, progress_callback)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
     logger.dbg("WebDavApi: downloading file: ", file_url)
 
     local handle = ltn12.sink.file(io.open(local_path, "w"))
-    handle = socketutil.wrapProgressReporterAroundSink(handle, progressReporter)
+    handle = socketutil.wrapSinkWithProgressCallback(handle, progress_callback)
 
     local code, headers, status = socket.skip(1, http.request {
         url      = file_url,

--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -172,23 +172,18 @@ function socketutil.redact_request(request)
     return safe_request
 end
 
-function socketutil.wrapProgressReporterAroundSink(sink, progressReporter)
-    if progressReporter == nil then
+function socketutil.wrapSinkWithProgressCallback(sink, progressCallback)
+    if progressCallback == nil then
         return sink
     end
 
-    assert(progressReporter.expected_size_bytes, "progressReporter.expected_size_bytes is nil")
-    assert(progressReporter.reportProgressCallback, "progressReporter.reportProgressCallback is nil")
-
     local downloaded_bytes = 0
     local progress_reporter_sink = function(chunk, err)
-        if chunk == nil then
-            progressReporter.reportProgressCallback(1)
-        else
+        if chunk ~= nil then
             -- accumulate the downloaded bytes so we don't need to check the actual file every time
             downloaded_bytes = downloaded_bytes + chunk:len()
-            progressReporter.reportProgressCallback(downloaded_bytes / progressReporter.expected_size_bytes)
         end
+        progressCallback(downloaded_bytes)
         return sink(chunk, err)
     end
 

--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -172,22 +172,22 @@ function socketutil.redact_request(request)
     return safe_request
 end
 
-function socketutil.wrapSinkWithProgressCallback(sink, progressCallback)
-    if progressCallback == nil then
+function socketutil.chainSinkWithProgressCallback(sink, progressCallback)
+    if sink == nil or progressCallback == nil then
         return sink
     end
 
     local downloaded_bytes = 0
-    local progress_reporter_sink = function(chunk, err)
+    local progress_reporter_filter = function(chunk, err)
         if chunk ~= nil then
             -- accumulate the downloaded bytes so we don't need to check the actual file every time
             downloaded_bytes = downloaded_bytes + chunk:len()
+            progressCallback(downloaded_bytes)
         end
-        progressCallback(downloaded_bytes)
-        return sink(chunk, err)
+        return chunk, err
     end
 
-    return progress_reporter_sink
+    return ltn12.sink.chain(progress_reporter_filter, sink)
 end
 
 return socketutil

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -70,7 +70,7 @@ function ProgressbarDialog:init()
     if self.title then
         vertical_group[#vertical_group + 1] = TextWidget:new {
             text = self.title or "",
-            face = Font:getFace("cfont", 18),
+            face = Font:getFace("ffont"),
             bold = true,
             max_width = progress_bar_width,
         }
@@ -78,7 +78,7 @@ function ProgressbarDialog:init()
     if self.subtitle then
         vertical_group[#vertical_group + 1] = TextWidget:new {
             text = self.subtitle or "",
-            face = Font:getFace("cfont", 16),
+            face = Font:getFace("smallffont"),
             max_width = progress_bar_width,
         }
     end

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -168,7 +168,7 @@ end
 
 ---- Closes dialog.
 function ProgressbarDialog:close()
-   UIManager:close(self, "ui")
+    UIManager:close(self, "ui")
 end
 
 return ProgressbarDialog

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -66,7 +66,7 @@ function ProgressbarDialog:init()
     self.last_redraw_time_ms = 0
 
     -- create the dialog
-    local progress_bar_width = Screen:scaleBySize(360)
+    local progress_bar_width = Screen:getWidth() - Screen:scaleBySize(80)
     local progress_bar_height = Screen:scaleBySize(18)
 
     -- only add relevant widgets
@@ -167,12 +167,12 @@ end
 
 --- opens dialog
 function ProgressbarDialog:show()
-    UIManager:show(self)
+    UIManager:show(self, "ui")
 end
 
 ---- closes dialog
 function ProgressbarDialog:close()
-    UIManager:close(self)
+   UIManager:close(self, "ui")
 end
 
 return ProgressbarDialog

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -70,48 +70,41 @@ function ProgressbarDialog:init()
     local progress_bar_width = Screen:scaleBySize(360)
     local progress_bar_height = Screen:scaleBySize(18)
 
-    self.title_text = TextWidget:new {
-        text = self.title or "",
-        face = Font:getFace("cfont", 18),
-        bold = true,
-        max_width = progress_bar_width,
-    }
-
-    self.subtitle_text = TextWidget:new {
-        text = self.subtitle or "",
-        face = Font:getFace("cfont", 16),
-        max_width = progress_bar_width,
-    }
-
-    self.progress_bar = ProgressWidget:new {
-        width = progress_bar_width,
-        height = progress_bar_height,
-        padding = Size.padding.large,
-        margin = Size.margin.tiny,
-        percentage = 0,
-    }
-
     -- only add relevant widgets
     local vertical_group = VerticalGroup:new {}
     if self.title then
-        vertical_group[#vertical_group + 1] = self.title_text
+        vertical_group[#vertical_group + 1] = TextWidget:new {
+            text = self.title or "",
+            face = Font:getFace("cfont", 18),
+            bold = true,
+            max_width = progress_bar_width,
+        }
     end
     if self.subtitle then
-        vertical_group[#vertical_group + 1] = self.subtitle_text
+        vertical_group[#vertical_group + 1] = TextWidget:new {
+            text = self.subtitle or "",
+            face = Font:getFace("cfont", 16),
+            max_width = progress_bar_width,
+        }
     end
     if self.progress_bar_visible then
+        self.progress_bar = ProgressWidget:new {
+            width = progress_bar_width,
+            height = progress_bar_height,
+            padding = Size.padding.large,
+            margin = Size.margin.tiny,
+            percentage = 0,
+        }
         vertical_group[#vertical_group + 1] = self.progress_bar
     end
 
-    self.frame_container = FrameContainer:new {
+    self[1] = FrameContainer:new {
         radius = Size.radius.window,
         bordersize = Size.border.window,
         padding = Size.padding.large,
         background = Blitbuffer.COLOR_WHITE,
         vertical_group
     }
-
-    self[1] = self.frame_container
 end
 
 dbg:guard(ProgressbarDialog, "init",

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -58,11 +58,6 @@ function ProgressbarDialog:init()
     self.align = "center"
     self.dimen = Screen:getSize()
 
-    -- set default values if not provided
-    self.title = self.title ~= nil and self.title or nil
-    self.subtitle = self.subtitle ~= nil and self.subtitle or nil
-    self.progress_max = self.progress_max ~= nil and self.progress_max or nil
-
     self.progress_bar_visible = self.progress_max ~= nil and self.progress_max > 0
 
     -- refresh time in seconds

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -19,8 +19,8 @@ A dialog that shows a progress bar with a title and subtitle
 local progressbar_dialog = ProgressbarDialog:new {
     title = nil,
     subtitle = nil,
-    refresh_time_seconds = 3,
     progress_max = nil
+    refresh_time_seconds = 3,
 }
 
 -- attach progress callback and call show()
@@ -30,7 +30,7 @@ progressbar_dialog:show()
 progressbar_dialog:close()
 
 -----------------------general use case-----------------------------------------
--- manually call reportProgress with the current progress (value between 0-max_progress)
+-- manually call reportProgress with the current progress (value between 0-progress_max)
 progressbar_dialog:reportProgress( <progress value> )
 ----------------------------------------------------------------------------------
 
@@ -47,9 +47,9 @@ Note: provide at least one of title, subtitle or progress_max
 @param subtitle string the subtitle of the dialog
 @param progress_max number the maximum progress (e.g. size of the file in bytes for file downloads)
                     reportProgress() should be called with the current
-                    progress (value between 0-max_progress) to update the progress bar
+                    progress (value between 0-progress_max) to update the progress bar
                     optional: if `progress_max` is nil, the progress bar will be hidden
-@param refresh_time_seconds number refresh time in seconds -  used with refresh_mode "time"
+@param refresh_time_seconds number refresh time in seconds
 --]]
 local ProgressbarDialog = WidgetContainer:extend {}
 
@@ -170,7 +170,7 @@ function ProgressbarDialog:reportProgress(progress)
         return
     end
 
-    -- set percentage of progress bar internally, this does not yet update
+    -- set percentage of progress bar internally, this does not yet update the screen element
     self.progress_bar:setPercentage(progress / self.progress_max)
 
     -- actually draw the progress bar update

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -1,16 +1,16 @@
-local UIManager       = require("ui/uimanager")
-local Device          = require("device")
-local Screen          = Device.screen
-local VerticalGroup   = require("ui/widget/verticalgroup")
+local Blitbuffer = require("ffi/blitbuffer")
+local Device = require("device")
+local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local ProgressWidget = require("ui/widget/progresswidget")
+local Size = require("ui/size")
+local TextWidget = require("ui/widget/textwidget")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local Size            = require("ui/size")
-local FrameContainer  = require("ui/widget/container/framecontainer")
-local Blitbuffer      = require("ffi/blitbuffer")
-local ProgressWidget  = require("ui/widget/progresswidget")
-local dbg             = require("dbg")
-local TextWidget      = require("ui/widget/textwidget")
-local Font            = require("ui/font")
-local time            = require("ui/time")
+local dbg = require("dbg")
+local time = require("ui/time")
+local Screen = Device.screen
 
 --[[--
 A dialog that shows a progress bar with a title and subtitle

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -7,10 +7,10 @@ local Size            = require("ui/size")
 local FrameContainer  = require("ui/widget/container/framecontainer")
 local Blitbuffer      = require("ffi/blitbuffer")
 local ProgressWidget  = require("ui/widget/progresswidget")
-local dbg = require("dbg")
+local dbg             = require("dbg")
 local TextWidget      = require("ui/widget/textwidget")
 local Font            = require("ui/font")
-local time = require("ui/time")
+local time            = require("ui/time")
 
 --[[--
 A dialog that shows a progress bar with a title and subtitle
@@ -96,15 +96,15 @@ function ProgressbarDialog:init()
     }
 
     -- only add relevant widgets
-    local vertical_group = VerticalGroup:new{ }
+    local vertical_group = VerticalGroup:new {}
     if self.title then
-        vertical_group[#vertical_group+1] = self.title_text
+        vertical_group[#vertical_group + 1] = self.title_text
     end
     if self.subtitle then
-        vertical_group[#vertical_group+1] = self.subtitle_text
+        vertical_group[#vertical_group + 1] = self.subtitle_text
     end
     if self.progress_bar_visible then
-        vertical_group[#vertical_group+1] = self.progress_bar
+        vertical_group[#vertical_group + 1] = self.progress_bar
     end
 
     self.frame_container = FrameContainer:new {
@@ -117,14 +117,17 @@ function ProgressbarDialog:init()
 
     self[1] = self.frame_container
 end
+
 dbg:guard(ProgressbarDialog, "init",
-nil,
+    nil,
     function(self)
         assert(self.progress_max == nil or
             (type(self.progress_max) == "number" and self.progress_max > 0),
-            "Wrong self.progress_max type (expected nil or number greater than 0), value was: " .. tostring(self.progress_max))
+            "Wrong self.progress_max type (expected nil or number greater than 0), value was: " ..
+            tostring(self.progress_max))
         assert(type(self.refresh_time_seconds) == "number" and self.refresh_time_seconds > 0,
-            "Wrong self.refresh_time_seconds type (expected number greater than 0), value was: " .. tostring(self.refresh_time_seconds))
+            "Wrong self.refresh_time_seconds type (expected number greater than 0), value was: " ..
+            tostring(self.refresh_time_seconds))
         assert(self.title == nil or type(self.title) == "string",
             "Wrong title type (expected nil or string), value was of type: " .. type(self.title))
         assert(self.subtitle == nil or type(self.subtitle) == "string",

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -35,9 +35,10 @@ progressbar_dialog:reportProgress( <progress value> )
 ----------------------------------------------------------------------------------
 
 ------------------use case with luasocket sink----------------------------------
-local progress_callback = progressbar_dialog:getProgressCallback()
 local sink = ltn12.sink.file(io.open(local_path, "w"))
-sink = socketutil.chainSinkWithProgressCallback(sink, progress_callback)
+sink = socketutil.chainSinkWithProgressCallback(sink, function(progress)
+    progressbar_dialog:reportProgress(progress)
+end)
 -- start pushing data to the sink, this is usually some function that accepts a luasocket sink
 something:startDownload(sink)
 ----------------------------------------------------------------------------------
@@ -175,27 +176,6 @@ function ProgressbarDialog:reportProgress(progress)
 
     -- actually draw the progress bar update
     self:redrawProgressbarIfNeeded()
-end
-
---- Returns the progressCallback or nil if the progress bar is not visible
--- meant to be used with socketutil.chainSinkWithProgressCallback
---[[
-usage:
-------------------------------------------------------------
-local handle = ltn12.sink.file(io.open(local_path, "w"))
-local sink = socketutil.chainSinkWithProgressCallback(handle, progress_dialog:getProgressCallback())
-...start download with sink...
-------------------------------------------------------------
-]]
-function ProgressbarDialog:getProgressCallback()
-    if self.progress_bar_visible then
-        local progressCallback = function(progress)
-            self:reportProgress(progress)
-        end
-        return progressCallback
-    end
-
-    return nil
 end
 
 --- opens dialog

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -52,16 +52,15 @@ Note: provide at least one of title, subtitle or progress_max
                     optional: if `progress_max` is nil, the progress bar will be hidden
 @param refresh_time_seconds number refresh time in seconds
 --]]
-local ProgressbarDialog = WidgetContainer:extend {}
+local ProgressbarDialog = WidgetContainer:extend {
+    refresh_time_seconds = 3,
+}
 
 function ProgressbarDialog:init()
     self.align = "center"
     self.dimen = Screen:getSize()
 
     self.progress_bar_visible = self.progress_max ~= nil and self.progress_max > 0
-
-    -- refresh time in seconds
-    self.refresh_time_seconds = self.refresh_time_seconds and self.refresh_time_seconds or 3
 
     -- used for internal state
     self.last_redraw_time_ms = 0

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -11,6 +11,7 @@ local TitleBar        = require("ui/widget/titlebar")
 local logger          = require("logger")
 local TextWidget      = require("ui/widget/textwidget")
 local Font            = require("ui/font")
+local time = require("ui/time")
 
 --[[--
 A progress bar dialog widget that shows a progress bar for luasocket sinks
@@ -72,7 +73,6 @@ function ProgressbarDialog:init()
 
     -- refresh time in seconds
     -- defauilt: 3 seconds
-    -- @note: lowest rate is 1 second due to lua's os.time() precision limit of seconds
     self.refresh_time_seconds = self.refresh_time_seconds and self.refresh_time_seconds or 3
     -- used with refresh_mode "fixed_percentage"
     -- default: every 20%
@@ -90,7 +90,7 @@ function ProgressbarDialog:init()
     -- used for internal state
     self.last_percent = 0
     self.last_step = 0
-    self.last_redraw_time = 0
+    self.last_redraw_time_ms = 0
 
     -- create the dialog
     local progress_bar_width = Screen:scaleBySize(360)
@@ -172,9 +172,11 @@ function ProgressbarDialog:redrawProgressbarIfNeeded()
 
     if self.refresh_mode == "time" then
         -- check if enough time has passed
-        local current_time = os.time()
-        if os.difftime(current_time, self.last_redraw_time) >= self.refresh_time_seconds then
-            self.last_redraw_time = current_time
+        local current_time_ms = time.now()
+        local time_delta_ms = current_time_ms - self.last_redraw_time_ms
+        local refresh_time_ms = self.refresh_time_seconds * 1000 * 1000
+        if time_delta_ms >= refresh_time_ms then
+            self.last_redraw_time_ms = current_time_ms
             self:redrawProgressbar()
         end
     elseif self.refresh_mode == "fixed_percentage" then


### PR DESCRIPTION
~~This is currently a **draft PR**.
I just wanted to get general feedback on the whole idea and implementation, as I'm quite new to this code base.~~

The goal of this PR is to provide a progress bar when downloading files via cloud storage e.g. Dropbox/WebDav/FTP.
In the current implementation this only works for Dropbox and WebDav, **for FTP the file size is not available when downloading**.

Depending on the use case it might be best to move this "progress bar window"-component into it's own widget, so it can be used for other things as well (e.g. #11217).

Here is a picture of the new download window:
<img src="https://github.com/user-attachments/assets/7eac4813-2401-4b66-aa59-0674252bac55" width="250"> <img src="https://github.com/user-attachments/assets/774be9c4-2912-4057-bc4e-26b0af3da095" width="250">

Here is the current status with FTP. The filesize is 'N/A' and we don't show the progress bar in the dialog:
<img src="https://github.com/user-attachments/assets/ac2a773d-13fa-4b47-bc6c-4e2101063182" width="250"><img src="https://github.com/user-attachments/assets/6cd73eff-6911-4998-a66d-62e5b0ed5b66" width="250">

Stuff that needs more consideration:
- [ ] ~~How often should the progress bar update (to limit redraw calls)? currently this is set to update every 20% progress increase (so at 20%, 40%,..)~~
- [ ] I'm not that familiar with the "luasocket" so the file sink wrapper might need some changes especially in case errors happen, I'm not sure how to test/debug  this
- [ ] ~~variable naming and code structuring (see TODO's in code)~~
- [ ] In general more testing is needed, to verify that this feature does not cause any crashes


Regarding FTP downloads, it might be possible to request the file size before we start the actual download so we can show a progress bar as well, however this should be done in a new separate issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13650)
<!-- Reviewable:end -->
