### PR TITLE
appimage: update appimagetool

### DIFF
--- a/make/appimage.mk
+++ b/make/appimage.mk
@@ -1,7 +1,7 @@
 APPIMAGE_DIR = $(PLATFORM_DIR)/appimage
 
 APPIMAGETOOL = appimagetool-x86_64.AppImage
-APPIMAGETOOL_URL = https://github.com/AppImage/AppImageKit/releases/download/13/$(APPIMAGETOOL)
+APPIMAGETOOL_URL = https://github.com/AppImage/appimagetool/releases/download/continuous/$(APPIMAGETOOL)
 
 KOREADER_APPIMAGE = koreader-$(DIST)-$(MACHINE)-$(VERSION).AppImage
 


### PR DESCRIPTION
The more recent versions use ZSTD for compression, and net us a nice 2 MB reduction of the final AppImage' size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13885)
<!-- Reviewable:end -->
