### PR TITLE
Coverbrowser: optimize display mode switching

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -184,7 +184,6 @@ function FileChooser:getListItem(dirpath, f, fullpath, attributes, collate)
         else
             item.text = item.text.."/"
             item.bidi_wrap_func = BD.directory
-            item.is_file = false
             if collate.can_collate_mixed and collate.item_func ~= nil then -- used by user plugin/patch, don't remove
                 collate.item_func(item)
             end
@@ -322,9 +321,6 @@ function FileChooser:refreshPath()
     local itemmatch
     if self.focused_path then
         itemmatch = {path = self.focused_path}
-        -- We use focused_path only once, but remember it
-        -- for CoverBrowser to re-apply it on startup if needed
-        self.prev_focused_path = self.focused_path
         self.focused_path = nil
     end
     local subtitle = self.name ~= "filemanager" and BD.directory(filemanagerutil.abbreviate(self.path)) -- PathChooser
@@ -381,19 +377,6 @@ function FileChooser:onFolderUp()
     if not (G_reader_settings:isTrue("lock_home_folder") and
             self.path == G_reader_settings:readSetting("home_dir")) then
         self:changeToPath(string.format("%s/..", self.path), self.path)
-    end
-end
-
-function FileChooser:changePageToPath(path)
-    if not path then return end
-    for num, item in ipairs(self.item_table) do
-        if not item.is_file and item.path == path then
-            local page = math.floor((num-1) / self.perpage) + 1
-            if page ~= self.page then
-                self:onGotoPage(page)
-            end
-            break
-        end
     end
 end
 

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -987,6 +987,7 @@ function Menu:updatePageInfo(select_number)
     if #self.item_table > 0 then
         local is_focused = self.itemnumber and self.itemnumber > 0
         if is_focused or Device:hasDPad() then
+            self.prev_itemnumber = self.itemnumber -- for CoverBrowser
             self.itemnumber = nil -- focus only once
             select_number = select_number or 1 -- default to select the first item
             local x, y
@@ -1388,7 +1389,7 @@ function Menu:onLastPage()
 end
 
 function Menu:onGotoPage(page)
-    self.prev_focused_path = nil
+    self.prev_itemnumber = nil
     self.page = page
     self:updateItems(1, true)
     return true

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -610,7 +610,7 @@ function CoverBrowser:refreshFileManagerInstance()
     local fc = self.ui.file_chooser
     if fc then
         fc:_recalculateDimen()
-        fc:changeToPath(fc.path, fc.prev_focused_path)
+        fc:switchItemTable(nil, nil, fc.prev_itemnumber, { dummy = "" }) -- dummy itemmatch to draw focus
     end
 end
 


### PR DESCRIPTION
Avoid re-reading the storage, avoid re-building the titlebar subtitle.
Fixes https://github.com/koreader/koreader/issues/13818#issuecomment-2889089691 (double auto-execution).
Also removed unused FileChooser method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13822)
<!-- Reviewable:end -->
