### PR TITLE
gettext: fix handling of fuzzy translations

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -200,7 +200,7 @@ function GetText_mt.__index.changeLang(new_lang)
                     local n = tonumber(k:match("msgstr%[([0-9]+)%]"))
                     local msgstr = v
 
-                    if n and msgstr then
+                    if n and msgstr and msgstr ~= "" then
                         addTranslation(data.msgctxt, data.msgid, msgstr, n)
                     end
                 end

--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -189,6 +189,7 @@ function GetText_mt.__index.changeLang(new_lang)
     end
 
     local data = {}
+    local in_comments = false
     local fuzzy = false
     local headers
     local what = nil
@@ -258,7 +259,18 @@ function GetText_mt.__index.changeLang(new_lang)
             what = nil
         else
             -- comment
-            if not line:match("^#") then
+            if line:match("^#") then
+                if not in_comments then
+                    in_comments = true
+                    fuzzy = false
+                end
+                if line:match(", fuzzy") then
+                    fuzzy = true
+                end
+            elseif fuzzy then
+                in_comments = false
+            else
+                in_comments = false
                 -- new data item (msgid, msgstr, ...
                 local w, s = line:match("^%s*([%a_%[%]0-9]+)%s+\"(.*)\"%s*$")
                 if w then
@@ -267,7 +279,7 @@ function GetText_mt.__index.changeLang(new_lang)
                     -- string continuation
                     s = line:match("^%s*\"(.*)\"%s*$")
                 end
-                if what and s and not fuzzy then
+                if what and s then
                     -- unescape \n or msgid won't match
                     s = s:gsub("\\n", "\n")
                     -- unescape " or msgid won't match
@@ -275,14 +287,7 @@ function GetText_mt.__index.changeLang(new_lang)
                     -- unescape \\ or msgid won't match
                     s = s:gsub("\\\\", "\\")
                     data[what] = (data[what] or "") .. s
-                elseif what and s == "" and fuzzy then -- luacheck: ignore 542
-                    -- Ignore the likes of msgid "" and msgstr ""
-                else
-                    -- Don't save this fuzzy string and unset fuzzy for the next one.
-                    fuzzy = false
                 end
-            elseif line:match("#, fuzzy") then
-                fuzzy = true
             end
         end
     end


### PR DESCRIPTION
The code would incorrectly load part of them, examples:
    
- the fuzzy translation is not ignored (because of the context, which is itself ignored):
    ```
    msgctxt "Status of group of books"
    msgid "All"
    msgstr "Kaikki"
    ```
- not ignored, with an invalid original string (`"Please configure it in the settings."`):
    ```po
    msgid ""
    "The download folder is not valid.\n"
    "Please configure it in the settings."
    msgstr ""
    "Le répertoire de téléchargement est invalide.\n"
    "Veuillez le configurer dans les paramètres."
    ```
- and in this case the second fuzzy entry end up overwriting the valid translation (with `"لم يتم حفظ الملف في:\n%1"`):
    ```po
    msgid ""
    "%1\n"
    "%2"
    msgstr ""
    "%1\n"
    "%2"
    
    msgid ""
    "Could not save file to:\n"
    "%1\n"
    "%2"
    msgstr ""
    "لم يتم حفظ الملف في:\n"
    "%1"
    ```
