### PR TITLE
Add Remote Note Input plugin for sending note text to KOReader via local network from a browser

### DIFF
--- a/plugins/remotenoteinput.koplugin/_meta.lua
+++ b/plugins/remotenoteinput.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "remotenoteinput",
+    fullname = _("Remote Note Input"),
+    description = _([[Send text to KOReader’s note editor from any browser over local Wi-Fi — helpful for input methods like Pinyin.]]),
+}

--- a/plugins/remotenoteinput.koplugin/html/404.html
+++ b/plugins/remotenoteinput.koplugin/html/404.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page Not Found</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #333333;
+            --accent-color: #13998B;
+            --border-color: #e0e0e0;
+            --input-bg: #f5f5f5;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-color: #1a1a1a;
+                --text-color: #e0e0e0;
+                --border-color: #404040;
+                --input-bg: #2a2a2a;
+            }
+        }
+
+        body {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 20px;
+        }
+
+        .error-container {
+            max-width: 600px;
+            width: 100%;
+            padding: 0 15px;
+        }
+
+        .error-code {
+            font-size: 5rem;
+            font-weight: 300;
+            color: var(--accent-color);
+            margin: 0 0 1rem;
+            line-height: 1;
+        }
+
+        .error-icon {
+            width: 120px;
+            height: 120px;
+            margin: 0 auto 2rem;
+            border: 3px solid var(--accent-color);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .error-icon svg {
+            width: 60px;
+            height: 60px;
+            fill: var(--accent-color);
+        }
+
+        .error-message {
+            font-size: 1.25rem;
+            margin: 0 0 2rem;
+            line-height: 1.4;
+            opacity: 0.9;
+        }
+
+        .home-btn {
+            padding: 12px 32px;
+            background-color: var(--accent-color);
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: all 0.2s;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .home-btn:hover {
+            opacity: 0.9;
+            transform: translateY(-1px);
+        }
+
+        @media (max-width: 480px) {
+            .error-code {
+                font-size: 4rem;
+            }
+
+            .error-icon {
+                width: 100px;
+                height: 100px;
+                margin-bottom: 1.5rem;
+            }
+
+            .error-icon svg {
+                width: 50px;
+                height: 50px;
+            }
+
+            .error-message {
+                font-size: 1.1rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-icon">
+            <svg viewBox="0 0 24 24">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+            </svg>
+        </div>
+        <h1 class="error-code">404</h1>
+        <!-- The page you're looking for can't be found. -->
+        <p class="error-message">
+            %1
+        </p>
+        <!-- Return Home -->
+        <a href="/remote-note-input" class="home-btn">%2</a>
+    </div>
+</body>
+</html>

--- a/plugins/remotenoteinput.koplugin/html/remote-note-input.html
+++ b/plugins/remotenoteinput.koplugin/html/remote-note-input.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!--  Remote Note Input  -->
+    <title>%1</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #333333;
+            --accent-color: #13998B;
+            --border-color: #e0e0e0;
+            --input-bg: #f5f5f5;
+            --switch-bg: #cccccc;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-color: #1a1a1a;
+                --text-color: #e0e0e0;
+                --border-color: #404040;
+                --input-bg: #2a2a2a;
+                --switch-bg: #555555;
+            }
+
+            .instructions {
+                color: #999;
+                background-color: rgba(19, 153, 139, 0.1);
+            }
+        }
+
+        body {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            margin: 0;
+            padding: 0;
+            line-height: 1.6;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            width: 100%;
+            padding: 0 15px;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            font-size: 1.5em;
+            color: var(--accent-color);
+            margin: 2rem 0;
+            text-align: center;
+            font-weight: 500;
+        }
+
+        .note-input {
+            width: 100%;
+            height: 500px;
+            padding: 15px;
+            margin-bottom: 25px;
+            background-color: var(--input-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            color: var(--text-color);
+            resize: vertical;
+            font-size: 16px;
+            box-sizing: border-box;
+            transition: border-color 0.2s;
+        }
+
+        .note-input:focus {
+            outline: none;
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 2px rgba(19, 153, 139, 0.1);
+        }
+
+        .settings {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 30px;
+            padding: 15px;
+            background-color: var(--input-bg);
+            border-radius: 6px;
+            gap: 10px;
+        }
+
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 50px;
+            height: 28px;
+        }
+
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--switch-bg);
+            transition: .4s;
+            border-radius: 34px;
+        }
+
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 22px;
+            width: 22px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            transition: .4s;
+            border-radius: 50%;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        input:checked+.slider {
+            background-color: var(--accent-color);
+        }
+
+        input:checked+.slider:before {
+            transform: translateX(22px);
+        }
+
+        .submit-btn {
+            display: block;
+            width: 100%;
+            padding: 14px;
+            background-color: var(--accent-color);
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            transition: all 0.2s;
+            font-weight: 500;
+        }
+
+        .submit-btn:hover {
+            opacity: 0.9;
+            transform: translateY(-1px);
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: var(--accent-color);
+            color: white;
+            padding: 12px 24px;
+            border-radius: 4px;
+            font-size: 14px;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s, visibility 0.3s;
+            z-index: 1000;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            max-width: 80%;
+            text-align: center;
+        }
+
+        .toast.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .instructions {
+            font-size: 0.85em;
+            color: #666;
+            margin: 20px 0 10px;
+            padding: 12px;
+            line-height: 1.5;
+            border-left: 3px solid var(--accent-color);
+            background-color: rgba(19, 153, 139, 0.05);
+            border-radius: 4px;
+        }
+
+        @media (max-width: 480px) {
+            body {
+                padding: 15px;
+            }
+
+            .note-input {
+                height: 400px;
+                font-size: 15px;
+            }
+
+            .settings {
+                padding: 12px;
+            }
+
+            .toast {
+                width: 90%;
+                bottom: 10px;
+            }
+
+            .instructions {
+                font-size: 0.8em;
+                margin: 15px 0;
+                padding: 10px;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <h1>Highlight Note</h1>
+        <!--  Write down your thoughts about this highlight... -->
+        <textarea class="note-input" placeholder="%2"></textarea>
+        <div class="settings">
+            <span>Clear after sending</span>
+            <label class="switch">
+                <input type="checkbox" id="clearToggle" checked>
+                <span class="slider"></span>
+            </label>
+        </div>
+        <!--  Send to KOReader -->
+        <button class="submit-btn" onclick="handleSubmit()">%3</button>
+        <div class="instructions">%4</div>
+        <div class="toast"></div>
+    </div>
+
+    <script>
+        function showToast(message, isSuccess) {
+            const toast = document.querySelector('.toast');
+            toast.textContent = message;
+            toast.style.backgroundColor = isSuccess ? '#13998B' : '#ff4444';
+            toast.classList.add('active');
+
+            setTimeout(() => {
+                toast.classList.remove('active');
+            }, 3000);
+        }
+
+        function handleSubmit() {
+            const noteInput = document.querySelector('.note-input');
+            const clearToggle = document.getElementById('clearToggle');
+
+            if (!noteInput.value.trim()) {
+                // Please enter some text
+                showToast('%5', false);
+                return;
+            }
+
+            const btn = document.querySelector('.submit-btn');
+            btn.disabled = true;
+            // Sending...
+            btn.textContent = '%6';
+
+            fetch('/send-note', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/text' },
+                body: noteInput.value
+            })
+                .then(response => {
+                    // Network error
+                    if (!response.ok) throw new Error("%7");
+
+                    return response.json();
+                })
+                .then(data => {
+                    console.log(data);
+                    if (data.code === 0) {
+                        // Sent successfully
+                        showToast(data.message || '%8', true);
+                        if (clearToggle.checked) noteInput.value = '';
+                    } else {
+                        // Failed to send
+                        showToast(data.message || '%9', false);
+                    }
+                })
+                .catch(error => {
+                    // Failed to send
+                    showToast('%10', false);
+                })
+                .finally(() => {
+                    btn.disabled = false;
+                    // Send to KOReader
+                    btn.textContent = '%11';
+                });
+        }
+    </script>
+</body>
+</html>

--- a/plugins/remotenoteinput.koplugin/main.lua
+++ b/plugins/remotenoteinput.koplugin/main.lua
@@ -1,0 +1,425 @@
+-- This plugin allows you type notes into KOReader from any browser-enabled device on the same local network
+local Device = require("device")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local InfoMessage = require("ui/widget/infomessage")
+local logger = require("logger")
+local util = require("util")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local RemoteNoteInput = WidgetContainer:extend {
+    name = "remotenoteinput",
+}
+
+local should_auto_run = G_reader_settings:isTrue("remotenoteinput_autostart")
+
+function RemoteNoteInput:init()
+    self.port = G_reader_settings:readSetting("remotenoteinput_port", "8088")
+    if should_auto_run then
+        UIManager:nextTick(function()
+            self:start()
+        end)
+    end
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function RemoteNoteInput:isRunning()
+    return self.http_socket ~= nil
+end
+
+function RemoteNoteInput:start()
+    -- Make a hole in the Kindle's firewall
+    if Device:isKindle() then
+        os.execute(string.format("%s %s %s",
+            "iptables -A INPUT -p tcp --dport", self.port,
+            "-m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT"))
+        os.execute(string.format("%s %s %s",
+            "iptables -A OUTPUT -p tcp --sport", self.port,
+            "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
+    end
+
+    local ServerClass = require("ui/message/simpletcpserver")
+    self.http_socket = ServerClass:new {
+        host = "*",
+        port = self.port,
+        receiveCallback = function(data, id)
+            return self:onRequest(data, id)
+        end,
+    }
+    self.http_socket:start()
+    self.http_messagequeue = UIManager:insertZMQ(self.http_socket)
+end
+
+function RemoteNoteInput:stop()
+    -- Plug the hole in the Kindle's firewall
+    if Device:isKindle() then
+        os.execute(string.format("%s %s %s",
+            "iptables -D INPUT -p tcp --dport", self.port,
+            "-m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT"))
+        os.execute(string.format("%s %s %s",
+            "iptables -D OUTPUT -p tcp --sport", self.port,
+            "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
+    end
+
+    if self.http_socket then
+        self.http_socket:stop()
+        self.http_socket = nil
+    end
+    if self.http_messagequeue then
+        UIManager:removeZMQ(self.http_messagequeue)
+        self.http_messagequeue = nil
+    end
+end
+
+function RemoteNoteInput:onEnterStandby()
+    if self:isRunning() then
+        self:stop()
+    end
+end
+
+function RemoteNoteInput:onSuspend()
+    if self:isRunning() then
+        self:stop()
+    end
+end
+
+function RemoteNoteInput:onExit()
+    if self:isRunning() then
+        self:stop()
+    end
+end
+
+function RemoteNoteInput:onCloseWidget()
+    if self:isRunning() then
+        self:stop()
+    end
+end
+
+function RemoteNoteInput:onLeaveStandby()
+    if should_auto_run and not self:isRunning() then
+        self:start()
+    end
+end
+
+function RemoteNoteInput:onResume()
+    if should_auto_run and not self:isRunning() then
+        self:start()
+    end
+end
+
+function RemoteNoteInput:parse_http_request(data, request_id)
+    local request = {
+        request_id = request_id,
+        method = nil,
+        uri = nil,
+        headers = {},
+        body = ""
+    }
+
+    request.method, request.uri = data:match("^(%u+) ([^%s]+) HTTP/%d%.%d\r?\n")
+    if not request.method or not request.uri then
+        return nil
+    end
+
+    for key, value in data:gmatch("\r?\n([^:]+):%s*([^\r\n]*)") do
+        request.headers[key:lower()] = value
+    end
+
+    local header_end = data:find("\r\n\r\n", 1, true) or data:find("\n\n", 1, true)
+    if header_end then
+        request.body = data:sub(header_end + 4)
+    end
+
+    return request
+end
+
+local HTTP_STATUS_CODES = {
+    [200] = 'OK',
+    [201] = 'Created',
+    [202] = 'Accepted',
+    [204] = 'No Content',
+    [301] = 'Moved Permanently',
+    [302] = 'Found',
+    [304] = 'Not Modified',
+    [400] = 'Bad Request',
+    [401] = 'Unauthorized',
+    [403] = 'Forbidden',
+    [404] = 'Not Found',
+    [405] = 'Method Not Allowed',
+    [406] = 'Not Acceptable',
+    [408] = 'Request Timeout',
+    [410] = 'Gone',
+    [500] = 'Internal Server Error',
+    [501] = 'Not Implemented',
+    [503] = 'Service Unavailable',
+}
+
+local CONTENT_TYPES = {
+    CSS = "text/css",
+    HTML = "text/html",
+    JS = "application/javascript",
+    JSON = "application/json",
+    PNG = "image/png",
+    TEXT = "text/plain",
+}
+
+function RemoteNoteInput:renderHtml(file_name, ...)
+    local html_file_path = self.path .. "/html/" .. file_name
+    local f = assert(io.open(html_file_path, "r"), "File not found: " .. file_name)
+    local html = f:read("*a")
+    f:close()
+    return T(html, ...)
+end
+
+function RemoteNoteInput:renderRemoteNoteInputHtml()
+    return self:renderHtml("remote-note-input.html",
+        _("Remote Note Input"),
+        _("Write down your thoughts about this highlight..."),
+        _("Send to KOReader"),
+        _([[Usage tip: After highlighting text in KOReader, tap “Add Note” from the popup menu to open the note
+editor. You can then type your note on this webpage and tap “Send” — the text will be automatically appended
+to the current note input field in KOReader, making input faster and easier.]]),
+        _("Please enter some text"),
+        _("Sending..."),
+        _("Network error"),
+        _("Sent successfully"),
+        _("Failed to send"),
+        _("Failed to send"),
+        _("Send to KOReader")
+    )
+end
+
+function RemoteNoteInput:render404Html()
+    return self:renderHtml("404.html",
+        _("The page you're looking for can't be found."),
+        _("Return Home")
+    )
+end
+
+function RemoteNoteInput:onRequest(data, request_id)
+    local request = self:parse_http_request(data, request_id)
+    local uri = request.uri
+    local method = request.method
+
+    if method == "GET" then
+        if util.stringStartsWith(uri, "/remote-note-input") then
+            local html = self:renderRemoteNoteInputHtml()
+            self:sendResponse(request.request_id, 200, CONTENT_TYPES.HTML, html)
+        else
+            local html = self:render404Html()
+            self:sendResponse(request.request_id, 200, CONTENT_TYPES.HTML, html)
+        end
+    elseif method == "POST" then
+        if util.stringStartsWith(uri, "/send-note") then
+            local isAdded = self:addTextToNoteInput(request.body)
+            local message
+            if isAdded then
+                message = _("Send Success")
+            else
+                message = _("Edit note dialog is not open, Please open it to receive text")
+            end
+            self:sendResponse(request.request_id, 200, CONTENT_TYPES.JSON, T("{\"code\": 0, \"message\": \"%1\"}", message))
+        end
+    else
+        self:sendResponse(request.request_id, 405, CONTENT_TYPES.TEXT, "Method Not Allowed")
+    end
+end
+
+function RemoteNoteInput:addTextToNoteInput(text)
+    local isAdded = false
+    for widget in UIManager:topdown_widgets_iter() do
+        if widget.title == _("Edit note") then
+            widget:addTextToInput(text)
+            isAdded = true
+            break
+        end
+    end
+    return isAdded
+end
+
+function RemoteNoteInput:sendResponse(request_id, status_code, content_type, body)
+    if not status_code then
+        status_code = 400
+    end
+    if not body then
+        body = ""
+    end
+    if type(body) ~= "string" then
+        body = tostring(body)
+    end
+
+    local response = {}
+    table.insert(response, T("HTTP/1.0 %1 %2", status_code, HTTP_STATUS_CODES[status_code] or "Unspecified"))
+
+    if content_type then
+        local charset = ""
+        if util.stringStartsWith(content_type, "text/") then
+            charset = "; charset=utf-8"
+        end
+        table.insert(response, T("Content-Type: %1%2", content_type, charset))
+    end
+
+    table.insert(response, T("Content-Length: %1", #body))
+    table.insert(response, "Connection: close")
+    table.insert(response, "")
+    table.insert(response, body)
+    response = table.concat(response, "\r\n")
+    if self.http_socket then
+        logger.dbg("self.http_socket:send(response, request_id)")
+        self.http_socket:send(response, request_id)
+    end
+end
+
+function RemoteNoteInput:isConnected()
+    if not Device:hasWifiToggle() then
+        return true
+    end
+end
+
+function RemoteNoteInput:getWebPageUrl()
+    if Device.retrieveNetworkInfo then
+        local info = Device:retrieveNetworkInfo()
+        if not info then
+            return nil
+        end
+
+        local ip
+        for line in info:gmatch("[^\r\n]+") do
+            if line:find("IP") then
+                ip = line:match("(%d+%.%d+%.%d+%.%d+)")
+                if ip then
+                    break
+                end
+            end
+        end
+        if not ip then
+            return nil
+        end
+        return T("http://%1:%2/remote-note-input", ip, self.port)
+    else
+        return nil
+    end
+end
+
+function RemoteNoteInput:getWebPageUrlMenuText()
+    if self:isRunning() then
+        local url = self:getWebPageUrl()
+        if url then
+            return T(_("Go to: %1"), url)
+        else
+            return T(_("No address available"))
+        end
+    else
+        return _("Not Running")
+    end
+end
+
+function RemoteNoteInput:addToMainMenu(menu_items)
+    menu_items.remote_note_input = {
+        text = _("Remote Note Input"),
+        sorting_hint = ("more_tools"),
+        sub_item_table = {
+            {
+                text_func = function()
+                    if self:isRunning() then
+                        return _("Stop Server")
+                    else
+                        return _("Start Server")
+                    end
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    if self:isRunning() then
+                        self:stop()
+                    else
+                        self:start()
+                    end
+                    touchmenu_instance:updateItems()
+                end
+            },
+            {
+                text_func = function()
+                    return self:getWebPageUrlMenuText()
+                end,
+                enabled_func = function()
+                    return self:isRunning()
+                end,
+                callback = function()
+                    UIManager:show(InfoMessage:new {
+                        text = self:getWebPageUrlMenuText(),
+                    })
+                end,
+                separator = true,
+            },
+            {
+                text = _("Auto start server"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("remotenoteinput_autostart")
+                end,
+                callback = function(touchmenu_instance)
+                    G_reader_settings:flipNilOrFalse("remotenoteinput_autostart")
+                    touchmenu_instance:updateItems()
+                end,
+            },
+            {
+                text_func = function()
+                    return T(_("Port: %1"), self.port)
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local InputDialog = require("ui/widget/inputdialog")
+                    local port_dialog
+                    port_dialog = InputDialog:new {
+                        title = _("Set custom port"),
+                        input = self.port,
+                        input_type = "number",
+                        input_hint = _("Port number (default is 8088)"),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function()
+                                        UIManager:close(port_dialog)
+                                    end,
+                                },
+                                {
+                                    text = _("OK"),
+                                    -- keep_menu_open = true,
+                                    callback = function()
+                                        local port = port_dialog:getInputValue()
+                                        if port and port >= 1 and port <= 65535 then
+                                            self.port = port
+                                            G_reader_settings:saveSetting("remotenoteinput_port", port)
+                                            if self:isRunning() then
+                                                self:stop()
+                                                self:start()
+                                            end
+                                        end
+                                        UIManager:close(port_dialog)
+                                        touchmenu_instance:updateItems()
+                                    end,
+                                },
+                            },
+                        },
+                    }
+                    UIManager:show(port_dialog)
+                    port_dialog:onShowKeyboard()
+                end,
+            },
+            {
+                text = _("Help"),
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    UIManager:show(InfoMessage:new {
+                        text = _("Remote Note Input lets you type text in a browser on any device over local Wi-Fi and send it directly to KOReader’s note editor. It’s especially useful when using input methods like Pinyin that require word selection. Make sure the “Edit note” dialog is open in KOReader before sending."),
+                    })
+                    touchmenu_instance:updateItems()
+                end,
+            }
+        },
+    }
+end
+
+return RemoteNoteInput


### PR DESCRIPTION
Hi，When using Pinyin input, selecting the correct characters from many homophones can slow down typing—especially on e-ink devices. Inspired by how devices like Apple TV let you enter text via your phone, I wanted to improve KOReader’s note-taking by allowing text input from devices with better keyboards, smarter input methods, or voice typing.

The Remote Note Input plugin starts a local web server inside KOReader. When the Edit note dialog is open, you can access a web page on any device in the same Wi-Fi network and send text directly into the note editor.（Make sure the note editor is open before sending, or the input will be ignored.）

This plugin is especially helpful for input methods like Pinyin, but it’s also great for anyone looking to type faster—since e-ink devices aren’t ideal for long or complex input.
<img width="926" alt="截屏2025-05-25 23 22 55" src="https://github.com/user-attachments/assets/c324ee65-63a9-4217-8293-e54589c20e3c" />

<img width="953" alt="SCR-20250525-ueqs" src="https://github.com/user-attachments/assets/81bf0892-c9be-4853-8dfc-382a99a61ead" />

![Reader_史蒂夫·乔布斯传 epub_p1091_2025-05-25_231348](https://github.com/user-attachments/assets/7d2795ee-a748-415c-9fa2-b6376c750b80)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13853)
<!-- Reviewable:end -->
