### PR TITLE
feat: add calibre and sidecar path map

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -110,6 +110,11 @@ function Calibre:addToMainMenu(menu_items)
                 keep_menu_open = true,
                 sub_item_table = self:getWirelessMenuTable(),
             },
+            {
+                text = _("Metadata settings"),
+                keep_menu_open = true,
+                sub_item_table = self:getMetadataMenuTable(),
+            },
         }
     }
     -- insert the metadata search
@@ -121,6 +126,23 @@ function Calibre:addToMainMenu(menu_items)
             end
         }
     end
+end
+
+-- metadata options
+function Calibre:getMetadataMenuTable()
+    return {
+        {
+            text = _("Enable calibre to doc sidecar path map"),
+            checked_func = function()
+                return G_reader_settings:nilOrTrue("calibre_metadata_keep_sidecar_path_map")
+            end,
+            help_text = _(
+[[If you are using Calibre koreader plugin, this option is required to make it work properly if you're not using the default document sidecar settings.]]),
+            callback = function()
+                return G_reader_settings:flipNilOrTrue("calibre_metadata_keep_sidecar_path_map")
+            end,
+        },
+    }
 end
 
 -- search options available from UI

--- a/spec/unit/calibre_metadata_spec.lua
+++ b/spec/unit/calibre_metadata_spec.lua
@@ -1,0 +1,76 @@
+local function count_keys(t)
+    local count = 0
+    for _ in pairs(t) do
+        count = count + 1
+    end
+    return count
+end
+
+local function ends_with(str, ending)
+    return string.sub(str, -#ending) == ending
+end
+
+describe("Calibre Metadata", function()
+    local CalibreMetadata
+    local sample_pdf = "spec/base/unit/data/simple.pdf"
+    local book = {
+        lpath = sample_pdf,
+        uuid = "test_uuid",
+    }
+
+    setup(function()
+        require("commonrequire")
+        CalibreMetadata = dofile("plugins/calibre.koplugin/metadata.lua")
+    end)
+
+    describe("removing books", function()
+        before_each(function()
+            CalibreMetadata.books[1] = book
+        end)
+
+        it("clean() should remove books", function()
+            assert.is.same(1, #CalibreMetadata.books)
+
+            CalibreMetadata:clean()
+
+            assert.is.same(0, #CalibreMetadata.books)
+        end)
+        it("remove the given book", function()
+            assert.is.same(1, #CalibreMetadata.books)
+
+            CalibreMetadata:removeBook(sample_pdf)
+
+            assert.is.same(0, #CalibreMetadata.books)
+        end)
+    end)
+
+    describe("adding books", function()
+        after_each(function()
+            CalibreMetadata:clean()
+        end)
+
+        it("should add a book to the map books", function()
+            CalibreMetadata:addBook(book)
+
+            assert.is.same(sample_pdf, CalibreMetadata.books[1].lpath)
+            assert.is.same(1, #CalibreMetadata.books)
+        end)
+        it("should not result in duplicates", function()
+            CalibreMetadata:addBook(book)
+
+            assert.is.same(1, #CalibreMetadata.books)
+        end)
+        it("should be added to sidecar map by default", function()
+            CalibreMetadata:addBook(book)
+
+            assert.is.same(1, count_keys(CalibreMetadata.book_to_sidecar_map))
+            assert.is.is_true(ends_with(CalibreMetadata.book_to_sidecar_map["test_uuid"], ".sdr"))
+        end)
+        it("should not be added to sidecar map when disabled", function()
+            CalibreMetadata.keep_sidecar_path_map = false
+            CalibreMetadata:addBook(book)
+
+            assert.is.same(0, count_keys(CalibreMetadata.book_to_sidecar_map))
+        end)
+    end)
+end)


### PR DESCRIPTION
This adds a new feature to the calibre plugin to store a json file that contains a map with calibre uuid as key and korader sdr path as value.

```shell
cat ./koreader-emulator-x86_64-unknown-linux-gnu-debug/books/.sidecarmap.calibre.json
{
    "c3095f1c-fe01-452c-9556-dfe187e5c95a": "Books/ONE/One-Punch man/One-Punch Man, Vol. 1 - ONE (26).sdr"
}
```

This will allow the calibre koreader plugin to lookup sdr paths dynamically.

Relates-To: https://github.com/harmtemolder/koreader-calibre-plugin/issues/57

Change-Id: 6d8e7d97cf06811d007415e199f53c5b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13834)
<!-- Reviewable:end -->
