### PR TITLE
feat(opds): add support for facets via a context menu

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -147,7 +147,7 @@ function OPDSBrowser:showFacetMenu()
 
     -- Add sub-catalog to bookmarks option first
     table.insert(buttons, {{
-        text = _("Add catalog"),
+        text = "\u{f067} " .. _("Add catalog"),
         callback = function()
             UIManager:close(dialog)
             self:addSubCatalog(catalog_url)
@@ -173,7 +173,7 @@ function OPDSBrowser:showFacetMenu()
     if self.facet_groups then
         for group_name, facets in ffiUtil.orderedPairs(self.facet_groups) do
             table.insert(buttons, {
-                { text = group_name, enabled = false, align = "left" }
+                { text = "\u{f0b0} " .. group_name, enabled = false, align = "left" }
             })
 
             for __, link in ipairs(facets) do
@@ -688,7 +688,7 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
 
         -- Set appropriate title bar icon based on content
         if self.facet_groups or self.search_url then
-            self:setTitleBarLeftIcon("appbar.settings")
+            self:setTitleBarLeftIcon("appbar.menu")
             self.onLeftButtonTap = function()
                 self:showFacetMenu()
             end


### PR DESCRIPTION
This commit introduces support for OPDS 1.2 facets, enabling advanced filtering and sorting in compatible catalogs.

To maintain a clean and uncluttered book list, facet options are not mixed with catalog entries. Instead, they are presented in a dedicated context menu, providing a more intuitive user experience.

- When a catalog provides facets or a search link, the top-left button in the OPDS browser now functions as a menu trigger, displaying all available actions for the current feed.
- Facet links (`<link rel="http://opds-spec.org/facet">`) are parsed and grouped according to the `opds:facetGroup` attribute.
- The new context menu includes all facet groups, the catalog's search action, and the option to bookmark the current feed, unifying all feed-level operations.
- Support for `opds:activeFacet` is added to visually indicate the current filter or sort order with a "✓" mark.
- The `thr:count` attribute is now displayed, showing the number of items available in a facet.
- The parsing logic in `opdsbrowser.lua` has been updated to cleanly separate feed-level links (like facets) from catalog entries, ensuring robust handling and proper pagination.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14089)
<!-- Reviewable:end -->
