### PR TITLE
Pass `ui` parameter to all collate `item_func`

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -183,7 +183,7 @@ function FileChooser:getListItem(dirpath, f, fullpath, attributes, collate)
             item.text = item.text.."/"
             item.bidi_wrap_func = BD.directory
             if collate.can_collate_mixed and collate.item_func ~= nil then -- used by user plugin/patch, don't remove
-                collate.item_func(item)
+                collate.item_func(item, self.ui)
             end
             if dirpath then -- file browser or PathChooser
                 item.mandatory = self:getMenuItemMandatory(item)

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -22,10 +22,7 @@ local PathChooser = FileChooser:extend{
 }
 
 function PathChooser:init()
-    local collate = G_reader_settings:readSetting("collate")
-    if self.show_files and (collate == "title" or collate == "authors" or collate == "series" or collate == "keywords") then
-        self.ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
-    end
+    self.ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
 
     if self.title == true then -- default title depending on options
         if self.select_directory and not self.select_file then


### PR DESCRIPTION
I'd like to have the `ui` parameter to the `item_func` of a collate always available, regardless of which collate is in use and whether the item is a file or directory. This allows user patches that add new collates to access all functionality for sorting.

@hius07 It's not entirely clear to me why the `self.ui` parameter was only set conditionally in `PathChooser` in #13437. Is there a specific reason for that choice?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13981)
<!-- Reviewable:end -->
