### PR TITLE
tools/mkrelease: fix bug in AWK helpers

### DIFF
--- a/tools/mkrelease.sh
+++ b/tools/mkrelease.sh
@@ -19,7 +19,7 @@ OPTIONS:
 declare -r AWK_HELPERS='
 function print_entry(path, size, crc) {
     sub("/$", "", path)
-    if (crc)
+    if (crc != "")
         print path, size, crc
     else
         print path"/"


### PR DESCRIPTION
The manifest entry for `koreader/frontend/socketutil.lua` is wrong:
```
koreader/frontend/socketutil.lua/
```
That's because the CRC for that file (0E376639) compare as a false value when used conditionally with `if (0E376639)`. The correct way to check for an empty string is to use: `if (0E376639 != "")`.

NOTE: no impact that I could see on the actual generated archive, e.g.
for kindlepw2: the file is still included.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13847)
<!-- Reviewable:end -->
