### PR TITLE
[DictQuickLookup] create addQueryWordToFirstResult method

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1158,7 +1158,9 @@ function DictQuickLookup:changeDictionary(index, skip_update)
         self.displaynb = T("%1 / %2", index, #self.results)
         -- add queried word to 1st result's definition, so we can see
         -- what was the selected text and if we selected wrong
-        self:addQueryWordToFirstResult(index)
+        if index == 1 then
+            self:addQueryWordToResult()
+        end
     end
     self.displaydictname = self.dictionary
     if self.preferred_dictionaries then
@@ -1180,16 +1182,14 @@ function DictQuickLookup:changeDictionary(index, skip_update)
     end
 end
 
-function DictQuickLookup:addQueryWordToFirstResult(index)
+function DictQuickLookup:addQueryWordToResult()
     -- Extracted to a separate method so it can be removed by user patches.
-    if index == 1 then
-        if self.is_html then
-            self.definition = self.definition.."<br/>_______<br/>"
-        else
-            self.definition = self.definition.."\n_______\n"
-        end
-        self.definition = self.definition..T(_("(query : %1)"), self.word)
+    if self.is_html then
+        self.definition = self.definition.."<br/>_______<br/>"
+    else
+        self.definition = self.definition.."\n_______\n"
     end
+    self.definition = self.definition..T(_("(query : %1)"), self.word)
 end
 
 --[[ No longer used


### PR DESCRIPTION
### what's new

* **Extraction of logic into a new method**: The code responsible for appending the queried word to the first result's definition has been moved from `DictQuickLookup:changeDictionary` to a new method, `DictQuickLookup:addQueryWordToFirstResult`, making the code easier to override or remove via user patches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13911)
<!-- Reviewable:end -->
