### PR TITLE
Invert document-related dialogs independently of UI layout

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -530,6 +530,7 @@ ReaderFooter.default_settings = {
     progress_pct_format = "0",
     pages_left_includes_current_page = false,
     initial_marker = false,
+    invert_progress_direction = false,
 }
 
 function ReaderFooter:init()
@@ -2454,6 +2455,13 @@ function ReaderFooter:onToggleChapterProgressBar()
         self.progress_bar.initial_percentage = self.initial_pageno / self.pages
     end
     self:refreshFooter(true)
+end
+
+function ReaderFooter:setUILayoutMiroring(invert_direction)
+    if self.progress_bar then
+        self.progress_bar.invert_direction = invert_direction
+        self:maybeUpdateFooter()
+    end
 end
 
 function ReaderFooter:getBookProgress()

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -213,6 +213,7 @@ function ReaderMenu:setUpdateItemTable()
             {
                 text = _("Save document settings as default"),
                 keep_menu_open = true,
+                separator = true,
                 callback = function()
                     UIManager:show(ConfirmBox:new{
                         text = _("Save current document settings as default values?"),
@@ -229,6 +230,51 @@ function ReaderMenu:setUpdateItemTable()
             },
         },
     }
+
+    if not Device:isTouchDevice() then
+        -- This menu entry is a duplicate of the one found in page_turns for touch devices
+        -- but we need to add it here for non-touch devices.
+        table.insert(self.menu_items.document_settings.sub_item_table, {
+            text_func = function()
+                local text = _("Invert document-related dialogs")
+                if G_reader_settings:isTrue("invert_ui_layout_mirroring") then
+                    text = text .. "   ★"
+                end
+                return text
+            end,
+            checked_func = function()
+                return self.view:shouldInvertBiDiLayoutMirroring()
+            end,
+            callback = function()
+                UIManager:broadcastEvent(Event:new("ToggleUILayoutMiroring"))
+            end,
+            hold_callback = function(touchmenu_instance)
+                local invert_ui_layout_mirroring = G_reader_settings:isTrue("invert_ui_layout_mirroring")
+                local MultiConfirmBox = require("ui/widget/multiconfirmbox")
+                UIManager:show(MultiConfirmBox:new{
+                    text = invert_ui_layout_mirroring and _("The default (★) for newly opened books is to Invert document-related dialogs.\n\nWould you like to change it?")
+                    or _("The default (★) for newly opened books is not to Invert document-related dialogs.\n\nWould you like to change it?"),
+                    choice1_text_func = function()
+                        return invert_ui_layout_mirroring and _("Don't Invert") or _("Don't Invert (★)")
+                    end,
+                    choice1_callback = function()
+                        G_reader_settings:makeFalse("invert_ui_layout_mirroring")
+                        if touchmenu_instance then touchmenu_instance:updateItems() end
+                    end,
+                    choice2_text_func = function()
+                        return invert_ui_layout_mirroring and _("Invert (★)") or _("Invert")
+                    end,
+                    choice2_callback = function()
+                        G_reader_settings:makeTrue("invert_ui_layout_mirroring")
+                        if touchmenu_instance then touchmenu_instance:updateItems() end
+                    end,
+                })
+            end,
+            help_text = _([[
+When enabled the UI direction for the Table of Contents, Book Map, and Page Browser dialogs will mirror the default UI direction.
+Useful when used alongside Invert page turns.]]),
+        })
+    end
 
     self.menu_items.page_overlap = dofile("frontend/ui/elements/page_overlap.lua")
 

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -993,6 +993,12 @@ function ReaderView:onReadSettings(config)
     else
         self.inverse_reading_order = G_reader_settings:isTrue("inverse_reading_order")
     end
+    if config:has("invert_ui_layout_mirroring") then
+        self.invert_ui_layout_mirroring = config:isTrue("invert_ui_layout_mirroring")
+    else
+        self.invert_ui_layout_mirroring = G_reader_settings:isTrue("invert_ui_layout_mirroring")
+    end
+    self.footer:setUILayoutMiroring(self.invert_ui_layout_mirroring)
     self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or G_defaults:readSetting("DSHOWOVERLAP")
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height")
@@ -1001,8 +1007,18 @@ function ReaderView:onReadSettings(config)
 end
 
 function ReaderView:shouldInvertBiDiLayoutMirroring()
-    -- A few widgets may temporarily invert UI layout mirroring when both these settings are true
-    return self.inverse_reading_order and G_reader_settings:isTrue("invert_ui_layout_mirroring")
+    return self.invert_ui_layout_mirroring
+end
+
+function ReaderView:onToggleUILayoutMiroring(toggle)
+    if toggle == nil then
+        toggle = not self.invert_ui_layout_mirroring
+    end
+    if self.invert_ui_layout_mirroring ~= toggle then
+        self.invert_ui_layout_mirroring = toggle
+        self.footer:setUILayoutMiroring(self.invert_ui_layout_mirroring)
+    end
+    return true
 end
 
 function ReaderView:onPageUpdate(new_page_no)
