### PR TITLE
FileChooser: Un-blacklist 'dict' and 'custom-dict' dirs in File browser

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -31,7 +31,6 @@ local FileChooser = BookList:extend{
         -- Kobo
         "^%.adobe%-digital%-editions$",
         "^certificates$",
-        "^custom%-dict$",
         "^iink$",
         "^kepub$",
         "^markups$",

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -32,7 +32,6 @@ local FileChooser = BookList:extend{
         "^%.adobe%-digital%-editions$",
         "^certificates$",
         "^custom%-dict$",
-        "^dict$",
         "^iink$",
         "^kepub$",
         "^markups$",


### PR DESCRIPTION
Discussed from [here](https://github.com/koreader/koreader/issues/4505#issuecomment-2887337723).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13829)
<!-- Reviewable:end -->
