### PR TITLE
ToC: search

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -10,11 +10,13 @@ local GestureRange = require("ui/gesturerange")
 local Geom = require("ui/geometry")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
+local util = require("util")
 local _ = require("gettext")
 local N_ = _.ngettext
 local Screen = Device.screen
@@ -675,6 +677,7 @@ function ReaderToc:getChapterPagesDone(pageno)
 end
 
 function ReaderToc:updateCurrentNode()
+    if self.search_string ~= nil and self.search_string ~= "*" then return end
     if #self.collapsed_toc > 0 and self.pageno then
         for i, v in ipairs(self.collapsed_toc) do
             if v.page >= self.pageno then
@@ -695,10 +698,10 @@ end
 function ReaderToc:expandParentNode(index)
     if index then
         local nodes_to_expand = {}
-        local depth = self.toc[index].depth
+        local depth = self.filtered_toc[index].depth
         for i = index - 1, 1, -1 do
-            if depth > self.toc[i].depth then
-                depth = self.toc[i].depth
+            if depth > self.filtered_toc[i].depth then
+                depth = self.filtered_toc[i].depth
                 table.insert(nodes_to_expand, i)
             end
             if depth == 1 then break end
@@ -812,16 +815,36 @@ function ReaderToc:onShowToc()
     -- update collapsible state
     if #self.toc > 0 and #self.collapsed_toc == 0 then
         local depth = 0
-        for i = #self.toc, 1, -1 do
-            local v = self.toc[i]
-            -- node v has child node(s)
-            if v.depth < depth then
-                v.state = self.expand_button:new{}
+        if self.search_string then
+            for i = #self.toc, 1, -1 do
+                local v = self.toc[i]
+                if v.depth < depth or self.search_string == "*" or util.stringSearch(v.title, self.search_string) ~= 0 then
+                    if v.depth < depth then
+                        v.state = self.collapse_button:new{}
+                        self.expanded_nodes[i] = true
+                    end
+                    table.insert(self.collapsed_toc, 1, v)
+                    depth = v.depth
+                end
             end
-            if v.depth < self.collapse_depth then
-                table.insert(self.collapsed_toc, 1, v)
+            self.filtered_toc = {}
+            for i, v in ipairs(self.collapsed_toc) do
+                v.index = i
+                self.filtered_toc[i] = v
             end
-            depth = v.depth
+        else
+            for i = #self.toc, 1, -1 do
+                local v = self.toc[i]
+                -- node v has child node(s)
+                if v.depth < depth then
+                    v.state = self.expand_button:new{}
+                end
+                if v.depth < self.collapse_depth then
+                    table.insert(self.collapsed_toc, 1, v)
+                end
+                depth = v.depth
+            end
+            self.filtered_toc = self.toc
         end
     end
     local can_collapse = self:getMaxDepth() > 1
