### PR TITLE
[plugin] wallabag - allow filtering download to starred articles

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -88,6 +88,7 @@ function Wallabag:init()
 
     -- These settings do have defaults
     self.filter_tag                    = self.wb_settings.data.wallabag.filter_tag or ""
+    self.filter_starred                = self.wb_settings.data.wallabag.filter_starred or false
     self.ignore_tags                   = self.wb_settings.data.wallabag.ignore_tags or ""
     self.auto_tags                     = self.wb_settings.data.wallabag.auto_tags or ""
     self.archive_finished              = self.wb_settings.data.wallabag.archive_finished or true
@@ -258,6 +259,17 @@ function Wallabag:addToMainMenu(menu_items)
                                             self.ignore_tags = tags
                                         end
                                     )
+                                end,
+                            },
+                            {
+                                text = _("Only download starred articles"),
+                                keep_menu_open = true,
+                                checked_func = function()
+                                    return self.filter_starred or false
+                                end,
+                                callback = function()
+                                    self.filter_starred = not self.filter_starred
+                                    self:saveSettings()
                                 end,
                             },
                             {
@@ -614,6 +626,10 @@ function Wallabag:getArticleList()
 
     if self.filter_tag ~= "" then
         filtering = "&tags=" .. self.filter_tag
+    end
+
+    if self.filter_starred then
+        filtering = filtering .. "&starred=1"
     end
 
     local article_list = {}
@@ -1593,6 +1609,7 @@ function Wallabag:saveSettings()
         password                      = self.password,
         directory                     = self.directory,
         filter_tag                    = self.filter_tag,
+        filter_starred                = self.filter_starred,
         ignore_tags                   = self.ignore_tags,
         auto_tags                     = self.auto_tags,
         archive_finished              = self.archive_finished,


### PR DESCRIPTION
Adds a checkbox in the wallabag download settings, restricting the download of articles from wallabag to starred/favorite items

<img width="953" height="638" alt="image" src="https://github.com/user-attachments/assets/819c9718-3a85-4ff8-8981-d83fa3e36dfe" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14051)
<!-- Reviewable:end -->
