### PR TITLE
Remarkable: fixes for remarkable 2

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -337,7 +337,11 @@ function Remarkable:initNetworkManager(NetworkMgr)
 
     NetworkMgr:setWirelessBackend("wpa_supplicant", {ctrl_interface = "/var/run/wpa_supplicant/wlan0"})
 
-    NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn
+    function NetworkMgr.isWifiOn()
+        -- When disabling wifi by using the csl command, wpa_supplicant service will be disabled
+        return os.execute("systemctl is-active --quiet wpa_supplicant") == 0
+    end
+
     NetworkMgr.isConnected = NetworkMgr.ifHasAnAddress
 end
 

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -344,9 +344,10 @@ end
 function Remarkable:exit()
     if isRmPaperPro then
         os.execute("mv -f ~/.config/remarkable/xochitl.conf.bak ~/.config/remarkable/xochitl.conf")
-        if os.getenv("KO_DONT_GRAB_INPUT") == "1" then
-            os.execute("~/xovi/start")
-        end
+    end
+
+    if os.getenv("KO_DONT_GRAB_INPUT") == "1" then
+        os.execute("~/xovi/start")
     end
     Generic.exit(self)
 end

--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -312,7 +312,7 @@ function Remarkable:supportsScreensaver() return true end
 
 function Remarkable:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback, interactive)
-        if isRmPaperPro then
+        if isRmPaperPro or isRm2 then
             os.execute("/usr/bin/csl wifi -p on")
         else
             os.execute("./enable-wifi.sh")
@@ -321,7 +321,7 @@ function Remarkable:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:turnOffWifi(complete_callback)
-        if isRmPaperPro then
+        if isRmPaperPro or isRm2 then
             os.execute("/usr/bin/csl wifi -p off")
         else
             os.execute("./disable-wifi.sh")
@@ -367,7 +367,7 @@ function Remarkable:saveSettings()
 end
 
 function Remarkable:resume()
-    if isRmPaperPro then
+    if isRmPaperPro or isRm2 then
         os.execute("csl wifi -p on")
     else
         os.execute("./enable-wifi.sh")
@@ -375,7 +375,7 @@ function Remarkable:resume()
 end
 
 function Remarkable:suspend()
-    if isRmPaperPro then
+    if isRmPaperPro or isRm2 then
         os.execute("csl wifi -p off")
     else
         os.execute("./disable-wifi.sh")


### PR DESCRIPTION
Enhanced a bit the support for remarkable 2 with xovi.


- Uses csl instead of the enable / disable shell scripts that blocks the wifi after use, forcing the user to restart the whole tablet.
- Restart xovi after quitting koreader.

I just wonder if it would a good idea to have an environment variable that disables the network management (or at least the on / off part) completely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14091)
<!-- Reviewable:end -->
