### PR TITLE
NewsDownloader: Include author's name in summary when "Download full article"=false

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -80,6 +80,31 @@ local function getFeedLink(possible_link)
     end
 end
 
+-- Look for author names that look like
+-- <author><name> Author Name </name></author>
+-- and return a byline with the name,
+-- or names separated by commas.
+local function getByline(feed)
+    if feed.author then
+        if feed.author.name then -- single author
+            return "By " .. feed.author.name
+        end
+        local i = 0
+        local authors = {}
+        for _ in pairs(feed.author) do -- multiple authors
+            i = i + 1
+            if feed.author[i] == nil then
+                break
+            end
+            authors[i] = feed.author[i].name
+        end
+        if #authors > 0 then
+            return "By " .. table.concat(authors, ", ")
+        end
+    end
+    return ""
+end
+
 function NewsDownloader:init()
     self.ui.menu:registerToMainMenu(self)
 end
@@ -680,6 +705,7 @@ function NewsDownloader:createFromDescription(feed, title, content, feed_output_
     else
         logger.dbg("NewsDownloader: News file will be stored to :", news_file_path)
         local article_message = T(_("%1\n%2"), message, title_with_date)
+        local byline = getByline(feed)
         local footer = _("If this is only a summary, the full article can be downloaded by going to the News Downloader settings and changing 'Download full article' to 'true'.")
 
         local base_url = getFeedLink(feed.link)
@@ -707,12 +733,12 @@ function NewsDownloader:createFromDescription(feed, title, content, feed_output_
 <title>%s</title>
 </head>
 <body>
-<header><h1>%s</h1></header>
+<header><h1>%s</h1><p><address>%s</address></p></header>
 <article>%s</article>
 <br>
 <footer><small>%s</small></footer>
 </body>
-</html>]], title, title, content, footer)
+</html>]], title, title, byline, content, footer)
         local link = getFeedLink(feed.link)
         DownloadBackend:createEpub(news_file_path, html, link, include_images, article_message)
     end

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -81,25 +81,46 @@ local function getFeedLink(possible_link)
 end
 
 -- Look for author names that look like
--- <author><name> Author Name </name></author>
--- and return a byline with the name,
--- or names separated by commas.
+-- <dc:creator>First Author, Second Author</dc:creator>
+-- or
+-- <author><name>First Author</name></author>
+-- <author><name>Second Author</name></author>...
+-- and return a byline or empty string
 local function getByline(feed)
-    if feed.author then
-        if feed.author.name then -- single author
-            return "By " .. feed.author.name
-        end
+    if type(feed["dc:creator"]) == "string" then
+        return "By " .. feed["dc:creator"]
+    end
+    if type(feed["dc:creator"]) == "table" then
         local i = 0
         local authors = {}
-        for _ in pairs(feed.author) do -- multiple authors
+        for _ in pairs(feed["dc:creator"]) do
             i = i + 1
-            if feed.author[i] == nil then
+            if feed["dc:creator"][i] == nil then
                 break
             end
-            authors[i] = feed.author[i].name
+            authors[i] = feed["dc:creator"][i]
         end
         if #authors > 0 then
             return "By " .. table.concat(authors, ", ")
+        end
+    end
+    if feed.author then
+        if type(feed.author.name) == "string" then -- single author
+            return "By " .. feed.author.name
+        end
+        if type(feed.author) == "table" then
+            local i = 0
+            local authors = {}
+            for _ in pairs(feed.author) do -- multiple authors
+                i = i + 1
+                if feed.author[i] == nil then
+                    break
+                end
+                authors[i] = feed.author[i].name
+            end
+            if #authors > 0 then
+                return "By " .. table.concat(authors, ", ")
+            end
         end
     end
     return ""

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -88,7 +88,7 @@ end
 -- and return a byline or empty string
 local function getByline(feed)
     if type(feed["dc:creator"]) == "string" then
-        return "By " .. feed["dc:creator"]
+        return feed["dc:creator"]
     end
     if type(feed["dc:creator"]) == "table" then
         local i = 0
@@ -101,12 +101,12 @@ local function getByline(feed)
             authors[i] = feed["dc:creator"][i]
         end
         if #authors > 0 then
-            return "By " .. table.concat(authors, ", ")
+            return table.concat(authors, ", ")
         end
     end
     if feed.author then
         if type(feed.author.name) == "string" then -- single author
-            return "By " .. feed.author.name
+            return feed.author.name
         end
         if type(feed.author) == "table" then
             local i = 0
@@ -119,7 +119,7 @@ local function getByline(feed)
                 authors[i] = feed.author[i].name
             end
             if #authors > 0 then
-                return "By " .. table.concat(authors, ", ")
+                return table.concat(authors, ", ")
             end
         end
     end
@@ -755,6 +755,7 @@ function NewsDownloader:createFromDescription(feed, title, content, feed_output_
 </head>
 <body>
 <header><h1>%s</h1><p><address>%s</address></p></header>
+<br>
 <article>%s</article>
 <br>
 <footer><small>%s</small></footer>


### PR DESCRIPTION
Currently, if an RSS feed is downloaded with "Download full article"=false, the author's name is not included in the resulting EPUB.

Two common ways of marking up the authors' name are:

1. `<author><name>Author Name</name></author>`
2. `<dc:creator> Author One and Author Two </dc:creator> `

This change adds a function that looks for one or more names in one of the above formats and adds a byline with the names to the HTML. The line break `<br>` was added to ensure there is at least some space between the byline and the content of the article, even if the content does not enclosed by `<p>`. 