### PR TITLE
[SDL] set useDPadAsActionKeys flag with DISABLE_TOUCH

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -70,6 +70,7 @@ local Device = Generic:extend{
     hasKeys = yes,
     hasSymKey = os.getenv("DISABLE_TOUCH") == "1" and yes or no,
     hasDPad = yes,
+    useDPadAsActionKeys = os.getenv("DISABLE_TOUCH") == "1" and yes or no,
     hasWifiToggle = no,
     hasSeamlessWifiToggle = no,
     isTouchDevice = yes,


### PR DESCRIPTION
This change adds the property, `useDPadAsActionKeys`, to the  SDL `Device` object, allowing to emulate [more closely now] a non-touch kindle device with `./kodev run -t`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13769)
<!-- Reviewable:end -->
