### PR TITLE
plugin handlers traceback

### DIFF
--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -55,22 +55,47 @@ local function getMenuTable(plugin)
     return t
 end
 
-local function sandboxPluginEventHandlers(plugin)
-    for key, value in pairs(plugin) do
-        if key:sub(1, 2) == "on" and type(value) == "function" then
-            plugin[key] = function(self, ...)
-                local ok, re = pcall(value, self, ...)
-                if ok then
-                    return re
-                else
-                    logger.err("failed to call event handler", key, re)
-                    return false
-                end
-            end
-        end
+-- Event handlers defined by plugins are wrapped in a HandlerSandbox
+-- The purpose of the sandbox is to get meaningful stack-traces out of errors happening in plugins.
+local HandlerSandbox = { mt = {} }
+
+function HandlerSandbox.new(context, fname, f, module)
+    local t = {
+        context = context,
+        fname = fname,
+        f = f,
+    }
+    return setmetatable(t, HandlerSandbox.mt)
+end
+
+function HandlerSandbox:call(module,...)
+    -- NOTE the signature is (self, module, ...)
+    -- self refers to the HandlerSandbox instance but module refers to the
+    -- self parameter of the handlers
+    local traceback = function (err)
+         -- do not print 2 topmost entries in traceback. The first is this local function
+         -- and the second is the call method of HandlerSandbox.
+         logger.err("An error occurred while executing a handler:\n" ..err .. "\n" .. debug.traceback(self.context.name .. ":" .. self.fname, 2))
+    end
+    local ok, re = xpcall(self.f, traceback, module, ...)
+    -- NOTE backward compatibility with previous implementation
+    -- of handler wrapping that returned false on error
+    if ok then
+        return re
+    else
+        return false
     end
 end
 
+HandlerSandbox.mt.__call = HandlerSandbox.call
+
+local function sandboxPluginEventHandlers(plugin)
+    for key, value in pairs(plugin) do
+        if key:sub(1, 2) == "on" and type(value) == "function" then
+            plugin[key] = HandlerSandbox.new(plugin, key, value)
+        end
+    end
+end
 
 local PluginLoader = {
     show_info = true,

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -1,3 +1,17 @@
+--[[--
+Allows extending KOReader through plugins.
+
+Plugins will be sourced from DEFAULT_PLUGIN_PATH. If set, extra_plugin_paths
+is also used. Directories are considered plugins if the name matches
+".+%.koplugin".
+
+Running with debug turned on will log stacktraces for event handlers.
+Plugins are controlled by the following settings.
+
+- plugins_disabled
+- extra_plugin_paths
+]]
+local dbg = require("dbg")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util = require("util")
@@ -55,7 +69,7 @@ local function getMenuTable(plugin)
     return t
 end
 
--- Event handlers defined by plugins are wrapped in a HandlerSandbox
+-- Event handlers defined by plugins are wrapped in a HandlerSandbox.
 -- The purpose of the sandbox is to get meaningful stack-traces out of errors happening in plugins.
 local HandlerSandbox = { mt = {} }
 
@@ -64,20 +78,27 @@ function HandlerSandbox.new(context, fname, f, module)
         context = context,
         fname = fname,
         f = f,
+        log_stacktrace = dbg.is_on,
     }
     return setmetatable(t, HandlerSandbox.mt)
 end
 
-function HandlerSandbox:call(module,...)
+function HandlerSandbox:call(module, ...)
     -- NOTE the signature is (self, module, ...)
     -- self refers to the HandlerSandbox instance but module refers to the
     -- self parameter of the handlers
-    local traceback = function (err)
-         -- do not print 2 topmost entries in traceback. The first is this local function
-         -- and the second is the call method of HandlerSandbox.
-         logger.err("An error occurred while executing a handler:\n" ..err .. "\n" .. debug.traceback(self.context.name .. ":" .. self.fname, 2))
+    local ok, re
+    if self.log_stacktrace then
+        local traceback = function(err)
+             -- do not print 2 topmost entries in traceback. The first is this local function
+             -- and the second is the `call` method of HandlerSandbox.
+             logger.err("An error occurred while executing a handler:\n"..err.."\n"..debug.traceback(self.context.name..":"..self.fname, 2))
+        end
+        ok, re = xpcall(self.f, traceback, module, ...)
+    else
+        ok, re = pcall(self.f, module, ...)
+        if not ok then logger.err("An error occurred while executing handler "..self.context.name..":"..self.fname..":\n", re) end
     end
-    local ok, re = xpcall(self.f, traceback, module, ...)
     -- NOTE backward compatibility with previous implementation
     -- of handler wrapping that returned false on error
     if ok then


### PR DESCRIPTION
Errors in plugins are logged but they are not actionable. As a plugin developer I expect some help from koreader.

