### PR TITLE
Highlights: extend

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -503,7 +503,7 @@ function ReaderAnnotation:getInsertionIndex(item)
 end
 
 function ReaderAnnotation:addItem(item)
-    item.datetime = os.date("%Y-%m-%d %H:%M:%S")
+    item.datetime = item.datetime or os.date("%Y-%m-%d %H:%M:%S")
     item.pageno = self.ui.rolling and self.document:getPageFromXPointer(item.page) or item.page
     item.pageref = self:getPageRef(item.page, item.pageno)
     local index = self:getInsertionIndex(item)
@@ -512,7 +512,7 @@ function ReaderAnnotation:addItem(item)
 end
 
 function ReaderAnnotation:onAnnotationsModified(items)
-    if items.index_modified == nil then -- not needed when annotation added or removed
+    if items.index_modified == nil or items.modify_datetime then -- not needed when annotation added or removed
         items[1].datetime_updated = os.date("%Y-%m-%d %H:%M:%S")
     end
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -68,12 +68,11 @@ function ReaderHighlight:init()
     self._highlight_buttons = {
         -- highlight and add_note are for the document itself,
         -- so we put them first.
-        ["01_select"] = function(this)
+        ["01_select"] = function(this, index)
             return {
-                text = _("Select"),
-                enabled = this.hold_pos ~= nil,
+                text = index and _("Extend") or _("Select"),
                 callback = function()
-                    this:startSelection()
+                    this:startSelection(index)
                     this:onClose()
                 end,
             }
@@ -1003,7 +1002,11 @@ function ReaderHighlight:onTapSelectModeIcon()
         cancel_text = _("Close"),
         ok_callback = function()
             self.select_mode = false
-            self:deleteHighlight(self.highlight_idx)
+            if self.ui.annotation.annotations[self.highlight_idx].is_tmp then
+                self:deleteHighlight(self.highlight_idx)
+            else
+                UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+            end
         end,
     })
     return true
@@ -1025,7 +1028,11 @@ function ReaderHighlight:onTap(_, ges)
                     if box.index == self.highlight_idx then
                         -- tap on the first fragment: abort select mode, clear highlight
                         self.select_mode = false
-                        self:deleteHighlight(box.index)
+                        if self.ui.annotation.annotations[box.index].is_tmp then
+                            self:deleteHighlight(box.index)
+                        else
+                            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+                        end
                         return true
                     end
                 else
@@ -2046,7 +2053,7 @@ function ReaderHighlight:onHoldRelease()
         if self.selected_text then
             self.select_mode = false
             self:extendSelection()
-            if default_highlight_action == "select" then
+            if default_highlight_action == "select" or not self.selected_text.is_tmp then
                 self:saveHighlight(true)
                 self:clear()
             else
@@ -2203,8 +2210,10 @@ function ReaderHighlight:saveHighlight(extend_to_sentence)
             pos0 = self.selected_text.pos0,
             pos1 = self.selected_text.pos1,
             text = util.cleanupSelectedText(self.selected_text.text),
-            drawer = self.view.highlight.saved_drawer,
-            color = self.view.highlight.saved_color,
+            datetime = self.selected_text.datetime,
+            drawer = self.selected_text.drawer or self.view.highlight.saved_drawer,
+            color = self.selected_text.color or self.view.highlight.saved_color,
+            note = self.selected_text.note,
             chapter = self.ui.toc:getTocTitleByPage(pg_or_xp),
         }
         if self.ui.paging then
@@ -2214,7 +2223,8 @@ function ReaderHighlight:saveHighlight(extend_to_sentence)
         end
         local index = self.ui.annotation:addItem(item)
         self.view.footer:maybeUpdateFooter()
-        self.ui:handleEvent(Event:new("AnnotationsModified", { item, nb_highlights_added = 1, index_modified = index }))
+        self.ui:handleEvent(Event:new("AnnotationsModified",
+            { item, nb_highlights_added = 1, index_modified = index, modify_datetime = not self.selected_text.is_tmp }))
         return index
     end
 end
@@ -2435,8 +2445,14 @@ function ReaderHighlight:showNoteMarkerDialog()
     UIManager:show(dialog)
 end
 
-function ReaderHighlight:startSelection()
-    self.highlight_idx = self:saveHighlight()
+function ReaderHighlight:startSelection(index)
+    if index then -- extend existing highlight
+        UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+    else -- new highlight
+        index = self:saveHighlight()
+        self.ui.annotation.annotations[index].is_tmp = true
+    end
+    self.highlight_idx = index
     self.select_mode = true
 end
 
@@ -2494,6 +2510,11 @@ function ReaderHighlight:extendSelection()
     end
     self:deleteHighlight(self.highlight_idx) -- starting fragment
     self.selected_text = {
+        is_tmp = item1.is_tmp,
+        datetime = item1.datetime,
+        drawer = item1.drawer,
+        color = item1.color,
+        note = item1.note,
         text = new_text,
         pos0 = new_pos0,
         pos1 = new_pos1,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -71,6 +71,7 @@ function ReaderHighlight:init()
         ["01_select"] = function(this, index)
             return {
                 text = index and _("Extend") or _("Select"),
+                enabled = not (index and this.ui.annotation.annotations[index].text_edited),
                 callback = function()
                     this:startSelection(index)
                     this:onClose()


### PR DESCRIPTION
To extend an existing highlight: tap on it

![1](https://github.com/user-attachments/assets/480ef312-9aa2-41fc-a052-23a5e9d0e964)

Tap on three dots

![2](https://github.com/user-attachments/assets/21916e32-d1b9-4d49-9206-99f7cbd18f95)

Tap on Extend

![3](https://github.com/user-attachments/assets/b508f489-f86d-4809-9396-e4624998a3f8)

You are now in select mode. Select ending fragment to combine the existing highlight with it.
As usual, tap on an icon or on the highlight to exit select mode without changes.
Style, color, note are preserved.
Edited highlight text is removed because we have a new highlighted text.
Closes https://github.com/koreader/koreader/issues/13776.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13815)
<!-- Reviewable:end -->
