### PR TITLE
Fulltext search: skim mode

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -306,6 +306,7 @@ function ReaderPaging:enterSkimMode()
             zoom_mode    = self.view.zoom_mode,
             current_page = self.current_page,
             location     = self:getBookLocation(),
+            visible_area = self.visible_area,
         }
         self.view.document.configurable.text_wrap = 0
         self.view.page_scroll = false
@@ -325,6 +326,7 @@ function ReaderPaging:exitSkimMode()
             self.current_page = 0 -- do not emit extra PageUpdate event
             self:onRestoreBookLocation(self.skim_backup.location)
         end
+        self.visible_area = self.skim_backup.visible_area
         self.skim_backup = nil
     end
 end


### PR DESCRIPTION
1. **PDF**: some search results can be invisible when only a part of the page is displayed.
Switch to the "full page view" when showing the search results.
Closes #12686

2. **Find all**: in the find all results list, on tapping an entry - go to the page with the entry and show new small popup dialog. Closes #12900 
The buttons:
(1) go back to original page where the search started
(2) previous entry (long-press - the first found entry)
(3) show Find all results list
(4) next entry (long-press - the last found entry)
(5) new search

<img width="400" height="540" alt="1" src="https://github.com/user-attachments/assets/7cae6dcb-8fb3-4e32-90bc-e89c274b3865" />

For comparison, usual forward/backward search

<img width="400" height="540" alt="2" src="https://github.com/user-attachments/assets/3adc749e-6220-447c-b712-a3a01043d061" />
