### PR TITLE
DJVU: add getTextBoxes()

### DIFF
--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -60,6 +60,10 @@ function DjvuDocument:getPageTextBoxes(pageno)
     return self._document:getPageText(pageno)
 end
 
+function DjvuDocument:getTextBoxes(pageno)
+    return self.koptinterface:getTextBoxes(self, pageno)
+end
+
 function DjvuDocument:getPanelFromPage(pageno, pos)
     return self.koptinterface:getPanelFromPage(self, pageno, pos)
 end


### PR DESCRIPTION
Crash reported in https://github.com/koreader/koreader/issues/13895.
Also crashed when changing highlight boundaries.

The first step only. Needs more testing on various systems with various djvu files, so keep the issue opened.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13897)
<!-- Reviewable:end -->