@@ -832,13 +855,12 @@ function ReaderToc:onShowToc()
     local button_size = self.expand_button:getSize()
     local toc_menu = Menu:new{
         title = self:getTitle(),
-        item_table = self.collapsed_toc,
+        subtitle = self.search_string and T(_("Query: %1"), self.search_string) or "",
         state_w = can_collapse and button_size.w or 0,
         ui = self.ui,
+        covers_fullscreen = true,
         is_borderless = true,
         is_popout = false,
-        width = Screen:getWidth(),
-        height = Screen:getHeight(),
         single_line = true,
         align_baselines = true,
         with_dots = items_with_dots,
@@ -846,6 +868,11 @@ function ReaderToc:onShowToc()
         items_font_size = items_font_size,
         items_padding = can_collapse and math.floor(Size.padding.fullscreen / 2) or nil, -- c.f., note above. Menu's default is twice that.
         line_color = Blitbuffer.COLOR_WHITE,
+        title_bar_fm_style = true,
+        title_bar_left_icon = "appbar.menu",
+        onLeftButtonTap = function()
+            self:showTocDialog()
+        end,
         on_close_ges = {
             GestureRange:new{
                 ges = "two_finger_swipe",
@@ -917,15 +944,17 @@ function ReaderToc:onShowToc()
     self.toc_menu = toc_menu
 
     self:updateCurrentNode()
-    -- auto expand the parent node of current page
-    local idx = self:getTocIndexByPage(self.pageno)
-    if idx then
-        self:expandParentNode(idx)
-        -- Also do it for other toc items on current page
-        idx = idx + 1
-        while self.toc[idx] and self.toc[idx].page == self.pageno do
+    if self.search_string == nil then
+        -- auto expand the parent node of current page
+        local idx = self:getTocIndexByPage(self.pageno)
+        if idx then
             self:expandParentNode(idx)
+            -- Also do it for other toc items on current page
             idx = idx + 1
+            while self.toc[idx] and self.toc[idx].page == self.pageno do
+                self:expandParentNode(idx)
+                idx = idx + 1
+            end
         end
     end
 
@@ -937,12 +966,52 @@ function ReaderToc:onShowToc()
     return true
 end
 
+function ReaderToc:showTocDialog()
+    local function set_show_toc(search_string)
+        self.search_string = search_string
+        self.toc_menu_items_built = search_string and true
+        self.expanded_nodes = {}
+        self.collapsed_toc = {}
+        self.toc_menu.close_callback()
+        self:onShowToc()
+    end
+    if self.search_string then
+        set_show_toc()
+    else
+        local input_dialog
+        input_dialog = InputDialog:new{
+            title =  _("Enter text to search for in ToC"),
+            buttons = {{
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(input_dialog)
+                    end,
+                },
+                {
+                    text = _("Search"),
+                    callback = function()
+                        local str = input_dialog:getInputText()
+                        if str ~= "" then
+                            UIManager:close(input_dialog)
+                            set_show_toc(str)
+                        end
+                    end,
+                },
+            }},
+        }
+        UIManager:show(input_dialog)
+        input_dialog:onShowKeyboard()
+    end
+end
+
 -- expand TOC node of index in raw toc table
 function ReaderToc:expandToc(index)
     if self.expanded_nodes[index] == true then return end
 
     self.expanded_nodes[index] = true
-    local cur_node = self.toc[index]
+    local cur_node = self.filtered_toc[index]
     local cur_depth = cur_node.depth
     local collapsed_index = nil
     for i, v in ipairs(self.collapsed_toc) do
@@ -955,8 +1024,8 @@ function ReaderToc:expandToc(index)
     -- either the toc entry of index has no child nodes
     -- or it's parent nodes are not expanded yet
     if not collapsed_index then return end
-    for i = index + 1, #self.toc do
-        local v = self.toc[i]
+    for i = index + 1, #self.filtered_toc do
+        local v = self.filtered_toc[i]
         if v.depth == cur_depth + 1 then
             collapsed_index = collapsed_index + 1
             table.insert(self.collapsed_toc, collapsed_index, v)
@@ -976,7 +1045,7 @@ function ReaderToc:collapseToc(index)
     if self.expanded_nodes[index] == true then
         self.expanded_nodes[index] = nil
     end
-    local cur_node = self.toc[index]
+    local cur_node = self.filtered_toc[index]
     local cur_depth = cur_node.depth
     local i = 1
     local is_child_node = false


### PR DESCRIPTION
Tap the titlebar left icon to enter the search string.
If the search string is found in a subchapter, the whole parent chapter tree is shown expanded.
Easter egg: "*" search string shows and expands all ToC trees.
Tap the titlebar left icon again to return to the full ToC.
Closes https://github.com/koreader/koreader/issues/12921.

![1](https://github.com/user-attachments/assets/49da64d8-e800-4fc5-8886-fcaca3c0e282)

![2](https://github.com/user-attachments/assets/74c23232-cea2-4da7-8a64-511de3211ef4)
