### PR TITLE
Fix hibreak/bigme b7 buttons being inverted when the device is rotated

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -244,7 +244,7 @@ function Device:init()
     }
 
     -- disable translation for specific models, where media keys follow gravity, see https://github.com/koreader/koreader/issues/12423
-    if android.prop.model == "go7" or android.prop.model == "gocolor7" or android.prop.model == "gocolor7_2" or android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" then
+    if android.prop.model == "go7" or android.prop.model == "gocolor7" or android.prop.model == "gocolor7_2" or android.prop.model == "hibreak" or android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" then
         self.input:disableRotationMap()
     end
 

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -252,6 +252,7 @@ function Device:init()
         moaanmix7 = true,
         xiaomi_reader = true,
     }
+
     if models[android.prop.model] then
         self.input:disableRotationMap()
     end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -252,7 +252,6 @@ function Device:init()
         moaanmix7 = true,
         xiaomi_reader = true,
     }
-    
     if models[android.prop.model] then
         self.input:disableRotationMap()
     end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -244,7 +244,16 @@ function Device:init()
     }
 
     -- disable translation for specific models, where media keys follow gravity, see https://github.com/koreader/koreader/issues/12423
-    if android.prop.model == "go7" or android.prop.model == "gocolor7" or android.prop.model == "gocolor7_2" or android.prop.model == "hibreak" or android.prop.model == "moaanmix7" or android.prop.model == "xiaomi_reader" then
+    local models = {
+        go7 = true,
+        gocolor7 = true,
+        gocolor7_2 = true,
+        hibreak = true,
+        moaanmix7 = true,
+        xiaomi_reader = true,
+    }
+    
+    if models[android.prop.model] then
         self.input:disableRotationMap()
     end
 


### PR DESCRIPTION
Seems like #9223 , confirmed that disabling rotation via a userpatch resolved the issue.

At what point would this make sense to handle this in a different way, eg a list?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14317)
<!-- Reviewable:end -->
