### PR TITLE
Moving download all and remove all buttons in OPDS download menu

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -605,6 +605,7 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
             })
         end
         self:switchItemTable(self.catalog_title, menu_table)
+        Menu.setTitleBarLeftIcon(self, "plus")
         self.onLeftButtonTap = function()
             self:addSubCatalog(item_url)
         end
@@ -951,8 +952,6 @@ function OPDSBrowser:onMenuSelect(item)
         logger.dbg("Downloads available:", item)
         self:showDownloads(item)
     else -- catalog or Search item
-        self.title_bar_left_icon = "plus"
-        Menu.init(self)
         if #self.paths == 0 then -- root list
             if item.idx == 1 then
                 if #self.downloads > 0 then
@@ -965,6 +964,7 @@ function OPDSBrowser:onMenuSelect(item)
             self.root_catalog_password  = item.password
             self.root_catalog_raw_names = item.raw_names
         end
+--         UIManager:forceRePaint()
         local connect_callback
         if item.searchable then
             connect_callback = function()
@@ -1102,7 +1102,6 @@ function OPDSBrowser:showDownloadList()
             self.item_table[1].mandatory = #self.downloads
             self:updateItems(1, true)
         end
-        self:init()
     end
     self:updateDownloadListItemTable()
     UIManager:show(self.download_list)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1089,6 +1089,10 @@ function OPDSBrowser:showDownloadList()
         title_bar_fm_style = true,
         onMenuSelect = self.showDownloadListItemDialog,
         _manager = self,
+        title_bar_left_icon = "plus",
+        onLeftButtonTap = function()
+            self:showDownloadListMenu()
+        end
     }
     self.download_list.close_callback = function()
         UIManager:close(self.download_list)
@@ -1103,6 +1107,35 @@ function OPDSBrowser:showDownloadList()
     UIManager:show(self.download_list)
 end
 
+function OPDSBrowser:showDownloadListMenu()
+    local dialog
+    dialog = ButtonDialog:new{
+        buttons = {
+            {{
+                    text = _("Remove all"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        self:confirmClearDownloadList()
+                    end,
+                    align = "left",
+            }},
+            {{
+                    text = _("Download all"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        self:confirmDownloadDownloadList()
+                    end,
+                    align = "left",
+            }},
+        },
+        shrink_unneeded_width = true,
+        anchor = function()
+            return self.title_bar.left_button.image.dimen
+        end,
+    }
+    UIManager:show(dialog)
+end
+
 function OPDSBrowser:updateDownloadListItemTable(item_table)
     if item_table == nil then
         item_table = {}
@@ -1115,6 +1148,35 @@ function OPDSBrowser:updateDownloadListItemTable(item_table)
     end
     local title = T(_("Downloads (%1)"), #item_table)
     self.download_list:switchItemTable(title, item_table)
+end
+
+function OPDSBrowser:confirmDownloadDownloadList()
+    UIManager:show(ConfirmBox:new{
+        text = _("Download all books?\nExisting files will be overwritten."),
+        ok_text = _("Download"),
+        ok_callback = function()
+            NetworkMgr:runWhenConnected(function()
+                Trapper:wrap(function()
+                    self:downloadDownloadList()
+                end)
+            end)
+        end,
+    })
+end
+
+function OPDSBrowser:confirmClearDownloadList()
+    UIManager:show(ConfirmBox:new{
+        text = _("Remove all downloads?"),
+        ok_text = _("Remove"),
+        ok_callback = function()
+            for i in ipairs(self.downloads) do
+                self.downloads[i] = nil
+            end
+            self.download_list_updated = true
+            self._manager.updated = true
+            self.download_list:close_callback()
+        end,
+    })
 end
 
 function OPDSBrowser:showDownloadListItemDialog(item)
@@ -1155,35 +1217,14 @@ function OPDSBrowser:showDownloadListItemDialog(item)
                 text = _("Remove all"),
                 callback = function()
                     textviewer:onClose()
-                    UIManager:show(ConfirmBox:new{
-                        text = _("Remove all downloads?"),
-                        ok_text = _("Remove"),
-                        ok_callback = function()
-                            for i in ipairs(self._manager.downloads) do
-                                self._manager.downloads[i] = nil
-                            end
-                            self._manager.download_list_updated = true
-                            self._manager._manager.updated = true
-                            self:close_callback()
-                        end,
-                    })
+                    self._manager:confirmClearDownloadList()
                 end,
             },
             {
                 text = _("Download all"),
                 callback = function()
                     textviewer:onClose()
-                    UIManager:show(ConfirmBox:new{
-                        text = _("Download all books?\nExisting files will be overwritten."),
-                        ok_text = _("Download"),
-                        ok_callback = function()
-                            NetworkMgr:runWhenConnected(function()
-                                Trapper:wrap(function()
-                                    self._manager:downloadDownloadList()
-                                end)
-                            end)
-                        end,
-                    })
+                    self._manager:confirmDownloadDownloadList()
                 end,
             },
         },

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1089,10 +1089,10 @@ function OPDSBrowser:showDownloadList()
         title_bar_fm_style = true,
         onMenuSelect = self.showDownloadListItemDialog,
         _manager = self,
-        title_bar_left_icon = "plus",
+        title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function()
             self:showDownloadListMenu()
-        end
+        end,
     }
     self.download_list.close_callback = function()
         UIManager:close(self.download_list)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -63,7 +63,7 @@ local OPDSBrowser = Menu:extend{
 function OPDSBrowser:init()
     self.item_table = self:genItemTableFromRoot()
     self.catalog_title = nil
-    self.title_bar_left_icon = "plus"
+    self.title_bar_left_icon = "appbar.menu"
     self.onLeftButtonTap = function()
         self:showOPDSMenu()
     end
@@ -951,6 +951,8 @@ function OPDSBrowser:onMenuSelect(item)
         logger.dbg("Downloads available:", item)
         self:showDownloads(item)
     else -- catalog or Search item
+        self.title_bar_left_icon = "plus"
+        Menu.init(self)
         if #self.paths == 0 then -- root list
             if item.idx == 1 then
                 if #self.downloads > 0 then
@@ -1090,9 +1092,7 @@ function OPDSBrowser:showDownloadList()
         onMenuSelect = self.showDownloadListItemDialog,
         _manager = self,
         title_bar_left_icon = "appbar.menu",
-        onLeftButtonTap = function()
-            self:showDownloadListMenu()
-        end,
+        onLeftButtonTap = self.showDownloadListMenu
     }
     self.download_list.close_callback = function()
         UIManager:close(self.download_list)
