### PR TITLE
ReaderFooter: document position is not used

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -237,65 +237,55 @@ footerTextGeneratorMap = {
         end
     end,
     page_progress = function(footer)
-        if footer.pageno then
-            if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
-                -- (Page labels might not be numbers)
-                return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
-                                          footer.ui.pagemap:getLastPageLabel(true))
-            end
-            if footer.ui.document:hasHiddenFlows() then
-                -- i.e., if we are hiding non-linear fragments and there's anything to hide,
-                local flow = footer.ui.document:getPageFlow(footer.pageno)
-                local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
-                local pages = footer.ui.document:getTotalPagesInFlow(flow)
-                if flow == 0 then
-                    return ("%d // %d"):format(page, pages)
-                else
-                    return ("[%d / %d]%d"):format(page, pages, flow)
-                end
+        if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
+            -- (Page labels might not be numbers)
+            return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
+                                      footer.ui.pagemap:getLastPageLabel(true))
+        elseif footer.ui.document:hasHiddenFlows() then
+            -- i.e., if we are hiding non-linear fragments and there's anything to hide,
+            local flow = footer.ui.document:getPageFlow(footer.pageno)
+            local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
+            local pages = footer.ui.document:getTotalPagesInFlow(flow)
+            if flow == 0 then
+                return ("%d // %d"):format(page, pages)
             else
-                return ("%d / %d"):format(footer.pageno, footer.pages)
+                return ("[%d / %d]%d"):format(page, pages, flow)
             end
-        elseif footer.position then
-            return ("%d / %d"):format(footer.position, footer.doc_height)
+        else
+            return ("%d / %d"):format(footer.pageno, footer.pages)
         end
     end,
     pages_left_book = function(footer)
         local symbol_type = footer.settings.item_prefix
         local prefix = symbol_prefix[symbol_type].pages_left_book
-        if footer.pageno then
-            if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
-                -- (Page labels might not be numbers)
-                local label, idx, count = footer.ui.pagemap:getCurrentPageLabel(false) -- luacheck: no unused
-                local remaining = count - idx
-                if footer.settings.pages_left_includes_current_page then
-                    remaining = remaining + 1
-                end
-                return ("%s %s / %s"):format(prefix, remaining, footer.ui.pagemap:getLastPageLabel(true))
+        if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
+            -- (Page labels might not be numbers)
+            local label, idx, count = footer.ui.pagemap:getCurrentPageLabel(false) -- luacheck: no unused
+            local remaining = count - idx
+            if footer.settings.pages_left_includes_current_page then
+                remaining = remaining + 1
             end
-            if footer.ui.document:hasHiddenFlows() then
-                -- i.e., if we are hiding non-linear fragments and there's anything to hide,
-                local flow = footer.ui.document:getPageFlow(footer.pageno)
-                local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
-                local pages = footer.ui.document:getTotalPagesInFlow(flow)
-                local remaining = pages - page
-                if footer.settings.pages_left_includes_current_page then
-                    remaining = remaining + 1
-                end
-                if flow == 0 then
-                    return ("%s %d // %d"):format(prefix, remaining, pages)
-                else
-                    return ("%s [%d / %d]%d"):format(prefix, remaining, pages, flow)
-                end
+            return ("%s %s / %s"):format(prefix, remaining, footer.ui.pagemap:getLastPageLabel(true))
+        elseif footer.ui.document:hasHiddenFlows() then
+            -- i.e., if we are hiding non-linear fragments and there's anything to hide,
+            local flow = footer.ui.document:getPageFlow(footer.pageno)
+            local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
+            local pages = footer.ui.document:getTotalPagesInFlow(flow)
+            local remaining = pages - page
+            if footer.settings.pages_left_includes_current_page then
+                remaining = remaining + 1
+            end
+            if flow == 0 then
+                return ("%s %d // %d"):format(prefix, remaining, pages)
             else
