### PR TITLE
ci: update build configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       CCACHE_MAXSIZE: "128M"
       CLICOLOR_FORCE: "1"
       EMULATE_READER: "1"
+      KODEBUG: ""
       MAKEFLAGS: "PARALLEL_JOBS=3 OUTPUT_DIR=build INSTALL_DIR=install"
     steps:
       # Checkout / fetch. {{{

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       # Bump first number to reset all caches.
       CACHE_KEY: "1-macOS-${{ matrix.image }}-${{ matrix.platform }}-XC${{ matrix.xcode_version }}-DT${{ matrix.deployment_target }}"
       CLICOLOR_FORCE: '1'
+      KODEBUG: ""
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
       MAKEFLAGS: 'OUTPUT_DIR=build INSTALL_DIR=install TARGET=macos'
 


### PR DESCRIPTION
Explicitly set `KODEBUG` in preparation for bumping base with https://github.com/koreader/koreader-base/pull/2118.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14069)
<!-- Reviewable:end -->
