### PR TITLE
Network timeout settings for wallabug plugin

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -105,6 +105,12 @@ function Wallabag:init()
     self.offline_queue                 = self.wb_settings.data.wallabag.offline_queue or {}
     self.use_local_archive             = self.wb_settings.data.wallabag.use_local_archive or false
 
+    -- Timeout settings
+    self.file_block_timeout = self.wb_settings.data.wallabag.file_block_timeout or socketutil.FILE_BLOCK_TIMEOUT
+    self.file_total_timeout = self.wb_settings.data.wallabag.file_total_timeout or socketutil.FILE_TOTAL_TIMEOUT
+    self.large_block_timeout = self.wb_settings.data.wallabag.large_block_timeout or socketutil.LARGE_BLOCK_TIMEOUT
+    self.large_total_timeout = self.wb_settings.data.wallabag.large_total_timeout or socketutil.LARGE_TOTAL_TIMEOUT
+
     -- archive_directory only has a default if directory is set
     self.archive_directory = self.wb_settings.data.wallabag.archive_directory
     if not self.archive_directory or self.archive_directory == "" then
@@ -352,6 +358,67 @@ function Wallabag:addToMainMenu(menu_items)
                                 end,
                             },
                         },
+                    },
+                    {
+                        text = _("Network timeout settings"),
+                        sub_item_table = {
+                            {
+                                text_func = function()
+                                    return T(_("File download block timeout: %1s"), self.file_block_timeout)
+                                end,
+                                keep_menu_open = true,
+                                callback = function(touchmenu_instance)
+                                    self:setTimeoutValue(
+                                        touchmenu_instance,
+                                        _("File download block timeout (seconds)"),
+                                        self.file_block_timeout,
+                                        function(value) self.file_block_timeout = value end
+                                    )
+                                end,
+                            },
+                            {
+                                text_func = function()
+                                    return T(_("File download total timeout: %1s"), self.file_total_timeout)
+                                end,
+                                keep_menu_open = true,
+                                callback = function(touchmenu_instance)
+                                    self:setTimeoutValue(
+                                        touchmenu_instance,
+                                        _("File download total timeout (seconds)"),
+                                        self.file_total_timeout,
+                                        function(value) self.file_total_timeout = value end
+                                    )
+                                end,
+                            },
+                            {
+                                text_func = function()
+                                    return T(_("API request block timeout: %1s"), self.large_block_timeout)
+                                end,
+                                keep_menu_open = true,
+                                callback = function(touchmenu_instance)
+                                    self:setTimeoutValue(
+                                        touchmenu_instance,
+                                        _("API request block timeout (seconds)"),
+                                        self.large_block_timeout,
+                                        function(value) self.large_block_timeout = value end
+                                    )
+                                end,
+                            },
+                            {
+                                text_func = function()
+                                    return T(_("API request total timeout: %1s"), self.large_total_timeout)
+                                end,
+                                keep_menu_open = true,
+                                callback = function(touchmenu_instance)
+                                    self:setTimeoutValue(
+                                        touchmenu_instance,
+                                        _("API request total timeout (seconds)"),
+                                        self.large_total_timeout,
+                                        function(value) self.large_total_timeout = value end
+                                    )
+                                end,
+                            },
+                        }
                     },
                     {
                         text = _("History settings"),
@@ -761,10 +828,10 @@ function Wallabag:callAPI(method, url, headers, body, filepath, quiet)
 
     if filepath ~= nil then
         request.sink = ltn12.sink.file(io.open(filepath, "w"))
-        socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+        socketutil:set_timeout(self.file_block_timeout, self.file_total_timeout)
     else
         request.sink = ltn12.sink.table(sink)
-        socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
+        socketutil:set_timeout(self.large_block_timeout, self.large_total_timeout)
     end
 
     if body ~= nil then
@@ -1486,6 +1553,44 @@ function Wallabag:setArchiveDirectory(touchmenu_instance)
     }:chooseDir()
 end
 
