### PR TITLE
[ScreenSaver] handle case where a file is lastfile but has now been reset

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -468,16 +468,18 @@ function Screensaver:setup(event, event_message)
     local ReaderUI = require("apps/reader/readerui")
     local ui = ReaderUI.instance
     local lastfile = G_reader_settings:readSetting("lastfile")
+    local is_document_cover = false
     if self.screensaver_type == "document_cover" then
         -- Set lastfile to the document of which we want to show the cover.
         lastfile = G_reader_settings:readSetting("screensaver_document_cover")
         self.screensaver_type = "cover"
-        self.is_document_cover = true
+        is_document_cover = true
     end
     if self.screensaver_type == "cover" then
         local excluded
-        if not self.is_document_cover and lastfile then
-            local exclude_finished_book, exclude_on_hold_book
+        if not is_document_cover and lastfile then
+            local exclude_finished_book
+            local exclude_on_hold_book
             local exclude_book_in_fm = not ui and G_reader_settings:isTrue("screensaver_hide_cover_in_filemanager")
             if BookList.hasBookBeenOpened(lastfile) then
                 local doc_settings

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -476,21 +476,24 @@ function Screensaver:setup(event, event_message)
     end
     if self.screensaver_type == "cover" then
         local excluded
-        if lastfile and BookList.hasBookBeenOpened(lastfile) then
-            local doc_settings
-            if ui and ui.doc_settings then
-                doc_settings = ui.doc_settings
-            else
-                doc_settings = BookList.getDocSettings(lastfile)
-            end
-            excluded = doc_settings:isTrue("exclude_screensaver")
-
-            local book_summary = doc_settings:readSetting("summary")
-            local book_finished = book_summary and book_summary.status == "complete"
-            local book_on_hold = book_summary and book_summary.status == "abandoned"
-            local exclude_finished_book = G_reader_settings:isTrue("screensaver_exclude_finished_books") and book_finished
-            local exclude_on_hold_book = G_reader_settings:isTrue("screensaver_exclude_on_hold_books") and book_on_hold
+        if not self.is_document_cover and lastfile then
+            local exclude_finished_book, exclude_on_hold_book
             local exclude_book_in_fm = not ui and G_reader_settings:isTrue("screensaver_hide_cover_in_filemanager")
+            if BookList.hasBookBeenOpened(lastfile) then
+                local doc_settings
+                if ui and ui.doc_settings then
+                    doc_settings = ui.doc_settings
+                else
+                    doc_settings = BookList.getDocSettings(lastfile)
+                end
+                excluded = doc_settings:isTrue("exclude_screensaver")
+
+                local book_summary = doc_settings:readSetting("summary")
+                local book_finished = book_summary and book_summary.status == "complete"
+                local book_on_hold = book_summary and book_summary.status == "abandoned"
+                exclude_finished_book = G_reader_settings:isTrue("screensaver_exclude_finished_books") and book_finished
+                exclude_on_hold_book = G_reader_settings:isTrue("screensaver_exclude_on_hold_books") and book_on_hold
+            end
             local should_exclude_book = exclude_book_in_fm or exclude_finished_book or exclude_on_hold_book
             if should_exclude_book then
                 excluded = true

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -472,6 +472,7 @@ function Screensaver:setup(event, event_message)
         -- Set lastfile to the document of which we want to show the cover.
         lastfile = G_reader_settings:readSetting("screensaver_document_cover")
         self.screensaver_type = "cover"
+        self.is_document_cover = true
     end
     if self.screensaver_type == "cover" then
         local excluded
@@ -496,6 +497,11 @@ function Screensaver:setup(event, event_message)
                 self.show_message = false
             end
         else
+            if not self.is_document_cover and lastfile then
+                -- book was the last file opened but has now been reset (i.e marked unopened)
+                lastfile = nil
+                self.show_message = false
+            end
             -- No DocSetting, not excluded
             excluded = false
         end

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -500,11 +500,6 @@ function Screensaver:setup(event, event_message)
                 self.show_message = false
             end
         else
-            if not self.is_document_cover and lastfile then
-                -- book was the last file opened but has now been reset (i.e marked unopened)
-                lastfile = nil
-                self.show_message = false
-            end
             -- No DocSetting, not excluded
             excluded = false
         end


### PR DESCRIPTION
### bug fix:

* Added a new flag `is_document_cover` to track whether the screensaver is displaying a document cover (`frontend/ui/screensaver.lua`).
* Updated the logic to reset `lastfile` and disable `show_message` if the last opened file has been marked as unopened and the screensaver is not displaying a document cover (`frontend/ui/screensaver.lua`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13747)
<!-- Reviewable:end -->
