### PR TITLE
android: remove vendor hacks from event_map

### DIFF
--- a/frontend/device/android/event_map.lua
+++ b/frontend/device/android/event_map.lua
@@ -27,8 +27,4 @@ return {
     [84] = "Search",--SEARCH
     [92] = "LPgBack", -- PAGE_UP
     [93] = "LPgFwd",  -- PAGE_DOWN
-
-    [104] = "LPgBack", -- T68 PageUp
-    [109] = "LPgFwd",  -- T68 PageDown
-    [139] = "Menu",    -- T68 Menu
 }


### PR DESCRIPTION
We included keys that are not aosp, for a few? onyx t68 clones

We don't need them and they might clash with other vendor definitions.

C.f https://github.com/koreader/koreader/issues/13649

Wiki updated: https://github.com/koreader/koreader/wiki/Android-tips-and-tricks#customize-keys

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13660)
<!-- Reviewable:end -->
