### PR TITLE
calibre: increase no-activity timeout

### DIFF
--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -337,7 +337,7 @@ function CalibreWireless:connect()
 
     -- Heartbeat monitoring…
     while ok and not self.disconnected_by_server do
-        ok = resume_in(15)
+        ok = resume_in(5 * 60)
     end
 
     local msg


### PR DESCRIPTION
Calibre does not send the expected regular "NOOP" pings during its "Analyzing books on the device…" phase, and that operation can take a long time (75s for 4500 books on a recent machine).

Close #13844.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13846)
<!-- Reviewable:end -->
