### PR TITLE
[SortWidget] bug fix: Fix keyboard hold events targeting wrong item

### DIFF
--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -43,7 +43,7 @@ function SortItemWidget:init()
             range = self.dimen,
         }
     }
-    self.ges_events.Hold = {
+    self.ges_events.HoldTouch = {
         GestureRange:new{
             ges = "hold",
             range = self.dimen,
@@ -122,8 +122,7 @@ function SortItemWidget:onTap(_, ges)
     return true
 end
 
-function SortItemWidget:onHold()
-    if not Device:isTouchDevice() then return false end -- let SortWidget:onHold handle it
+function SortItemWidget:onHoldTouch()
     if self.item.hold_callback then
         self.item:hold_callback(function() self.show_parent:_populateItems() end)
     elseif self.item.callback then
@@ -355,16 +354,13 @@ function SortWidget:registerKeyEvents()
         self.key_events.NextPage = { { Device.input.group.PgFwd } }
         self.key_events.PrevPage = { { Device.input.group.PgBack } }
         self.key_events.ShowWidgetMenu = { { "Menu" } }
-        if Device:hasScreenKB() then
-            self.key_events.MoveUp = { { "ScreenKB", "Up" }, event = "MoveItemKB", args = -1 }
-            self.key_events.MoveDown = { { "ScreenKB", "Down" }, event = "MoveItemKB", args = 1 }
-            self.key_events.FirstPage = { { "ScreenKB", Device.input.group.PgBack }, event = "GoToPage", args = 1 }
-            self.key_events.LastPage = { { "ScreenKB", Device.input.group.PgFwd }, event = "GoToPage", args = self.pages }
-        elseif Device:hasKeyboard() then
-            self.key_events.MoveUp = { { "Shift", "Up" }, event = "MoveItemKB", args = -1 }
-            self.key_events.MoveDown = { { "Shift", "Down" }, event = "MoveItemKB", args = 1 }
-            self.key_events.FirstPage = { { "Shift", Device.input.group.PgBack }, event = "GoToPage", args = 1 }
-            self.key_events.LastPage = { { "Shift", Device.input.group.PgFwd }, event = "GoToPage", args = self.pages }
+        if Device:hasScreenKB() or Device:hasKeyboard() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.HoldNonTouch = { { modifier, "Press" } }
+            self.key_events.MoveUp = { { modifier, "Up" }, event = "MoveItemKB", args = -1 }
+            self.key_events.MoveDown = { { modifier, "Down" }, event = "MoveItemKB", args = 1 }
+            self.key_events.FirstPage = { { modifier, Device.input.group.PgBack }, event = "GoToPage", args = 1 }
+            self.key_events.LastPage = { { modifier, Device.input.group.PgFwd }, event = "GoToPage", args = self.pages }
         end
     end
 end
@@ -612,8 +608,7 @@ function SortWidget:onCancel()
     return true
 end
 
-function SortWidget:onHold()
-    if Device:isTouchDevice() then return false end -- let SortItemWidget:onHold handle it
+function SortWidget:onHoldNonTouch()
     -- Handle keyboard-triggered hold events by acting on the focused item directly
     if not self.selected or not self.selected.y then
         return true

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -122,16 +122,6 @@ function SortItemWidget:onTap(_, ges)
     return true
 end
 
-function SortItemWidget:onHold()
-    if self.item.hold_callback then
-        self.item:hold_callback(function() self.show_parent:_populateItems() end)
-    elseif self.item.callback then
-        self.item:callback()
-        self.show_parent:_populateItems()
-    end
-    return true
-end
-
 local SortWidget = FocusManager:extend{
     title = "",
     width = nil,
@@ -608,6 +598,35 @@ function SortWidget:onCancel()
     end
 
     self:onGoToPage(self.show_page)
+    return true
+end
+
+function SortWidget:onHold()
+    -- Handle keyboard-triggered hold events by acting on the focused item directly
+    if not self.selected or not self.selected.y then
+        return true
+    end
+
+    local focused_row = self.selected.y
+    local idx_offset = (self.show_page - 1) * self.items_per_page
+    local page_last = math.min(idx_offset + self.items_per_page, #self.item_table)
+    local items_on_page = page_last - idx_offset
+
+    -- Skip if focus is on footer or invalid
+    if focused_row < 1 or focused_row > items_on_page then
+        return true
+    end
+
+    local item_idx = idx_offset + focused_row
+    local item = self.item_table[item_idx]
+
+    if item and item.hold_callback then
+        item.hold_callback(function() self:_populateItems() end)
+    elseif item and item.callback then
+        item.callback()
+        self:_populateItems()
+    end
+
     return true
 end
 

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -610,31 +610,11 @@ end
 
 function SortWidget:onHoldNonTouch()
     -- Handle keyboard-triggered hold events by acting on the focused item directly
-    if not self.selected or not self.selected.y then
+    local focused_item = self:getFocusItem()
+    if not focused_item then
         return true
     end
-
-    local focused_row = self.selected.y
-    local idx_offset = (self.show_page - 1) * self.items_per_page
-    local page_last = math.min(idx_offset + self.items_per_page, #self.item_table)
-    local items_on_page = page_last - idx_offset
-
-    -- Skip if focus is on footer or invalid
-    if focused_row < 1 or focused_row > items_on_page then
-        return true
-    end
-
-    local item_idx = idx_offset + focused_row
-    local item = self.item_table[item_idx]
-
-    if item and item.hold_callback then
-        item.hold_callback(function() self:_populateItems() end)
-    elseif item and item.callback then
-        item.callback()
-        self:_populateItems()
-    end
-
-    return true
+    return focused_item:onHoldTouch()
 end
 
 function SortWidget:onReturn()

--- a/frontend/ui/widget/sortwidget.lua
+++ b/frontend/ui/widget/sortwidget.lua
@@ -122,6 +122,17 @@ function SortItemWidget:onTap(_, ges)
     return true
 end
 
+function SortItemWidget:onHold()
+    if not Device:isTouchDevice() then return false end -- let SortWidget:onHold handle it
+    if self.item.hold_callback then
+        self.item:hold_callback(function() self.show_parent:_populateItems() end)
+    elseif self.item.callback then
+        self.item:callback()
+        self.show_parent:_populateItems()
+    end
+    return true
+end
+
 local SortWidget = FocusManager:extend{
     title = "",
     width = nil,
@@ -602,6 +613,7 @@ function SortWidget:onCancel()
 end
 
 function SortWidget:onHold()
+    if Device:isTouchDevice() then return false end -- let SortItemWidget:onHold handle it
     -- Handle keyboard-triggered hold events by acting on the focused item directly
     if not self.selected or not self.selected.y then
         return true


### PR DESCRIPTION
### bug fix

When using <kbd>shift</kbd>/<kbd>screenkb</kbd>  + <kbd>press</kbd>  on non-touch devices, hold events were always affecting the first item instead of the focused one. Added onHold() handler to SortWidget that directly targets the focused item, bypassing the coordinate-based gesture system that was causing the misdirection.

* Renamed the `onHold` method to `onHoldTouch` in `SortItemWidget`, ensuring the method does not clash with FocusManager's own Hold events.
* Updated the `registerKeyEvents()` method in `SortWidget` to add a new `HoldNonTouch` event for keyboard-based hold actions, and unified modifier handling for screen keyboard and physical keyboard inputs.
* Added a new `onHoldNonTouch` method in `SortWidget` to handle keyboard-triggered hold events by invoking the `onHoldTouch` method on the currently focused item, enabling consistent hold behaviour for non-touch devices.

### related issues
* fixes #13258

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14252)
<!-- Reviewable:end -->
