### PR TITLE
Fix file transfer from Calibre to Remarkable Paper Pro

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -920,7 +920,7 @@ end
 function util.diskUsage(dir)
     -- safe way of testing df & awk
     local function doCommand(d)
-        local handle = io.popen("df -k " .. util.shell_escape({d}) .. " 2>/dev/null | awk '$3 ~ /[0-9]+/ { print $2,$3,$4 }' 2>/dev/null || echo ::ERROR::")
+        local handle = io.popen("df -kP " .. util.shell_escape({d}) .. " 2>/dev/null | awk '$3 ~ /[0-9]+/ { print $2,$3,$4 }' 2>/dev/null || echo ::ERROR::")
         if not handle then return end
         local output = handle:read("*all")
         handle:close()


### PR DESCRIPTION
The output of df wraps on to multiple lines on the rmpp due to the device mapped mount points. Enabling the posix -P option to df prevents this and allow the output to be parsed as normal.

Closes #13731

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13732)
<!-- Reviewable:end -->
