### PR TITLE
Minor changes to PageBrowser/BookMap/ReaderHandmade

### DIFF
--- a/frontend/apps/reader/modules/readerhandmade.lua
+++ b/frontend/apps/reader/modules/readerhandmade.lua
@@ -511,7 +511,7 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
         input = item.title,
         input_hint = _("TOC chapter title"),
         description = T(_([[On page %1.]]), pageno),
-        cursor_at_end = false,
+        cursor_at_end = item_found and true or false, -- cursor at start for new entries for easy manual addition of chapter number
         buttons = {
             {
                 {

--- a/frontend/apps/reader/modules/readerhandmade.lua
+++ b/frontend/apps/reader/modules/readerhandmade.lua
@@ -404,6 +404,11 @@ function ReaderHandMade:updateHighlightDialog()
                     this:onClose()
                     self:addOrEditPageTocItem(nil, nil, selected_text)
                 end,
+                hold_callback = function() -- no dialog: directly creates new TOC item with selection (if none existing)
+                    local selected_text = this.selected_text
+                    this:onClose()
+                    self:addOrEditPageTocItem(nil, nil, selected_text, true)
+               end,
             }
         end)
     else
@@ -454,7 +459,7 @@ function ReaderHandMade:hasPageTocItem(pageno, xpointer)
     return is_match
 end
 
-function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, selected_text)
+function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, selected_text, no_dialog)
     local xpointer, title
     if selected_text then
         -- If we get selected_text, it's from the highlight dialog after text selection
@@ -490,6 +495,7 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
         input = item.title,
         input_hint = _("TOC chapter title"),
         description = T(_([[On page %1.]]), pageno),
+        cursor_at_end = false,
         buttons = {
             {
                 {
@@ -532,12 +538,28 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
                         text = _("Use selected text"),
                         callback = function()
                             -- Just replace the text without saving, to allow editing/fixing it
-                            dialog:setInputText(selected_text.text, nil, false)
+                            dialog:setInputText(selected_text.text, nil, true)
                         end,
                     } or nil,
             } or nil,
         },
     }
+    if no_dialog then
+        if item_found then return true end  -- no changes if existing TOC entry
+        if selected_text then -- via highlight dialog
+            item.title = selected_text.text
+            table.insert(self.toc, idx, item)
+            self.ui:handleEvent(Event:new("UpdateToc"))
+        else -- via Page browser
+            item.title = ""
+            table.insert(self.toc, idx, item)
+            self.ui:handleEvent(Event:new("UpdateToc"))
+            if when_updated_callback then
+                when_updated_callback()
+            end
+        end
+        return true
+    end
     UIManager:show(dialog)
     dialog:onShowKeyboard()
     return true

--- a/frontend/apps/reader/modules/readerhandmade.lua
+++ b/frontend/apps/reader/modules/readerhandmade.lua
@@ -489,6 +489,22 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
             depth = 1, -- we only support 1-level chapters to keep the UX simple
         }
     end
+    if no_dialog then
+        if item_found then return true end  -- no changes if existing TOC entry
+        if selected_text then -- via highlight dialog
+            item.title = selected_text.text
+            table.insert(self.toc, idx, item)
+            self.ui:handleEvent(Event:new("UpdateToc"))
+        else -- via Page browser
+            item.title = ""
+            table.insert(self.toc, idx, item)
+            self.ui:handleEvent(Event:new("UpdateToc"))
+            if when_updated_callback then
+                when_updated_callback()
+            end
+        end
+        return true
+    end
     local dialog
     dialog = InputDialog:new{
         title = item_found and _("Edit custom TOC chapter") or _("Create new custom ToC chapter"),
@@ -544,22 +560,6 @@ function ReaderHandMade:addOrEditPageTocItem(pageno, when_updated_callback, sele
             } or nil,
         },
     }
-    if no_dialog then
-        if item_found then return true end  -- no changes if existing TOC entry
-        if selected_text then -- via highlight dialog
-            item.title = selected_text.text
-            table.insert(self.toc, idx, item)
-            self.ui:handleEvent(Event:new("UpdateToc"))
-        else -- via Page browser
-            item.title = ""
-            table.insert(self.toc, idx, item)
-            self.ui:handleEvent(Event:new("UpdateToc"))
-            if when_updated_callback then
-                when_updated_callback()
-            end
-        end
-        return true
-    end
     UIManager:show(dialog)
     dialog:onShowKeyboard()
     return true

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -83,6 +83,7 @@ function ReaderThumbnail:addToMainMenu(menu_items)
         -- Show the alternative overview mode (which is just a restricted
         -- variation of the main book map) with long-press (let's avoid
         -- adding another item in the crowded first menu).