This patch provides a way to get a lua stack trace when a plugin event  handler raises an error. This is achieved by wrapping each event handler with `xpcall` in place of `pcall`. This lua builint allows executing a error handler before the stack is unwound. The traceback we get is then from the execution in the plugin context.

The following is an example of where I am stuck. These are the last two errors I got. I am not sure if I have uncovered known errors or I am doing something wrong in the wrapping.

I made this patch by unpacking the appimage but I will transition to kodev soon to test more.

```bash
edoput@nibbler ~/r/koreader [SIGINT]> ./AppRun
---------------------------------------------
                launching...
  _  _____  ____                _
 | |/ / _ \|  _ \ ___  __ _  __| | ___ _ __
 | ' / | | | |_) / _ \/ _` |/ _` |/ _ \ '__|
 | . \ |_| |  _ <  __/ (_| | (_| |  __/ |
 |_|\_\___/|_| \_\___|\__,_|\__,_|\___|_|

 It's a scroll... It's a codex... It's KOReader!

 [*] Current time: 04/24/25-19:04:43
has monolibtic? no (libs/libkoreader-monolibtic.so: cannot open shared object file: No such file or directory)
lib_search_path: libs/?
lib_basic_format: lib%s.so
lib_version_format: lib%s.so.%s
 [*] Version: v2025.04

ffi.load: rt.so.1 (RTLD_GLOBAL)
ffi.findlib: utf8proc [3]
ffi.load: libs/libutf8proc.so.3
ffi.findlib: blitbuffer
ffi.load: libs/libblitbuffer.so
ffi.findlib: SDL2-2.0 [0]
ffi.load: libs/libSDL2-2.0.so.0
Starting SDL in /home/edoput/repo/koreader/
ffi.findlib: lodepng
ffi.load: libs/liblodepng.so
04/24/25-19:04:43 INFO  initializing for device Emulator 
04/24/25-19:04:43 INFO  framebuffer resolution: {
  h = 1401,
  w = 2560
} --[[table: 0x7fbd9350e678]] 
ffi.findlib: wrap-mupdf
ffi.load: libs/libwrap-mupdf.so
ffi.findlib: sqlite3 [0]
ffi.load: libs/libsqlite3.so.0
ffi.findlib: freetype [6]
ffi.load: libs/libfreetype.so.6
ffi.findlib: harfbuzz [0]
ffi.load: libs/libharfbuzz.so.0
ffi.findlib: zstd [1]
ffi.load: libs/libzstd.so.1
04/24/25-19:04:43 INFO  Looking for plugins in directory: plugins 
04/24/25-19:04:43 ERROR An error occurred while executing a handler:
plugins/profiles.koplugin/main.lua:994: attempt to index field 'autoexec' (a nil value)
profiles:onStart
stack traceback:
	plugins/profiles.koplugin/main.lua:994: in function 'executeAutoExecEvent'
	plugins/profiles.koplugin/main.lua:929: in function <plugins/profiles.koplugin/main.lua:927>
	[C]: in function 'xpcall'
	frontend/pluginloader.lua:78: in function 'onStart'
	plugins/profiles.koplugin/main.lua:34: in function 'init'
	frontend/ui/widget/widget.lua:46: in function <frontend/ui/widget/widget.lua:40>
	[C]: in function 'pcall'
	frontend/pluginloader.lua:293: in function 'createPluginInstance'
	frontend/apps/filemanager/filemanager.lua:412: in function 'init'
	frontend/ui/widget/widget.lua:46: in function 'new'
	frontend/apps/filemanager/filemanager.lua:1272: in function 'showFiles'
	./reader.lua:270: in main chunk
	[C]: at 0x563b0891c260 
04/24/25-19:04:44 ERROR An error occurred while executing a handler:
plugins/profiles.koplugin/main.lua:957: attempt to index field 'autoexec' (a nil value)
profiles:onPathChanged
stack traceback:
	plugins/profiles.koplugin/main.lua:957: in function <plugins/profiles.koplugin/main.lua:955>
	[C]: in function 'xpcall'
	frontend/pluginloader.lua:78: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/apps/filemanager/filemanager.lua:426: in function 'init'
	frontend/ui/widget/widget.lua:46: in function 'new'
	frontend/apps/filemanager/filemanager.lua:1272: in function 'showFiles'
	./reader.lua:270: in main chunk
	[C]: at 0x563b0891c260 
04/24/25-19:08:43 INFO  Preparing to quit UIManager 
04/24/25-19:08:43 INFO  UIManager: No dialogs left to show 
04/24/25-19:08:43 INFO  Tearing down UIManager with exit code: 0 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13677)
<!-- Reviewable:end -->
