### PR TITLE
Dispatcher: update action name or value

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1955,6 +1955,8 @@ function ReaderFooter:genPresetMenuItemTable()
                     choice1_text = _("Delete"),
                     choice1_callback = function()
                         footer_presets[preset_name] = nil
+                        local Dispatcher = require("dispatcher")
+                        Dispatcher.updateActionValueInPlugins(self.ui, "load_footer_preset", preset_name)
                         touchmenu_instance.item_table = self:genPresetMenuItemTable()
                         touchmenu_instance:updateItems()
                     end,

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -454,11 +454,6 @@ local function dispatcherRegisterStyleTweak(tweak_id, tweak_title)
         {category="none", event="ToggleStyleTweak", arg=tweak_id, title=T(_("Style tweak '%1' toggle"), tweak_title), rolling=true})
 end
 
-local function dispatcherUnregisterStyleTweak(tweak_id)
-    Dispatcher:removeAction(ReaderStyleTweak.dispatcher_prefix_toggle..tweak_id)
-    Dispatcher:removeAction(ReaderStyleTweak.dispatcher_prefix_set..tweak_id)
-end
-
 function ReaderStyleTweak:init()
     self.tweaks_in_dispatcher = G_reader_settings:readSetting("style_tweaks_in_dispatcher") or {}
     self.tweaks_by_id = {}
@@ -570,11 +565,10 @@ You can enable individual tweaks on this book with a tap, or view more details a
                         toggle_tweak_in_dispatcher_callback = function()
                             if self.tweaks_in_dispatcher[item.id] then
                                 self.tweaks_in_dispatcher[item.id] = nil
-                                dispatcherUnregisterStyleTweak(item.id)
-                                if self.ui.profiles then
-                                    self.ui.profiles:updateProfiles(self.dispatcher_prefix_toggle..item.id)
-                                    self.ui.profiles:updateProfiles(self.dispatcher_prefix_set..item.id)
-                                end
+                                Dispatcher:removeAction(self.dispatcher_prefix_toggle..item.id)
+                                Dispatcher.updateActionNameInPlugins(self.ui, self.dispatcher_prefix_toggle..item.id)
+                                Dispatcher:removeAction(self.dispatcher_prefix_set..item.id)
+                                Dispatcher.updateActionNameInPlugins(self.ui, self.dispatcher_prefix_set..item.id)
                             else
                                 self.tweaks_in_dispatcher[item.id] = item.title
                                 dispatcherRegisterStyleTweak(item.id, item.title)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1231,4 +1231,28 @@ function Dispatcher:execute(settings, exec_props)
     end
 end
 
+function Dispatcher.updateActionNameInPlugins(ui, old_name, new_name)
+    if ui.gestures then
+        ui.gestures:updateActionName(old_name, new_name)
+    end
+    if ui.hotkeys then
+        ui.hotkeys:updateActionName(old_name, new_name)
+    end
+    if ui.profiles then
+        ui.profiles:updateActionName(old_name, new_name)
+    end
+end
+
+function Dispatcher.updateActionValueInPlugins(ui, action_name, old_value, new_value)
+    if ui.gestures then
+        ui.gestures:updateActionValue(action_name, old_value, new_value)
+    end
+    if ui.hotkeys then
+        ui.hotkeys:updateActionValue(action_name, old_value, new_value)
+    end
+    if ui.profiles then
+        ui.profiles:updateActionValue(action_name, old_value, new_value)
+    end
+end
+
 return Dispatcher

--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -162,9 +162,7 @@ end
 function BookShortcuts:deleteShortcut(name)
     self.shortcuts.data[name] = nil
     Dispatcher:removeAction(name)
-    if self.ui.profiles then
-        self.ui.profiles:updateProfiles(name)
-    end
+    Dispatcher.updateActionNameInPlugins(self.ui, name)
     self.updated = true
 end
 

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -1222,7 +1222,7 @@ function Gestures:onFlushSettings()
     end
 end
 
