### PR TITLE
Fix downloading of PDFs with non-standard mimetype from wallabag

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -775,7 +775,7 @@ function Wallabag:downloadArticle(article)
             end
         elseif DocumentRegistry:hasProvider(nil, mimetype) then
             logger.dbg("Wallabag:downloadArticle: ignoring EPUB in favor of mimetype", mimetype)
-            file_ext = "." .. DocumentRegistry:mimeToExt(article.mimetype)
+            file_ext = "." .. DocumentRegistry:mimeToExt(mimetype)
             item_url = article.url
         else
             logger.dbg("Wallabag:downloadArticle: not ignoring EPUB, because there is no provider for", mimetype)

--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -741,7 +741,9 @@ end
 -- @treturn int 1 failed, 2 skipped, 3 downloaded
 function Wallabag:downloadArticle(article)
     local skip_article = false
+    logger.dbg("Wallabag:downloadArticle: article.title =", article.title)
     local title = util.getSafeFilename(article.title, self.directory, 230, 0)
+    logger.dbg("Wallabag:downloadArticle: local title =", title)
     local file_ext = ".epub"
     local item_url = "/api/entries/" .. article.id .. "/export.epub"
 
@@ -752,9 +754,12 @@ function Wallabag:downloadArticle(article)
     local mimetype = type(article.mimetype) == "string" and util.trim(article.mimetype:match("^[^;]*")) or nil
 
     if self.download_original_document then
+        logger.dbg("Wallabag:downloadArticle: local mimetype =", mimetype)
+        logger.dbg("Wallabag:downloadArticle: article.url =", article.url)
         if mimetype == "text/html" then
             logger.dbg("Wallabag:downloadArticle: not ignoring EPUB, because", article.url, "is HTML")
         elseif mimetype == nil then -- base ourselves on the file extension
+            logger.dbg("Wallabag:downloadArticle: mimetype = nil, using article.url instead")
             if util.getFileNameSuffix(article.url):lower():find("^html?$") then
                 logger.dbg("Wallabag:downloadArticle: not ignoring EPUB, because", article.url, "appears to be HTML")
             elseif DocumentRegistry:hasProvider(article.url) then


### PR DESCRIPTION
Downloading a PDF with a mimetype that includes `;...` failed. I then noticed that the original `article.mimetype` was used to lookup the file extension, instead of the cleaned up `local mimetype`. This fixes that.

I was also adding debug logging while trying to replicate #14147, and figured it might be useful to leave those in, but didn't think those are worth a separate PR, so left them here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14271)
<!-- Reviewable:end -->
