### PR TITLE
[ReaderHighlight] NT: add better support for extending highlights

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -75,6 +75,9 @@ function ReaderHighlight:init()
                 callback = function()
                     this:startSelection(index)
                     this:onClose()
+                    if not Device:isTouchDevice() then
+                        self:onStartHighlightIndicator()
+                    end
                 end,
             }
         end,
@@ -2676,6 +2679,13 @@ end
 function ReaderHighlight:onHighlightPress()
     if not self._current_indicator_pos then return false end
     if self._start_indicator_highlight then
+        self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+        self:onStopHighlightIndicator()
+        return true
+    end
+    -- Check if we're in select mode (extending an existing highlight)
+    if self.select_mode and self.highlight_idx then
+        self:onHold(nil, self:_createHighlightGesture("hold"))
         self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
         self:onStopHighlightIndicator()
         return true

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2796,6 +2796,16 @@ function ReaderHighlight:onStartHighlightIndicator()
 end
 
 function ReaderHighlight:onStopHighlightIndicator(need_clear_selection)
+    -- If we're in select mode and user presses back, end the selection
+    if self.select_mode and self.highlight_idx then
+        self.select_mode = false
+        if self.ui.annotation.annotations[self.highlight_idx].is_tmp then
+            self:deleteHighlight(self.highlight_idx) -- temporary highlight, delete it
+        else
+            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+        end
+        self.highlight_idx = nil
+    end
     if self._current_indicator_pos then
         local rect = self._current_indicator_pos
         self._previous_indicator_pos = rect

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2683,7 +2683,7 @@ function ReaderHighlight:onHighlightPress()
         self:onStopHighlightIndicator()
         return true
     end
-    -- Check if we're in select mode (extending an existing highlight)
+    -- Check if we're in select mode (or extending an existing highlight)
     if self.select_mode and self.highlight_idx then
         self:onHold(nil, self:_createHighlightGesture("hold"))
         self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))


### PR DESCRIPTION
### what's new

* [`frontend/apps/reader/modules/readerhighlight.lua`](diffhunk://#diff-db51db4b48e0314c642050876de6cd601d148eaaa00d4511523f811531d63ccfR78-R80): Updated `init()` to conditionally trigger `onStartHighlightIndicator()` for non-touch devices.
* [`frontend/apps/reader/modules/readerhighlight.lua`](diffhunk://#diff-db51db4b48e0314c642050876de6cd601d148eaaa00d4511523f811531d63ccfR2686-R2692): Enhanced `onHighlightPress()` to handle select mode, improving the user experience for extending highlights.
* [`frontend/apps/reader/modules/readerhighlight.lua`](diffhunk://#diff-db51db4b48e0314c642050876de6cd601d148eaaa00d4511523f811531d63ccfR2799-R2808): Updated `onStopHighlightIndicator()` to properly end selection mode when the user presses back. Temporary highlights are deleted, and UI regions are refreshed for non-temporary highlights.

### related PRs

* Extends #13815 (I'll see myself out!)

### screen recording

<div align="center">
  <img src="https://github.com/user-attachments/assets/02151792-a73e-462b-b3e4-a7a82251c28f" alt="name" width="400" />
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13917)
<!-- Reviewable:end -->
