### PR TITLE
Minor fixes

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -449,9 +449,10 @@ footerTextGeneratorMap = {
             tmp:free()
         end
         local separator_width = is_filler_inside and footer.separator_width or 0
+        local filler_space = " "
         if footer.filler_space_width == nil then
             tmp = TextWidget:new{
-                text = " ",
+                text = filler_space,
                 face = footer.footer_text_face,
                 bold = footer.settings.text_font_bold,
             }
@@ -460,7 +461,7 @@ footerTextGeneratorMap = {
         end
         local filler_nb = math.floor((max_width - text_width + separator_width) / footer.filler_space_width)
         if filler_nb > 0 then
-            return " ":rep(filler_nb), true
+            return filler_space:rep(filler_nb), true
         end
     end,
 }

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -460,7 +460,7 @@ footerTextGeneratorMap = {
         end
         local filler_nb = math.floor((max_width - text_width + separator_width) / footer.filler_space_width)
         if filler_nb > 0 then
-            return filler_space:rep(filler_nb), true
+            return " ":rep(filler_nb), true
         end
     end,
 }

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2130,7 +2130,7 @@ function ReaderFooter:genAllFooterText(gen_to_skip)
         local text, merge = gen(self)
         if text and text ~= "" then
             count = count + 1
-            if self.settings.item_prefix == "compact_items" then
+            if self.settings.item_prefix == "compact_items" and gen ~= footerTextGeneratorMap.dynamic_filler then
                 -- remove whitespace from footer items if symbol_type is compact_items
                 -- use a hair-space to avoid issues with RTL display
                 text = text:gsub("%s", "\u{200A}")

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -449,10 +449,9 @@ footerTextGeneratorMap = {
             tmp:free()
         end
         local separator_width = is_filler_inside and footer.separator_width or 0
-        local filler_space = "\u{200A}" -- HAIR SPACE
         if footer.filler_space_width == nil then
             tmp = TextWidget:new{
-                text = filler_space,
+                text = " ",
                 face = footer.footer_text_face,
                 bold = footer.settings.text_font_bold,
             }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -343,7 +343,7 @@ end
 
 function ReaderHighlight:onReaderReady()
     self:setupTouchZones()
-    if self.ui.paging and G_reader_settings:isTrue("highlight_write_into_pdf_notify") then
+    if self.document.is_pdf and G_reader_settings:isTrue("highlight_write_into_pdf_notify") then
         UIManager:show(Notification:new{
             text = T(_("Write highlights into PDF: %1"), self.highlight_write_into_pdf and _("on") or _("off")),
         })

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1125,6 +1125,7 @@ end
 
 -- merge TitleBar layout into self FocusManager layout
 function Menu:mergeTitleBarIntoLayout()
+    if not self.title_bar then return end
     if Device:hasSymKey() or Device:hasScreenKB() then
         -- Title bar items can be accessed through key mappings on kindle
         return


### PR DESCRIPTION
(1) Use usual space as dynamic filler symbol to avoid zero width on small font sizes (closes https://github.com/koreader/koreader/issues/13925).
(2) Show "Write highlights into PDF" notification for pdf files only.
(3) Do not try to merge titlebar layout when there is no titlebar (https://github.com/koreader/koreader/issues/13879).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13930)
<!-- Reviewable:end -->
