### PR TITLE
[Kobo] Enable wake on page turn buttons

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -822,6 +822,15 @@ function Input:handlePowerManagementOnlyEv(ev)
         return keycode
     end
 
+    -- Treat page turn button like the latest kobo firmware when suspended
+    if G_reader_settings:isTrue("pageturn_power") then
+        if keycode == "RPgBack" or keycode == "LPgBack"
+        or keycode == "RPgFwd" or keycode == "LPgFwd" then
+            -- When suspended we pretend that the page turn button is a power button
+            return "PowerRelease"
+        end
+    end
+
     if self.fake_event_set[keycode] then
         if self.fake_event_args[keycode] then
             table.insert(self.fake_event_args[keycode], ev.value)

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -240,7 +240,7 @@ if Device:isKobo() then
 
     if Device:hasKeys() and Device:isMTK() then
         common_settings.pageturn_power = {
-            text = _("Wake up on Page-turn button presses"),
+            text = _("Wake up on page-turn button presses"),
             checked_func = function()
                 return G_reader_settings:isTrue("pageturn_power")
             end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -238,7 +238,7 @@ if Device:isKobo() then
         end
     }
 
-    if Device:hasKeys() then
+    if Device:hasKeys() and Device:isMTK then
         common_settings.pageturn_power = {
             text = _("Wake up on page turn key presses"),
             checked_func = function()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -238,9 +238,9 @@ if Device:isKobo() then
         end
     }
 
-    if Device:hasKeys() and Device:isMTK then
+    if Device:hasKeys() and Device:isMTK() then
         common_settings.pageturn_power = {
-            text = _("Wake up on page turn key presses"),
+            text = _("Wake up on Page-turn button presses"),
             checked_func = function()
                 return G_reader_settings:isTrue("pageturn_power")
             end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -237,6 +237,18 @@ if Device:isKobo() then
             UIManager:askForRestart()
         end
     }
+
+    common_settings.pageturn_power = {
+        text = _("Wakeup if page button pressed"),
+        checked_func = function()
+            return G_reader_settings:isTrue("pageturn_power")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("pageturn_power")
+            UIManager:askForRestart()
+        end
+    }
+
 end
 
 if Device:isKindle() and PowerD:hasHallSensor() then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -238,17 +238,18 @@ if Device:isKobo() then
         end
     }
 
-    common_settings.pageturn_power = {
-        text = _("Wakeup if page button pressed"),
-        checked_func = function()
-            return G_reader_settings:isTrue("pageturn_power")
-        end,
-        callback = function()
-            G_reader_settings:flipNilOrFalse("pageturn_power")
-            UIManager:askForRestart()
-        end
-    }
-
+    if Device:hasKeys() then
+        common_settings.pageturn_power = {
+            text = _("Wakeup if page button pressed"),
+            checked_func = function()
+                return G_reader_settings:isTrue("pageturn_power")
+            end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("pageturn_power")
+                UIManager:askForRestart()
+            end
+        }
+    end
 end
 
 if Device:isKindle() and PowerD:hasHallSensor() then

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -240,7 +240,7 @@ if Device:isKobo() then
 
     if Device:hasKeys() then
         common_settings.pageturn_power = {
-            text = _("Wakeup if page button pressed"),
+            text = _("Wake up on page turn key presses"),
             checked_func = function()
                 return G_reader_settings:isTrue("pageturn_power")
             end,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -246,7 +246,6 @@ if Device:isKobo() then
             end,
             callback = function()
                 G_reader_settings:flipNilOrFalse("pageturn_power")
-                UIManager:askForRestart()
             end
         }
     end

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -240,7 +240,7 @@ if Device:isKobo() then
 
     if Device:hasKeys() and Device:isMTK() then
         common_settings.pageturn_power = {
-            text = _("Wake up on page-turn button presses"),
+            text = _("Wake up on page-turn button press"),
             checked_func = function()
                 return G_reader_settings:isTrue("pageturn_power")
             end,

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -56,7 +56,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
-        "pageturn_power", -- if Device:hasKeys() and Device:isKobo()
+        "pageturn_power", -- if Device:isKobo() and Device:hasKeys()
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -56,7 +56,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
-        "pageturn_power",
+        "pageturn_power", -- if Device:hasKeys() and Device:isKobo()
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -56,6 +56,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
+        "pageturn_power",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -104,6 +104,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
+        "pageturn_power",
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -104,7 +104,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
-        "pageturn_power", -- if Device:hasKeys() and Device:isKobo()
+        "pageturn_power", -- if Device:isKobo() and Device:hasKeys()
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -104,7 +104,7 @@ local order = {
         "autostandby",
         "autosuspend",
         "autoshutdown",
-        "pageturn_power",
+        "pageturn_power", -- if Device:hasKeys() and Device:isKobo()
         "ignore_sleepcover",
         "ignore_open_sleepcover",
         "cover_events",


### PR DESCRIPTION
Adds menu items (toggles) and functionality to turn a kobo back on with the page turn buttons.

Fix #13668

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13669)
<!-- Reviewable:end -->