@@ -1208,6 +1224,7 @@ function ReaderView:onSaveSettings()
         self.document.configurable.rotation_mode = Screen:getRotationMode() -- will be saved by ReaderConfig
     end
     self.ui.doc_settings:saveSetting("inverse_reading_order", self.inverse_reading_order)
+    self.ui.doc_settings:saveSetting("invert_ui_layout_mirroring", self.invert_ui_layout_mirroring)
     self.ui.doc_settings:saveSetting("show_overlap_enable", self.page_overlap_enable)
     self.ui.doc_settings:saveSetting("page_overlap_style", self.page_overlap_style)
 end

--- a/frontend/ui/widget/progresswidget.lua
+++ b/frontend/ui/widget/progresswidget.lua
@@ -61,6 +61,7 @@ local ProgressWidget = Widget:extend{
     _orig_bordersize = nil,
     initial_pos_marker = false, -- overlay a marker at the initial percentage position
     initial_percentage = nil,
+    invert_direction = false, -- manually invert the direction regardless of UI mirroring
 }
 
 function ProgressWidget:init()
@@ -125,6 +126,11 @@ function ProgressWidget:paintTo(bb, x, y)
     if self.dimen.w == 0 or self.dimen.h == 0 then return end
 
     local _mirroredUI = BD.mirroredUILayout()
+    -- Apply inversion if requested (XOR operation with mirrored UI)
+    if self.invert_direction then
+        _mirroredUI = not _mirroredUI
+    end
+
     -- We'll draw every bar element in order, bottom to top.
     local fill_width = my_size.w - 2*(self.margin_h + self.bordersize)
     local fill_y = y + self.margin_v + self.bordersize
@@ -185,11 +191,20 @@ function ProgressWidget:paintTo(bb, x, y)
 
         -- Overlay the initial position marker on top of that
         if self.initial_pos_marker and self.initial_percentage >= 0 then
-            if self.height <= INITIAL_MARKER_HEIGHT_THRESHOLD then
-                self.initial_pos_icon:paintTo(bb, Math.round(fill_x + math.ceil(fill_width * self.initial_percentage) - self.height / 4), y - Math.round(self.height / 6))
+            local marker_x, icon_x, icon_y
+            if _mirroredUI then
+                marker_x = x + self.margin_h + self.bordersize + math.ceil(fill_width - (fill_width * self.initial_percentage))
             else
-                self.initial_pos_icon:paintTo(bb, Math.round(fill_x + math.ceil(fill_width * self.initial_percentage) - self.height / 2), y)
+                marker_x = x + self.margin_h + self.bordersize + math.ceil(fill_width * self.initial_percentage)
             end
+            if self.height <= INITIAL_MARKER_HEIGHT_THRESHOLD then
+                icon_x = Math.round(marker_x - self.height * (1/4))
+                icon_y = y - Math.round(self.height * (1/6))
+            else
+                icon_x = Math.round(marker_x - self.height * (1/2))
+                icon_y = y
+            end
+            self.initial_pos_icon:paintTo(bb, icon_x, icon_y)
         end
     end
 
@@ -229,7 +244,13 @@ function ProgressWidget:getPercentageFromPosition(pos)
     if x < 0 or x > width then
         return nil
     end
-    if BD.mirroredUILayout() then
+    local mirrored = BD.mirroredUILayout()
+    -- Invert if requested
+    if self.invert_direction then
+        mirrored = not mirrored
+    end
+
+    if mirrored then
         x = width - x
     end
     return x / width

--- a/plugins/docsettingtweak.koplugin/directory_defaults_template.lua
+++ b/plugins/docsettingtweak.koplugin/directory_defaults_template.lua
@@ -18,6 +18,7 @@ return {--do NOT change this line
  --[[
     ["/mnt/us/documents/hebrew"] = {
         ["inverse_reading_order"] = true
+        ["invert_ui_layout_mirroring"] = true
     },
     ["/mnt/onboard/smalltext"] = {
         ["copt_font_size"] = 34,


### PR DESCRIPTION
Continuation of #13382 

Most of the work is from @Commodore64user, I just had a hard time following the commits & merges, so i rebased on master and broke it up into logical commits.

This makes `invert_ui_layout_mirroring` into a per document setting. this allows it to be set independently of `inverse_reading_order` This will be a bit of a BC break for those whom have it set true globally, as before it only took effect if `inverse_reading_order` was true, and now it will always be true. I don't see any real solution for this as we cannot know which the user would prefer. (if they read in more than one language, it will probably involve directory_defaults or profiles.)

This also has with @Commodore64user work to make the progress bar invertable.

Someone can add dispatcher items for `invert_ui_layout_mirroring` if wanted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14075)
<!-- Reviewable:end -->
