### PR TITLE
ci: fix call to ldoc

### DIFF
--- a/.ci/after_success_docs_translation.sh
+++ b/.ci/after_success_docs_translation.sh
@@ -24,7 +24,7 @@ git clone git@github.com:koreader/doc.git koreader_doc
 
 # push doc update
 pushd doc && {
-    luajit "$(command -v ldoc)" .
+    ldoc .
     if [ ! -d html ]; then
         echo "Failed to generate documents..."
         exit 1


### PR DESCRIPTION
Since luarocks >= 3.12.0 is broken, and does not honor `wrap_bin_scripts = false` anymore, just call ldoc directly so it works even if a wrapper script is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14207)
<!-- Reviewable:end -->
