### PR TITLE
Add .footnote1 class to classic classname footnotes style tweak

### DIFF
--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -950,7 +950,8 @@ ol.references > li > .mw-cite-backlink { display: none; }
 Show footnotes with classic classnames at the bottom of pages.
 This tweak can be duplicated as a user style tweak when books contain footnotes wrapped with other class names.]]),
             css = [[
-.footnote, .footnotes, .fn,
+.footnote, .footnote1,
+.footnotes, .fn,
 .note, .note1, .note2, .note3,
 .ntb, .ntb-txt, .ntb-txt-j,
 .fnote, .fnote1,


### PR DESCRIPTION
These would be likely to show up after a calibre conversion. See <https://www.mobileread.com/forums/showthread.php?p=4527981#post4527981>.

I'm not entirely sure to what extent it's wise to add, but we already have some equivalents after all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14119)
<!-- Reviewable:end -->
