### PR TITLE
reMarkable: Make sleep/waking up w/o launcher work and properly exit when KO_DONT_GRAB_INPUT is set

### DIFF
--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -353,6 +353,8 @@ function BasePowerD:getBatterySymbol(is_charged, is_charging, capacity)
     end
 end
 
-function BasePowerD:hasHallSensor() return false end
+function BasePowerD:hasHallSensor()
+    return false
+end
 
 return BasePowerD

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -353,4 +353,6 @@ function BasePowerD:getBatterySymbol(is_charged, is_charging, capacity)
     end
 end
 
+function BasePowerD:hasHallSensor() return false end
+
 return BasePowerD

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -304,6 +304,13 @@ function Remarkable:initNetworkManager(NetworkMgr)
     NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 
+function Remarkable:exit()
+    if isRmPaperPro and os.getenv("KO_DONT_GRAB_INPUT") == "1" then
+        os.execute("~/xovi/start")
+    end
+    Generic.exit(self)
+end
+
 function Remarkable:setDateTime(year, month, day, hour, min, sec)
     if hour == nil or min == nil then return true end
     local command
@@ -320,10 +327,19 @@ function Remarkable:saveSettings()
 end
 
 function Remarkable:resume()
+    if isRmPaperPro then
+        os.execute("csl wifi -p on")
+    else
+        os.execute("./enable-wifi.sh")
+    end
 end
 
 function Remarkable:suspend()
-    os.execute("./disable-wifi.sh")
+    if isRmPaperPro then
+        os.execute("csl wifi -p off")
+    else
+        os.execute("./disable-wifi.sh")
+    end
     os.execute("systemctl suspend")
 end
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -294,8 +294,9 @@ function Remarkable:init()
     end
 
     if isRmPaperPro then
-        -- enable wakelock
-        os.execute("csl power -w koreader")
+        -- disable autosuspend of xochitl
+        os.execute("cp -a ~/.config/remarkable/xochitl.conf ~/.config/remarkable/xochitl.conf.bak")
+        os.execute("sed -ri 's/IdleSuspendDelay=[0-9]+/IdleSuspendDelay=0/' ~/.config/remarkable/xochitl.conf")
     end
 
     if self.powerd:hasHallSensor() then
@@ -342,7 +343,7 @@ end
 
 function Remarkable:exit()
     if isRmPaperPro then
-        os.execute("csl power -u koreader")
+        os.execute("mv -f ~/.config/remarkable/xochitl.conf.bak ~/.config/remarkable/xochitl.conf")
         if os.getenv("KO_DONT_GRAB_INPUT") == "1" then
             os.execute("~/xovi/start")
         end
@@ -383,10 +384,16 @@ function Remarkable:suspend()
 end
 
 function Remarkable:powerOff()
+    if isRmPaperPro then
+        os.execute("mv -f ~/.config/remarkable/xochitl.conf.bak ~/.config/remarkable/xochitl.conf")
+    end
     os.execute("systemctl poweroff")
 end
 
 function Remarkable:reboot()
+    if isRmPaperPro then
+        os.execute("mv -f ~/.config/remarkable/xochitl.conf.bak ~/.config/remarkable/xochitl.conf")
+    end
     os.execute("systemctl reboot")
 end
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -192,6 +192,7 @@ function Remarkable:init()
     -- If we are launched while Oxide is running, remove Power from the event map
     if oxide_running then
         event_map[116] = nil