+        hold_keep_menu_open = false,
         hold_callback = function()
             self:onShowBookMap(true)
         end,

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1332,11 +1332,19 @@ function BookMapWidget:onShowBookMapMenu()
         {{
             text = _("Page browser on tap"),
             checked_func = function()
-                return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
+                if self.overview_mode then 
+                    return G_reader_settings:nilOrTrue("book_map_overview_tap_to_page_browser")
+                else
+                    return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")
+                end
             end,
             align = "left",
             callback = function()
-                G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
+                if self.overview_mode then
+                    return G_reader_settings:flipNilOrTrue("book_map_overview_tap_to_page_browser")
+                else
+                    return G_reader_settings:flipNilOrTrue("book_map_tap_to_page_browser")
+                end
             end,
         }},
         {{
@@ -1412,6 +1420,11 @@ function BookMapWidget:onShowBookMapMenu()
                         self:update()
                     end
                 end,
+                hold_callback = function()
+                    if self:updatePagesPerRow(50, true) then
+                        self:update()
+                    end
+                end,
                 width = plus_minus_width,
             },
             {
@@ -1419,6 +1432,11 @@ function BookMapWidget:onShowBookMapMenu()
                 enabled_func = function() return self.pages_per_row > self.min_pages_per_row end,
                 callback = function()
                     if self:updatePagesPerRow(-10, true) then
+                        self:update()
+                    end
+                end,
+                hold_callback = function()
+                    if self:updatePagesPerRow(-50, true) then
                         self:update()
                     end
                 end,
@@ -1905,7 +1923,7 @@ function BookMapWidget:onTap(arg, ges)
         page = row:getPageAtX(x, true)
     end
     if page then
-        if not G_reader_settings:nilOrTrue("book_map_tap_to_page_browser") then
+        if (self.overview_mode and G_reader_settings:isFalse("book_map_overview_tap_to_page_browser")) or (not self.overview_mode and G_reader_settings:isFalse("book_map_tap_to_page_browser")) then
             self:onClose(true)
             self.ui.link:addCurrentLocationToStack()
             self.ui:handleEvent(Event:new("GotoPage", page))

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -1332,7 +1332,7 @@ function BookMapWidget:onShowBookMapMenu()
         {{
             text = _("Page browser on tap"),
             checked_func = function()
-                if self.overview_mode then 
+                if self.overview_mode then
                     return G_reader_settings:nilOrTrue("book_map_overview_tap_to_page_browser")
                 else
                     return G_reader_settings:nilOrTrue("book_map_tap_to_page_browser")

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -1750,9 +1750,7 @@ function PageBrowserWidget:onThumbnailHold(page, ges)
             align = "left",
             callback = function()
                 UIManager:close(button_dialog)
-                self.ui.handmade:addOrEditPageTocItem(page, function()
-                    self:updateEditableStuff(true)
-                end)
+                self.ui.handmade:addOrEditPageTocItem(page, function() self:updateEditableStuff(true) end)
             end,
             hold_callback = function() -- no dialog: adds empty TOC item if none existing
                 UIManager:close(button_dialog)

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -1010,6 +1010,11 @@ function PageBrowserWidget:onShowMenu()
                         self:updateLayout()
                     end
                 end,
+                hold_callback = function()
+                    if self:updateNbCols(-2, true) then
+                        self:updateLayout()
+                    end
+                end,
                 width = plus_minus_width,
             },
             {
@@ -1017,6 +1022,11 @@ function PageBrowserWidget:onShowMenu()
                 enabled_func = function() return self.nb_cols < self.max_nb_cols end,
                 callback = function()
                     if self:updateNbCols(1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                hold_callback = function()
+                    if self:updateNbCols(2, true) then
                         self:updateLayout()
                     end
                 end,
@@ -1037,6 +1047,11 @@ function PageBrowserWidget:onShowMenu()
                         self:updateLayout()
                     end
                 end,
+                hold_callback = function()
+                    if self:updateNbRows(-2, true) then
+                        self:updateLayout()
+                    end
+                end,
                 width = plus_minus_width,
             },
             {
@@ -1044,6 +1059,11 @@ function PageBrowserWidget:onShowMenu()
                 enabled_func = function() return self.nb_rows < self.max_nb_rows end,
                 callback = function()
                     if self:updateNbRows(1, true) then
+                        self:updateLayout()
+                    end
+                end,
+                hold_callback = function()
+                    if self:updateNbRows(2, true) then
                         self:updateLayout()
                     end
                 end,

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -1734,6 +1734,10 @@ function PageBrowserWidget:onThumbnailHold(page, ges)
                     self:updateEditableStuff(true)
                 end)
             end,
+            hold_callback = function() -- no dialog: adds empty TOC item if none existing
+                UIManager:close(button_dialog)
+                self.ui.handmade:addOrEditPageTocItem(page, function() self:updateEditableStuff(true) end, nil, true)
+            end,
         }})
     end
     if handmade_hidden_flows_edit_enabled then


### PR DESCRIPTION
Discussed [here](https://github.com/koreader/koreader/issues/10433#issuecomment-2439732594), and subsequent comments, with @poire-z. 

Summary of changes: 
1. In Page browser: long-press on <kbd>Start TOC chapter here</kbd> will create empty TOC item; no dialog (if existing TOC item, nothing happens)
2. Similarly in highlight menu: Long press will create the TOC entry without the edit dialog
3. Opening Book map (overview) via long press in top menu will close the menu on launch
4. Book map allows larger page slot width adjustment via long press on +/- buttons
5. Cursor will be placed at start of text when editing Custom TOC chapter titles (not discussed yet)
I found that cursor placement at the front is more convenient in most scenarios. When adding chapter titles from scanned PDFs, the chapter number is often not part of the text (because it is often printed in a larger, stylized form and not part of the OCR'd text). Placing the cursor at the front allows the user to quickly insert just the chapter number in front of the chapter title.
6. Page browser: Long press +/- to add/remove 2 lines/columns at once ([discussion](https://github.com/koreader/koreader/issues/10320#issuecomment-2474811987))
7. Forgot to mention: Regular Book map and Book map (overview) will save separate settings for reader page on tap vs. Page browser on tap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13691)
<!-- Reviewable:end -->
