### PR TITLE
[ReaderFooter] add status bar presets

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1164,7 +1164,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             return not self.settings.progress_style_thin
                         end,
                         callback = function()
-                            self.settings.progress_style_thin = false
+                            self.settings.progress_style_thin = nil
                             local bar_height = self.settings.progress_style_thick_height
                             self.progress_bar:updateStyle(true, bar_height)
                             self:setTocMarkers()
@@ -1916,10 +1916,8 @@ function ReaderFooter:getNamedPresetMenuItems()
                     choice1_text = _("Delete"),
                     choice1_callback = function()
                         self:deleteNamedPreset(preset_name)
-                        if touchmenu_instance then
-                            touchmenu_instance.item_table = self:getNamedPresetMenuItems()
-                            touchmenu_instance:updateItems()
-                        end
+                        touchmenu_instance.item_table = self:getNamedPresetMenuItems()
+                        touchmenu_instance:updateItems()
                     end,
                     choice2_text = _("Update"),
                     choice2_callback = function()
@@ -1940,7 +1938,6 @@ function ReaderFooter:createPresetFromCurrentSettings(touchmenu_instance)
     local input_dialog
     input_dialog = InputDialog:new{
         title = _("Enter preset name"),
-        input = "",
         buttons = {
             {
                 {
@@ -1958,10 +1955,8 @@ function ReaderFooter:createPresetFromCurrentSettings(touchmenu_instance)
                         if preset_name == "" or preset_name:match("^%s*$") then return end
                         self:saveToNamedPreset(preset_name)
                         UIManager:close(input_dialog)
-                        if touchmenu_instance then
-                            touchmenu_instance.item_table = self:getNamedPresetMenuItems()
-                            touchmenu_instance:updateItems()
-                        end
+                        touchmenu_instance.item_table = self:getNamedPresetMenuItems()
+                        touchmenu_instance:updateItems()
                     end,
                 },
             },
@@ -1972,17 +1967,15 @@ function ReaderFooter:createPresetFromCurrentSettings(touchmenu_instance)
 end
 
 function ReaderFooter:saveToNamedPreset(preset_name)
-    local footer_presets = G_reader_settings:readSetting("footer_presets", {})
-    local current_settings = util.tableDeepCopy(self.settings)
-    footer_presets[preset_name] = current_settings
+    local footer_presets = G_reader_settings:readSetting("footer_presets")
+    footer_presets[preset_name] = util.tableDeepCopy(self.settings)
     G_reader_settings:saveSetting("footer_presets", footer_presets)
 end
 
 function ReaderFooter:loadFromNamedPreset(preset_name)
-    local footer_presets = G_reader_settings:readSetting("footer_presets", {})
+    local footer_presets = G_reader_settings:readSetting("footer_presets")
     local preset = footer_presets[preset_name]
     if preset and next(preset) then -- only load if preset exists and is not empty
-        self.settings = {} -- erase current settings to avoid unexpected merges
         self.settings = util.tableDeepCopy(preset)
          -- Apply loaded settings
         self:updateFooterTextGenerator()
@@ -1992,14 +1985,13 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
 end
 
 function ReaderFooter:deleteNamedPreset(preset_name)
-    local footer_presets = G_reader_settings:readSetting("footer_presets", {})
+    local footer_presets = G_reader_settings:readSetting("footer_presets")
     footer_presets[preset_name] = nil
-    G_reader_settings:saveSetting("footer_presets", footer_presets)
 end
 
--- function ReaderFooter:onFooterPresetLoad(preset_name)
---     self:loadFromNamedPreset(preset_name)
--- end
+function ReaderFooter:onFooterPresetLoad(preset_name)
+    self:loadFromNamedPreset(preset_name)
+end
 
 function ReaderFooter:addAdditionalFooterContent(content_func)
     table.insert(self.additional_footer_content, content_func)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1954,7 +1954,7 @@ function ReaderFooter:createPresetFromCurrentSettings(touchmenu_instance)
                         local preset_name = input_dialog:getInputText()
                         if preset_name == "" or preset_name:match("^%s*$") then return end
                         -- Check if preset name already exists
-                        local footer_presets = G_reader_settings:readSetting("footer_presets", {})
+                        local footer_presets = G_reader_settings:readSetting("footer_presets")
                         if footer_presets[preset_name] then
                             UIManager:show(InfoMessage:new{
                                 text = T(_("A preset named '%1' already exists. Please choose a different name."), preset_name),

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1907,20 +1907,6 @@ function ReaderFooter:getNamedPresetMenuItems()
         table.insert(items, {
             text = preset_name,
             keep_menu_open = true,
-            checked_func = function()
-                local preset = footer_presets[preset_name]
-                -- Check if the current settings match the preset, we start with the loose ones (easiest to check).
-                if G_reader_settings:readSetting("reader_footer_mode") ~= preset.reader_footer_mode or
-                   G_reader_settings:readSetting("reader_footer_custom_text") ~= preset.reader_footer_custom_text or
-                   G_reader_settings:readSetting("reader_footer_custom_text_repetitions") ~= preset.reader_footer_custom_text_repetitions then
-                    return false
-                end
-                -- This only checks if values in self.settings match 'preset', but not vice versa. That should be enough.
-                for k, v in pairs(self.settings) do
-                    if preset.footer[k] ~= v then return false end
-                end
-                return true
-            end,
             callback = function()
                 self:loadFromNamedPreset(preset_name)
             end,
@@ -2004,22 +1990,20 @@ end
 function ReaderFooter:loadFromNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets")
     local preset = footer_presets[preset_name]
-    if preset and next(preset) then -- only load if preset exists and is not empty
-        G_reader_settings:saveSetting("footer", util.tableDeepCopy(preset.footer))
-        G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
-        G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
-        G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
-        self.settings = G_reader_settings:readSetting("footer")
-        self.mode = preset.reader_footer_mode
-        self.custom_text = preset.reader_footer_custom_text
-        self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
-        self:updateFooterTextGenerator()
-        self:refreshFooter(true, true)
-    end
+    G_reader_settings:saveSetting("footer", util.tableDeepCopy(preset.footer))
+    G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
+    G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
+    G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
+    self.settings = G_reader_settings:readSetting("footer")
+    self.mode = preset.reader_footer_mode
+    self.custom_text = preset.reader_footer_custom_text
+    self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
+    self:updateFooterTextGenerator()
+    self:refreshFooter(true, true)
 end
 
 function ReaderFooter:onFooterPresetLoad(preset_name)
-    self:loadFromNamedPreset(preset_name)
+    -- tbc
 end
 
 function ReaderFooter:addAdditionalFooterContent(content_func)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1915,7 +1915,8 @@ function ReaderFooter:getNamedPresetMenuItems()
                     text = T(_("What would you like to do with preset '%1'?"), preset_name),
                     choice1_text = _("Delete"),
                     choice1_callback = function()
-                        self:deleteNamedPreset(preset_name)
+                        local footer_presets = G_reader_settings:readSetting("footer_presets")
+                        footer_presets[preset_name] = nil
                         touchmenu_instance.item_table = self:getNamedPresetMenuItems()
                         touchmenu_instance:updateItems()
                     end,
@@ -2001,11 +2002,6 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
         self:updateFooterTextGenerator()
         self:refreshFooter(true, true)
     end
-end
-
-function ReaderFooter:deleteNamedPreset(preset_name)
-    local footer_presets = G_reader_settings:readSetting("footer_presets")
-    footer_presets[preset_name] = nil
 end
 
 function ReaderFooter:onFooterPresetLoad(preset_name)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -511,6 +511,8 @@ function ReaderFooter:init()
     self.mode_index = {}
     self.mode_nb = 0
 
+    self.NUM_PRESETS = 5
+
     local handled_modes = {}
     if self.settings.order then
         -- Start filling self.mode_index from what's been ordered by the user and saved
@@ -1670,7 +1672,6 @@ With this feature enabled, the current page is factored in, resulting in the cou
             separator = true,
         })
     end
-    self.NUM_PRESETS = 5
     table.insert(sub_items, {
         text = _("Status bar presets"),
         separator = true,
@@ -1946,6 +1947,7 @@ function ReaderFooter:genPresetSlotMenuItems(slot_num)
                     end,
                     choice2_text = _("Update"),
                     choice2_callback = function()
+                        self.settings.presets[slot_num] = {}
                         self:saveToPresetSlot(slot_num)
                         if touchmenu_instance then touchmenu_instance:updateItems() end
                     end,

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1915,7 +1915,6 @@ function ReaderFooter:getNamedPresetMenuItems()
                     text = T(_("What would you like to do with preset '%1'?"), preset_name),
                     choice1_text = _("Delete"),
                     choice1_callback = function()
-                        local footer_presets = G_reader_settings:readSetting("footer_presets")
                         footer_presets[preset_name] = nil
                         touchmenu_instance.item_table = self:getNamedPresetMenuItems()
                         touchmenu_instance:updateItems()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1953,6 +1953,15 @@ function ReaderFooter:createPresetFromCurrentSettings(touchmenu_instance)
                     callback = function()
                         local preset_name = input_dialog:getInputText()
                         if preset_name == "" or preset_name:match("^%s*$") then return end
+                        -- Check if preset name already exists
+                        local footer_presets = G_reader_settings:readSetting("footer_presets", {})
+                        if footer_presets[preset_name] then
+                            UIManager:show(InfoMessage:new{
+                                text = T(_("A preset named '%1' already exists. Please choose a different name."), preset_name),
+                                timeout = 2,
+                            })
+                            return
+                        end
                         self:saveToNamedPreset(preset_name)
                         UIManager:close(input_dialog)
                         touchmenu_instance.item_table = self:getNamedPresetMenuItems()

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1977,42 +1977,29 @@ end
 
 function ReaderFooter:saveToNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets")
-    -- Save the main footer settings
-    footer_presets[preset_name] = util.tableDeepCopy(self.settings)
-    -- Save additional footer-related settings
-    footer_presets[preset_name].reader_footer_mode = G_reader_settings:readSetting("reader_footer_mode")
-    footer_presets[preset_name].reader_footer_custom_text = G_reader_settings:readSetting("reader_footer_custom_text")
-    footer_presets[preset_name].reader_footer_custom_text_repetitions = G_reader_settings:readSetting("reader_footer_custom_text_repetitions")
-    G_reader_settings:saveSetting("footer_presets", footer_presets)
+    -- Save all footer settings to the preset
+    footer_presets[preset_name] = {
+        footer = util.tableDeepCopy(self.settings),
+        reader_footer_mode = G_reader_settings:readSetting("reader_footer_mode"),
+        reader_footer_custom_text = G_reader_settings:readSetting("reader_footer_custom_text"),
+        reader_footer_custom_text_repetitions = G_reader_settings:readSetting("reader_footer_custom_text_repetitions"),
+    }
 end
 
 function ReaderFooter:loadFromNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets")
     local preset = footer_presets[preset_name]
     if preset and next(preset) then -- only load if preset exists and is not empty
-        -- Filter out additional settings before copying to self.settings
-        local filtered_preset = util.tableDeepCopy(preset)
-        filtered_preset.reader_footer_mode = nil
-        filtered_preset.reader_footer_custom_text = nil
-        filtered_preset.reader_footer_custom_text_repetitions = nil
-        self.settings = filtered_preset
-        -- Also load additional footer-related settings that were saved
-        if preset.reader_footer_mode then
-            G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
-            self.mode = preset.reader_footer_mode
-        end
-        if preset.reader_footer_custom_text then
-            G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
-            self.custom_text = preset.reader_footer_custom_text
-        end
-        if preset.reader_footer_custom_text_repetitions then
-            G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
-            self.custom_text_repetitions = preset.reader_footer_custom_text_repetitions
-        end
-        -- Apply loaded settings
+        G_reader_settings:saveSetting("footer", preset.footer)
+        G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
+        G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
+        G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
+        self.settings = G_reader_settings:readSetting("footer")
+        self.mode = preset.reader_footer_mode
+        self.custom_text = preset.reader_footer_custom_text
+        self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
         self:updateFooterTextGenerator()
         self:refreshFooter(true, true)
-        G_reader_settings:saveSetting("footer", self.settings)
     end
 end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2002,17 +2002,20 @@ function ReaderFooter:saveToNamedPreset(preset_name)
 end
 
 function ReaderFooter:loadFromNamedPreset(preset_name)
-    local preset = G_reader_settings:readSetting("footer_presets")[preset_name]
-    G_reader_settings:saveSetting("footer", util.tableDeepCopy(preset.footer))
-    G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
-    G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
-    G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
-    self.settings = G_reader_settings:readSetting("footer")
-    self.mode = preset.reader_footer_mode
-    self.custom_text = preset.reader_footer_custom_text
-    self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
-    self:updateFooterTextGenerator()
-    self:refreshFooter(true, true)
+    local footer_presets = G_reader_settings:readSetting("footer_presets")
+    local preset = footer_presets[preset_name]
+    if preset and next(preset) then -- only load if preset exists and is not empty
+        G_reader_settings:saveSetting("footer", util.tableDeepCopy(preset.footer))
+        G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
+        G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
+        G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
+        self.settings = G_reader_settings:readSetting("footer")
+        self.mode = preset.reader_footer_mode
+        self.custom_text = preset.reader_footer_custom_text
+        self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
+        self:updateFooterTextGenerator()
+        self:refreshFooter(true, true)
+    end
 end
 
 function ReaderFooter:onFooterPresetLoad(preset_name)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1973,8 +1973,7 @@ end
 
 function ReaderFooter:saveToNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets", {})
-    local current_settings = {}
-    current_settings = util.tableDeepCopy(self.settings)
+    local current_settings = util.tableDeepCopy(self.settings)
     footer_presets[preset_name] = current_settings
     G_reader_settings:saveSetting("footer_presets", footer_presets)
 end

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1907,6 +1907,20 @@ function ReaderFooter:getNamedPresetMenuItems()
         table.insert(items, {
             text = preset_name,
             keep_menu_open = true,
+            checked_func = function()
+                local preset = footer_presets[preset_name]
+                -- Return false if any setting doesn't match
+                if G_reader_settings:readSetting("reader_footer_mode") ~= preset.reader_footer_mode or
+                   G_reader_settings:readSetting("reader_footer_custom_text") ~= preset.reader_footer_custom_text or
+                   G_reader_settings:readSetting("reader_footer_custom_text_repetitions") ~= preset.reader_footer_custom_text_repetitions then
+                    return false
+                end
+                -- this only checks if values in self.settings match 'preset', but not vice versa. 'preset' has additional keys not present in self.settings
+                for k, v in pairs(self.settings) do
+                    if preset[k] ~= v then return false end
+                end
+                return true
+            end,
             callback = function()
                 self:loadFromNamedPreset(preset_name)
             end,
@@ -1996,6 +2010,7 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
         filtered_preset.reader_footer_custom_text = nil
         filtered_preset.reader_footer_custom_text_repetitions = nil
         self.settings = filtered_preset
+        G_reader_settings:saveSetting("footer", self.settings)
         -- Also load additional footer-related settings that were saved
         if preset.reader_footer_mode then
             G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
@@ -2012,7 +2027,6 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
         -- Apply loaded settings
         self:updateFooterTextGenerator()
         self:refreshFooter(true, true)
-        G_reader_settings:saveSetting("footer", self.settings)
     end
 end
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1981,7 +1981,12 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets")
     local preset = footer_presets[preset_name]
     if preset and next(preset) then -- only load if preset exists and is not empty
-        self.settings = util.tableDeepCopy(preset)
+        -- Filter out additional settings before copying to self.settings
+        local filtered_preset = util.tableDeepCopy(preset)
+        filtered_preset.reader_footer_mode = nil
+        filtered_preset.reader_footer_custom_text = nil
+        filtered_preset.reader_footer_custom_text_repetitions = nil
+        self.settings = filtered_preset
         -- Also load additional footer-related settings that were saved
         if preset.reader_footer_mode then
             G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1968,7 +1968,12 @@ end
 
 function ReaderFooter:saveToNamedPreset(preset_name)
     local footer_presets = G_reader_settings:readSetting("footer_presets")
+    -- Save the main footer settings
     footer_presets[preset_name] = util.tableDeepCopy(self.settings)
+    -- Save additional footer-related settings
+    footer_presets[preset_name].reader_footer_mode = G_reader_settings:readSetting("reader_footer_mode")
+    footer_presets[preset_name].reader_footer_custom_text = G_reader_settings:readSetting("reader_footer_custom_text")
+    footer_presets[preset_name].reader_footer_custom_text_repetitions = G_reader_settings:readSetting("reader_footer_custom_text_repetitions")
     G_reader_settings:saveSetting("footer_presets", footer_presets)
 end
 
@@ -1977,7 +1982,20 @@ function ReaderFooter:loadFromNamedPreset(preset_name)
     local preset = footer_presets[preset_name]
     if preset and next(preset) then -- only load if preset exists and is not empty
         self.settings = util.tableDeepCopy(preset)
-         -- Apply loaded settings
+        -- Also load additional footer-related settings that were saved
+        if preset.reader_footer_mode then
+            G_reader_settings:saveSetting("reader_footer_mode", preset.reader_footer_mode)
+            self.mode = preset.reader_footer_mode
+        end
+        if preset.reader_footer_custom_text then
+            G_reader_settings:saveSetting("reader_footer_custom_text", preset.reader_footer_custom_text)
+            self.custom_text = preset.reader_footer_custom_text
+        end
+        if preset.reader_footer_custom_text_repetitions then
+            G_reader_settings:saveSetting("reader_footer_custom_text_repetitions", preset.reader_footer_custom_text_repetitions)
+            self.custom_text_repetitions = preset.reader_footer_custom_text_repetitions
+        end
+        -- Apply loaded settings
         self:updateFooterTextGenerator()
         self:refreshFooter(true, true)
         G_reader_settings:saveSetting("footer", self.settings)


### PR DESCRIPTION
### what's new

This PR seeks to enhance the status bar admin, recently I found myself in a situation where my usual status bar was simply inadequate for the content and was therefore forced to make some adjustments, but hey, I now need to remember what settings I had before and.. I ain't got time for that. So PRESETS yay!

Users will be able to save multiple presets and switch to them simply by selecting them, that's it. 
This allows for things like: having a status bar specifically for PDFs and another for ePUB, or another for when on Landscape mode, etc.

### changes


* Added a new menu item "Status bar presets" to the status bar menu, enabling users to manage named presets for status bar settings.
* Implemented `getNamedPresetMenuItems` to dynamically generate menu items for creating, loading, updating, and deleting named presets.
* Added helper methods:
  - [`createPresetFromCurrentSettings`](diffhunk://#diff-4038ff488983c6e982c7a1599a70800196fcb0cd9cf43071e4fd354286afaa8dR1893-R2004): Allows users to save the current settings as a new preset.
  - [`saveToNamedPreset`](diffhunk://#diff-4038ff488983c6e982c7a1599a70800196fcb0cd9cf43071e4fd354286afaa8dR1893-R2004): Saves a preset with a specific name.
  - [`loadFromNamedPreset`](diffhunk://#diff-4038ff488983c6e982c7a1599a70800196fcb0cd9cf43071e4fd354286afaa8dR1893-R2004): Loads and applies a named preset.
* Updated the `progress_style_thin` setting to default to `false` instead of `nil` when toggled, ensuring its entry is maintained in `self.settings`
* Added new dependencies for widgets and utility modules, including `InfoMessage`, `InputDialog`, `MultiConfirmBox`, `ffiUtil`, and `util`.

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/4a53f109-2de2-48f3-806d-d52aadc0412d" width=40% height=40%> 
<img src="https://github.com/user-attachments/assets/def55b5a-14c6-4856-8420-14292ebfb084" width=40% height=40%> 
</p>

<div align="center">
  <img src="https://github.com/user-attachments/assets/b87a2558-8206-43a6-b898-33c4af06df5c" alt="presets" width="400" />
</div>

### related issues


* fixes #12677
* fixes #13002
* fixes #7586
* #11590
* #12572

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13689)
<!-- Reviewable:end -->