+        event_map[143] = nil
     end
 
     self.input = require("device/input"):new{

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -268,6 +268,11 @@ function Remarkable:init()
         PluginShare.pause_auto_suspend = true
     end
 
+    if isRmPaperPro then
+        -- enable wakelock
+        os.execute("csl power -w koreader")
+    end
+
     Generic.init(self)
 end
 
@@ -305,8 +310,11 @@ function Remarkable:initNetworkManager(NetworkMgr)
 end
 
 function Remarkable:exit()
-    if isRmPaperPro and os.getenv("KO_DONT_GRAB_INPUT") == "1" then
-        os.execute("~/xovi/start")
+    if isRmPaperPro then
+        os.execute("csl power -u koreader")
+        if os.getenv("KO_DONT_GRAB_INPUT") == "1" then
+            os.execute("~/xovi/start")
+        end
     end
     Generic.exit(self)
 end

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -3,5 +3,6 @@ return {
     [105] = "LPgBack",
     [106] = "RPgFwd",
     [116] = "Power",
+    [143] = "Power",
 }
--- TODO libremarkable has 143 as "wakeup" - don't know what that corresponds to?
+-- 116 is issued when the device gets to sleep, 143 when it's waked up. Both should be handled as "Power" to make waking up work without launcher (e.g. rMPP)

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -1,4 +1,5 @@
 return {
+    [20001] = "SleepCover",
     [102] = "Home",
     [105] = "LPgBack",
     [106] = "RPgFwd",

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -3,6 +3,6 @@ return {
     [105] = "LPgBack",
     [106] = "RPgFwd",
     [116] = "Power",
-    [143] = "Power",
+    [143] = "Resume",
 }
--- 116 is issued when the device gets to sleep, 143 when it's waked up. Both should be handled as "Power" to make waking up work without launcher (e.g. rMPP)
+-- 116 is issued when the device gets to sleep, 143 when it's waked up.

--- a/frontend/device/remarkable/event_map.lua
+++ b/frontend/device/remarkable/event_map.lua
@@ -5,4 +5,4 @@ return {
     [116] = "Power",
     [143] = "Resume",
 }
--- 116 is issued when the device gets to sleep, 143 when it's waked up.
+-- 116 is issued when the device gets to sleep, 143 when it wakes up.

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -74,6 +74,28 @@ function Remarkable_PowerD:isChargingHW()
     return self:read_str_file(self.status_file) == "Charging"
 end
 
+function Remarkable_PowerD:hasHallSensor()
+    return self.hall_file ~= nil
+end
+
+function Remarkable_PowerD:isHallSensorEnabled()
+    local int = self:read_int_file(self.hall_file)
+    return int == 0
+end
+
+function Remarkable_PowerD:onToggleHallSensor(toggle)
+    if toggle == nil then
+        -- Flip it
+        toggle = self:isHallSensorEnabled() and 1 or 0
+    else
+        -- Honor the requested state
+        toggle = toggle and 1 or 0
+    end
+    ffiUtil.writeToSysfs(toggle, self.hall_file)
+
+    G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", toggle == 0 and true or false)
+end
+
 function Remarkable_PowerD:beforeSuspend()
     -- Inhibit user input and emit the Suspend event.
     self.device:_beforeSuspend()

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -239,20 +239,9 @@ if Device:isKobo() then
     }
 end
 
-if Device:isKindle() and PowerD:hasHallSensor() then
+if PowerD:hasHallSensor() then
     common_settings.cover_events = {
-        text = _("Disable Kindle cover events"),
-        help_text = _([[Toggle the Hall effect sensor.
-This is used to detect if the cover is closed, which will automatically sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
-        keep_menu_open = true,
-        checked_func = function() return not PowerD:isHallSensorEnabled() end,
-        callback = function() PowerD:onToggleHallSensor() end,
-    }
-end
-
-if Device:isRemarkable() and PowerD:hasHallSensor() then
-    common_settings.cover_events = {
-        text = _("Disable reMarkable cover events"),
+        text = _("Disable cover events"),
         help_text = _([[Toggle the Hall effect sensor.
 This is used to detect if the cover is closed, which will automatically sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
         keep_menu_open = true,

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -250,6 +250,17 @@ This is used to detect if the cover is closed, which will automatically sleep an
     }
 end
 
+if Device:isRemarkable() and PowerD:hasHallSensor() then
+    common_settings.cover_events = {
+        text = _("Disable reMarkable cover events"),
+        help_text = _([[Toggle the Hall effect sensor.
+This is used to detect if the cover is closed, which will automatically sleep and wake the device. If there is no cover present the sensor may cause spurious wakeups when located next to a magnetic source.]]),
+        keep_menu_open = true,
+        checked_func = function() return not PowerD:isHallSensorEnabled() end,
+        callback = function() PowerD:onToggleHallSensor() end,
+    }
+end
+
 common_settings.night_mode = {
     text = _("Night mode"),
     checked_func = function() return G_reader_settings:isTrue("night_mode") end,


### PR DESCRIPTION
For waking up w/o launcher, we now handle event code 143, properly fixing issue #8891.
For proper exit when KO_DONT_GRAB_INPUT is set, we use a workaround that relaunches xochitl.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13795)
<!-- Reviewable:end -->
