### PR TITLE
OPDS Plugin: Ensure the default download filename is consistent across different platforms.

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -581,6 +581,9 @@ function OPDSBrowser:showDownloads(item)
     if item.author then
         filename = item.author .. " - " .. filename
     end
+    -- Ensure the default download filename is consistent across different platforms. In particular
+    -- this is needed for Process Sync to work correctly if it is configured to rely on file names.
+    filename = filename:gsub('[\\,%/,:,%*,%?,%",%<,%>,%|]','_')local filename_orig = filename
     local filename_orig = filename
     if self.root_catalog_raw_names then
         filename = nil


### PR DESCRIPTION
The OPDS plugin uses util.getSafeFilename() to remove any special characters from the filename for downloads. Tthis function works differently on different platforms, with some characters that are common in book titles (like : and ?) being allowed on some platforms but replaced with _ on others. In particular this breaks Progress Sync if it is configured to rely on filenames and the book title contains any of those special characters.

If the user knows what the problem is it's easy enough to work around by changing the filename, but the default behaviour of silently failing to sync is not a good user experience.

This change gives a better default behaviour by ensuring the default filename when the file is downloaded via OPDS is the same across different platforms, while still letting the user change the filename to include special characters if the platform supports them.