### PR TITLE
fix: missing remarkable-aarch64 make file

### DIFF
--- a/make/remarkable-aarch64.mk
+++ b/make/remarkable-aarch64.mk
@@ -1,0 +1,20 @@
+REMARKABLE_DIR = $(PLATFORM_DIR)/remarkable
+REMARKABLE_PACKAGE = koreader-remarkable-aarch64$(KODEDUG_SUFFIX)-$(VERSION).zip
+REMARKABLE_PACKAGE_OTA = koreader-remarkable-aarch64$(KODEDUG_SUFFIX)-$(VERSION).targz
+
+define UPDATE_PATH_EXCLUDES +=
+plugins/SSH.koplugin
+tools
+endef
+
+update: all
+	# ensure that the binaries were built for ARM
+	file --dereference $(INSTALL_DIR)/koreader/luajit | grep ARM
+	# Remarkable scripts
+	$(SYMLINK) $(REMARKABLE_DIR)/* $(INSTALL_DIR)/koreader/
+	$(SYMLINK) $(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader/
+	# Create packages.
+	$(strip $(call mkupdate,$(REMARKABLE_PACKAGE)))
+	$(strip $(call mkupdate,$(REMARKABLE_PACKAGE_OTA)))
+
+PHONY += update


### PR DESCRIPTION
I overlooked this file so kodev release didn't work, sorry for the oversight

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13656)
<!-- Reviewable:end -->
