### PR TITLE
Style tweaks: fix saving document settings as default

### DIFF
--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -347,7 +347,10 @@ function ReaderMenu:saveDocumentSettingsAsDefault()
     if self.ui.rolling then
         G_reader_settings:saveSetting("cre_font", self.ui.font.font_face)
         G_reader_settings:saveSetting("copt_css", self.ui.document.default_css)
-        G_reader_settings:saveSetting("style_tweaks", self.ui.styletweak.global_tweaks)
+        local style_tweaks = G_reader_settings:readSetting("style_tweaks")
+        for tweak_id, is_enabled in pairs(self.ui.styletweak.doc_tweaks) do
+            style_tweaks[tweak_id] = is_enabled or nil
+        end
         prefix = "copt_"
     else
         prefix = "kopt_"


### PR DESCRIPTION
Closes https://github.com/koreader/koreader/issues/13658.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13673)
<!-- Reviewable:end -->
