### PR TITLE
[DictQuickLookup] enable full-screen mode for open dictionary window

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -211,7 +211,7 @@ function DictQuickLookup:init()
         }
     end
 
-    self.temp_large_window = DictQuickLookup.temp_large_window_request and DictQuickLookup.temp_large_window_request.full_screen == true
+    self.temp_large_window = DictQuickLookup.temp_large_window_request and DictQuickLookup.temp_large_window_request.is_large_window == true
 
     -- We no longer support setting a default dict with Tap on title.
     -- self:changeToDefaultDict()
@@ -1021,7 +1021,7 @@ function DictQuickLookup:setTemporaryLargeWindowMode()
     -- We want to remember the current dict_index (e.g. 5/7), so that it can be restored later.
     DictQuickLookup.temp_large_window_request = {
         dict_index = self.dict_index,
-        full_screen = true, -- note: any would-be child window will also open in fullscreen mode.
+        is_large_window = true, -- note: any would-be child window will also open in fullscreen mode.
     }
     -- Re-trigger the lookup, and close this instance _after_ the new one is created.
     if self.is_wiki then

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -68,11 +68,11 @@ local DictQuickLookup = InputContainer:extend{
     -- Static class member, used by ReaderWiktionary to communicate state from a closed widget to the next opened one.
     rotated_update_wiki_languages_on_close = nil,
 
-    _is_temporary_fullscreen_mode = false,
+    _is_temporary_large_window = false,
 }
 
 -- Static variable to hold request data for temporary fullscreen
-DictQuickLookup.temp_fullscreen_request = nil
+DictQuickLookup.temp_large_window_request = nil
 
 function DictQuickLookup.getWikiSaveEpubDefaultDir()
     local dir = G_reader_settings:readSetting("home_dir") or filemanagerutil.getDefaultDir()
@@ -198,7 +198,7 @@ function DictQuickLookup:init()
                     end
                 end
             },