-                local remaining = footer.pages - footer.pageno
-                if footer.settings.pages_left_includes_current_page then
-                    remaining = remaining + 1
-                end
-                return ("%s %d / %d"):format(prefix, remaining, footer.pages)
+                return ("%s [%d / %d]%d"):format(prefix, remaining, pages, flow)
             end
-        elseif footer.position then
-            return ("%s %d / %d"):format(prefix, footer.doc_height - footer.position, footer.doc_height)
+        else
+            local remaining = footer.pages - footer.pageno
+            if footer.settings.pages_left_includes_current_page then
+                remaining = remaining + 1
+            end
+            return ("%s %d / %d"):format(prefix, remaining, footer.pages)
         end
     end,
     pages_left = function(footer)
@@ -602,7 +592,6 @@ function ReaderFooter:init()
         return
     end
 
-    self.pageno = self.view.state.page
     self.has_no_mode = true
     self.reclaim_height = self.settings.reclaim_height
     for _, m in ipairs(self.mode_index) do
@@ -970,8 +959,7 @@ end
 function ReaderFooter:disableFooter()
     self.onReaderReady = function() end
     self.resetLayout = function() end
-    self.updateFooterPage = function() end
-    self.updateFooterPos = function() end
+    self.updateFooter = function() end
     self.mode = self.mode_list.off
     self.view.footer_visible = false
 end
@@ -2100,7 +2088,7 @@ function ReaderFooter:setTocMarkers(reset)
                         table.insert(self.progress_bar.ticks, pos)
                     end
                 end
-                self.progress_bar.last = self.doc_height or self.ui.document.info.doc_height
+                self.progress_bar.last = self.ui.document.info.doc_height
             end
         end
     else
@@ -2124,14 +2112,6 @@ function ReaderFooter:getDataFromStatistics(title, pages)
 end
 
 function ReaderFooter:onUpdateFooter(force_repaint, full_repaint)
-    if self.pageno then
-        self:updateFooterPage(force_repaint, full_repaint)
-    else
-        self:updateFooterPos(force_repaint, full_repaint)
-    end
-end
-
-function ReaderFooter:updateFooterPage(force_repaint, full_repaint)
     if type(self.pageno) ~= "number" then return end
     if self.settings.chapter_progress_bar then
         if self.progress_bar.initial_pos_marker then
@@ -2144,23 +2124,6 @@ function ReaderFooter:updateFooterPage(force_repaint, full_repaint)
         self.progress_bar:setPercentage(self:getChapterProgress(true))
     else
         self.progress_bar:setPercentage(self:getBookProgress())
-    end
-    self:updateFooterText(force_repaint, full_repaint)
-end
-
-function ReaderFooter:updateFooterPos(force_repaint, full_repaint)
-    if type(self.position) ~= "number" then return end
-    if self.settings.chapter_progress_bar then
-        if self.progress_bar.initial_pos_marker then
-            if self.pageno and (self.ui.toc:getNextChapter(self.pageno) == self.ui.toc:getNextChapter(self.initial_pageno)) then
-                self.progress_bar.initial_percentage = self:getChapterProgress(true, self.initial_pageno)
-            else
-                self.progress_bar.initial_percentage = -1
-            end
-        end
-        self.progress_bar:setPercentage(self:getChapterProgress(true))
-    else
-        self.progress_bar:setPercentage(self.position / self.doc_height)
     end
     self:updateFooterText(force_repaint, full_repaint)
 end
@@ -2296,46 +2259,35 @@ end
 -- and will then emit a "TocReset" after the new ToC is made.
 function ReaderFooter:onTocReset()
     self:setTocMarkers(true)
-    if self.view.view_mode == "page" then
-        self:updateFooterPage()
-    else
-        self:updateFooterPos()
-    end
+    self:onUpdateFooter()
 end
 
 function ReaderFooter:onPageUpdate(pageno)
-    local toc_markers_update = false
+    local old_pageno = self.pageno
+    self.pageno = pageno
+    self.initial_pageno = self.initial_pageno or pageno
+    self.pages = self.ui.document:getPageCount()
+    self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
     if self.ui.document:hasHiddenFlows() then
