### PR TITLE
[KeyValuePage] back button returns to parent

### DIFF
--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -319,6 +319,11 @@ function KeyValuePage:init()
         self.key_events.CloseWithKey = { { Input.group.Back } }
         self.key_events.NextPage = { { Input.group.PgFwd } }
         self.key_events.PrevPage = { { Input.group.PgBack } }
+        if Device:hasScreenKB() or Device:hasKeyboard() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.FirstPage = { { modifier, Input.group.PgFwd }, event = "GoToPage", args = 1 }
+            self.key_events.LastPage = { { modifier, Input.group.PgBack }, event = "GoToPage", args = self.pages}
+        end
     end
     if Device:isTouchDevice() then
         self.ges_events.Swipe = {
@@ -566,6 +571,11 @@ end
 function KeyValuePage:goToPage(page)
     self.show_page = page
     self:_populateItems()
+end
+
+function KeyValuePage:onGoToPage(page)
+    self:goToPage(page)
+    return true
 end
 
 -- make sure self.item_margin and self.item_height are set before calling this
@@ -819,9 +829,8 @@ function KeyValuePage:onClose()
 end
 
 function KeyValuePage:onCloseWithKey()
-    if self.page_return_arrow and self.callback_return ~= nil then
-        self:onReturn()
-        return true
+    if self.page_return_arrow and self.callback_return then
+        self:callback_return()
     end
     self:onClose()
     return true

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -316,7 +316,7 @@ function KeyValuePage:init()
     end
 
     if Device:hasKeys() then
-        self.key_events.Close = { { Input.group.Back } }
+        self.key_events.CloseWithKey = { { Input.group.Back } }
         self.key_events.NextPage = { { Input.group.PgFwd } }
         self.key_events.PrevPage = { { Input.group.PgBack } }
     end
@@ -815,6 +815,15 @@ function KeyValuePage:onClose()
     if self.close_callback then
         self.close_callback()
     end
+    return true
+end
+
+function KeyValuePage:onCloseWithKey()
+    if self.page_return_arrow and self.callback_return ~= nil then
+        self:onReturn()
+        return true
+    end
+    self:onClose()
     return true
 end
 


### PR DESCRIPTION
### what's new

* Added a new `onCloseWithKey()` method that checks for a return arrow and callback before invoking the appropriate close or return logic, providing clearer behavior when closing the page via a key event.

*  fix #14266

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14270)
<!-- Reviewable:end -->
