### PR TITLE
feat: add set lock orientation in dispatcher

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -224,7 +224,20 @@ if Device:hasGSensor() then
 
     function DeviceListener:onLockGSensor()
         G_reader_settings:flipNilOrFalse("input_lock_gsensor")
-        Device:lockGSensor(G_reader_settings:isTrue("input_lock_gsensor"))
+        self:setLockGsensor(G_reader_settings:isTrue("input_lock_gsensor"))
+        return true
+    end
+
+    -- @param flag bool on/off
+    function DeviceListener:onSetLockGSensor(flag)
+        self:setLockGsensor(flag)
+        return true
+    end
+
+    -- @param flag bool on/off
+    function DeviceListener:setLockGsensor(flag)
+        G_reader_settings:saveSetting("input_lock_gsensor", flag)
+        Device:lockGSensor(flag)
         local new_text
         if G_reader_settings:isTrue("input_lock_gsensor") then
             new_text = _("Orientation locked.")
@@ -232,7 +245,6 @@ if Device:hasGSensor() then
             new_text = _("Orientation unlocked.")
         end
         Notification:notify(new_text)
-        return true
     end
 end
 

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -91,7 +91,8 @@ local settingsList = {
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
     temp_gsensor_on = {category="none", event="TempGSensorOn", title=_("Enable accelerometer for 5 seconds"), device=true, condition=Device:hasGSensor()},
-    lock_gsensor = {category="none", event="LockGSensor", title=_("Lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
+    lock_gsensor = {category="none", event="LockGSensor", title=_("Toggle lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
+    set_lock_gsensor = {category="string", event="SetLockGSensor", title=_("Set lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor(), args = {true, false}, toggle = { _("true"), _("false")}},
     rotation_mode = {category="string", device=true}, -- title=_("Rotation"), parsed from CreOptions
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},
@@ -329,6 +330,7 @@ local dispatcher_menu_order = {
     "toggle_gsensor",
     "temp_gsensor_on",
     "lock_gsensor",
+    "set_lock_gsensor",
     "rotation_mode",
     "toggle_rotation",
     "invert_rotation",


### PR DESCRIPTION
ATM you can only toggle G sensor lock in dispatcher, this commit adds the ability to set the lock to on or off.

This can be useful in profiles that want to set an explicit mode instead of toggling the setting.

Change-Id: 5805932cf901fc05a4072b801847ae92

---

A quality of life improvement for https://github.com/koreader/koreader/pull/13675

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13835)
<!-- Reviewable:end -->
