### PR TITLE
tools/mkrelease: handle corner case

### DIFF
--- a/tools/mkrelease.sh
+++ b/tools/mkrelease.sh
@@ -237,7 +237,12 @@ if [[ -r "${output}" ]]; then
                 "${sevenzip[@]}" -ba -slt l "${output}" |
                     awk "${AWK_HELPERS}"'
                         /^[^=]+ = / { e[$1] = $3; }
-                        /^$/ && e["Size"] != "" { print_entry(e["Path"], e["Size"], e["CRC"]) }
+                        /^$/ && e["Size"] != "" {
+                            # Handle empty files (no CRC).
+                            if (e["CRC"] == "" && e["Attributes"] !~ /^D/ && e["Size"] == 0)
+                                e["CRC"] = "00000000";
+                            print_entry(e["Path"], e["Size"], e["CRC"])
+                        }
                         ' | sort
             )"
             ;;


### PR DESCRIPTION
7z shows an empty CRC for empty files when generating an archive manifest:
```
▸ mkdir dir
▸ touch dir/empty
▸ echo foobar >dir/foobar
▸ 7z a test.7z dir
[…]

▸ 7z -ba h dir
                        dir
B22C9747             7  dir/foobar
00000000             0  dir/empty

▸ 7z -ba -slt l test.7z
Path = dir
Size = 0
Packed Size = 0
Modified = 2025-09-27 22:55:25.7947183
Attributes = D drwxr-xr-x
CRC =
Encrypted = -
Method =
Block =

Path = dir/empty
Size = 0
Packed Size = 0
Modified = 2025-09-27 22:43:34.0722990
Attributes = A -rw-r--r--
CRC =
Encrypted = -
Method =
Block =

Path = dir/foobar
Size = 7
Packed Size = 11
Modified = 2025-09-27 22:55:25.7947183
Attributes = A -rw-r--r--
CRC = B22C9747
Encrypted = -
Method = LZMA2:12
Block = 0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14369)
<!-- Reviewable:end -->
