### PR TITLE
Touchmenu: fix menu refreshing on check

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -99,7 +99,7 @@ function ReaderBookmark:addToMainMenu(menu_items)
             checked_func = function()
                 return self.ui.paging.bookmark_flipping_mode
             end,
-            on_check_closed_in_callback = true,
+            check_callback_closes_menu = true,
             callback = function(touchmenu_instance)
                 self.ui.paging:onToggleBookmarkFlipping()
                 touchmenu_instance:closeMenu()

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -99,6 +99,7 @@ function ReaderBookmark:addToMainMenu(menu_items)
             checked_func = function()
                 return self.ui.paging.bookmark_flipping_mode
             end,
+            on_check_closed_in_callback = true,
             callback = function(touchmenu_instance)
                 self.ui.paging:onToggleBookmarkFlipping()
                 touchmenu_instance:closeMenu()

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1122,7 +1122,7 @@ See Style tweaks → Miscellaneous → Alternative ToC hints.]])
             checked_func = function()
                 return self.ui.document:isTocAlternativeToc()
             end,
-            on_check_closed_in_callback = true,
+            check_callback_closes_menu = true,
             callback = function(touchmenu_instance)
                 if self.ui.document:isTocAlternativeToc() then
                     UIManager:show(ConfirmBox:new{

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1122,6 +1122,7 @@ See Style tweaks → Miscellaneous → Alternative ToC hints.]])
             checked_func = function()
                 return self.ui.document:isTocAlternativeToc()
             end,
