### PR TITLE
[MovableContainer] allow widget repositioning on non-touch devices

### DIFF
--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -100,11 +100,6 @@ function ButtonDialog:init()
                 table.insert(back_group, "Menu")
                 self.key_events.Close = { { back_group } }
             end
-            if Device:hasKeyboard() or Device:hasScreenKB() then
-                local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
-                self.key_events.MovePositionUp    = { { modifier, "Up" },    event = "MovePosition", args = true }
-                self.key_events.MovePositionDown  = { { modifier, "Down" },  event = "MovePosition", args = false }
-            end
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {
@@ -281,27 +276,6 @@ function ButtonDialog:onShow()
     UIManager:setDirty(self, function()
         return "ui", self.movable.dimen
     end)
-end
-
-function ButtonDialog:onMovePosition(is_moving_up)
-    local screen_h = Screen:getHeight()
-    local dialog_h = self.movable.dimen.h
-    local padding = Size.padding.small
-    local new_y
-    if is_moving_up then
-        new_y = padding
-    else
-        new_y = screen_h - dialog_h - padding
-    end
-    -- Calculate the offset required to position the dialog at new_y
-    local offset = Geom:new{
-        x = self.movable._moved_offset_x, -- keep current x offset
-        y = new_y - self.movable._orig_y,  -- set new y offset
-    }
-    self.movable:setMovedOffset(offset)
-    -- Force a complete screen redraw to ensure the old dialog is cleared
-    UIManager:setDirty("all", "ui")
-    return true
 end
 
 function ButtonDialog:onCloseWidget()

--- a/frontend/ui/widget/buttondialog.lua
+++ b/frontend/ui/widget/buttondialog.lua
@@ -100,6 +100,11 @@ function ButtonDialog:init()
                 table.insert(back_group, "Menu")
                 self.key_events.Close = { { back_group } }
             end
+            if Device:hasKeyboard() or Device:hasScreenKB() then
+                local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+                self.key_events.MovePositionUp    = { { modifier, "Up" },    event = "MovePosition", args = true }
+                self.key_events.MovePositionDown  = { { modifier, "Down" },  event = "MovePosition", args = false }
+            end
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {
@@ -276,6 +281,27 @@ function ButtonDialog:onShow()
     UIManager:setDirty(self, function()
         return "ui", self.movable.dimen
     end)
+end
+
+function ButtonDialog:onMovePosition(is_moving_up)
+    local screen_h = Screen:getHeight()
+    local dialog_h = self.movable.dimen.h
+    local padding = Size.padding.small
+    local new_y
+    if is_moving_up then
+        new_y = padding
+    else
+        new_y = screen_h - dialog_h - padding
+    end
+    -- Calculate the offset required to position the dialog at new_y
+    local offset = Geom:new{
+        x = self.movable._moved_offset_x, -- keep current x offset
+        y = new_y - self.movable._orig_y,  -- set new y offset
+    }
+    self.movable:setMovedOffset(offset)
+    -- Force a complete screen redraw to ensure the old dialog is cleared
+    UIManager:setDirty("all", "ui")
+    return true
 end
 
 function ButtonDialog:onCloseWidget()

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -69,8 +69,8 @@ function MovableContainer:init()
     if Device:hasKeys() and self.is_movable_with_keys then
         if Device:hasKeyboard() or Device:hasScreenKB() then
             local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
-            self.key_events.MovePositionUp    = { { modifier, "Up" },    event = "MovePosition", args = true }
-            self.key_events.MovePositionDown  = { { modifier, "Down" },  event = "MovePosition", args = false }
+            self.key_events.MovePositionTop     = { { modifier, "Up" },    event = "MovePosition", args = true }
+            self.key_events.MovePositionBottom  = { { modifier, "Down" },  event = "MovePosition", args = false }
         end
     end
     if Device:isTouchDevice() and not self.unmovable then
@@ -429,15 +429,15 @@ function MovableContainer:resetEventState()
     self._moving = false
 end
 
-function MovableContainer:onMovePosition(is_moving_up)
+function MovableContainer:onMovePosition(is_moving_to_top)
     if not self.is_movable_with_keys then return false end
     local screen_h = Screen:getHeight()
     local dialog_h = self.dimen.h
     local padding = Size.padding.small
     local new_y
-    if is_moving_up then
+    if is_moving_to_top then
         new_y = padding
-    else -- Move down
+    else -- move down
         new_y = screen_h - dialog_h - padding
     end
     -- Calculate the offset required to position the container at new_y

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -20,6 +20,7 @@ local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Math = require("optmath")
+local Size = require("ui/size")
 local UIManager = require("ui/uimanager")
 local Screen = Device.screen
 local logger = require("logger")
@@ -39,6 +40,8 @@ local MovableContainer = InputContainer:extend{
     -- This can be passed if a MovableContainer should be present (as a no-op),
     -- so we don't need to change the widget layout.
     unmovable = nil,
+    -- Whether this container should be movable with keyboard/dpad
+    is_movable_with_keys = true,
 
     -- Initial position can be set related to an existing widget
     -- 'anchor' should be a Geom object (a widget's 'dimen', or a point), and
@@ -63,6 +66,13 @@ local MovableContainer = InputContainer:extend{
 }
 
 function MovableContainer:init()
+    if Device:hasKeys() and self.is_movable_with_keys then
+        if Device:hasKeyboard() or Device:hasScreenKB() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.MovePositionUp    = { { modifier, "Up" },    event = "MovePosition", args = true }
+            self.key_events.MovePositionDown  = { { modifier, "Down" },  event = "MovePosition", args = false }
+        end
+    end
     if Device:isTouchDevice() and not self.unmovable then
         local range = Geom:new{
             x = 0, y = 0,
@@ -417,6 +427,28 @@ function MovableContainer:resetEventState()
     -- Can be called explicitly to prevent bad widget interactions.
     self._touch_pre_pan_was_inside = false
     self._moving = false
+end
+
+function MovableContainer:onMovePosition(is_moving_up)
+    if not self.is_movable_with_keys then return false end
+    local screen_h = Screen:getHeight()
+    local dialog_h = self.dimen.h
+    local padding = Size.padding.small
+    local new_y
+    if is_moving_up then
+        new_y = padding
+    else -- Move down
+        new_y = screen_h - dialog_h - padding
+    end
+    -- Calculate the offset required to position the container at new_y
+    local offset = Geom:new{
+        x = self._moved_offset_x, -- keep current x offset
+        y = new_y - self._orig_y,  -- set new y offset
+    }
+    self:setMovedOffset(offset)
+    -- Force a complete screen redraw to ensure the old position is cleared
+    UIManager:setDirty("all", "ui")
+    return true
 end
 
 return MovableContainer

--- a/frontend/ui/widget/container/movablecontainer.lua
+++ b/frontend/ui/widget/container/movablecontainer.lua
@@ -429,15 +429,15 @@ function MovableContainer:resetEventState()
     self._moving = false
 end
 
-function MovableContainer:onMovePosition(is_moving_to_top)
+function MovableContainer:onMovePosition(move_to_top)
     if not self.is_movable_with_keys then return false end
     local screen_h = Screen:getHeight()
     local dialog_h = self.dimen.h
     local padding = Size.padding.small
     local new_y
-    if is_moving_to_top then
+    if move_to_top then
         new_y = padding
-    else -- move down
+    else -- move to the bottom
         new_y = screen_h - dialog_h - padding
     end
     -- Calculate the offset required to position the container at new_y

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -735,6 +735,7 @@ function DictQuickLookup:init()
             -- a few things before forwarding them
             "touch", "pan", "pan_release",
         },
+        is_movable_with_keys = false,
         self.dict_frame,
     }
 


### PR DESCRIPTION
### what's new

* Added key event bindings in `MovableContainer:init()` to allow users to move the dialog up or down using keyboard modifiers (`Shift` or `ScreenKB`) combined with arrow keys (`Up` and `Down`). These events trigger the new `MovePosition` event.
* Added a property `is_movable_with_keys` to the MovableContainer class, that allows disabling it on widget where it is not necessary or not desirable, like dictionary widget.
* Introduced the `MovableContainer:onMovePosition(is_moving_to_top)` method to handle dialog repositioning. This method calculates the new vertical position based on the screen height, dialog height, and padding, updates the dialog's offset, and forces a screen redraw to reflect the changes.

### screen recording 

<div align="center">
  <img src="https://github.com/user-attachments/assets/5fe175e9-e612-4b52-9f70-13c7732387b8" alt="buttondialog" width="400" />
</div>

* closes #12596

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13703)
<!-- Reviewable:end -->
