### PR TITLE
Add option to start SSH server with KOReader

### DIFF
--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -29,11 +29,21 @@ local SSH = WidgetContainer:extend{
 function SSH:init()
     self.SSH_port = G_reader_settings:readSetting("SSH_port") or "2222"
     self.allow_no_password = G_reader_settings:isTrue("SSH_allow_no_password")
+    self.autostart = G_reader_settings:isTrue("SSH_autostart")
+
+    if self.autostart then
+        self:start()
+    end
+
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end
 
 function SSH:start()
+    if self:isRunning() then
+        return
+    end
+
     local cmd = string.format("%s %s %s %s%s %s",
         "./dropbear",
         "-E",
@@ -198,6 +208,15 @@ function SSH:addToMainMenu(menu_items)
                 callback = function()
                     self.allow_no_password = not self.allow_no_password
                     G_reader_settings:flipNilOrFalse("SSH_allow_no_password")
+                end,
+            },
+            {
+                text = _("Start SSH server with KOReader"),
+                checked_func = function() return self.autostart end,
+                enabled_func = function() return not self:isRunning() end,
+                callback = function()
+                    self.autostart = not self.autostart
+                    G_reader_settings:flipNilOrFalse("SSH_autostart")
                 end,
             },
        }

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -41,6 +41,7 @@ end
 
 function SSH:start()
     if self:isRunning() then
+        logger.dbg("[Network] Not starting SSH server, already running.")
         return
     end
 


### PR DESCRIPTION
Adds the option to start the SSH server when KOReader is launched. Tested on Kindle 7th Generation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13772)
<!-- Reviewable:end -->