+            on_check_closed_in_callback = true,
             callback = function(touchmenu_instance)
                 if self.ui.document:isTocAlternativeToc() then
                     UIManager:show(ConfirmBox:new{

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -998,7 +998,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         checked_func = function()
             return location[settings] ~= nil and Dispatcher:_itemsCount(location[settings]) == 0
         end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 local actions = location[settings]

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -995,11 +995,10 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
     menu.ignored_by_menu_search = true -- all those would be duplicated
     table.insert(menu, {
         text = _("Nothing"),
-        keep_menu_open = true,
-        no_refresh_on_check = true,
         checked_func = function()
             return location[settings] ~= nil and Dispatcher:_itemsCount(location[settings]) == 0
         end,
+        on_check_updated_in_callback = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 local actions = location[settings]

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -14,6 +14,7 @@ local function genMenuItem(text, mode)
             return Screen:getRotationMode() == mode
         end,
         radio = true,
+        on_check_closed_in_callback = true,
         callback = function(touchmenu_instance)
             UIManager:broadcastEvent(Event:new("SetRotationMode", mode))
             touchmenu_instance:closeMenu()

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -14,7 +14,7 @@ local function genMenuItem(text, mode)
             return Screen:getRotationMode() == mode
         end,
         radio = true,
-        on_check_closed_in_callback = true,
+        check_callback_closes_menu = true,
         callback = function(touchmenu_instance)
             UIManager:broadcastEvent(Event:new("SetRotationMode", mode))
             touchmenu_instance:closeMenu()

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -50,8 +50,8 @@ local TouchMenuItem = InputContainer:extend{
     dimen = nil,
     face = Font:getFace("smallinfofont"),
     show_parent = nil,
-    on_check_updated_in_callback = nil, -- set to true for item with checkmark if its callback updates menu
-    on_check_closed_in_callback = nil, -- set to true for item with checkmark if its callback closes menu
+    check_callback_updates_menu = nil, -- set to true for item with checkmark if its callback updates menu
+    check_callback_closes_menu = nil, -- set to true for item with checkmark if its callback closes menu
 }
 
 function TouchMenuItem:init()
@@ -208,7 +208,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
         -- Unhighlight
         --
         self.item_frame.invert = false
-        if self.item.keep_menu_open or self.item.on_check_updated_in_callback then
+        if self.item.keep_menu_open or self.item.check_callback_updates_menu then
             UIManager:widgetInvert(self.item_frame, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
             UIManager:setDirty(nil, "ui", highlight_dimen)
         end
@@ -925,7 +925,7 @@ function TouchMenu:onMenuSelect(item, tap_on_checkmark)
                 -- must set keep_menu_open=true if that is wished)
                 callback(self)
                 if refresh then
-                    if not (item.on_check_updated_in_callback or item.on_check_closed_in_callback) then
+                    if not (item.check_callback_updates_menu or item.check_callback_closes_menu) then
                         self:updateItems()
                     end
                 elseif not item.keep_menu_open then

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -206,8 +206,7 @@ function TouchMenuItem:onTapSelect(arg, ges)
         -- Unhighlight
         --
         self.item_frame.invert = false
-        -- NOTE: If the menu is going to be closed, we can safely drop that.
-        if self.item.keep_menu_open then
+        if self.item.keep_menu_open or self.item.on_check_updated_in_callback then
             UIManager:widgetInvert(self.item_frame, highlight_dimen.x, highlight_dimen.y, highlight_dimen.w)
             UIManager:setDirty(nil, "ui", highlight_dimen)
         end
@@ -924,7 +923,7 @@ function TouchMenu:onMenuSelect(item, tap_on_checkmark)
                 -- must set keep_menu_open=true if that is wished)
                 callback(self)
                 if refresh then
-                    if not item.no_refresh_on_check then
+                    if not (item.on_check_updated_in_callback or item.on_check_closed_in_callback) then
                         self:updateItems()
                     end
                 elseif not item.keep_menu_open then

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -50,6 +50,8 @@ local TouchMenuItem = InputContainer:extend{
     dimen = nil,
     face = Font:getFace("smallinfofont"),
     show_parent = nil,
+    on_check_updated_in_callback = nil, -- set to true for item with checkmark if its callback updates menu
+    on_check_closed_in_callback = nil, -- set to true for item with checkmark if its callback closes menu
 }
 
 function TouchMenuItem:init()

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -171,7 +171,7 @@ function SSH:addToMainMenu(menu_items)
             {
                 text = _("SSH server"),
                 checked_func = function() return self:isRunning() end,
-                on_check_updated_in_callback = true,
+                check_callback_updates_menu = true,
                 callback = function(touchmenu_instance)
                     self:onToggleSSHServer()
                     -- sleeping might not be needed, but it gives the feeling

--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -170,8 +170,8 @@ function SSH:addToMainMenu(menu_items)
         sub_item_table = {
             {
                 text = _("SSH server"),
-                keep_menu_open = true,
                 checked_func = function() return self:isRunning() end,
+                on_check_updated_in_callback = true,
                 callback = function(touchmenu_instance)
                     self:onToggleSSHServer()
                     -- sleeping might not be needed, but it gives the feeling

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -131,6 +131,7 @@ function AutoTurn:addToMainMenu(menu_items)
             return self:_enabled() and T(_("Autoturn: %1"), time_string) or _("Autoturn")
         end,
         checked_func = function() return self:_enabled() end,
+        on_check_updated_in_callback = true,
         callback = function(menu)
             local DateTimeWidget = require("ui/widget/datetimewidget")
             local autoturn_seconds = G_reader_settings:readSetting("autoturn_timeout_seconds", 30)

--- a/plugins/autoturn.koplugin/main.lua
+++ b/plugins/autoturn.koplugin/main.lua
@@ -131,7 +131,7 @@ function AutoTurn:addToMainMenu(menu_items)
             return self:_enabled() and T(_("Autoturn: %1"), time_string) or _("Autoturn")
         end,
         checked_func = function() return self:_enabled() end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(menu)
             local DateTimeWidget = require("ui/widget/datetimewidget")
             local autoturn_seconds = G_reader_settings:readSetting("autoturn_timeout_seconds", 30)

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -608,6 +608,7 @@ function AutoWarmth:getSubMenuItems()
                 return not self.easy_mode
             end,
             help_text = _("In the expert mode, different types of twilight can be used in addition to civil twilight."),
+            on_check_updated_in_callback = true,
             callback = function(touchmenu_instance)
                 self.easy_mode = not self.easy_mode
                 G_reader_settings:saveSetting("autowarmth_easy_mode", self.easy_mode)
@@ -662,6 +663,7 @@ function AutoWarmth:getFlOffDuringDayMenu()
                 return _("Frontlight off during day")
             end
         end,
+        on_check_updated_in_callback = true,
         callback = function(touchmenu_instance)
             if self.easy_mode then
                 self.fl_off_during_day = not self.fl_off_during_day
@@ -889,6 +891,7 @@ function AutoWarmth:getScheduleMenu()
             checked_func = function()
                 return self.scheduler_times[num] ~= nil
             end,
+            on_check_updated_in_callback = true,
             callback = function(touchmenu_instance)
                 local hh = 12
                 local mm = 0
@@ -1112,6 +1115,7 @@ function AutoWarmth:getWarmthMenu()
                     })
                 end
             end,
+            on_check_updated_in_callback = true,
             callback = function(touchmenu_instance)
                 if Device:hasNaturalLight() then
                     if self.control_warmth and self.control_nightmode then

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -608,7 +608,7 @@ function AutoWarmth:getSubMenuItems()
                 return not self.easy_mode
             end,
             help_text = _("In the expert mode, different types of twilight can be used in addition to civil twilight."),
-            on_check_updated_in_callback = true,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 self.easy_mode = not self.easy_mode
                 G_reader_settings:saveSetting("autowarmth_easy_mode", self.easy_mode)
@@ -663,7 +663,7 @@ function AutoWarmth:getFlOffDuringDayMenu()
                 return _("Frontlight off during day")
             end
         end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             if self.easy_mode then
                 self.fl_off_during_day = not self.fl_off_during_day
@@ -891,7 +891,7 @@ function AutoWarmth:getScheduleMenu()
             checked_func = function()
                 return self.scheduler_times[num] ~= nil
             end,
-            on_check_updated_in_callback = true,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 local hh = 12
                 local mm = 0
@@ -1115,7 +1115,7 @@ function AutoWarmth:getWarmthMenu()
                     })
                 end
             end,
-            on_check_updated_in_callback = true,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 if Device:hasNaturalLight() then
                     if self.control_warmth and self.control_nightmode then

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -303,7 +303,7 @@ function Calibre:getWirelessMenuTable()
                     checked_func = function()
                         return G_reader_settings:has("calibre_wireless_url")
                     end,
-                    on_check_updated_in_callback = true,
+                    check_callback_updates_menu = true,
                     callback = function(touchmenu_instance)
                         local MultiInputDialog = require("ui/widget/multiinputdialog")
                         local url_dialog

--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -303,6 +303,7 @@ function Calibre:getWirelessMenuTable()
                     checked_func = function()
                         return G_reader_settings:has("calibre_wireless_url")
                     end,
+                    on_check_updated_in_callback = true,
                     callback = function(touchmenu_instance)
                         local MultiInputDialog = require("ui/widget/multiinputdialog")
                         local url_dialog

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -502,6 +502,7 @@ function CoverImage:menuEntryCache()
                 checked_func = function()
                     return self.cover_image_cache_maxfiles >= 0
                 end,
+                on_check_updated_in_callback = true,
                 callback = function(touchmenu_instance)
                     self:sizeSpinner(touchmenu_instance, "cover_image_cache_maxfiles", _("Number of covers"), -1, 100, 36, self.cleanCache)
                 end,
@@ -522,6 +523,7 @@ function CoverImage:menuEntryCache()
                 checked_func = function()
                     return self.cover_image_cache_maxsize >= 0
                 end,
+                on_check_updated_in_callback = true,
                 callback = function(touchmenu_instance)
                     self:sizeSpinner(touchmenu_instance, "cover_image_cache_maxsize", _("Cache size"), -1, 100, 5, self.cleanCache, C_("Data storage size", "MB"))
                 end,
@@ -574,6 +576,7 @@ function CoverImage:menuEntrySetPath(key, title, help, info, default, folder_onl
         checked_func = function()
             return isFileOk(self[key]) or (isPathAllowed(self[key]) and folder_only)
         end,
+        on_check_updated_in_callback = true,
         callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
                 text = info,

--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -502,7 +502,7 @@ function CoverImage:menuEntryCache()
                 checked_func = function()
                     return self.cover_image_cache_maxfiles >= 0
                 end,
-                on_check_updated_in_callback = true,
+                check_callback_updates_menu = true,
                 callback = function(touchmenu_instance)
                     self:sizeSpinner(touchmenu_instance, "cover_image_cache_maxfiles", _("Number of covers"), -1, 100, 36, self.cleanCache)
                 end,
@@ -523,7 +523,7 @@ function CoverImage:menuEntryCache()
                 checked_func = function()
                     return self.cover_image_cache_maxsize >= 0
                 end,
-                on_check_updated_in_callback = true,
+                check_callback_updates_menu = true,
                 callback = function(touchmenu_instance)
                     self:sizeSpinner(touchmenu_instance, "cover_image_cache_maxsize", _("Cache size"), -1, 100, 5, self.cleanCache, C_("Data storage size", "MB"))
                 end,
@@ -576,7 +576,7 @@ function CoverImage:menuEntrySetPath(key, title, help, info, default, folder_onl
         checked_func = function()
             return isFileOk(self[key]) or (isPathAllowed(self[key]) and folder_only)
         end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             UIManager:show(ConfirmBox:new{
                 text = info,

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -298,7 +298,7 @@ function Gestures:genMenu(ges)
             checked_func = function()
                 return util.tableEquals(self.gestures[ges], self.defaults[ges])
             end,
-            on_check_updated_in_callback = true,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 local function do_remove()
                     self.gestures[ges] = util.tableDeepCopy(self.defaults[ges])
@@ -315,7 +315,7 @@ function Gestures:genMenu(ges)
         checked_func = function()
             return self.gestures[ges] == nil
         end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 self.gestures[ges] = nil

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -295,11 +295,10 @@ function Gestures:genMenu(ges)
     if gestures_list[ges] ~= nil then
         table.insert(sub_items, {
             text = T(_("%1 (default)"), Dispatcher:menuTextFunc(self.defaults[ges])),
-            keep_menu_open = true,
-            no_refresh_on_check = true,
             checked_func = function()
                 return util.tableEquals(self.gestures[ges], self.defaults[ges])
             end,
+            on_check_updated_in_callback = true,
             callback = function(touchmenu_instance)
                 local function do_remove()
                     self.gestures[ges] = util.tableDeepCopy(self.defaults[ges])
@@ -313,11 +312,10 @@ function Gestures:genMenu(ges)
     end
     table.insert(sub_items, {
         text = _("Pass through"),
-        keep_menu_open = true,
-        no_refresh_on_check = true,
         checked_func = function()
             return self.gestures[ges] == nil
         end,
+        on_check_updated_in_callback = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 self.gestures[ges] = nil

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -192,11 +192,10 @@ function HotKeys:genMenu(hotkey)
         local default_text = default_action and Dispatcher:menuTextFunc(default_action) or _("No action")
         table.insert(sub_items, {
             text = T(_("%1 (default)"), default_text),
-            keep_menu_open = true,
-            no_refresh_on_check = true,
             checked_func = function()
                 return util.tableEquals(self.hotkeys[hotkey], self.defaults[hotkey])
             end,
+            on_check_updated_in_callback = true,
             callback = function(touchmenu_instance)
                 local function do_remove()
                     self.hotkeys[hotkey] = util.tableDeepCopy(self.defaults[hotkey])
@@ -209,12 +208,10 @@ function HotKeys:genMenu(hotkey)
     end
     table.insert(sub_items, {
         text = _("No action"),
-        keep_menu_open = true,
-        no_refresh_on_check = true,
-        separator = true,
         checked_func = function()
             return self.hotkeys[hotkey] == nil or next(self.hotkeys[hotkey]) == nil
         end,
+        on_check_updated_in_callback = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 self.hotkeys[hotkey] = nil
@@ -223,6 +220,7 @@ function HotKeys:genMenu(hotkey)
             end
             Dispatcher.removeActions(self.hotkeys[hotkey], do_remove)
         end,
+        separator = true,
     })
     Dispatcher:addSubMenu(self, sub_items, self.hotkeys, hotkey)
     -- Since we are already handling potential conflicts via overrideConflictingKeyEvents(), both "No action" and "Nothing",

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -195,7 +195,7 @@ function HotKeys:genMenu(hotkey)
             checked_func = function()
                 return util.tableEquals(self.hotkeys[hotkey], self.defaults[hotkey])
             end,
-            on_check_updated_in_callback = true,
+            check_callback_updates_menu = true,
             callback = function(touchmenu_instance)
                 local function do_remove()
                     self.hotkeys[hotkey] = util.tableDeepCopy(self.defaults[hotkey])
@@ -211,7 +211,7 @@ function HotKeys:genMenu(hotkey)
         checked_func = function()
             return self.hotkeys[hotkey] == nil or next(self.hotkeys[hotkey]) == nil
         end,
-        on_check_updated_in_callback = true,
+        check_callback_updates_menu = true,
         callback = function(touchmenu_instance)
             local function do_remove()
                 self.hotkeys[hotkey] = nil

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -632,7 +632,7 @@ function Profiles:genAutoExecPathChangedMenuItem(text, event, profile_name, sepa
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, condition)
                     end,
-                    on_check_updated_in_callback = true,
+                    check_callback_updates_menu = true,
                     callback = function(touchmenu_instance)
                         local dialog
                         local buttons = {{
@@ -763,7 +763,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                                 checked_func = function()
                                     return util.tableGetValue(self.autoexec, event, profile_name, condition, prop) and true
                                 end,
-                                on_check_updated_in_callback = true,
+                                check_callback_updates_menu = true,
                                 callback = function(touchmenu_instance)
                                     local dialog
                                     local buttons = self.document == nil and {} or {{
@@ -833,7 +833,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[3][2]) and true
                     end,
-                    on_check_updated_in_callback = true,
+                    check_callback_updates_menu = true,
                     callback = function(touchmenu_instance)
                         local condition = conditions[3][2]
                         local dialog
@@ -898,7 +898,7 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[4][2]) and true
                     end,
-                    on_check_updated_in_callback = true,
+                    check_callback_updates_menu = true,
                     callback = function(touchmenu_instance)
                         local condition = conditions[4][2]
                         local collections = util.tableGetValue(self.autoexec, event, profile_name, condition)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -629,10 +629,10 @@ function Profiles:genAutoExecPathChangedMenuItem(text, event, profile_name, sepa
                         local value = util.tableGetValue(self.autoexec, event, profile_name, condition)
                         return value and txt .. ": " .. value or txt
                     end,
-                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, condition)
                     end,
+                    on_check_updated_in_callback = true,
                     callback = function(touchmenu_instance)
                         local dialog
                         local buttons = {{
@@ -760,10 +760,10 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                                     local txt = util.tableGetValue(self.autoexec, event, profile_name, condition, prop)
                                     return txt and title .. " " .. txt or title:sub(1, -2)
                                 end,
-                                no_refresh_on_check = true,
                                 checked_func = function()
                                     return util.tableGetValue(self.autoexec, event, profile_name, condition, prop) and true
                                 end,
+                                on_check_updated_in_callback = true,
                                 callback = function(touchmenu_instance)
                                     local dialog
                                     local buttons = self.document == nil and {} or {{
@@ -830,10 +830,10 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     enabled_func = function()
                         return not util.tableGetValue(self.autoexec, event_always, profile_name)
                     end,
-                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[3][2]) and true
                     end,
+                    on_check_updated_in_callback = true,
                     callback = function(touchmenu_instance)
                         local condition = conditions[3][2]
                         local dialog
@@ -895,10 +895,10 @@ function Profiles:genAutoExecDocConditionalMenuItem(text, event, profile_name, s
                     enabled_func = function()
                         return not util.tableGetValue(self.autoexec, event_always, profile_name)
                     end,
-                    no_refresh_on_check = true,
                     checked_func = function()
                         return util.tableGetValue(self.autoexec, event, profile_name, conditions[4][2]) and true
                     end,
+                    on_check_updated_in_callback = true,
                     callback = function(touchmenu_instance)
                         local condition = conditions[4][2]
                         local collections = util.tableGetValue(self.autoexec, event, profile_name, condition)


### PR DESCRIPTION
By default, on tapping an item with a checkmark the Touchmenu:
(1) keeps the menu open
(2) highlights the item
(3) unhighlights the item
(4) fires the callback
(5) updates itself to show the changes.

If the callback updates the menu, (5) is not needed.
If the callback closes the menu, (3) and (5) are not needed.

This PR allows to avoid menu update duplicating and to avoid calling unneeded unhighlighting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/13996)
<!-- Reviewable:end -->
