### PR TITLE
Fulltext search: start page

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -779,7 +779,7 @@ function ReaderSearch:showAllResultsMenuDialog()
             {
                 text_func = function()
                     local pn = self.ui.rolling and self.ui.document:getPageFromXPointer(self.start_page) or self.start_page
-                    return T(_("Go to search start page: %1"), self.ui.annotation:getPageRef(self.start_page, pn) or pn)
+                    return T(_("Go back to original page: %1"), self.ui.annotation:getPageRef(self.start_page, pn) or pn)
                 end,
                 callback = function()
                     UIManager:close(button_dialog)

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -215,6 +215,7 @@ function ReaderSearch:searchCallback(reverse, text)
     if search_text == nil or search_text == "" then return end
     self.ui.doc_settings:saveSetting("fulltext_search_last_search_text", search_text)
     self.last_search_text = search_text
+    self.start_page = self.ui.paging and self.view.state.page or self.ui.document:getXPointer()
 
     local regex_error
     if text then -- from highlight dialog
@@ -774,12 +775,35 @@ function ReaderSearch:showAllResultsMenuDialog()
                 end,
             },
         },
+        {
+            {
+                text_func = function()
+                    local pn = self.ui.rolling and self.ui.document:getPageFromXPointer(self.start_page) or self.start_page
+                    return T(_("Go to search start page: %1"), self.ui.annotation:getPageRef(self.start_page, pn) or pn)
+                end,
+                callback = function()
+                    UIManager:close(button_dialog)
+                    self.result_menu.close_callback()
+                    self:onGoToStartPage()
+                end,
+            },
+        },
     }
     button_dialog = ButtonDialog:new{
         title_align = "center",
         buttons = buttons,
     }
     UIManager:show(button_dialog)
+end
+
+function ReaderSearch:onGoToStartPage()
+    if self.start_page then
+        if self.ui.rolling then
+            self.ui.rolling:onGotoXPointer(self.start_page)
+        else
+            self.ui.paging:onGotoPage(self.start_page)
+        end
+    end
 end
 
 return ReaderSearch

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -180,7 +180,7 @@ local settingsList = {
     ----
     fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), reader=true},
     fulltext_search_findall_results = {category="none", event="ShowFindAllResults", title=_("Last fulltext search results"), reader=true},
-    fulltext_search_start_page = {category="none", event="GoToStartPage", title=_("Go to fulltext search start page"), reader=true},
+    fulltext_search_start_page = {category="none", event="GoToStartPage", title=_("Fulltext search: go back to original page"), reader=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     book_map = {category="none", event="ShowBookMap", title=_("Book map"), reader=true, condition=Device:isTouchDevice() or (Device:hasDPad() and Device:useDPadAsActionKeys())},
     book_map_overview = {category="none", event="ShowBookMap", arg=true, title=_("Book map (overview)"), reader=true, condition=Device:isTouchDevice() or (Device:hasDPad() and Device:useDPadAsActionKeys())},

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -180,6 +180,7 @@ local settingsList = {
     ----
     fulltext_search = {category="none", event="ShowFulltextSearchInput", title=_("Fulltext search"), reader=true},
     fulltext_search_findall_results = {category="none", event="ShowFindAllResults", title=_("Last fulltext search results"), reader=true},
+    fulltext_search_start_page = {category="none", event="GoToStartPage", title=_("Go to fulltext search start page"), reader=true},
     toc = {category="none", event="ShowToc", title=_("Table of contents"), reader=true},
     book_map = {category="none", event="ShowBookMap", title=_("Book map"), reader=true, condition=Device:isTouchDevice() or (Device:hasDPad() and Device:useDPadAsActionKeys())},
     book_map_overview = {category="none", event="ShowBookMap", arg=true, title=_("Book map (overview)"), reader=true, condition=Device:isTouchDevice() or (Device:hasDPad() and Device:useDPadAsActionKeys())},
@@ -417,6 +418,7 @@ local dispatcher_menu_order = {
     ----
     "fulltext_search",
     "fulltext_search_findall_results",
+    "fulltext_search_start_page",
     "toc",
     "book_map",
     "book_map_overview",


### PR DESCRIPTION
Easy jump to the page which the search started on.
Helps in https://github.com/koreader/koreader/discussions/13779, allowing to browse through all search results without jumping back every time.
Also an action, can be added to a profile.

![1](https://github.com/user-attachments/assets/f6effef7-33e6-4d24-ad7a-916a8a466cde)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13798)
<!-- Reviewable:end -->