-        local flow = self.pageno and self.ui.document:getPageFlow(self.pageno)
-        local new_flow = pageno and self.ui.document:getPageFlow(pageno)
-        if pageno and new_flow ~= flow then
-            toc_markers_update = true
+        if old_pageno == nil then
+            self:setTocMarkers(true)
+        else
+            local old_flow = self.ui.document:getPageFlow(old_pageno)
+            local new_flow = self.ui.document:getPageFlow(pageno)
+            if old_flow ~= new_flow then
+                self:setTocMarkers(true)
+            end
         end
     end
-    self.pageno = pageno
-    if not self.initial_pageno then
-        self.initial_pageno = pageno
-    end
-    self.pages = self.ui.document:getPageCount()
-    if toc_markers_update then
-        self:setTocMarkers(true)
-    end
-    self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
-    self:updateFooterPage()
+    self:onUpdateFooter()
 end
 
 function ReaderFooter:onPosUpdate(pos, pageno)
-    self.position = pos
-    self.doc_height = self.ui.document.info.doc_height
-    if pageno then
-        self.pageno = pageno
-        if not self.initial_pageno then
-            self.initial_pageno = pageno
-        end
-        self.pages = self.ui.document:getPageCount()
-        self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
-    end
-    self:updateFooterPos()
+    self.pageno = pageno
+    self.initial_pageno = self.initial_pageno or pageno
+    self.pages = self.ui.document:getPageCount()
+    self.ui.doc_settings:saveSetting("doc_pages", self.pages) -- for Book information
+    self:onUpdateFooter()
 end
 
 function ReaderFooter:onReaderReady()
@@ -2351,9 +2303,10 @@ function ReaderFooter:onReaderReady()
         self:updateFooterContainer()
     end
     self:resetLayout(self.settings.progress_margin) -- set widget dimen
-    self:setTocMarkers()
+    if not self.ui.document:hasHiddenFlows() then -- otherwise will be done in the first onPageUpdate()
+        self:setTocMarkers()
+    end
     self.updateFooterText = self._updateFooterText
-    self:onUpdateFooter()
     self:rescheduleFooterAutoRefreshIfNeeded()
 end
 
@@ -2550,13 +2503,8 @@ function ReaderFooter:onOutOfScreenSaver()
     self:rescheduleFooterAutoRefreshIfNeeded()
 end
 
-function ReaderFooter:onSuspend()
-    self:unscheduleFooterAutoRefresh()
-end
-
-function ReaderFooter:onCloseDocument()
-    self:unscheduleFooterAutoRefresh()
-end
+ReaderFooter.onSuspend       = ReaderFooter.unscheduleFooterAutoRefresh
+ReaderFooter.onCloseDocument = ReaderFooter.unscheduleFooterAutoRefresh
 
 -- Used by event handlers that can trip without direct UI interaction...
 function ReaderFooter:maybeUpdateFooter()
@@ -2564,11 +2512,9 @@ function ReaderFooter:maybeUpdateFooter()
     self:onUpdateFooter(self:shouldBeRepainted())
 end
 
-function ReaderFooter:onFrontlightStateChanged()
-    self:maybeUpdateFooter()
-end
-ReaderFooter.onCharging    = ReaderFooter.onFrontlightStateChanged
-ReaderFooter.onNotCharging = ReaderFooter.onFrontlightStateChanged
+ReaderFooter.onFrontlightStateChanged = ReaderFooter.maybeUpdateFooter
+ReaderFooter.onCharging    = ReaderFooter.maybeUpdateFooter
+ReaderFooter.onNotCharging = ReaderFooter.maybeUpdateFooter
 
 function ReaderFooter:onNetworkConnected()
     if self.settings.wifi_status then

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -960,6 +960,7 @@ function ReaderFooter:disableFooter()
     self.onReaderReady = function() end
     self.resetLayout = function() end
     self.updateFooter = function() end
