### PR TITLE
feat: scale cover screensaver to fill screen

### DIFF
--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -128,7 +128,17 @@ return {
                             G_reader_settings:flipNilOrFalse("screensaver_rotate_auto_for_best_fit")
                             touchmenu_instance:updateItems()
                         end,
+                    },
+                    {
+                        text = _("Scale cover to fill screen"),
+                        checked_func = function()
+                            return G_reader_settings:isTrue("screensaver_scale_cover_images")
+                        end,
+                        callback = function(touchmenu_instance)
+                            G_reader_settings:flipNilOrFalse("screensaver_scale_cover_images")
+                        end
                     }
+
                 },
             },
             {

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -610,6 +610,25 @@ function Screensaver:show()
             stretch_limit_percentage = G_reader_settings:readSetting("screensaver_stretch_limit_percentage"),
         }
         if self.image then
+            if G_reader_settings:isTrue("screensaver_scale_cover_images") then
+                local image_w = self.image:getWidth()
+                local image_h = self.image:getHeight()
+                local screen_w = Screen:getWidth()
+                local screen_h = Screen:getHeight()
+
+                if G_reader_settings:isTrue("screensaver_rotate_auto_for_best_fit") then
+                    if(image_w > image_h) {
+                        local tmp = image_w
+                        image_w = image_h
+                        image_h = tmp
+                    }
+                end
+
+                if widget_settings.scale_factor == 0 then
+                    widget_settings.scale_factor = math.max(screen_w / image_w, screen_h / image_h)
+                end
+            end
+
             widget_settings.image = self.image
             widget_settings.image_disposable = true
         elseif self.image_file then


### PR DESCRIPTION
A check box is added to Sreen->Sleep screen->Wallpaper->Border fill, rotation, and fit: Scale cover image to fill screen,
When setting a book cover as screensaver, you can choose to scale cover image to fill screen instead of stretching it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13979)
<!-- Reviewable:end -->