-function Gestures:updateProfiles(action_old_name, action_new_name)
+function Gestures:updateActionName(action_old_name, action_new_name)
     for _, section in ipairs({ "gesture_fm", "gesture_reader" }) do
         local gestures = self.settings_data.data[section]
         for gesture_name, gesture in pairs(gestures) do
@@ -1234,7 +1234,7 @@ function Gestures:updateProfiles(action_old_name, action_new_name)
                                 gesture.settings.order[i] = action_new_name
                             else
                                 table.remove(gesture.settings.order, i)
-                                if #gesture.settings.order == 0 then
+                                if #gesture.settings.order < 2 then
                                     gesture.settings.order = nil
                                     if next(gesture.settings) == nil then
                                         gesture.settings = nil
@@ -1249,6 +1249,39 @@ function Gestures:updateProfiles(action_old_name, action_new_name)
                 if action_new_name then
                     gesture[action_new_name] = true
                 else
+                    if next(gesture) == nil then
+                        self.settings_data.data[section][gesture_name] = nil
+                    end
+                end
+                self.updated = true
+            end
+        end
+    end
+end
+
+function Gestures:updateActionValue(action_name, old_value, new_value)
+    for _, section in ipairs({ "gesture_fm", "gesture_reader" }) do
+        local gestures = self.settings_data.data[section]
+        for gesture_name, gesture in pairs(gestures) do
+            if gesture[action_name] == old_value then
+                if new_value then
+                    gesture[action_name] = new_value
+                else
+                    if gesture.settings and gesture.settings.order then
+                        for i, action in ipairs(gesture.settings.order) do
+                            if action == action_name then
+                                table.remove(gesture.settings.order, i)
+                                if #gesture.settings.order < 2 then
+                                    gesture.settings.order = nil
+                                    if next(gesture.settings) == nil then
+                                        gesture.settings = nil
+                                    end
+                                end
+                                break
+                            end
+                        end
+                    end
+                    gesture[action_name] = nil
                     if next(gesture) == nil then
                         self.settings_data.data[section][gesture_name] = nil
                     end

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -530,7 +530,7 @@ function HotKeys:onFlushSettings()
     end
 end
 
-function HotKeys:updateProfiles(action_old_name, action_new_name)
+function HotKeys:updateActionName(action_old_name, action_new_name)
     for _, section in ipairs({ "hotkeys_fm", "hotkeys_reader" }) do
         local hotkeys = self.settings_data.data[section]
         for shortcut_name, shortcut in pairs(hotkeys) do
@@ -542,7 +542,7 @@ function HotKeys:updateProfiles(action_old_name, action_new_name)
                                 shortcut.settings.order[i] = action_new_name
                             else
                                 table.remove(shortcut.settings.order, i)
-                                if #shortcut.settings.order == 0 then
+                                if #shortcut.settings.order < 2 then
                                     shortcut.settings.order = nil
                                     if next(shortcut.settings) == nil then
                                         shortcut.settings = nil
@@ -557,6 +557,39 @@ function HotKeys:updateProfiles(action_old_name, action_new_name)
                 if action_new_name then
                     shortcut[action_new_name] = true
                 else
+                    if next(shortcut) == nil then
+                        self.settings_data.data[section][shortcut_name] = nil
+                    end
+                end
+                self.updated = true
+            end
+        end
+    end
+end
+
+function HotKeys:updateActionValue(action_name, old_value, new_value)
+    for _, section in ipairs({ "hotkeys_fm", "hotkeys_reader" }) do
+        local hotkeys = self.settings_data.data[section]
+        for shortcut_name, shortcut in pairs(hotkeys) do
+            if shortcut[action_name] == old_value then
+                if new_value then
+                    shortcut[action_name] = new_value
+                else
+                    if shortcut.settings and shortcut.settings.order then
+                        for i, action in ipairs(shortcut.settings.order) do
+                            if action == action_name then
+                                table.remove(shortcut.settings.order, i)
+                                if #shortcut.settings.order < 2 then
+                                    shortcut.settings.order = nil
+                                    if next(shortcut.settings) == nil then
+                                        shortcut.settings = nil
+                                    end
+                                end
+                                break
+                            end
+                        end
+                    end
+                    shortcut[action_name] = nil
                     if next(shortcut) == nil then
                         self.settings_data.data[section][shortcut_name] = nil
                     end

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -248,7 +248,7 @@ function Profiles:getSubMenuItems()
                 callback = function()
                     if v.settings.registered then
                         dispatcherUnregisterProfile(k)
