### PR TITLE
calibre: handle a missing inbox folder

### DIFF
--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -235,7 +235,7 @@ function CalibreWireless:connect()
 
     -- Setup inbox directory.
     local inbox_dir = G_reader_settings:readSetting("inbox_dir")
-    if not inbox_dir then
+    if not inbox_dir or lfs.attributes(inbox_dir, "mode") ~= "directory" then
         self:setInboxDir(re)
         inbox_dir = coroutine.yield()
     end


### PR DESCRIPTION
Prompt the user again if the inbox folder has been configured but is missing (or not a directory).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14293)
<!-- Reviewable:end -->
