### PR TITLE
close keyboard after calling search with preset

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -921,6 +921,7 @@ function ReaderDictionary:onShowDictionaryLookup()
                         buttons = dialog_buttons,
                         shrink_unneeded_width = true,
                     }
+                    self.dictionary_lookup_dialog:onCloseKeyboard()
                     UIManager:show(button_dialog)
                 end,
             }

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1490,6 +1490,7 @@ function DictQuickLookup:onLookupInputWord(hint)
                         buttons = dialog_buttons,
                         shrink_unneeded_width = true,
                     }
+                    self.input_dialog:onCloseKeyboard()
                     UIManager:show(button_dialog)
                 end,
             }


### PR DESCRIPTION
### what did I miss

* [`frontend/apps/reader/modules/readerdictionary.lua`](diffhunk://#diff-9bf52aa6dd626652cce10a9f206f685470fa308bac3f1df9d6a94730fed7f321R924): Added a call to `onCloseKeyboard` for `dictionary_lookup_dialog` to close the keyboard when calling Search with preset.
* [`frontend/ui/widget/dictquicklookup.lua`](diffhunk://#diff-f250b2c70dbfef162af814861c9c2f8cc36c8c7c7f9628ce75286dee13a8e5edR1493): Added a call to `onCloseKeyboard` for `input_dialog` to close the keyboard when calling Search with preset.

In my defence, during my extensive testing, _using exclusively the keyboard_ (mouse does not work on emulator), I always had to press <kbd>esc</kbd> which would always close the keyboard, oh well.