-                        self:updateProfiles(self.prefix..k)
+                        Dispatcher.updateActionNameInPlugins(self.ui, self.prefix..k)
                         self.data[k].settings.registered = nil
                     else
                         dispatcherRegisterProfile(k)
@@ -279,7 +279,7 @@ function Profiles:getSubMenuItems()
                         if v.settings.registered then
                             dispatcherUnregisterProfile(k)
                             dispatcherRegisterProfile(new_name)
-                            self:updateProfiles(self.prefix..k, self.prefix..new_name)
+                            Dispatcher.updateActionNameInPlugins(self.ui, self.prefix..k, self.prefix..new_name)
                         end
                         self.data[k] = nil
                         self.updated = true
@@ -319,7 +319,7 @@ function Profiles:getSubMenuItems()
                             self:updateAutoExec(k)
                             if v.settings.registered then
                                 dispatcherUnregisterProfile(k)
-                                self:updateProfiles(self.prefix..k)
+                                Dispatcher.updateActionNameInPlugins(self.ui, self.prefix..k)
                             end
                             self.data[k] = nil
                             self.updated = true
@@ -461,7 +461,7 @@ function Profiles:getProfileFromCurrentBookSettings(new_name)
     return profile
 end
 
-function Profiles:updateProfiles(action_old_name, action_new_name)
+function Profiles:updateActionName(action_old_name, action_new_name)
     for _, profile in pairs(self.data) do
         if profile[action_old_name] then
             if profile.settings and profile.settings.order then
@@ -471,7 +471,7 @@ function Profiles:updateProfiles(action_old_name, action_new_name)
                             profile.settings.order[i] = action_new_name
                         else
                             table.remove(profile.settings.order, i)
-                            if #profile.settings.order == 0 then
+                            if #profile.settings.order < 2 then
                                 profile.settings.order = nil
                             end
                         end
@@ -486,10 +486,29 @@ function Profiles:updateProfiles(action_old_name, action_new_name)
             self.updated = true
         end
     end
-    if self.ui.gestures then -- search and update the profile action in assigned gestures
-        self.ui.gestures:updateProfiles(action_old_name, action_new_name)
-    elseif self.ui.hotkeys then -- search and update the profile action in assigned keyboard shortcuts
-        self.ui.hotkeys:updateProfiles(action_old_name, action_new_name)
+end
+
+function Profiles:updateActionValue(action_name, old_value, new_value)
+    for _, profile in pairs(self.data) do
+        if profile[action_name] == old_value then
+            if new_value then
+                profile[action_name] = new_value
+            else
+                if profile.settings and profile.settings.order then
+                    for i, action in ipairs(profile.settings.order) do
+                        if action == action_name then
+                            table.remove(profile.settings.order, i)
+                            if #profile.settings.order < 2 then
+                                profile.settings.order = nil
+                            end
+                            break
+                        end
+                    end
+                end
+                profile[action_name] = nil
+            end
+            self.updated = true
+        end
     end
 end
 


### PR DESCRIPTION
Dispatcher action names and values are stored in the Gesures, HotKeys and Profiles plugin settings.
Since we have removable/renamable actions (profiles, presets, style tweaks, book shortcuts), here is a unified interface to maintain settings of the above plugins.