+--- A dialog used for setting a generic timeout value.
+function Wallabag:setTimeoutValue(touchmenu_instance, title_text, current_value, setter_func)
+    self.timeout_dialog = InputDialog:new{
+        title = title_text,
+        input = tostring(current_value),
+        input_type = "number", -- For numeric keyboard
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(self.timeout_dialog)
+                    end,
+                },
+                {
+                    text = _("Apply"),
+                    is_enter_default = true,
+                    callback = function()
+                        local new_value = tonumber(self.timeout_dialog:getInputText())
+                        if new_value and new_value > 0 then
+                            setter_func(new_value)
+                            self:saveSettings()
+                            touchmenu_instance:updateItems()
+                            UIManager:close(self.timeout_dialog)
+                        else
+                            UIManager:show(InfoMessage:new{ text = _("Invalid input. Please enter a positive number greater than 0.")})
+                            -- Keep dialog open by not closing it here.
+                        end
+                    end,
+                }
+            }
+        },
+    }
+    UIManager:show(self.timeout_dialog)
+    self.timeout_dialog:onShowKeyboard()
+end
+
 function Wallabag:saveSettings()
     local tempsettings = {
         server_url                    = self.server_url,
@@ -1512,6 +1617,11 @@ function Wallabag:saveSettings()
         offline_queue                  = self.offline_queue,
         use_local_archive             = self.use_local_archive,
         archive_directory             = self.archive_directory,
+        -- NEW Timeout settings
+        file_block_timeout            = self.file_block_timeout,
+        file_total_timeout            = self.file_total_timeout,
+        large_block_timeout           = self.large_block_timeout,
+        large_total_timeout           = self.large_total_timeout,
     }
 
     self.wb_settings:saveSetting("wallabag", tempsettings)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -364,13 +364,13 @@ function Wallabag:addToMainMenu(menu_items)
                         sub_item_table = {
                             {
                                 text_func = function()
-                                    return T(_("Article download block timeout: %1 s"), self.file_block_timeout)
+                                    return T(_("Article download connection timeout: %1 s"), self.file_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
                                     self:setTimeoutValue(
                                         touchmenu_instance,
-                                        _("Article download block timeout (seconds)"),
+                                        _("Article download connection timeout (seconds)"),
                                         self.file_block_timeout,
                                         function(value) self.file_block_timeout = value end
                                     )
@@ -392,13 +392,13 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("API request block timeout: %1 s"), self.large_block_timeout)
+                                    return T(_("API request connection timeout: %1 s"), self.large_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
                                     self:setTimeoutValue(
                                         touchmenu_instance,
-                                        _("API request block timeout (seconds)"),
+                                        _("API request connection timeout (seconds)"),
                                         self.large_block_timeout,
                                         function(value) self.large_block_timeout = value end
                                     )

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -1552,7 +1552,6 @@ function Wallabag:setArchiveDirectory(touchmenu_instance)
     }:chooseDir()
 end
 
---- A dialog used for setting a generic timeout value.
 function Wallabag:setTimeoutValue(touchmenu_instance, title_text, current_value, setter_func)
     self.timeout_dialog = InputDialog:new{
         title = title_text,

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -364,7 +364,7 @@ function Wallabag:addToMainMenu(menu_items)
                         sub_item_table = {
                             {
                                 text_func = function()
-                                    return T(_("File download block timeout: %1\u{202F}s"), self.file_block_timeout)
+                                    return T(_("File download block timeout: %1 s"), self.file_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -378,7 +378,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("File download total timeout: %1\u{202F}s"), self.file_total_timeout)
+                                    return T(_("File download total timeout: %1 s"), self.file_total_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -392,7 +392,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("API request block timeout: %1\u{202F}s"), self.large_block_timeout)
+                                    return T(_("API request block timeout: %1 s"), self.large_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -406,7 +406,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("API request total timeout: %1\u{202F}s"), self.large_total_timeout)
+                                    return T(_("API request total timeout: %1 s"), self.large_total_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -364,13 +364,13 @@ function Wallabag:addToMainMenu(menu_items)
                         sub_item_table = {
                             {
                                 text_func = function()
-                                    return T(_("File download block timeout: %1 s"), self.file_block_timeout)
+                                    return T(_("Article download block timeout: %1 s"), self.file_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
                                     self:setTimeoutValue(
                                         touchmenu_instance,
-                                        _("File download block timeout (seconds)"),
+                                        _("Article download block timeout (seconds)"),
                                         self.file_block_timeout,
                                         function(value) self.file_block_timeout = value end
                                     )
@@ -378,13 +378,13 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("File download total timeout: %1 s"), self.file_total_timeout)
+                                    return T(_("Article download total timeout: %1 s"), self.file_total_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
                                     self:setTimeoutValue(
                                         touchmenu_instance,
-                                        _("File download total timeout (seconds)"),
+                                        _("Article download total timeout (seconds)"),
                                         self.file_total_timeout,
                                         function(value) self.file_total_timeout = value end
                                     )

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -1569,7 +1569,7 @@ function Wallabag:setTimeoutValue(touchmenu_instance, title_text, current_value,
                     end,
                 },
                 {
-                    text = _("Apply"),
+                    text = _("Set timeout"),
                     is_enter_default = true,
                     callback = function()
                         local new_value = tonumber(self.timeout_dialog:getInputText())

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -364,7 +364,7 @@ function Wallabag:addToMainMenu(menu_items)
                         sub_item_table = {
                             {
                                 text_func = function()
-                                    return T(_("File download block timeout: %1s"), self.file_block_timeout)
+                                    return T(_("File download block timeout: %1\u{202F}s"), self.file_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -378,7 +378,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("File download total timeout: %1s"), self.file_total_timeout)
+                                    return T(_("File download total timeout: %1\u{202F}s"), self.file_total_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -392,7 +392,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("API request block timeout: %1s"), self.large_block_timeout)
+                                    return T(_("API request block timeout: %1\u{202F}s"), self.large_block_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)
@@ -406,7 +406,7 @@ function Wallabag:addToMainMenu(menu_items)
                             },
                             {
                                 text_func = function()
-                                    return T(_("API request total timeout: %1s"), self.large_total_timeout)
+                                    return T(_("API request total timeout: %1\u{202F}s"), self.large_total_timeout)
                                 end,
                                 keep_menu_open = true,
                                 callback = function(touchmenu_instance)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -105,7 +105,6 @@ function Wallabag:init()
     self.offline_queue                 = self.wb_settings.data.wallabag.offline_queue or {}
     self.use_local_archive             = self.wb_settings.data.wallabag.use_local_archive or false
 
-    -- Timeout settings
     self.file_block_timeout = self.wb_settings.data.wallabag.file_block_timeout or socketutil.FILE_BLOCK_TIMEOUT
     self.file_total_timeout = self.wb_settings.data.wallabag.file_total_timeout or socketutil.FILE_TOTAL_TIMEOUT
     self.large_block_timeout = self.wb_settings.data.wallabag.large_block_timeout or socketutil.LARGE_BLOCK_TIMEOUT
@@ -1617,7 +1616,6 @@ function Wallabag:saveSettings()
         offline_queue                  = self.offline_queue,
         use_local_archive             = self.use_local_archive,
         archive_directory             = self.archive_directory,
-        -- NEW Timeout settings
         file_block_timeout            = self.file_block_timeout,
         file_total_timeout            = self.file_total_timeout,
         large_block_timeout           = self.large_block_timeout,


### PR DESCRIPTION
Added an ability to set network timeouts manually (for example, in case of slow wallabag server). 

![FileManager_2025-05-14_200617](https://github.com/user-attachments/assets/b8b51c1f-2ff8-4423-8f7c-259d60ebd57e)
![FileManager_2025-05-14_200627](https://github.com/user-attachments/assets/f4ac6a1f-1101-415a-aa7f-e45c18478adb)



Closes https://github.com/koreader/koreader/issues/9101

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13786)
<!-- Reviewable:end -->
