### PR TITLE
Exporter: better logs, bump deprecation message

### DIFF
--- a/plugins/exporter.koplugin/_meta.lua
+++ b/plugins/exporter.koplugin/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "exporter",
     fullname = _("Export highlights"),
     description = _("Exports highlights and notes."),
-    deprecated = { "feature", "Flomo, Memos"},
+    deprecated = { "feature", "Joplin "},
 }

--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -17,6 +17,8 @@ local socketutil = require("socketutil")
 local util = require("util")
 local _ = require("gettext")
 
+local msg_failed = "json request failed: %s"
+
 local BaseExporter = {
     clipping_dir = DataStorage:getFullDataDir() .. "/clipboard"
 }
@@ -180,9 +182,10 @@ Makes a json request against a remote endpoint
 function BaseExporter:makeJsonRequest(endpoint, method, body, headers)
     local sink = {}
     local extra_headers = headers or {}
-    local body_json = rapidjson.encode(body)
+    local body_json, err = rapidjson.encode(body)
     if not body_json then
-        return nil, "Invalid JSON string"
+        return nil, string.format(msg_failed,
+            "cannot encode body" .. err)
     end
     local source = ltn12.source.string(body_json)
     socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
@@ -203,20 +206,24 @@ function BaseExporter:makeJsonRequest(endpoint, method, body, headers)
         request.headers[k] = v
     end
 
-    local code = socket.skip(1, http.request(request))
+    local code, headers, status = socket.skip(1, http.request(request))
     socketutil:reset_timeout()
 
     if code ~= 200 then
-        return nil, "Server HTTP response code is not OK"
+        logger.info(code, headers, status, request_headers)
+        return nil, string.format(msg_failed,
+            status or code or "network unreachable")
     end
 
     if not sink[1] then
-        return nil, "No response from server"
+        return nil, string.format(msg_failed,
+            "no response from server")
     end
 
     local response, err = rapidjson.decode(sink[1])
     if not response then
-        return nil, "Unable to decode JSON: " .. err
+        return nil, string.format(msg_failed,
+            "unable to decode server response" .. err)
     end
 
     return response

--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -182,7 +182,9 @@ Makes a json request against a remote endpoint
 function BaseExporter:makeJsonRequest(endpoint, method, body, headers)
     local sink = {}
     local extra_headers = headers or {}
-    local body_json, err = rapidjson.encode(body)
+    local body_json, response, err
+
+    body_json, err = rapidjson.encode(body)
     if not body_json then
         return nil, string.format(msg_failed,
             "cannot encode body" .. err)
@@ -219,7 +221,7 @@ function BaseExporter:makeJsonRequest(endpoint, method, body, headers)
             "no response from server")
     end
 
-    local response, err = rapidjson.decode(sink[1])
+    response, err = rapidjson.decode(sink[1])
     if not response then
         return nil, string.format(msg_failed,
             "unable to decode server response" .. err)

--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -206,11 +206,10 @@ function BaseExporter:makeJsonRequest(endpoint, method, body, headers)
         request.headers[k] = v
     end
 
-    local code, headers, status = socket.skip(1, http.request(request))
+    local code, __, status = socket.skip(1, http.request(request))
     socketutil:reset_timeout()
 
     if code ~= 200 then
-        logger.info(code, headers, status, request_headers)
         return nil, string.format(msg_failed,
             status or code or "network unreachable")
     end


### PR DESCRIPTION
- Better error messages while doing remote requests
- Update deprecation notice

Closes https://github.com/koreader/koreader/issues/13653

Joplin won't be removed until https://github.com/koreader/koreader/issues/13623 is fixed and nextcloud is ready for production :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13659)
<!-- Reviewable:end -->
