### PR TITLE
Add PocketBook Verse Lite (PB619)

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -873,7 +873,7 @@ elseif codename == "617" then
 elseif codename == "618" then
     return PocketBook618
 elseif codename == "619" then
-    return PocketBook619    
+    return PocketBook619
 elseif codename == "622" then
     return PocketBook622
 elseif codename == "623" then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -545,6 +545,14 @@ local PocketBook618 = PocketBook:extend{
     display_dpi = 212,
 }
 
+-- PocketBook Verse Lite (619)
+local PocketBook619 = PocketBook:extend{
+    model = "PBVerseLite",
+    display_dpi = 212,
+    isAlwaysPortrait = yes,
+    hasKeys = no,
+}
+
 -- PocketBook Touch (622)
 local PocketBook622 = PocketBook:extend{
     model = "PBTouch",
@@ -864,6 +872,8 @@ elseif codename == "617" then
     return PocketBook617
 elseif codename == "618" then
     return PocketBook618
+elseif codename == "619" then
+    return PocketBook619    
 elseif codename == "622" then
     return PocketBook622
 elseif codename == "623" then


### PR DESCRIPTION
Add new PocketBook Verse Lite (PB619)

before: [crash.log](https://github.com/user-attachments/files/20127316/crash.log)
after: [crash.log](https://github.com/user-attachments/files/20127324/crash_1.log)

Picture:
![Verse Lite](https://github.com/user-attachments/assets/07fc812c-de6c-45e9-a22f-799132fdc9ef)

Technical Details:
Device: https://pocketbook.de/en/pocketbook-verse-lite
Model No.: PB619
Display Type: E-Ink Carta™
Display Resolution: 758 × 1024
Display Size: 6 inches (15.24 cm)
DPI: 212
Color Depth: 16 Grayscales
Touchscreen: Capacitive (Multi-Sensor)
Frontlight: Yes
SMARTlight: No
Processor: Dual-Core (2 × 1 GHz)
RAM: 512 MB
Internal Storage: 8 GB
Battery: Lithium-ion polymer battery, 1000 mAh
Position Sensor: Yes
Page Scrolling Buttons: No
Sleep Cover Function: Yes
Wi-Fi: Yes (2.4 GHz)
USB Port: Yes (USB-C)
Expandable Storage: No
USB OTG: No
Operating System: Linux 3.10.65

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13760)
<!-- Reviewable:end -->