+    self.onUpdateFooter = function() end
     self.mode = self.mode_list.off
     self.view.footer_visible = false
 end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -87,6 +87,7 @@ ReaderPaging.onPhysicalKeyboardConnected = ReaderPaging.registerKeyEvents
 
 function ReaderPaging:onReaderReady()
     self:setupTouchZones()
+    self.view.footer:onUpdateFooter()
 end
 
 function ReaderPaging:setupTouchZones()

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -87,7 +87,10 @@ ReaderPaging.onPhysicalKeyboardConnected = ReaderPaging.registerKeyEvents
 
 function ReaderPaging:onReaderReady()
     self:setupTouchZones()
-    self.view.footer:onUpdateFooter()
+     -- Statistics plugin updates the footer later, if enabled
+    if not (self.ui.statistics and self.ui.statistics.settings.is_enabled) then
+        self.view.footer:onUpdateFooter()
+    end
 end
 
 function ReaderPaging:setupTouchZones()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1123,19 +1123,11 @@ end
 --]]
 function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     if new_pos == self.current_pos then return end
-    if new_pos < 0 then
-        new_pos = 0
-    else
-        local max_pos = self.ui.document.info.doc_height - self.ui.dimen.h + self.view.footer:getHeight()
-        if max_pos < 0 then -- single-page document
-            new_pos = 0
-        elseif new_pos > max_pos then
-            -- Don't go past end of document, and ensure last line of the document
-            -- is shown just above the footer, whether footer is visible or not
-            new_pos = max_pos
-        end
-    end
---    if max_pos > 0 and new_pos > max_pos then new_pos = max_pos end
+    if new_pos < 0 then new_pos = 0 end
+    -- Don't go past end of document, and ensure last line of the document
+    -- is shown just above the footer, whether footer is visible or not
+    local max_pos = self.ui.document.info.doc_height - self.ui.dimen.h + self.view.footer:getHeight()
+    if new_pos > max_pos then new_pos = max_pos end
     -- adjust dim_area according to new_pos
     if self.view.view_mode ~= "page" and self.view.page_overlap_enable and do_dim_area then
         local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1123,11 +1123,19 @@ end
 --]]
 function ReaderRolling:_gotoPos(new_pos, do_dim_area)
     if new_pos == self.current_pos then return end
-    if new_pos < 0 then new_pos = 0 end
-    -- Don't go past end of document, and ensure last line of the document
-    -- is shown just above the footer, whether footer is visible or not
-    local max_pos = self.ui.document.info.doc_height - self.ui.dimen.h + self.view.footer:getHeight()
-    if new_pos > max_pos then new_pos = max_pos end
+    if new_pos < 0 then
+        new_pos = 0
+    else
+        local max_pos = self.ui.document.info.doc_height - self.ui.dimen.h + self.view.footer:getHeight()
+        if max_pos < 0 then -- single-page document
+            new_pos = 0
+        elseif new_pos > max_pos then
+            -- Don't go past end of document, and ensure last line of the document
+            -- is shown just above the footer, whether footer is visible or not
+            new_pos = max_pos
+        end
+    end
+--    if max_pos > 0 and new_pos > max_pos then new_pos = max_pos end
     -- adjust dim_area according to new_pos
     if self.view.view_mode ~= "page" and self.view.page_overlap_enable and do_dim_area then
         local footer_height = ((self.view.footer_visible and not self.view.footer.settings.reclaim_height) and 1 or 0) * self.view.footer:getHeight()


### PR DESCRIPTION
The footer does not use "document position".
No need to have separate code paths for "page" and "scroll" view modes.
Removed duplicated code and code execution when building and showing the footer.
Closes https://github.com/koreader/koreader/issues/14065.

Despite of the above optimization, the footer text generator is still executed 3 times when opening an epub book, but looks like this cannot be fixed with the current architecture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14076)
<!-- Reviewable:end -->
