### PR TITLE
[ReaderDictionary] Offer fuzzy search when dict query fails

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1237,7 +1237,7 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         lookupCancelled()
         return
     end
-    -- Intercept "No results" to offer fuzzy search to non-fuzzy people.
+    -- Intercept "No results" to offer fuzzy search to non-fussy people.
     if not fuzzy_search and results and results[1].no_result then
         self:dismissLookupInfo() -- Close the "Searching..." message
         UIManager:show(ConfirmBox:new{


### PR DESCRIPTION
### what's new

* When a dictionary lookup finds no results and fuzzy search is not already enabled, KOReader now offers the user an offer they can't refuse, the option of performing a one-time fuzzy search.
* The logic for handling lookup cancellation has been refactored into a local function (`lookupCancelled`) to avoid code duplication and improve readability. This function is now used both when a lookup is interrupted quickly and when the user cancels the fuzzy search prompt.

<div align="center">
  <img src="https://github.com/user-attachments/assets/2e02a190-8718-4a32-a3b9-26c798ee4921" alt="name" width="400" />
</div> 

### related issues

* #14239




