### PR TITLE
ota: prevent deadlock delaying an update

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -456,7 +456,6 @@ function Device:install()
             UIManager:show(InfoMessage:new{
                 text = _("The update will be applied the next time KOReader is started."),
                 unmovable = true,
-                dismissable = false,
             })
         end,
         unmovable = true,


### PR DESCRIPTION
When selecting "Later" after being prompted for installing an update now, the next info box would be undismissable, deadlocking the UI.