### PR TITLE
InputText: remove single keypress addChars only on hasDPad restriction

### DIFF
--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -706,7 +706,7 @@ function InputText:onKeyPress(key)
             handled = false
         end
     end
-    if not handled and Device:hasDPad() then
+    if not handled then
         -- FocusManager may turn on alternative key maps.
         -- These key map maybe single text keys.
         -- It will cause unexpected focus move instead of enter text to InputText


### PR DESCRIPTION
See <https://github.com/koreader/koreader/discussions/14358>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14360)
<!-- Reviewable:end -->
