### PR TITLE
Dictionary: fix invalid highlight when switching dictionary

### DIFF
--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -264,6 +264,8 @@ function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css
     self.document:layoutDocument(self.dimen.w, self.dimen.h, default_font_size)
 
     self.page_count = self.document:getPages()
+    self.page_boxes = nil
+    self:clearHighlight()
 end
 
 function HtmlBoxWidget:_render()


### PR DESCRIPTION
When the contents of the HtmlBoxWidget changed the page boxes were not invalidated, this resulted the highlight to show up at a wrong coordinate.

Fixes #14013

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14028)
<!-- Reviewable:end -->
