### PR TITLE
[ReaderDictionary] match words when they are Capitalised

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -17,6 +17,7 @@ local NetworkMgr = require("ui/network/manager")
 local SortWidget = require("ui/widget/sortwidget")
 local Trapper = require("ui/trapper")
 local UIManager = require("ui/uimanager")
+local Utf8Proc = require("ffi/utf8proc")
 local ffi = require("ffi")
 local C = ffi.C
 local ffiUtil  = require("ffi/util")
@@ -1000,8 +1001,11 @@ end
 function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     local words = {word}
     -- If a word starts with a capital letter, add lowercase version to words array.
-    if not fuzzy_search and word:match("^%u") then
-        table.insert(words, word:lower())
+    if not fuzzy_search then
+        local lowercased = Utf8Proc.lowercase(word, false)
+        if word ~= lowercased then
+            table.insert(words, lowercased)
+        end
     end
 
     if self.ui.languagesupport and self.ui.languagesupport:hasActiveLanguagePlugins() then

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -999,6 +999,10 @@ end
 
 function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     local words = {word}
+    -- If a word starts with a capital letter, add lowercase version to words array.
+    if not fuzzy_search and word:match("^%u") then
+        table.insert(words, word:lower())
+    end
 
     if self.ui.languagesupport and self.ui.languagesupport:hasActiveLanguagePlugins() then
         -- Get any other candidates from any language-specific plugins we have.


### PR DESCRIPTION
### what's new

This pull request introduces a small enhancement to the `ReaderDictionary` module. The change improves the handling of word lookups by adding a lowercase version of a word to the search array if the word starts with a capital letter and fuzzy search is disabled.

### why?

it does seem quite silly, that a user might not get any results due to punctuation, in the following example all "Count", "Back", "Your", "Wait", "Have", "Tonight", "Tomorrow" and "There" yield no results at all, event though the dictionary has entries for them (in lowercase)

<p align="center">
<img src="https://github.com/user-attachments/assets/b9603791-637b-4cca-a302-4e76d32bf398" > 
</p> 
<p align="center">
<img src="https://github.com/user-attachments/assets/ca25998a-666c-42fd-9352-d91ad204b1d3" width=40%> 
<img src="https://github.com/user-attachments/assets/c87b83ef-b3b7-42ef-906f-e20703c5e005" width=40%> 
</p> 

### related issues

* fixes #13346
* fixes #10348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13884)
<!-- Reviewable:end -->
