### PR TITLE
[Device, kindle] early return if kindleGetCurrentProfile() is nil

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -460,12 +460,12 @@ function Kindle:initNetworkManager(NetworkMgr)
 
     function NetworkMgr:getCurrentNetwork()
         local nw = kindleGetCurrentProfile()
-        if nw ~= nil then
-            logger.dbg("NetworkMgr:getCurrentNetwork: Current network found")
-            return { ssid = nw.essid }
+        if nw == nil then
+            logger.dbg("NetworkMgr:getCurrentNetwork: No current network profile found")
+            return nil
         end
-        logger.dbg("NetworkMgr:getCurrentNetwork: No current network profile found")
-        return nil
+        logger.dbg("NetworkMgr:getCurrentNetwork: Current network found")
+        return { ssid = nw.essid }
     end
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -459,8 +459,13 @@ function Kindle:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:getCurrentNetwork()
-        if not kindleGetCurrentProfile() then return {} end
-        return { ssid = kindleGetCurrentProfile().essid }
+        local nw = kindleGetCurrentProfile()
+        if nw ~= nil then
+            logger.dbg("NetworkMgr:getCurrentNetwork: Current network found")
+            return { ssid = nw.essid }
+        end
+        logger.dbg("NetworkMgr:getCurrentNetwork: No current network profile found")
+        return nil
     end
 
     NetworkMgr.isWifiOn = NetworkMgr.sysfsWifiOn

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -459,6 +459,7 @@ function Kindle:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:getCurrentNetwork()
+        if not kindleGetCurrentProfile() then return {} end
         return { ssid = kindleGetCurrentProfile().essid }
     end
 

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -464,7 +464,7 @@ function Kindle:initNetworkManager(NetworkMgr)
             logger.dbg("NetworkMgr:getCurrentNetwork: No current network profile found")
             return nil
         end
-        logger.dbg("NetworkMgr:getCurrentNetwork: Current network found")
+        logger.dbg("NetworkMgr:getCurrentNetwork: Current network:", nw.essid)
         return { ssid = nw.essid }
     end
 


### PR DESCRIPTION
### bug fix

* Improved error handling in `NetworkMgr:getCurrentNetwork()` to safely return an empty table if `kindleGetCurrentProfile()` is nil, preventing possible nil dereference issues.

@NiLuJe needs to bless this one.

fixes #14215

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14219)
<!-- Reviewable:end -->
