### PR TITLE
Collections: option to skip scanning folder

### DIFF
--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -289,7 +289,7 @@ function ReadCollection:updateItemsByPath(path, new_path) -- FM: rename folder, 
     end
 end
 
-function ReadCollection:updateCollectionFromFolder(collection_name, folders)
+function ReadCollection:updateCollectionFromFolder(collection_name, folders, is_showing)
     folders = folders or self.coll_settings[collection_name].folders
     local count = 0
     if folders then
@@ -318,7 +318,10 @@ function ReadCollection:updateCollectionFromFolder(collection_name, folders)
             end
         end
         for folder, folder_settings in pairs(folders) do
-            util.findFiles(folder, add_item_callback, folder_settings.subfolders)
+            if not is_showing or folder_settings.scan_on_show then
+                logger.dbg("ReadCollection: scanning folder", folder)
+                util.findFiles(folder, add_item_callback, folder_settings.subfolders)
+            end
         end
     end
     return count


### PR DESCRIPTION
Some devices (like Kindle) cannot be connected to a PC while KOReader is running.
Hence there's no need to scan connected folders every time when the collection is shown, it's enough to scan on program start only.
Disabling "Scan folder on showing collection" speeds up opening collections with connected folders.

The "eye" indicator in the mandatory means that the folder is scanned every time the collection is shown.
The "folder" indicator in the mandatory means that the subfolders are scanned.

<img width="400" height="540" alt="1" src="https://github.com/user-attachments/assets/f70fce2a-9c9c-400d-a0aa-da9c730771dd" />
