### PR TITLE
[ReaderHighlight] NT: add key event to simulate a very long press

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2671,7 +2671,7 @@ end
 
 -- dpad/keys support
 
-function ReaderHighlight:onHighlightPress()
+function ReaderHighlight:onHighlightPress(skip_tap_check)
     if not self._current_indicator_pos then return false end
     if self._start_indicator_highlight then
         self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
@@ -2679,7 +2679,7 @@ function ReaderHighlight:onHighlightPress()
         return true
     end
     -- Attempt to open an existing highlight
-    if self:onTap(nil, self:_createHighlightGesture("tap")) then
+    if not skip_tap_check and self:onTap(nil, self:_createHighlightGesture("tap")) then
         self:onStopHighlightIndicator(true) -- need_clear_selection=true
         return true
     end
@@ -2763,8 +2763,11 @@ function ReaderHighlight:onHighlightPress()
 end
 
 function ReaderHighlight:onHighlightModifierPress()
-    if not self._current_indicator_pos then return false end -- let hotkeys run its course
-    if not self._start_indicator_highlight then return true end -- don't trigger hotkeys during text selection
+    if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
+    if not self._start_indicator_highlight then
+        self:onHighlightPress(true)
+        return true -- don't trigger hotkeys during text selection
+    end
     -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
     self.long_hold_reached = true
     self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))


### PR DESCRIPTION
### what's new

On touch devices, it is possible to do a very long press (usually three seconds) on a selection, which brings up the `_highlight_buttons` dialogue. On non-touch devices, this is obviously not possible in the same way, so we now use <kbd>press</kbd> for the main action (normal highlight as seen in the screen recording), and <kbd>shift</kbd>/<kbd>screenkb</kbd> + <kbd>press</kbd> to call said dialogue.

* Updated `registerKeyEvents()` to unify handling for devices with physical keyboards and screen keyboards by introducing a `modifier` variable. This simplifies the logic for assigning key events for text selection.
* Added `onHighlightModifierPress()` method to simulate a long-press action using the modifier key, enabling long-press dialogs during text selection.

### screen recording

<div align="center">
  <img src="https://github.com/user-attachments/assets/ecb4248f-a163-461d-bae9-3b451ff47410" alt="name" width="400" />
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13914)
<!-- Reviewable:end -->