@@ -1102,8 +1102,10 @@ function OPDSBrowser:showDownloadList()
             self.item_table[1].mandatory = #self.downloads
             self:updateItems(1, true)
         end
+        self:init()
     end
     self:updateDownloadListItemTable()
+    logger.dbg(self.download_list.title_bar)
     UIManager:show(self.download_list)
 end
 
@@ -1112,18 +1114,18 @@ function OPDSBrowser:showDownloadListMenu()
     dialog = ButtonDialog:new{
         buttons = {
             {{
-                    text = _("Remove all"),
+                    text = _("Download all"),
                     callback = function()
                         UIManager:close(dialog)
-                        self:confirmClearDownloadList()
+                        self._manager:confirmDownloadDownloadList()
                     end,
                     align = "left",
             }},
             {{
-                    text = _("Download all"),
+                    text = _("Remove all"),
                     callback = function()
                         UIManager:close(dialog)
-                        self:confirmDownloadDownloadList()
+                        self._manager:confirmClearDownloadList()
                     end,
                     align = "left",
             }},

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -605,7 +605,7 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
             })
         end
         self:switchItemTable(self.catalog_title, menu_table)
-        Menu.setTitleBarLeftIcon(self, "plus")
+        self:setTitleBarLeftIcon("plus")
         self.onLeftButtonTap = function()
             self:addSubCatalog(item_url)
         end
@@ -964,7 +964,6 @@ function OPDSBrowser:onMenuSelect(item)
             self.root_catalog_password  = item.password
             self.root_catalog_raw_names = item.raw_names
         end
---         UIManager:forceRePaint()
         local connect_callback
         if item.searchable then
             connect_callback = function()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1105,7 +1105,6 @@ function OPDSBrowser:showDownloadList()
         self:init()
     end
     self:updateDownloadListItemTable()
-    logger.dbg(self.download_list.title_bar)
     UIManager:show(self.download_list)
 end
 


### PR DESCRIPTION
As discussed in #13946 
Adds button in download list to do download all and remove all. Currently, both options remain when selecting individual books. I think it should be completely moved to the top left but I understand there being a reason for wanting to keep it where it is and duplicate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14024)
<!-- Reviewable:end -->
