### PR TITLE
[Hotkeys] bug fix: don't override readerfont when reading pdf/djvu files

### DIFF
--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -421,8 +421,10 @@ function HotKeys:overrideConflictingKeyEvents()
         self.ui.bookmark.key_events = {} -- reset it.
         logger.dbg("Hotkey ReaderBookmark:registerKeyEvents() overridden.")
 
-        self.ui.font.key_events = {} -- reset it.
-        logger.dbg("Hotkey ReaderFont:registerKeyEvents() overridden.")
+        if self.ui.font then -- readerfont is not available for pdf/djvu files.
+            self.ui.font.key_events = {} -- reset it.
+            logger.dbg("Hotkey ReaderFont:registerKeyEvents() overridden.")
+        end
 
         if Device:hasScreenKB() or Device:hasSymKey() then
             local readerconfig = self.ui.config


### PR DESCRIPTION
### bug fix

* don't attempt to override readerfont's key events when opening pdf/djvu files. Reported https://github.com/koreader/koreader/issues/13895#issuecomment-2923450941

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13896)
<!-- Reviewable:end -->
