### PR TITLE
[feat] Dispatcher: Add 'Set page-turn button inversion'

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -86,7 +86,8 @@ local settingsList = {
     ----
     swap_left_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg="left", title=_("Invert left-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
     swap_right_page_turn_buttons = {category="none", event="SwapPageTurnButtons", arg="right", title=_("Invert right-side page-turn buttons"), device=true, condition= Device:hasDPad() and Device:useDPadAsActionKeys()},
-    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys(), separator=true},
+    swap_page_turn_buttons = {category="none", event="SwapPageTurnButtons", title=_("Invert page-turn buttons"), device=true, condition=Device:hasKeys()},
+    set_page_turn_buttons = {category="string", event="SetPageTurnButtonDirection", title=_("Set page-turn button inversion"), device=true, condition=Device:hasKeys(), args = {true, false}, toggle = { _("on"), _("off")}, separator=true},
     ----
     toggle_key_repeat = {category="none", event="ToggleKeyRepeat", title=_("Toggle key repeat"), device=true, condition=Device:hasKeys() and Device:canKeyRepeat(), separator=true},
     toggle_gsensor = {category="none", event="ToggleGSensor", title=_("Toggle accelerometer"), device=true, condition=Device:hasGSensor()},
@@ -323,9 +324,10 @@ local dispatcher_menu_order = {
     "touch_input_off",
     "toggle_touch_input",
     ----
-    "swap_page_turn_buttons",
     "swap_left_page_turn_buttons",
     "swap_right_page_turn_buttons",
+    "swap_page_turn_buttons",
+    "set_page_turn_buttons",
     ----
     "toggle_key_repeat",
     "toggle_gsensor",


### PR DESCRIPTION
Currently you can only toggle page turn buttons to inverted or not. This commit adds the ability to also have an option in dispatcher to set the value instead of just toggling.

This can be useful for profiles that want to set the value rather then toggle.

Change-Id: bde93e44794788fbc8b3c2ef6857d053

---

Quality of life improvement for  https://github.com/koreader/koreader/pull/13675

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13836)
<!-- Reviewable:end -->
