### PR TITLE
Added Onyx Boox Go 7 to devices that follow gravity.

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -244,7 +244,7 @@ function Device:init()
     }
 
     -- disable translation for specific models, where media keys follow gravity, see https://github.com/koreader/koreader/issues/12423
-    if android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" or android.prop.model == "gocolor7" then
+    if android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" or android.prop.model == "gocolor7" or android.prop.model == "go7" then
         self.input:disableRotationMap()
     end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -244,7 +244,7 @@ function Device:init()
     }
 
     -- disable translation for specific models, where media keys follow gravity, see https://github.com/koreader/koreader/issues/12423
-    if android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" or android.prop.model == "gocolor7" or android.prop.model == "go7" then
+    if android.prop.model == "go7" or android.prop.model == "gocolor7" or android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" then
         self.input:disableRotationMap()
     end
 


### PR DESCRIPTION
With Onyx Boox Go 7. When the device is rotated (Left Hand to Right Hand) the button function does not rotate.
need to add Onyx Boox Go 7 to list of devices that need disableRotationMap() activated.

user patch works in the meantime. On current android nightly ( v2025.04-90-g58860f65d_2025-05-27 )

``` lua
local logger = require("logger")
local Device = require("device")
Device.input.rotation_map = {
    [0] = {},
    [1] = {},
    [2] = {},
    [3] = {},
}
logger.info("Hardware button rotation disabled by user patch")

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13872)
<!-- Reviewable:end -->
