### PR TITLE
[ReaderDictionary] clean interpuncts, pipes and up arrows from text selection

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -852,6 +852,10 @@ function ReaderDictionary:cleanSelection(text, is_sane)
         text = text:gsub("\u{2019}", "'") -- Right single quotation mark
         -- Strip punctuation characters around selection
         text = util.stripPunctuation(text)
+        -- In some dictionaries, both interpuncts and pipes are used to delimiter syllables.
+        text = text:gsub("·", "")  -- interpunct
+        text = text:gsub("|", "")  -- pipe
+        text = text:gsub("↑", "") -- and up arrow, used in some dictionaries to indicate related words
         -- Strip some common english grammatical construct
         text = text:gsub("'s$", '') -- english possessive
         -- Strip some common french grammatical constructs


### PR DESCRIPTION
### what's new

* [`frontend/apps/reader/modules/readerdictionary.lua`](diffhunk://#diff-9bf52aa6dd626652cce10a9f206f685470fa308bac3f1df9d6a94730fed7f321R855-R858): Added logic to remove interpuncts (`·`), pipes (`|`), and up arrows (`↑`) from text selections, as these characters are used in some dictionaries for syllable delimitation or indicating related words.

<img width="529" height="232" alt="Image" src="https://github.com/user-attachments/assets/9887590a-c3c4-416a-9106-b79d81ef354b" />