### PR TITLE
Kobo books plugin

### DIFF
--- a/plugins/kobobooks.koplugin/_meta.lua
+++ b/plugins/kobobooks.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "kobobooks",
+    fullname = _("Kobo books"),
+    description = _([[The Kobo books plugin allows you to download your purchased books from the Kobo store.]]),
+}

--- a/plugins/kobobooks.koplugin/core/koboapi.lua
+++ b/plugins/kobobooks.koplugin/core/koboapi.lua
@@ -1,0 +1,455 @@
+local ffiUtil = require("ffi/util")
+local http = require("socket.http")
+local json = require("json")
+local logger = require("logger")
+local ltn12 = require("ltn12")
+local sha2 = require "ffi/sha2"
+local socket = require("socket")
+local socketurl = require("socket.url")
+local socketutil = require("socketutil")
+local util = require("util")
+
+local KOBO_AFFILIATE = "Kobo"
+local KOBO_APPLICATION_VERSION = "4.38.23171"
+local KOBO_DEFAULT_PLATFORM_ID = "00000000-0000-0000-0000-000000000373"
+local KOBO_DISPLAY_PROFILE = "Android"
+local KOBO_DEVICE_MODEL = "Kobo Aura ONE"
+local KOBO_DEVICE_OS = "3.0.35+"
+local KOBO_DEVICE_OS_VERSION = "NA"
+
+-- Most of these can be obtained from https://storeapi.kobo.com/v1/initialization, but if the URLs
+-- change then likely the APIs change too, so we use hardcoding.
+local API_URL_ACTIVATE = "https://auth.kobobooks.com/ActivateOnWeb"
+local API_URL_ACTIVATION_CHECK = "https://auth.kobobooks.com"
+local API_URL_AUTH_DEVICE = "https://storeapi.kobo.com/v1/auth/device"
+local API_URL_AUTH_REFRESH = "https://storeapi.kobo.com/v1/auth/refresh"
+local API_URL_LIBRARY_SYNC = "https://storeapi.kobo.com/v1/library/sync"
+local API_URL_WISHLIST = "https://storeapi.kobo.com/v1/user/wishlist"
+
+local KoboApi = {
+}
+
+local KoboApiState = {
+    access_token = "",
+    device_id = "",
+	library_sync_token = "",
+    refresh_token = "",
+    serial_number = "",
+    user_id = "",
+    user_key = "",
+}
+
+-- This should be in socket.url.
+local function parse_query_string(query)
+    local arguments = {}
+    for key, value in query:gmatch("([^&=]+)=([^&=]*)&?") do
+		key = util.urlDecode(key)
+		value = util.urlDecode(value)
+        if arguments[key] == nil then
+            arguments[key] = {value}
+        else
+            table.insert(arguments[key], value)
+        end
+    end
+    return arguments
+end
+
+local function generateRandomHexDigitString(length)
+	local characters = "0123456789abcdef"
+	local id = ""
+	for i = 1, length do
+		local index = math.random(#characters)
+		id = id .. characters:sub(index, index)
+	end
+	return id
+end
+
+local function areAuthenticationSettingsSet()
+	return string.len(KoboApiState.device_id) > 0 and string.len(KoboApiState.access_token) > 0 and string.len(KoboApiState.refresh_token) > 0
+end
+
+local function getErrorMessageFromApiResponse(json_response)
+	if json_response == nil or json_response["ResponseStatus"] == nil or json_response["ResponseStatus"]["Message"] == nil then
+		return ""
+	else
+		return json_response["ResponseStatus"]["Message"]
+	end
+end
+
+local function makeJsonPostRequest(url, post_data, additional_headers)
+	local json_post_data = json.encode(post_data)
+
+	local headers = {
+		["Content-Type"]   = "application/json",
+		["Content-Length"] = string.len(json_post_data),
+	}
+	if additional_headers ~= nil then
+		for key in pairs(additional_headers) do
+			headers[key] = additional_headers[key]
+		end
+	end
+
+    local sink = {}
+    local request = {
+        url     = url,
+        method  = "POST",
+		headers = headers,
+        source  = ltn12.source.string(json_post_data),
+        sink    = ltn12.sink.table(sink),
+    }
+
+    socketutil:set_timeout()
+    local code, _, status = socket.skip(1, http.request(request))
+    socketutil:reset_timeout()
+    local result_response = table.concat(sink)
+    local _, json_response = pcall(json.decode, result_response)
+	return code, status, json_response
+end
+
+local function callJsonApiInternal(url, http_method, body, additional_headers)
+	local headers = {
+		["Authorization"] = "Bearer " .. KoboApiState.access_token,
+		["Content-Type"]  = "application/json",
+	}
+
+	if additional_headers ~= nil then
+		for key in pairs(additional_headers) do
+			headers[key] = additional_headers[key]
+		end
+	end
+
+    local sink = {}
+    local request = {
+        url     = url,
+        method  = http_method,
+        headers = headers,
+        sink    = ltn12.sink.table(sink),
+    }
+
+	if body ~= nil then
+		local json_body = json.encode(body)
+		request.headers["Content-Length"] = string.len(json_body)
+		request.source = ltn12.source.string(json_body)
+	end
+
+    socketutil:set_timeout()
+    local code, headers, status = socket.skip(1, http.request(request))
+    socketutil:reset_timeout()
+    local json_response = table.concat(sink)
+    local _, response = pcall(json.decode, json_response)
+	return code, response, headers
+end
+
+
+local function callJsonApi(url, http_method, body, additional_headers)
+	local code, response, headers = callJsonApiInternal(url, http_method, body, additional_headers)
+	if code == 401 and response ~= nil and response["ResponseStatus"] ~= nil and response["ResponseStatus"]["ErrorCode"] == "ExpiredToken" then
+		if KoboApi:refreshAuthentication() then
+			code, response, headers = callJsonApiInternal(url, http_method, body, additional_headers)
+		end
+	end
+
+	return code, response, headers
+end
+
+function KoboApi:setApiSettings(settings)
+	for key in pairs(settings) do
+		if KoboApiState[key] ~= nil then
+			KoboApiState[key] = settings[key]
+		end
+	end
+end
+
+-- Return a copy.
+function KoboApi:getApiSettings()
+	local settings = {}
+	for key in pairs(KoboApiState) do
+		settings[key] = KoboApiState[key]
+	end
+	return settings
+end
+
+function KoboApi:isLoggedIn()
+	return #KoboApiState.user_id > 0 and #KoboApiState.user_key > 0
+end
+
+function KoboApi:refreshAuthentication()
+	local post_data = {
+		["AppVersion"] = KOBO_APPLICATION_VERSION,
+		["ClientKey"] = sha2.bin_to_base64(KOBO_DEFAULT_PLATFORM_ID),
+		["PlatformId"] = KOBO_DEFAULT_PLATFORM_ID,
+		["RefreshToken"] = KoboApiState.refresh_token,
+	}
+
+	local additional_headers = {
+		["Authorization"]  = "Bearer " .. KoboApiState.access_token,
+	}
+
+	local code, status, json_response = makeJsonPostRequest(API_URL_AUTH_REFRESH, post_data, additional_headers)
+	if json_response[ "TokenType" ] ~= "Bearer" then
+		logger.warn("KoboApi: authentication refresh returned with an unsupported token type: ", json_response[ "TokenType" ])
+		return false
+	end
+
+	KoboApiState.access_token = json_response[ "AccessToken" ]
+	KoboApiState.refresh_token = json_response[ "RefreshToken" ]
+	if not areAuthenticationSettingsSet() then
+		logger.warn("KoboApi: authentication settings are not set after authentication refresh." )
+		return false
+	end
+
+	return true
+end
+
+function KoboApi:waitTillActivation(activation_check_url)
+	while true do
+		local code, status, json_response = makeJsonPostRequest(activation_check_url, {})
+		if code ~= 200 then
+			logger.err("KoboApi: activation check returned with HTTP response code " .. code .. ".")
+			return nil, nil
+		end
+
+		if json_response == nil then
+			logger.err("KoboApi: error checking the activation's status. The response is not JSON.")
+			return nil, nil
+		end
+
+		if json_response["Status"] == "Complete" then
+			-- RedirectUrl looks like this:
+			-- kobo://UserAuthenticated?returnUrl=https%3A%2F%2Fwww.kobo.com%2Fww%2Fen%2F&userKey=...&userId=...&email=...
+			local redirect_url = json_response["RedirectUrl"]
+			local parsed = socketurl.parse(redirect_url)
+			local parsed_queries = parse_query_string(parsed.query)
+			if parsed_queries["userId"] == nil and #parsed_queries["userId"] ~= 1 then
+				logger.err("KoboApi: the redirect URL does not contain the user ID.")
+				return nil, nil
+			end
+			if parsed_queries["userKey"] == nil and #parsed_queries["userKey"] ~= 1 then
+				logger.err("KoboApi: the redirect URL does not contain the user key.")
+				return nil, nil
+			end
+			return parsed_queries["userId"][1], parsed_queries["userKey"][1]
+		end
+
+		ffiUtil.sleep(5)
+	end
+end
+
+function KoboApi:activateOnWeb()
+	KoboApiState.access_token = ""
+	KoboApiState.device_id = generateRandomHexDigitString(64)
+	KoboApiState.library_sync_token = ""
+	KoboApiState.refresh_token = ""
+	KoboApiState.serial_number = generateRandomHexDigitString(32)
+	KoboApiState.user_id = ""
+	KoboApiState.user_key = ""
+
+	local query =
+	    "?pwspid=" .. util.urlEncode(KOBO_DEFAULT_PLATFORM_ID) ..
+		"&wsa=" .. util.urlEncode(KOBO_AFFILIATE) ..
+		"&pwsdid=" .. util.urlEncode(KoboApiState.device_id) ..
+		"&pwsav=" .. util.urlEncode(KOBO_APPLICATION_VERSION) ..
+		"&pwsdm=" .. util.urlEncode(KOBO_DEFAULT_PLATFORM_ID) .. -- In the Android app this is the device model but Nickel sends the platform ID...
+		"&pwspos=" .. util.urlEncode(KOBO_DEVICE_OS) ..
+		"&pwspov=" .. util.urlEncode(KOBO_DEVICE_OS_VERSION)
+
+    local sink = {}
+    local request = {
+        url    = API_URL_ACTIVATE .. query,
+        method = "GET",
+        sink   = ltn12.sink.table(sink),
+    }
+
+    socketutil:set_timeout()
+    local code, _, status = socket.skip(1, http.request(request))
+    socketutil:reset_timeout()
+    local response_body = table.concat(sink)
+
+	if code ~= 200 then
+		logger.err("KoboApi: activation returned with HTTP response code " .. code .. ".")
+		return nil, nil
+	end
+
+	local activation_check_path = response_body:match('data%-poll%-endpoint="([^"]+)"')
+	if activation_check_path == nil then
+		logger.err("KoboApi: can't find the activation poll endpoint in the response. The page format might have changed.")
+		return nil, nil
+	end
+	-- NOTE: activation_check_path should be HTML unescaped here but currently it does not contain anything special, so this will work for now.
+	local activation_check_url = API_URL_ACTIVATION_CHECK .. activation_check_path
+
+	local activation_code = response_body:match("qrcodegenerator/generate.+%%26code%%3D(%d+)")
+	if activation_code == nil then
+		logger.err("KoboApi: can't find the activation code in the response. The page format might have changed.")
+		return nil, nil
+	end
+
+	return activation_check_url, activation_code
+end
+
+function KoboApi:authenticateDevice(user_id, user_key)
+	if #KoboApiState.device_id == 0 then
+		logger.err("KoboApi: device ID is empty, cannot start device authentication.")
+		return false
+	end
+	if #KoboApiState.serial_number == 0 then
+		logger.err("KoboApi: serial number is empty, cannot start device authentication.")
+		return false
+	end
+	if #user_id == 0 then
+		logger.err("KoboApi: user ID is empty, cannot start device authentication.")
+		return false
+	end
+	if #user_key == 0 then
+		logger.err("KoboApi: user key is empty, cannot start device authentication.")
+		return false
+	end
+
+	local post_data = {
+		["AffiliateName"] = KOBO_AFFILIATE,
+		["AppVersion"] = KOBO_APPLICATION_VERSION,
+		["ClientKey"] = sha2.bin_to_base64(KOBO_DEFAULT_PLATFORM_ID),
+		["DeviceId"] = KoboApiState.device_id,
+		["PlatformId"] = KOBO_DEFAULT_PLATFORM_ID,
+		["SerialNumber"] = KoboApiState.serial_number,
+		["UserKey"] = user_key,
+	}
+
+	local code, status, json_response = makeJsonPostRequest(API_URL_AUTH_DEVICE, post_data)
+
+	if code ~= 200 then
+		logger.err("KoboApi: device authentication returned with HTTP response code " .. code .. ".")
+		return false
+	end
+
+	if json_response["TokenType"] ~= "Bearer" then
+		logger.err("KoboApi: device authentication returned with an unsupported token type: \"" .. json_response["TokenType"] .. "\".")
+		return false
+	end
+
+	KoboApiState.access_token = json_response["AccessToken"]
+	KoboApiState.refresh_token = json_response["RefreshToken"]
+	if not areAuthenticationSettingsSet() then
+		logger.err("KoboApi: authentication settings are not set after device authentication.")
+	end
+
+	KoboApiState.user_id = user_id
+	KoboApiState.user_key = json_response["UserKey"]
+	return true
+end
+
+function KoboApi:getWishlist()
+    local items = {}
+    local current_page_index = 0
+
+    while true do
+		-- 100 is the default if PageSize is not specified
+		local url = API_URL_WISHLIST .. "?PageIndex=" .. current_page_index .. "&PageSize=100"
+
+		local code, response = callJsonApi(url, "GET")
+		if code ~= 200 then
+			logger.err("KoboApi: failed to GET user/wishlist. HTTP response code: " .. code .. ", message: ", getErrorMessageFromApiResponse(response))
+			return nil
+		end
+
+		for _, item in ipairs(response["Items"]) do
+        	table.insert(items, item)
+		end
+
+        current_page_index = current_page_index + 1
+        if current_page_index >= response["TotalPageCount"] then
+            break
+        end
+    end
+
+    return items
+end
+
+function KoboApi:getLibrarySync()
+    local items = {}
+
+    while true do
+		local additional_headers = nil
+		if #KoboApiState.library_sync_token > 0 then
+			additional_headers = {
+				["x-kobo-synctoken"] = KoboApiState.library_sync_token
+			}
+		end
+
+		local url = API_URL_LIBRARY_SYNC .. "?Filter=ALL&DownloadUrlFilter=Generic,Android&PrioritizeRecentReads=true"
+		local code, response, response_headers = callJsonApi(url, "GET", nil, additional_headers)
+		if code ~= 200 then
+			logger.err("KoboApi: failed to GET library/sync. HTTP response code: " .. code .. ", message: ", getErrorMessageFromApiResponse(response))
+			return nil
+		end
+
+		for _, item in ipairs(response) do
+        	table.insert(items, item)
+		end
+
+		if response_headers ~= nil and response_headers["x-kobo-synctoken"] ~= nil then
+			KoboApiState.library_sync_token = response_headers["x-kobo-synctoken"]
+		end
+
+		if response_headers == nil or response_headers["x-kobo-sync"] == nil or response_headers["x-kobo-sync"] ~= "continue" then
+			break
+		end
+    end
+
+    return items
+end
+
+function KoboApi:download(url, file_path)
+	-- We could simply use automatic redirection here and get the content keys separately from
+	-- https://storeapi.kobo.com/v1/products/books/{product_id}/access but Nickel also does it this way.
+	socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+	local code, headers, status = socket.skip(1, http.request {
+		url  = url,
+		sink = ltn12.sink.file(io.open(file_path, "w")),
+		redirect = false, -- do not handle redirect automatically
+	})
+	socketutil:reset_timeout()
+
+	-- If this is a redirection then the first response contains the link to the content keys.
+	local content_keys = nil
+	if code == 302 then -- redirected
+		local redirect_url = headers["location"]
+		if redirect_url == nil then
+			return false, content_keys, code, headers, status
+		end
+
+		-- Get the content keys.
+		if headers["link"] ~= nil then
+			-- Example link format (see the standard at https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link):
+			-- <https://storedownloads.kobo.com/download/key?downloadToken=...>; rel="http://storedownloads.kobo.com/content/relations/keys"
+			local content_keys_url = string.gsub(headers["link"], "<([^>]+)>.*", "%1")
+
+			local sink = {}
+			local request = {
+				url  = content_keys_url,
+				sink = ltn12.sink.table(sink),
+			}
+
+			socketutil:set_timeout()
+			code, headers, status = socket.skip(1, http.request(request))
+			socketutil:reset_timeout()
+			if code ~= 200 then
+				return false, content_keys, code, headers, status
+			end
+			local json_response = table.concat(sink)
+			local _, response = pcall(json.decode, json_response)
+			content_keys = response["Keys"]
+		end
+
+		socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+		code, headers, status = socket.skip(1, http.request {
+			url  = redirect_url,
+			sink = ltn12.sink.file(io.open(file_path, "w")),
+		})
+		socketutil:reset_timeout()
+	end
+
+	return code == 200, content_keys, code, headers, status
+end
+
+return KoboApi

--- a/plugins/kobobooks.koplugin/core/kobodb.lua
+++ b/plugins/kobobooks.koplugin/core/kobodb.lua
@@ -1,0 +1,571 @@
+local DataStorage = require("datastorage")
+local json = require("json")
+local logger = require("logger")
+local SQ3 = require("lua-ljsqlite3/init")
+
+local function getBookAuthor(book_json)
+    local contributors = book_json["ContributorRoles"]
+
+    local authors = {}
+    for _, contributor in ipairs(contributors) do
+        local role = contributor["Role"]
+        if role == "Author" then
+            local name = contributor["Name"]
+            if name ~= nil then
+                table.insert(authors, contributor["Name"])
+            end
+        end
+    end
+
+    -- Unfortunately the role field is not filled out in the data returned by the "library_sync" endpoint, so we only
+    -- use the first author and hope for the best. Otherwise we would get non-main authors too. For example Christopher
+    -- Buckley beside Joseph Heller for the -- terrible -- novel Catch-22.
+    if #authors == 0 and #contributors > 0 then
+        local name = contributors[1]["Name"]
+        if name ~= nil then
+            table.insert(authors, name)
+        end
+    end
+
+    return table.concat(authors, " & ")
+end
+
+local function getReadingState(reading_state_json)
+    local book_read = 0
+    local last_time_finished = nil
+    local status_info = reading_state_json["StatusInfo"]
+    if status_info ~= nil and status_info["Status"] == "Finished" then
+        book_read = 1
+        last_time_finished = status_info["LastTimeFinished"]
+    end
+    return book_read, last_time_finished
+end
+
+local function synchronizeBooksInDatabaseNewEntitlement(new_entitlement, statement)
+    local book_entitlement = new_entitlement["BookEntitlement"]
+    if book_entitlement == nil then
+        if new_entitlement["AudiobookEntitlement"] == nil then
+            logger.warn("KoboDb: missing BookEntitlement from JSON: ", json.encode(new_entitlement))
+        end
+        return
+    end
+
+    local entitlement_id = book_entitlement["Id"]
+    if entitlement_id == nil or #entitlement_id == 0 then
+        logger.warn("KoboDb: missing EntitlementId from JSON: ", json.encode(new_entitlement))
+        return
+    end
+
+    local book_metadata = new_entitlement["BookMetadata"]
+    if book_metadata == nil then
+        logger.warn("KoboDb: missing BookMetadata from JSON: ", json.encode(new_entitlement))
+        return
+    end
+
+    local title = book_metadata["Title"]
+    if title == nil or #title == 0 then
+        logger.warn("KoboDb: missing Title from JSON: ", json.encode(new_entitlement))
+        return
+    end
+
+    local reading_state = new_entitlement["ReadingState"]
+    local reading_state_json_text = ""
+    local book_read = 0
+    local last_time_finished = nil
+    if reading_state ~= nil then
+        reading_state_json_text = json.encode(reading_state)
+        book_read, last_time_finished = getReadingState(reading_state)
+    end
+
+    local archived = 0
+    if book_entitlement["IsRemoved"] then
+        if book_entitlement["IsHiddenFromArchive"] then
+            archived = 2
+        else
+            archived = 1
+        end
+    end
+
+    local book_entitlement_json_text = json.encode(book_entitlement)
+    local book_metadata_json_text = json.encode(book_metadata)
+
+    if entitlement_id ~= nil and #entitlement_id > 0 and title ~= nil and #title > 0 then
+		local author = getBookAuthor(book_metadata)
+        statement:reset():bind(entitlement_id, book_entitlement_json_text, reading_state_json_text, book_metadata_json_text, title, author, archived, book_read, last_time_finished):step()
+    end
+end
+
+local function synchronizeBooksInDatabaseChangedEntitlement(changed_entitlement, statement)
+    local book_entitlement = changed_entitlement["BookEntitlement"]
+    if book_entitlement == nil then
+        if changed_entitlement["AudiobookEntitlement"] == nil then
+            logger.warn("KoboDb: missing BookEntitlement from JSON: ", json.encode(changed_entitlement))
+        end
+        return
+    end
+
+    local entitlement_id = book_entitlement["Id"]
+    if entitlement_id == nil or #entitlement_id == 0 then
+        logger.warn("KoboDb: missing Id from JSON: ", json.encode(changed_entitlement))
+        return
+    end
+
+    -- TODO: Kobo: when a book gets unarchived then its reading state remains stuck as finished. There is no
+    -- ChangedReadingState in library_sync item...
+    local archived = 0
+    if book_entitlement["IsRemoved"] then
+        if book_entitlement["IsHiddenFromArchive"] then
+            archived = 2
+        else
+            archived = 1
+        end
+    end
+
+    local book_entitlement_json_text = json.encode(book_entitlement)
+    statement:reset():bind(book_entitlement_json_text, archived, entitlement_id):step()
+end
+
+local function synchronizeBooksInDatabaseChangedReadingState(changed_reading_state, statement)
+    local reading_state = changed_reading_state["ReadingState"]
+    if reading_state == nil then
+        logger.warn("KoboDb: missing ReadingState from JSON: ", json.encode(changed_reading_state))
+        return
+    end
+
+    local entitlement_id = reading_state["EntitlementId"]
+    if entitlement_id == nil or #entitlement_id == 0 then
+        logger.warn("KoboDb: missing EntitlementId from JSON: ", json.encode(changed_reading_state))
+        return
+    end
+
+    local reading_state_json_text = json.encode(reading_state)
+    local book_read, last_time_finished = getReadingState(reading_state)
+    statement:reset():bind(reading_state_json_text, book_read, last_time_finished, entitlement_id):step()
+end
+
+local function synchronizeBooksInDatabaseChangedProductMetadata(changed_product_metadata, statement)
+    local book_metadata = changed_product_metadata["BookMetadata"]
+    if book_metadata == nil then
+        logger.warn("KoboDb: missing BookMetadata from JSON: ", json.encode(changed_product_metadata))
+        return
+    end
+
+    local entitlement_id = book_metadata["EntitlementId"]
+    if entitlement_id == nil or #entitlement_id == 0 then
+        logger.warn("KoboDb: missing EntitlementId from JSON: ", json.encode(changed_product_metadata))
+        return
+    end
+
+    local title = book_metadata["Title"]
+    if title == nil or #title == 0 then
+        logger.warn("KoboDb: missing Title from JSON: ", json.encode(changed_product_metadata))
+        return
+    end
+
+    local author = getBookAuthor(book_metadata)
+    local book_metadata_json_text = json.encode(book_metadata)
+    statement:reset():bind(book_metadata_json_text, title, author, entitlement_id):step()
+end
+
+local function synchronizeBooksInDatabaseDeletedEntitlement(deleted_entitlement, statement)
+    local entitlement_id = deleted_entitlement["EntitlementId"]
+    if entitlement_id == nil or #entitlement_id == 0 then
+        logger.warn("KoboDb: missing EntitlementId from JSON: ", json.encode(deleted_entitlement))
+        return
+    end
+
+    statement:reset():bind(entitlement_id):step()
+end
+
+local function refreshWishlistInDatabaseNewItem(item, statement)
+    local product_metadata = item["ProductMetadata"]
+    if product_metadata == nil then
+        logger.warn("KoboDb: missing ProductMetadata from JSON: ", json.encode(item))
+        return
+    end
+
+    local book = product_metadata["Book"]
+    if book == nil then
+        logger.warn("KoboDb: missing Book from JSON: ", json.encode(item))
+        return
+    end
+
+    local cross_revision_id = book["CrossRevisionId"]
+    if cross_revision_id == nil or #cross_revision_id == 0 then
+        logger.warn("KoboDb: missing CrossRevisionId from JSON: ", json.encode(item))
+        return
+    end
+
+    local title = book["Title"]
+    if title == nil or #title == 0 then
+        logger.warn("KoboDb: missing Title from JSON: ", json.encode(item))
+        return
+    end
+
+    local author = getBookAuthor(book)
+    local item_json_text = json.encode(item)
+    local date_added = item["DateAdded"]
+    statement:reset():bind(cross_revision_id, item_json_text, title, author, date_added):step()
+end
+
+local function addDownloadInfo(download_info_list, json_source, format, platform, display_format, file_extension)
+    for _, json_item in ipairs(json_source) do
+        if json_item["Format"] == format and json_item["Platform"] == platform then
+            local url = json_item["Url"]
+            if url ~= nil and #url > 0 then
+                local download_item = {
+                    url = url,
+                    display_format = display_format,
+                    file_extension = file_extension,
+                }
+                table.insert(download_info_list, download_item)
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local KoboDb = {
+	db = nil,
+	db_path =  DataStorage:getDataDir() .. "/cache/kobo-store.sqlite",
+}
+
+function KoboDb:openDb()
+	if self.db ~= nil then
+		return
+	end
+
+    self.db = SQ3.open(self.db_path)
+
+    self.db:exec([[
+        CREATE TABLE IF NOT EXISTS "books" (
+            "entitlement_id"	TEXT NOT NULL UNIQUE COLLATE NOCASE,
+            "book_entitlement_json"	TEXT NOT NULL,
+            "reading_state_json"	TEXT NOT NULL,
+            "book_metadata_json"	TEXT NOT NULL,
+            "title"	TEXT NOT NULL,
+            "author"	TEXT NOT NULL,
+            "archived"	INTEGER NOT NULL,
+            "read"	INTEGER NOT NULL,
+            "last_time_finished"	TEXT,
+            PRIMARY KEY("entitlement_id")
+        );
+
+        CREATE TABLE IF NOT EXISTS "settings" (
+            "key"	TEXT NOT NULL UNIQUE,
+            "value"	TEXT NOT NULL,
+            PRIMARY KEY("key")
+        );
+
+        CREATE TABLE IF NOT EXISTS "wishlist" (
+            "cross_revision_id"	TEXT NOT NULL UNIQUE COLLATE NOCASE,
+            "item_json"	TEXT NOT NULL,
+            "title"	TEXT NOT NULL,
+            "author"	TEXT NOT NULL,
+            "date_added"	TEXT,
+            PRIMARY KEY("cross_revision_id")
+        );
+    ]]);
+end
+
+function KoboDb:closeDb()
+	if self.db == nil then
+		return
+	end
+
+	self.db:close()
+	self.db = nil
+end
+
+function KoboDb:loadApiSettings()
+	local api_settings = {}
+    local db_items = self.db:exec([[
+		SELECT key, value
+		FROM settings
+		WHERE KEY IN ('access_token', 'device_id', 'refresh_token', 'serial_number', 'user_id', 'user_key', 'library_sync_token');
+	]])
+
+    if db_items ~= nil then
+        for i, key in ipairs(db_items.key) do
+            api_settings[key] = db_items.value[i]
+        end
+    end
+
+	return api_settings
+end
+
+function KoboDb:saveApiSettings(new_api_settings)
+	local old_api_settings = self:loadApiSettings()
+    local statement = self.db:prepare([[
+        INSERT OR REPLACE INTO settings
+            (key, value)
+        VALUES (?, ?);
+    ]])
+
+	for key in pairs(new_api_settings) do
+		if new_api_settings[key] ~= old_api_settings[key] then
+			local value = new_api_settings[key]
+            statement:reset():bind(key, value):step()
+		end
+	end
+
+    statement:close()
+end
+
+function KoboDb:getBookInfo(entitlement_id)
+    local statement = self.db:prepare([[
+        SELECT title, author, archived, read, last_time_finished, book_metadata_json
+        FROM books
+        WHERE entitlement_id = ?;
+    ]])
+
+    local db_result = statement:reset():bind(entitlement_id):step()
+    statement:close()
+
+    local title = db_result[1]
+    local author = db_result[2]
+    local archived = db_result[3]
+    local read = db_result[4]
+    local last_time_finished = db_result[5] or ""
+    local _, book_metadata_json = pcall(json.decode, db_result[6])
+
+    local description = book_metadata_json["Description"] or ""
+    local isbn = book_metadata_json["Isbn"] or ""
+    local language = book_metadata_json["Language"] or ""
+    local publication_date = book_metadata_json["PublicationDate"] or ""
+
+    local download_info_list = {}
+    local json_download_urls = book_metadata_json["DownloadUrls"]
+    if json_download_urls ~= nil then
+        if not addDownloadInfo(download_info_list, json_download_urls, "EPUB3", "Generic", "EPUB 3", "epub") then
+            addDownloadInfo(download_info_list, json_download_urls, "KEPUB", "Android", "KEPUB", "epub")
+        end
+    end
+
+    local publisher_name = ""
+    local publisher_imprint = ""
+    if book_metadata_json["Publisher"] ~= nil then
+        publisher_name = book_metadata_json["Publisher"]["Name"] or ""
+        publisher_imprint = book_metadata_json["Publisher"]["Imprint"] or ""
+    end
+
+    local series_name = ""
+    local series_number = ""
+    if book_metadata_json["Series"] ~= nil then
+        series_name = book_metadata_json["Series"]["Name"] or ""
+        series_number = book_metadata_json["Series"]["Number"] or ""
+    end
+
+    if archived ~= 0 then
+        -- Downloading does not work for archived books.
+        download_info_list = {}
+
+        -- These are set in the StatusInfo but not valid if the book is archived.
+        read = 0
+        last_time_finished = ""
+    end
+
+    local book_info = {
+        archived = archived,
+        author = author,
+        date_added_to_wishlist = "", -- to make it compatible with getWishlistItemInfo
+        description = description,
+        download_info_list = download_info_list,
+        isbn = isbn,
+        language = language,
+        last_time_finished_reading = last_time_finished,
+        publication_date = publication_date,
+        publisher_name = publisher_name,
+        publisher_imprint = publisher_imprint,
+        read = read, -- 0 or 1
+        series_name = series_name,
+        series_number = series_number, -- text
+        title = title,
+    }
+
+    return book_info
+end
+
+function KoboDb:getWishlistItemInfo(cross_revision_id)
+    local statement = self.db:prepare([[
+        SELECT title, author, date_added, item_json
+        FROM wishlist
+        WHERE cross_revision_id = ?;
+    ]])
+
+    local db_result = statement:reset():bind(cross_revision_id):step()
+    statement:close()
+
+    local title = db_result[1]
+    local author = db_result[2]
+    local date_added = db_result[3] or ""
+    local _, item_json = pcall(json.decode, db_result[4])
+
+    local product_metadata = item_json["ProductMetadata"] or {}
+    local book = product_metadata["Book"] or {}
+    local description = book["Description"] or ""
+    local isbn = book["ISBN"] or ""
+    local language = book["Language"] or ""
+    local publication_date = book["PublicationDate"] or ""
+
+    local download_info_list = {}
+    local json_download_urls = book["RedirectPreviewUrls"]
+    if json_download_urls ~= nil then
+        if not addDownloadInfo(download_info_list, json_download_urls, "EPUB3_SAMPLE", "Generic", "Sample EPUB 3", "epub") then
+            addDownloadInfo(download_info_list, json_download_urls, "EPUB_SAMPLE", "Android", "Sample EPUB", "epub")
+        end
+    end
+
+    local publisher_name = book["PublisherName"] or ""
+    local series_name = book["SeriesName"] or ""
+    local series_number = book["SeriesNumber"] or ""
+
+    local book_info = {
+        author = author,
+        date_added_to_wishlist = date_added,
+        description = description,
+        download_info_list = download_info_list,
+        isbn = isbn,
+        language = language,
+        last_time_finished_reading = "", -- to make it compatible with getBookInfo
+        publication_date = publication_date,
+        publisher_name = publisher_name,
+        publisher_imprint = "", -- to make it compatible with getBookInfo
+        read = 0, -- to make it compatible with getBookInfo
+        series_name = series_name,
+        series_number = series_number, -- text
+        title = title,
+    }
+
+    return book_info
+end
+
+function KoboDb:getBooks(include_read, include_unread, include_archived)
+    -- NOTE: archived = 2 means hidden
+	local where = "WHERE archived = 0"
+    if include_archived then
+        where = "WHERE archived = 1"
+	elseif include_read and not include_unread then
+		where = "WHERE read = 1 AND archived = 0"
+	elseif not include_read and include_unread then
+		where = "WHERE read = 0 AND archived = 0"
+	elseif not include_read and not include_unread then
+		return {}
+	end
+
+    local books = {}
+    local db_books = self.db:exec(string.format("SELECT entitlement_id, title, author, read FROM books %s;", where))
+    if db_books ~= nil then
+        for i, entitlement_id in ipairs(db_books.entitlement_id) do
+            local book = {
+                entitlement_id = entitlement_id,
+                title = db_books.title[i],
+                author = db_books.author[i]
+            }
+            table.insert(books, book)
+        end
+    end
+
+    return books
+end
+
+function KoboDb:getWishlist()
+    local items = {}
+    local db_items = self.db:exec("SELECT cross_revision_id, title, author FROM wishlist;")
+    if db_items ~= nil then
+        for i, cross_revision_id in ipairs(db_items.cross_revision_id) do
+            local item = {
+                cross_revision_id = cross_revision_id,
+                title = db_items.title[i],
+                author = db_items.author[i]
+            }
+            table.insert(items, item)
+        end
+    end
+
+    return items
+end
+
+function KoboDb:applyLibrarySyncItems(library_sync_items)
+    local new_statement = self.db:prepare([[
+        INSERT OR REPLACE INTO books
+            (entitlement_id, book_entitlement_json, reading_state_json, book_metadata_json, title, author, archived, read, last_time_finished)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+    ]])
+
+    local change_entitlement_statement = self.db:prepare([[
+        UPDATE books
+        SET
+            book_entitlement_json = ?,
+            archived = ?
+        WHERE entitlement_id = ?;
+    ]])
+
+    local change_reading_state_statement = self.db:prepare([[
+        UPDATE books
+        SET
+            reading_state_json = ?,
+            read = ?,
+            last_time_finished = ?
+        WHERE entitlement_id = ?;
+    ]])
+
+    local change_book_metadata_statement = self.db:prepare([[
+        UPDATE books
+        SET
+            book_metadata_json = ?,
+            title = ?,
+            author = ?
+        WHERE entitlement_id = ?;
+    ]])
+
+    local deleted_statement = self.db:prepare([[
+        DELETE FROM books
+        WHERE entitlement_id = ?;
+    ]])
+
+    for _, item in ipairs(library_sync_items) do
+        if item["NewEntitlement"] ~= nil then
+            synchronizeBooksInDatabaseNewEntitlement(item["NewEntitlement"], new_statement)
+        elseif item["ChangedEntitlement"] ~= nil then
+            synchronizeBooksInDatabaseChangedEntitlement(item["ChangedEntitlement"], change_entitlement_statement)
+        elseif item["ChangedReadingState"] ~= nil then
+            synchronizeBooksInDatabaseChangedReadingState(item["ChangedReadingState"], change_reading_state_statement)
+        elseif item["ChangedProductMetadata"] ~= nil then
+            synchronizeBooksInDatabaseChangedProductMetadata(item["ChangedProductMetadata"], change_book_metadata_statement)
+        elseif item["DeletedEntitlement"] ~= nil then
+            synchronizeBooksInDatabaseDeletedEntitlement(item["DeletedEntitlement"], deleted_statement)
+        elseif item["NewTag"] == nil and item["ChangedTag"] == nil then
+            -- TODO: Kobo: can NewTag and ChangedTag used to update the wishlist?
+            logger.warn("KoboDb: unsupported library sync type: ", json.encode(item))
+        end
+    end
+
+    new_statement:close()
+    change_entitlement_statement:close()
+    change_reading_state_statement:close()
+    change_book_metadata_statement:close()
+    deleted_statement:close()
+end
+
+function KoboDb:clearWishlist()
+	self.db:exec("DELETE FROM wishlist;")
+end
+
+function KoboDb:refreshWishlist(wishlist_items)
+    local statement = self.db:prepare([[
+        INSERT OR REPLACE INTO wishlist
+            (cross_revision_id, item_json, title, author, date_added)
+        VALUES (?, ?, ?, ?, ?);
+    ]])
+
+    for _, item in ipairs(wishlist_items) do
+        refreshWishlistInDatabaseNewItem(item, statement)
+    end
+
+    statement:close()
+end
+
+return KoboDb

--- a/plugins/kobobooks.koplugin/core/kobodrm.lua
+++ b/plugins/kobobooks.koplugin/core/kobodrm.lua
@@ -1,0 +1,63 @@
+local crypto = require("ffi/crypto")
+local ffi = require("ffi")
+local sha2 = require "ffi/sha2"
+local ZipReader = require "ffi/zipreader"
+local ZipWriter = require "ffi/zipwriter"
+
+local KoboDrm = {
+}
+
+local function decrypt(content, content_key_base_64, device_id_user_id_key)
+    local content_key = sha2.base64_to_bin(content_key_base_64)
+
+    local content_key_cipher = crypto.get_aes_ecb_cipher(#device_id_user_id_key)
+    local decrypted_content_key, decrypted_content_key_length = crypto.evp_decrypt(content_key_cipher, content_key, device_id_user_id_key)
+    decrypted_content_key = ffi.string(decrypted_content_key, decrypted_content_key_length)
+
+    local content_cipher = crypto.get_aes_ecb_cipher(#decrypted_content_key)
+    local decrypted_content, decrypted_content_length = crypto.evp_decrypt(content_cipher, content, decrypted_content_key)
+    decrypted_content = crypto.pkcs7_unpad(decrypted_content, decrypted_content_length, crypto.get_cipher_block_size(content_cipher))
+
+    return decrypted_content
+end
+
+function KoboDrm:removeKoboDrm(device_id, user_id, content_keys, input_file_path, output_file_path)
+    local device_id_user_id = device_id .. user_id
+    local key = sha2.sha256(device_id_user_id)
+    local device_id_user_id_key = sha2.hex2bin(key.sub(key, 33))
+
+    local zip_reader = ZipReader:new()
+    local zip_reader_open_succeeded, _ = zip_reader:open(input_file_path)
+    if not zip_reader_open_succeeded then
+        return false
+    end
+
+    local zip_writer = ZipWriter:new()
+    local zip_writer_open_succeeded, _ = zip_writer:open(output_file_path)
+    if not zip_writer_open_succeeded then
+        zip_reader:close()
+        return false
+    end
+
+    for _, zip_entry in ipairs(zip_reader.files) do
+        local content = zip_reader:read_file(zip_entry)
+        local name = zip_entry.file_name:gsub("\\", "/")
+        local content_key = content_keys[name]
+        if content_key ~= nil then
+            content = decrypt(content, content_key, device_id_user_id_key)
+            if content == nil then
+                zip_reader:close()
+                zip_writer:close()
+                return false
+            end
+        end
+
+        zip_writer:add(zip_entry.file_name, content)
+    end
+
+    zip_reader:close()
+    zip_writer:close()
+    return true
+end
+
+return KoboDrm

--- a/plugins/kobobooks.koplugin/kobobrowser.lua
+++ b/plugins/kobobooks.koplugin/kobobrowser.lua
@@ -1,0 +1,522 @@
+local BD = require("ui/bidi")
+local ButtonDialog = require("ui/widget/buttondialog")
+local ConfirmBox = require("ui/widget/confirmbox")
+local ffiUtil = require("ffi/util")
+local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local KoboApi = require "core/koboapi"
+local KoboDb = require "core/kobodb"
+local KoboDrm = require "core/kobodrm"
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+local Menu = require("ui/widget/menu")
+local T = require("ffi/util").template
+local UIManager = require("ui/uimanager")
+local util = require("util")
+local _ = require("gettext")
+
+local function formatBookTitle(title, author)
+    if #author > 0 then
+        return author .. ": " .. title
+    else
+        return title
+    end
+end
+
+-- date: input date in a format like this: 2024-08-11T18:58:16.7429913Z
+local function formatDate(date)
+    -- TODO: Kobo: input is UTC, output should be local. Use newsdownloader.koplugin/lib/dateparser?
+    local year, month, day = date:match("(%d+)-(%d+)-(%d+)T")
+    return string.format("%s-%s-%s", year, month, day)
+end
+
+-- The go to parent button is disabled if there are no items, so we always add at least one.
+local function extendEmptyItems(items)
+    if #items > 0 then
+        return items
+    else
+        table.insert(items, {text = "No items"})
+        return items
+    end
+end
+
+local function loadBooks(include_read, include_unread, include_archived)
+    local books = KoboDb:getBooks(include_read, include_unread, include_archived)
+
+    local table_items = {}
+    for _, book in ipairs(books) do
+        local table_item = {
+            text = formatBookTitle(book.title, book.author),
+            type = "book",
+            entitlement_id = book.entitlement_id,
+        }
+        table.insert(table_items, table_item)
+    end
+
+    table.sort(table_items, function(a, b) return ffiUtil.strcoll(a.text, b.text) end)
+    return table_items
+end
+
+local function loadWishlist()
+    local items = KoboDb:getWishlist()
+
+    local table_items = {}
+    for i, item in ipairs(items) do
+        local table_item = {
+            text = formatBookTitle(item.title, item.author),
+            type = "wishlist_item",
+            cross_revision_id = item.cross_revision_id,
+        }
+        table.insert(table_items, table_item)
+    end
+
+    table.sort(table_items, function(a, b) return ffiUtil.strcoll(a.text, b.text) end)
+    return table_items
+end
+
+local function formatBookInformationDialogText(title, book_info)
+    local book_info_text = book_info.title
+
+    if #book_info.author > 0 then
+        book_info_text = book_info_text .. "\nby " .. book_info.author
+    end
+    if #book_info.series_name > 0 then
+        if #book_info.series_number > 0 then
+            book_info_text = book_info_text .. string.format("\nBook %s - %s", book_info.series_number, book_info.series_name)
+        else
+            book_info_text = book_info_text .. "\n" .. book_info.series_name
+        end
+    end
+    if #book_info.description > 0 then
+        book_info_text = book_info_text .. "\n\nDescription:\n"
+        book_info_text = book_info_text .. util.htmlToPlainTextIfHtml(book_info.description) .. "\n"
+    end
+    if #book_info.isbn > 0 then
+        book_info_text = book_info_text .. "\nISBN: " .. book_info.isbn
+    end
+    if #book_info.language > 0 then
+        book_info_text = book_info_text .. "\nLanguage: " .. book_info.language
+    end
+    if #book_info.publication_date > 0 then
+        book_info_text = book_info_text .. "\nPublication date: " .. formatDate(book_info.publication_date)
+    end
+    if #book_info.publisher_name > 0 then
+        book_info_text = book_info_text .. "\nPublisher: " .. book_info.publisher_name
+    end
+    if #book_info.publisher_imprint > 0 then
+        book_info_text = book_info_text .. "\nPublisher imprint: " .. book_info.publisher_imprint
+    end
+    if book_info.read ~= 0 then
+        if #book_info.last_time_finished_reading > 0 then
+            book_info_text = book_info_text .. string.format("\nRead date: %s", formatDate(book_info.last_time_finished_reading))
+        else
+            book_info_text = book_info_text .. "\nRead"
+        end
+    end
+    if #book_info.date_added_to_wishlist > 0 then
+        book_info_text = book_info_text .. string.format("\nWishlisting date: %s", formatDate(book_info.date_added_to_wishlist))
+    end
+
+    return book_info_text
+end
+
+local menu_items = {
+    {text = "Unread books", type = "unread_books"},
+    {text = "Read books", type = "read_books"},
+    {text = "All books", type = "all_books"},
+    {text = "Wishlist", type = "wishlist"},
+    {text = "Archived books", type = "archived_books"},
+    {text = "", type = ""},
+    {text = "Synchronize", type = "synchronize"},
+}
+
+local KoboBrowser = Menu:extend{
+    downloaded_a_book = false,
+}
+
+function KoboBrowser:init()
+    self.item_table = menu_items
+    Menu.init(self) -- call parent's init()
+end
+
+function KoboBrowser:onClose()
+    if self.downloaded_a_book then
+        self.downloaded_a_book = false
+        -- Refresh the file manager if it is open.
+        local FileManager = require("apps/filemanager/filemanager")
+        if FileManager.instance then
+            FileManager.instance:onRefresh()
+        end
+    end
+
+    return Menu.onClose(self)
+end
+
+function KoboBrowser:openBookList(title, include_read, include_unread)
+    local books = loadBooks(include_read, include_unread, false)
+    title = string.format("%s (%d)", title, #books)
+    self.paths = {true}
+    self:switchItemTable(title, extendEmptyItems(books))
+end
+
+function KoboBrowser:openWishlist()
+    local wishlist = loadWishlist()
+    local title = string.format("Wishlist (%d)", #wishlist)
+    self.paths = {true}
+    self:switchItemTable(title, extendEmptyItems(wishlist))
+end
+
+function KoboBrowser:openArchivedBooks()
+    local archivedBooks = loadBooks(false, false, true)
+    local title = string.format("Archived books (%d)", #archivedBooks)
+    self.paths = {true}
+    self:switchItemTable(title, extendEmptyItems(archivedBooks))
+end
+
+function KoboBrowser:loginWaitTillActivation(activation_check_url, finished_callback)
+    local user_id, user_key = KoboApi:waitTillActivation(activation_check_url)
+    if user_id == nil or user_key == nil then
+        UIManager:show(InfoMessage:new{
+            text = "Activation did not finish.",
+            icon = "notice-warning",
+        })
+        finished_callback()
+        return
+    end
+
+    if not KoboApi:authenticateDevice(user_id, user_key) then
+        UIManager:show(InfoMessage:new{
+            text = "Device authentication has failed.",
+            icon = "notice-warning",
+        })
+    end
+
+    finished_callback()
+end
+
+function KoboBrowser:login(finished_callback)
+    local activation_check_url, activation_code = KoboApi:activateOnWeb()
+    if activation_check_url == nil or activation_code == nil then
+        UIManager:show(InfoMessage:new{
+            text = "Failed to start web-based activation.",
+            icon = "notice-warning",
+        })
+        finished_callback()
+        return
+    end
+
+    local activation_message = T(_([[
+The Kobo KOReader plugin uses the same web-based activation method to log in as the Kobo e-readers.
+You will have to open the link below in your browser and enter the code, then you might need to login too if kobo.com asks you to.
+
+Open
+"https://www.kobo.com/activate"
+and enter %1 as the code.
+
+After finishing the activation on kobo.com press the I'm done with activation button below.
+]]), activation_code)
+
+    UIManager:show(ConfirmBox:new{
+        text = activation_message,
+        ok_text = _("I'm done with activation"),
+        ok_callback = function()
+            self:loginWaitTillActivation(activation_check_url, finished_callback)
+        end,
+        cancel_callback = function()
+            finished_callback()
+        end,
+    })
+end
+
+function KoboBrowser:synchronizeBooksAndWishlistInternal()
+    local library_sync_items = KoboApi:getLibrarySync()
+    if library_sync_items == nil then
+        UIManager:show(InfoMessage:new{
+            text = "Failed get library state from Kobo.",
+            icon = "notice-warning",
+        })
+    else
+        KoboDb:applyLibrarySyncItems(library_sync_items)
+    end
+
+    local wishlist_items = KoboApi:getWishlist()
+    if wishlist_items == nil then
+        UIManager:show(InfoMessage:new{
+            text = "Failed get wishlist from Kobo.",
+            icon = "notice-warning",
+        })
+    else
+        KoboDb:clearWishlist()
+        KoboDb:refreshWishlist(wishlist_items)
+    end
+end
+
+function KoboBrowser:synchronizeBooksAndWishlist()
+    UIManager:nextTick(function()
+        UIManager:show(InfoMessage:new{
+            text = _("Synchronizing…"),
+            timeout = 1,
+        })
+    end)
+
+    UIManager:tickAfterNext(function()
+        self:synchronizeBooksAndWishlistInternal()
+    end)
+end
+
+function KoboBrowser:loginAndSynchronizeBooksAndWishlist()
+    if KoboApi:isLoggedIn() then
+        self:synchronizeBooksAndWishlist()
+    else
+        local login_finished = function()
+            if KoboApi:isLoggedIn() then
+                KoboDb:saveApiSettings(KoboApi:getApiSettings())
+                self:synchronizeBooksAndWishlist()
+            end
+        end
+        self:login(login_finished)
+    end
+end
+
+function KoboBrowser:onMenuSelect(item)
+    if item.type == "unread_books" then
+        self:openBookList("Unread books", false, true)
+    elseif item.type == "read_books" then
+        self:openBookList("Read books", true, false)
+    elseif item.type == "all_books" then
+        self:openBookList("All books", true, true)
+    elseif item.type == "wishlist" then
+        self:openWishlist()
+    elseif item.type == "archived_books" then
+        self:openArchivedBooks()
+    elseif item.type == "synchronize" then
+        self:loginAndSynchronizeBooksAndWishlist()
+    elseif item.type == "book" or item.type == "wishlist_item" then
+        self:showBookDialog(item)
+    end
+end
+
+function KoboBrowser:onReturn()
+    self.paths = {}
+    self:switchItemTable("Kobo Catalog", menu_items)
+end
+
+function KoboBrowser.getCurrentDownloadDir()
+    return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
+end
+
+-- Downloads a book (with "File already exists" dialog)
+function KoboBrowser:downloadBook(filename, remote_url)
+    local download_dir = self.getCurrentDownloadDir()
+    filename = util.getSafeFilename(filename, download_dir)
+    local local_path = (download_dir ~= "/" and download_dir or "") .. '/' .. filename
+    local_path = util.fixUtf8(local_path, "_")
+
+    local function download()
+        UIManager:show(InfoMessage:new{
+            text = _("Downloading…"),
+            timeout = 1,
+        })
+
+        -- This is needed otherwise the Downloading… InfoMessage does not appear.
+        UIManager:nextTick(function()
+            local succeeded, content_keys, code, headers, status = KoboApi:download(remote_url, local_path)
+            if succeeded then
+                logger.dbg("File downloaded to", local_path)
+                self:onFileDownloaded(local_path, content_keys)
+            else
+                util.removeFile(local_path)
+                logger.dbg("KoboBrowser:downloadBook: Request failed with HTTP response code: " .. code .. ". Status:", status)
+                logger.dbg("KoboBrowser:downloadBook: Response headers:", headers)
+                UIManager:show(InfoMessage:new {
+                    text = T(_("Could not save file to:\n%1\n%2"),
+                        BD.filepath(local_path),
+                        status or code or "network unreachable"),
+                })
+            end
+        end)
+    end
+
+    if lfs.attributes(local_path) then
+        UIManager:show(ConfirmBox:new{
+            text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filepath(local_path)),
+            ok_text = _("Overwrite"),
+            ok_callback = function()
+                download()
+            end,
+        })
+    else
+        download()
+    end
+end
+
+function KoboBrowser:onFileDownloaded(file_path, content_keys)
+    self.downloaded_a_book = true
+
+    if content_keys ~= nil then
+        logger.dbg("KoboBrowser:onFileDownloaded: removing DRM from", file_path)
+        local api_settings = KoboApi:getApiSettings()
+        local output_file_path = file_path .. ".tmp"
+        if KoboDrm:removeKoboDrm(api_settings.device_id, api_settings.user_id, content_keys, file_path, output_file_path) then
+            os.remove(file_path)
+            os.rename(output_file_path, file_path)
+        else
+            UIManager:show(InfoMessage:new{
+                text = "DRM removal has failed.",
+                icon = "notice-warning",
+            })
+
+            return
+        end
+    end
+
+    UIManager:show(ConfirmBox:new{
+        text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file_path)),
+        ok_text = _("Read now"),
+        cancel_text = _("Read later"),
+        ok_callback = function()
+            local Event = require("ui/event")
+            UIManager:broadcastEvent(Event:new("SetupShowReader"))
+
+            self:onClose()
+
+            local ReaderUI = require("apps/reader/readerui")
+            ReaderUI:showReader(file_path)
+        end,
+    })
+end
+
+function KoboBrowser:showBookDialog(item)
+    -- TODO: Kobo: use more complete description from https://storeapi.kobo.com/v1/products/books/{Id} instead?
+    local book_info = nil
+    if item.type == "book" then
+        book_info = KoboDb:getBookInfo(item.entitlement_id)
+    elseif item.type == "wishlist_item" then
+        book_info = KoboDb:getWishlistItemInfo(item.cross_revision_id)
+    else
+        return -- type is checked on caller's side, so this is impossible
+    end
+
+    local filename = book_info.title
+    if #book_info.author > 0 then
+        filename = book_info.author .. " - " .. book_info.title
+    end
+    if item.type == "wishlist_item" then
+        filename = filename .. " (sample)"
+    end
+    local filename_original = filename
+
+    local function createTitle(path, file) -- title for ButtonDialog
+        return T(_("Download folder:\n%1\n\nDownload filename:\n%2\n\nDownload file type:"), BD.dirpath(path), file)
+    end
+
+    local buttons = {} -- buttons for ButtonDialog
+    local download_buttons = {} -- file type download buttons
+    for _, download_info in ipairs(book_info.download_info_list) do
+        table.insert(download_buttons, {
+            text = download_info.display_format .. "\u{2B07}", -- append DOWNWARDS BLACK ARROW
+            callback = function()
+                self:downloadBook(filename .. "." .. download_info.file_extension, download_info.url)
+                UIManager:close(self.download_dialog)
+            end,
+        })
+    end
+
+    local button_count = #download_buttons
+    if button_count > 0 then
+        if button_count == 1 then -- one wide button
+            table.insert(buttons, download_buttons)
+        else
+            if button_count % 2 == 1 then -- we need even number of buttons
+                table.insert(download_buttons, {text = ""})
+            end
+            for i = 1, button_count, 2 do -- two buttons in a row
+                table.insert(buttons, {download_buttons[i], download_buttons[i+1]})
+            end
+        end
+        table.insert(buttons, {}) -- separator
+    end
+
+    if #book_info.download_info_list > 0 then
+        table.insert(buttons, { -- action buttons
+            {
+                text = _("Choose folder"),
+                callback = function()
+                    require("ui/downloadmgr"):new{
+                        onConfirm = function(path)
+                            logger.dbg("Download folder set to", path)
+                            G_reader_settings:saveSetting("download_dir", path)
+                            self.download_dialog:setTitle(createTitle(path, filename))
+                        end,
+                    }:chooseDir(self.getCurrentDownloadDir())
+                end,
+            },
+            {
+                text = _("Change filename"),
+                callback = function()
+                    local dialog
+                    dialog = InputDialog:new{
+                        title = _("Enter filename"),
+                        input = filename or filename_original,
+                        input_hint = filename_original,
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function()
+                                        UIManager:close(dialog)
+                                    end,
+                                },
+                                {
+                                    text = _("Set filename"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        filename = dialog:getInputValue()
+                                        if filename == "" then
+                                            filename = filename_original
+                                        end
+                                        UIManager:close(dialog)
+                                        self.download_dialog:setTitle(createTitle(self.getCurrentDownloadDir(), filename))
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(dialog)
+                    dialog:onShowKeyboard()
+                end,
+            },
+        })
+    end
+
+    table.insert(buttons, {
+        {
+            text = _("Book information"),
+            callback = function()
+                local TextViewer = require("ui/widget/textviewer")
+                UIManager:show(TextViewer:new{
+                    title = item.text,
+                    title_multilines = true,
+                    text = formatBookInformationDialogText(item.text, book_info),
+                    text_type = "book_info",
+                })
+            end,
+        },
+    })
+
+    local title = "No download links found."
+    if #book_info.download_info_list > 0 then
+        title = createTitle(self.getCurrentDownloadDir(), filename)
+    elseif book_info.archived then
+        title = "This book is archived. You must be move it back to Library if you want to download it."
+    end
+
+    self.download_dialog = ButtonDialog:new{
+        title = title,
+        buttons = buttons,
+    }
+    UIManager:show(self.download_dialog)
+end
+
+return KoboBrowser

--- a/plugins/kobobooks.koplugin/kobocatalog.lua
+++ b/plugins/kobobooks.koplugin/kobocatalog.lua
@@ -1,0 +1,62 @@
+local Blitbuffer = require("ffi/blitbuffer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local KoboBrowser = require("kobobrowser")
+local KoboApi = require "core/koboapi"
+local KoboDb = require "core/kobodb"
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+local Screen = require("device").screen
+
+local KoboCatalog = WidgetContainer:extend{
+}
+
+function KoboCatalog:init()
+    KoboDb:openDb()
+    KoboApi:setApiSettings(KoboDb:loadApiSettings())
+
+    local kobo_browser = KoboBrowser:new{
+        title = _("Kobo books"),
+        show_parent = self,
+        is_popout = false,
+        is_borderless = true,
+        is_enable_shortcut = false,
+        close_callback = function() return self:onClose() end,
+    }
+
+    self[1] = FrameContainer:new{
+        padding = 0,
+        bordersize = 0,
+        background = Blitbuffer.COLOR_WHITE,
+        kobo_browser,
+    }
+end
+
+function KoboCatalog:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self[1].dimen -- i.e., FrameContainer
+    end)
+end
+
+function KoboCatalog:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "ui", self[1].dimen
+    end)
+end
+
+function KoboCatalog:showCatalog()
+    UIManager:show(KoboCatalog:new{
+        dimen = Screen:getSize(),
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
+    })
+end
+
+function KoboCatalog:onClose()
+	KoboDb:saveApiSettings(KoboApi:getApiSettings())
+    KoboDb:closeDb()
+
+    UIManager:close(self)
+    return true
+end
+
+return KoboCatalog

--- a/plugins/kobobooks.koplugin/main.lua
+++ b/plugins/kobobooks.koplugin/main.lua
@@ -1,0 +1,26 @@
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+
+local KoboBooks = WidgetContainer:extend{
+    name = "kobobooks",
+    is_doc_only = false, -- show in the menu even if no book is open in the reader
+}
+
+function KoboBooks:init()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function KoboBooks:showCatalog()
+    local KoboCatalog = require("kobocatalog")
+    KoboCatalog:showCatalog()
+end
+
+function KoboBooks:addToMainMenu(menu_items)
+	menu_items.kobobooks = {
+		text = _("Kobo books"),
+        sorting_hint = "main", -- in which menu this should be appended
+		callback = function() self:showCatalog() end
+	}
+end
+
+return KoboBooks


### PR DESCRIPTION
This plugin supports the following:
- viewing the list of read, unread, archived and wishlisted Kobo books
- viewing book information (description, language, publication date, publisher name, ISBN, last read date, wishlisting date)
- downloading purchased and Kobo Plus books

Depends on:
https://github.com/koreader/koreader-base/pull/2070
https://github.com/koreader/koreader-base/pull/2071

Some screenshots:
![kobo-books-main](https://github.com/user-attachments/assets/572a0f5a-fe61-4a29-b3c5-90f820d3b312)
![kobo-books-unread](https://github.com/user-attachments/assets/0f387ede-f804-4603-94b8-201eef18fe25)
![kobo-books-download](https://github.com/user-attachments/assets/e7d8810b-a520-41de-b5f4-5b7b1c60eef5)
![kobo-books-book-information](https://github.com/user-attachments/assets/1b088979-99c1-42c7-9374-c7b1e50d0619)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13726)
<!-- Reviewable:end -->
