### PR TITLE
Kobo: Don't send `PowerPress` twice when fudging page turn button events for `pageturn_power`

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -835,10 +835,14 @@ function Input:handlePowerManagementOnlyEv(ev)
     if G_reader_settings:isTrue("pageturn_power") then
         if keycode == "RPgBack" or keycode == "LPgBack"
         or keycode == "RPgFwd" or keycode == "LPgFwd" then
-            -- When suspended we pretend that the page turn button is a power button
-            if ev.value == KEY_PRESS then
-                return "PowerPress"
+            -- When suspended, pretend that the page turn button is *almost* a power button...
+            if ev.value == KEY_PRESS or ev.value == KEY_REPEAT then
+                -- Swallow key press/release events to avoid sending unbalanced events for the actual key being pressed
+                return
             elseif ev.value == KEY_RELEASE then
+                -- We only want to deal with key release events,
+                -- to avoid tripping the Kobo-specific "poweroff on hold" PowerPress handler...
+                -- (i.e., Power is a very very specific case where unbalanced press/release events *should* be fine).
                 return "PowerRelease"
             end
         end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -836,7 +836,11 @@ function Input:handlePowerManagementOnlyEv(ev)
         if keycode == "RPgBack" or keycode == "LPgBack"
         or keycode == "RPgFwd" or keycode == "LPgFwd" then
             -- When suspended we pretend that the page turn button is a power button
-            return "PowerRelease"
+            if ev.value == KEY_PRESS then
+                return "PowerPress"
+            elseif ev.value == KEY_RELEASE then
+                return "PowerRelease"
+            end
         end
     end
 


### PR DESCRIPTION
Should help with *some* #12787 reports, but not all, since that issue predates the PR that implemented the above feature (#13669)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14216)
<!-- Reviewable:end -->
