### PR TITLE
Reference pages: improve Toc and status bar

### DIFF
--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -103,6 +103,15 @@ end
 
 function ReaderGoto:gotoPage()
     local page_number = self.goto_dialog:getInputText()
+    if self.ui.pagemap and self.ui.pagemap:wantsPageLabels() then
+        local label = self.ui.pagemap:cleanPageLabel(page_number)
+        local _, pn = self.ui.pagemap:getPageLabelProps(label)
+        if pn then
+            self:close()
+            self.ui:handleEvent(Event:new("GotoPage", pn))
+        end
+        return
+    end
     local relative_sign = page_number:sub(1, 1)
     local number = tonumber(page_number)
     if number then
@@ -110,16 +119,7 @@ function ReaderGoto:gotoPage()
         if relative_sign == "+" or relative_sign == "-" then
             self.ui:handleEvent(Event:new("GotoRelativePage", number))
         else
-            if self.ui.pagemap and self.ui.pagemap:wantsPageLabels() then
-                number = self.ui.pagemap:getRenderedPageNumber(page_number, true)
-                if number then -- found
-                    self.ui:handleEvent(Event:new("GotoPage", number))
-                else
-                    return -- avoid self:close()
-                end
-            else
-                self.ui:handleEvent(Event:new("GotoPage", number))
-            end
+            self.ui:handleEvent(Event:new("GotoPage", number))
         end
         self:close()
     elseif self.ui.document:hasHiddenFlows() then


### PR DESCRIPTION
Reference pages (labels) are now shown well in different info windows. Good summary:
- #14310

This PR fixes some issues:
1. Table of content: chapter lengths.
2. Status bar: "Current page in chapter", "Pages left in chapter" indicators.
3. Go to: handle not-number labels.

Since some labels cannot be converted to a number, the label pagemap index is used instead.

Depending on book formatting, chapters can start not from the beginning of a reference page. This affects chapter lengths.
For example, a chapter starts at ref page 5 and takes ref pages 5, 6, part of 7.
The next chapter starts in the same ref page 7.
This means that the chapter length is 3 pages (not 7 - 5 = 2 as calculated for rendered pages).

Screenshots for example:
(1) a book with chapters starting from the beginning of a reference page (note that some labels are not numbers but nevertheless we can calculate chapter lengths)
(2) a book with chapters starting **not** from the beginning of a reference page

The status bar items are: "Current page", "Pages left in book", "Current page in chapter", "Pages left in chapter"

-----

<img width="400" height="540" alt="1" src="https://github.com/user-attachments/assets/e9fee6eb-7751-469e-984c-544f2e381c73" />

<img width="400" height="540" alt="2" src="https://github.com/user-attachments/assets/d9e5a1ba-a049-4835-a83b-cd784a247786" />

-----

<img width="400" height="540" alt="3" src="https://github.com/user-attachments/assets/d3f0c0d8-4499-49a1-8975-f5063734209c" />

<img width="400" height="540" alt="4" src="https://github.com/user-attachments/assets/cd891fbc-10c4-49e4-b87e-70e56e990329" />