### PR TITLE
fix/remarkable: rM2 RM2FB check fix

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -431,7 +431,7 @@ function Remarkable:setEventHandlers(UIManager)
 end
 
 if is_rm2 then
-    if not os.getenv("RM2FB_SHIM") or not is_qtfb_shimmed then
+    if not os.getenv("RM2FB_SHIM") and not is_qtfb_shimmed then
         error("reMarkable 2 requires a RM2FB server and client to work (https://github.com/ddvk/remarkable2-framebuffer or https://github.com/asivery/rmpp-qtfb-shim)")
     end
     return Remarkable2


### PR DESCRIPTION
While looking at code, I found out that it's checking for both RM2FB AND QTFB not one of those. It should only be triggered when both aren't present, so replace `or` to `and`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14222)
<!-- Reviewable:end -->