-            SetTemporaryFullScreenMode = {
+            SetTemporaryLargeWindowMode = {
                 GestureRange:new{
                     ges = "spread",
                     range = range,
@@ -211,14 +211,14 @@ function DictQuickLookup:init()
         }
     end
 
-    self.temp_large_window = DictQuickLookup.temp_fullscreen_request and DictQuickLookup.temp_fullscreen_request.full_screen == true
+    self.temp_large_window = DictQuickLookup.temp_large_window_request and DictQuickLookup.temp_large_window_request.full_screen == true
 
     -- We no longer support setting a default dict with Tap on title.
     -- self:changeToDefaultDict()
-    if DictQuickLookup.temp_fullscreen_request and DictQuickLookup.temp_fullscreen_request.dict_index then
-        self:changeDictionary(DictQuickLookup.temp_fullscreen_request.dict_index, true)
-        DictQuickLookup.temp_fullscreen_request.dict_index = nil
-        self._is_temporary_fullscreen_mode = true
+    if DictQuickLookup.temp_large_window_request and DictQuickLookup.temp_large_window_request.dict_index then
+        self:changeDictionary(DictQuickLookup.temp_large_window_request.dict_index, true)
+        DictQuickLookup.temp_large_window_request.dict_index = nil
+        self._is_temporary_large_window = true
     else
         self:changeDictionary(1, true) -- don't call update
     end
@@ -787,7 +787,7 @@ function DictQuickLookup:registerKeyEvents()
             local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
             self.key_events.ChangeToPrevDict = { { modifier, Input.group.PgBack } }
             self.key_events.ChangeToNextDict = { { modifier, Input.group.PgFwd } }
-            self.key_events.SetTemporaryFullScreenMode = { { modifier, "Home" } }
+            self.key_events.SetTemporaryLargeWindowMode = { { modifier, "Home" } }
             self.key_events.StartOrUpTextSelectorIndicator   = { { modifier, "Up" },   event = "StartOrMoveTextSelectorIndicator", args = { 0, -1, true } }
             self.key_events.StartOrDownTextSelectorIndicator = { { modifier, "Down" }, event = "StartOrMoveTextSelectorIndicator", args = { 0,  1, true } }
             self.key_events.FastLeftTextSelectorIndicator  = { { modifier, "Left" },  event = "MoveTextSelectorIndicator", args = { -1, 0, true } }
@@ -1002,12 +1002,12 @@ function DictQuickLookup:update()
     end)
 end
 
-function DictQuickLookup:onSetTemporaryFullScreenMode()
-    self:setTemporaryFullScreenMode()
+function DictQuickLookup:onSetTemporaryLargeWindowMode()
+    self:setTemporaryLargeWindowMode()
     return true
 end
 
-function DictQuickLookup:setTemporaryFullScreenMode()
+function DictQuickLookup:setTemporaryLargeWindowMode()
     if self.temp_large_window then return false end
     if self.is_wiki_fullpage or G_reader_settings:isTrue("dict_largewindow") then return false end
 
@@ -1019,7 +1019,7 @@ function DictQuickLookup:setTemporaryFullScreenMode()
         end
     end
     -- We want to remember the current dict_index (e.g. 5/7), so that it can be restored later.
-    DictQuickLookup.temp_fullscreen_request = {
+    DictQuickLookup.temp_large_window_request = {
         dict_index = self.dict_index,
         full_screen = true, -- note: any would-be child window will also open in fullscreen mode.
     }
@@ -1276,8 +1276,8 @@ function DictQuickLookup:onClose(no_clear)
 
     UIManager:close(self)
 
-    if self._is_temporary_fullscreen_mode then
-        DictQuickLookup.temp_fullscreen_request = nil
+    if self._is_temporary_large_window then
+        DictQuickLookup.temp_large_window_request = nil
     end
 
     if self.update_wiki_languages_on_close then

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -211,7 +211,7 @@ function DictQuickLookup:init()
         }
     end
 
-    self.temp_fullscreen = DictQuickLookup.temp_fullscreen_request and DictQuickLookup.temp_fullscreen_request.full_screen == true
+    self.temp_large_window = DictQuickLookup.temp_fullscreen_request and DictQuickLookup.temp_fullscreen_request.full_screen == true
 
     -- We no longer support setting a default dict with Tap on title.
     -- self:changeToDefaultDict()
@@ -232,7 +232,7 @@ function DictQuickLookup:init()
 
     -- Bigger window if fullpage Wikipedia article being shown,
     -- or when large windows for dict requested
-    local is_large_window = self.is_wiki_fullpage or G_reader_settings:isTrue("dict_largewindow") or self.temp_fullscreen
+    local is_large_window = self.is_wiki_fullpage or G_reader_settings:isTrue("dict_largewindow") or self.temp_large_window
     if is_large_window then
         self.width = Screen:getWidth() - 2*Size.margin.default
     else
@@ -1008,7 +1008,7 @@ function DictQuickLookup:onSetTemporaryFullScreenMode()
 end
 
 function DictQuickLookup:setTemporaryFullScreenMode()
-    if self.temp_fullscreen then return false end
+    if self.temp_large_window then return false end
     if self.is_wiki_fullpage or G_reader_settings:isTrue("dict_largewindow") then return false end
 
     -- Remove ourselves from window_list before creating the new instance, onHoldClose won't like it if we still exist.

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1021,12 +1021,12 @@ function DictQuickLookup:setTemporaryFullScreenMode()
     -- This setting will be reverted upon closing the new instance. Note that any would be child windows will also open in fullscreen mode.
     G_reader_settings:makeTrue("dict_largewindow")
 
-    local ui_ref = self.ui or UIManager
+    local ui = self.ui or UIManager
     -- Re-trigger the lookup, and close this instance _after_ the new one is created.
     if self.is_wiki then
-        ui_ref:handleEvent(Event:new("LookupWikipedia", self.word, self.is_sane_word, self.word_boxes, false, self.lang, function() self:onClose(true) end))
+        ui:handleEvent(Event:new("LookupWikipedia", self.word, self.is_sane_word, self.word_boxes, false, self.lang, function() self:onClose(true) end))
     else
-        ui_ref:handleEvent(Event:new("LookupWord", self.word, true, self.word_boxes, self.highlight, nil, function() self:onClose(true) end))
+        ui:handleEvent(Event:new("LookupWord", self.word, true, self.word_boxes, self.highlight, nil, function() self:onClose(true) end))
     end
     return true
 end


### PR DESCRIPTION
we've all been there, you look up a word definition only to realise is long AF and you ponder, why isn't there an easy way to go full screen mode here? well worry not past me... here it is.

### what's new

* **Static Variables and Properties**: Added a new static variable `temp_fullscreen_request` and a private property `_is_temporary_fullscreen_mode` to manage the temporary fullscreen state.
* **Gesture and Key Bindings**: Introduced a new gesture (`spread`) and a key binding (<kbd>screenkb/shift</kbd> + <kbd>home</kbd> ) to trigger the temporary fullscreen mode.
* **Initialisation Logic**: Updated the `init` method to check for `temp_fullscreen_request` and set the appropriate dictionary and fullscreen mode state during initialisation. 
* **Fullscreen Mode Implementation**: Added `setTemporaryFullScreenMode` and `onSetTemporaryFullScreenMode` methods to handle the logic for enabling fullscreen mode, including re-triggering lookups and managing the `window_list`.
* **Cleanup on Close**: Modified the `onClose` method to revert the fullscreen mode setting when the widget is closed. 

### screen recording

<div align="center">
  <img src="https://github.com/user-attachments/assets/5dc891d3-6d6f-4a59-b64b-493ccca954f5" alt="name" width="400" />
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13862)
<!-- Reviewable:end -->
