### PR TITLE
Add support for character-by-character highlighting for partial word translation

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1481,7 +1481,6 @@ function ReaderHighlight:showHighlightDialog(index)
             },
         },
     }
-
     edit_highlight_dialog = ButtonDialog:new{
         name = "edit_highlight_dialog", -- for unit tests
         buttons = buttons,


### PR DESCRIPTION
In certain cases—such as when words in a language are formed by adding affixes—it can be useful to highlight and translate only a part of the word rather than the entire word.
I propose adding support for character-by-character highlighting to enable more precise translation of word segments.
I'm not an expert in contributing to this project, so I'm not sure if this is the correct way to submit a modification.
If anything needs to be adjusted or done differently, please let me know—I'll do my best to fix or improve it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14153)
<!-- Reviewable:end -->
