### PR TITLE
[fix] Improve handling of illegal vFAT filenames.

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -948,14 +948,17 @@ end
 
 --- Replaces characters that are invalid filenames.
 --
--- Replaces the characters <code>\/:*?"<>|</code> with an <code>_</code>.
+-- Replaces the characters <code>\/:*?"<>|</code> with an <code>_</code>
+-- and removes trailing dots and spaces, in line with <https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions>.
 -- These characters are problematic on Windows filesystems. On Linux only
 -- <code>/</code> poses a problem.
 ---- @string str filename
 ---- @treturn string sanitized filename
 local function replaceAllInvalidChars(str)
     if str then
-        return str:gsub('[\\/:*?"<>|]', '_')
+        str = str:gsub('[\\/:*?"<>|]', '_')
+        str = str:gsub("[%.%s]+$", "")
+        return str
     end
 end
 

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -957,7 +957,7 @@ end
 local function replaceAllInvalidChars(str)
     if str then
         str = str:gsub('[\\/:*?"<>|]', '_')
-        str = str:gsub("[%.%s]+$", "")
+        str = str:gsub("[.%s]+$", "")
         return str
     end
 end


### PR DESCRIPTION
This change fixes an issue where a file/directory is not created when its name contains trailing spaces or dots. The issue has been observed on a Kobo device, but probably also applies to other systems using vFAT.

We also might want to consider handling other illegal vFAT filenames like `NUL` or `AUX`.

Please see the [official Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions) for more details on the naming conventions of vFAT (this change addresses the last bullet point).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14043)
<!-- Reviewable:end -->
