### PR TITLE
TouchMenu: optimize item removal

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1949,7 +1949,7 @@ function ReaderFooter:genPresetMenuItemTable()
             callback = function()
                 self:loadPreset(footer_presets[preset_name])
             end,
-            hold_callback = function(touchmenu_instance)
+            hold_callback = function(touchmenu_instance, item)
                 UIManager:show(MultiConfirmBox:new{
                     text = T(_("What would you like to do with preset '%1'?"), preset_name),
                     choice1_text = _("Delete"),
@@ -1957,7 +1957,7 @@ function ReaderFooter:genPresetMenuItemTable()
                         footer_presets[preset_name] = nil
                         UIManager:broadcastEvent(Event:new("DispatcherActionValueChanged",
                             { name = "load_footer_preset", old_value = preset_name, new_value = nil }))
-                        touchmenu_instance.item_table = self:genPresetMenuItemTable()
+                        table.remove(touchmenu_instance.item_table, item.idx)
                         touchmenu_instance:updateItems()
                     end,
                     choice2_text = _("Update"),

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -692,11 +692,13 @@ function TouchMenu:updateItems()
     table.insert(self.item_group, self.bar)
     table.insert(self.layout, self.bar.icon_widgets) -- for the focusmanager
 
+    local idx_offset = (self.page - 1) * self.perpage
     for c = 1, self.perpage do
         -- calculate index in item_table
-        local i = (self.page - 1) * self.perpage + c
+        local i = idx_offset + c
         if i <= #self.item_table then
             local item = self.item_table[i]
+            item.idx = i
             local item_tmp = TouchMenuItem:new{
                 item = item,
                 menu = self,
@@ -978,7 +980,7 @@ function TouchMenu:onMenuHold(item, text_truncated)
             end
             -- Provide callback with us, so it can call our
             -- closemenu() or updateItems() when it sees fit
-            callback(self)
+            callback(self, item)
         end
     elseif item.help_text or type(item.help_text_func) == "function" then
         local help_text = item.help_text

--- a/plugins/bookshortcuts.koplugin/main.lua
+++ b/plugins/bookshortcuts.koplugin/main.lua
@@ -137,13 +137,13 @@ function BookShortcuts:getSubMenuItems()
         table.insert(sub_item_table, {
             text = icon .. text,
             callback = function() self:onBookShortcut(k) end,
-            hold_callback = function(touchmenu_instance)
+            hold_callback = function(touchmenu_instance, item)
                 UIManager:show(ConfirmBox:new{
                     text = _("Do you want to delete this shortcut?") .. "\n\n" .. k .. "\n",
                     ok_text = _("Delete"),
                     ok_callback = function()
                         self:deleteShortcut(k)
-                        touchmenu_instance.item_table = self:getSubMenuItems()
+                        table.remove(touchmenu_instance.item_table, item.idx)
                         touchmenu_instance.page = 1
                         touchmenu_instance:updateItems()
                     end,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -222,7 +222,7 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
                                 self.last_view_pos = {}
                                 -- remove history items from the parent menu
                                 for j = #sub_item_table, 1, -1 do
-                                    if sub_item_table[j]._texteditor_id then
+                                    if sub_item_table[j].is_file then
                                         table.remove(sub_item_table)
                                     end
                                 end
@@ -258,12 +258,12 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
         table.insert(sub_item_table, {
             text = T("\u{f016} %1", BD.filename(filename)), -- file symbol
             keep_menu_open = true,
+            is_file = true, -- for history cleanup
             callback = function(touchmenu_instance)
                 self:setupWhenDoneFunc(touchmenu_instance)
                 self:checkEditFile(file_path, true)
             end,
-            _texteditor_id = file_path, -- for removal from menu itself
-            hold_callback = function(touchmenu_instance)
+            hold_callback = function(touchmenu_instance, item)
                 -- Show full path and some info, and propose to remove from history
                 local text
                 local attr = lfs.attributes(file_path)
@@ -281,13 +281,7 @@ Export text to QR code, that can be scanned, for example, by a phone.]]),
                     ok_text = _("Remove"),
                     ok_callback = function()
                         self:removeFromHistory(file_path)
-                        -- Also remove from menu itself
-                        for j=1, #sub_item_table do
-                            if sub_item_table[j]._texteditor_id == file_path then
-                                table.remove(sub_item_table, j)
-                                break
-                            end
-                        end
+                        table.remove(touchmenu_instance.item_table, item.idx)
                         touchmenu_instance:updateItems()
                     end,
                 })


### PR DESCRIPTION
Similar to the Menu widget, add `item.idx` to avoid rebuilding the whole menu or iterating over all items when removing an item.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13901)
<!-- Reviewable:end -->
