### PR TITLE
ReaderHighlight: fix long-pressing on image

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1682,7 +1682,7 @@ function ReaderHighlight:onHold(arg, ges)
         local ImageViewer = require("ui/widget/imageviewer")
         UIManager:show(ImageViewer:new{
             image = image,
-            with_title_bar = false,
+            with_title_bar = false, -- more room for image
             fullscreen = true,
         })
         self:onStopHighlightIndicator()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1678,15 +1678,13 @@ function ReaderHighlight:onHold(arg, ges)
     local image = self.ui.document:getImageFromPosition(self.hold_pos, true, true)
     if image then
         logger.dbg("hold on image")
+        self.hold_pos = nil
         local ImageViewer = require("ui/widget/imageviewer")
-        local imgviewer = ImageViewer:new{
+        UIManager:show(ImageViewer:new{
             image = image,
-            -- title_text = _("Document embedded image"),
-            -- No title, more room for image
             with_title_bar = false,
             fullscreen = true,
-        }
-        UIManager:show(imgviewer)
+        })
         self:onStopHighlightIndicator()
         return true
     end


### PR DESCRIPTION
Fix a bug caused by https://github.com/koreader/koreader/pull/14004: after long-pressing on an image, taps don't work until long-pressing on text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14048)
<!-- Reviewable:end -->
