### PR TITLE
[ScreenSaver] allow sleep screen message to be placed anywhere on screen

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20250914
+local CURRENT_MIGRATION_DATE = 20250929
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -909,6 +909,40 @@ if last_migration_date < 20250914 then
     G_reader_settings:saveSetting("readtimer", settings)
     G_reader_settings:delSetting("readtimer_show_value_in_header")
     G_reader_settings:delSetting("readtimer_show_value_in_footer")
+end
+
+-- 20250929, Screensaver message position refactor: top/middle/bottom -> banner/box with custom positioning
+-- https://github.com/koreader/koreader/pull/143XX
+if last_migration_date < 20250929 then
+    logger.info("Performing one-time migration for 20250929")
+
+    -- List of prefixes to check (empty string for normal settings, plus event prefixes)
+    local prefixes = {"", "poweroff_", "reboot_"}
+
+    for _, prefix in ipairs(prefixes) do
+        local old_position_key = prefix .. "screensaver_message_position"
+        local old_position = G_reader_settings:readSetting(old_position_key)
+
+        if old_position then
+            local new_container_key = prefix .. "screensaver_message_container"
+            local new_position_key = prefix .. "screensaver_message_vertical_position"
+
+            if old_position == "top" then
+                -- Top -> Banner at 0% from top
+                G_reader_settings:saveSetting(new_container_key, "banner")
+                G_reader_settings:saveSetting(new_position_key, 0)
+            elseif old_position == "middle" then
+                -- Middle -> Box at 50% (center)
+                G_reader_settings:saveSetting(new_container_key, "box")
+                G_reader_settings:saveSetting(new_position_key, 50)
+            elseif old_position == "bottom" then
+                -- Bottom -> Banner at 100% from top
+                G_reader_settings:saveSetting(new_container_key, "banner")
+                G_reader_settings:saveSetting(new_position_key, 100)
+            end
+            G_reader_settings:delSetting(old_position_key)
+        end
+    end
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -912,7 +912,7 @@ if last_migration_date < 20250914 then
 end
 
 -- 20250929, Screensaver message position refactor: top/middle/bottom -> banner/box with custom positioning
--- https://github.com/koreader/koreader/pull/143XX
+-- https://github.com/koreader/koreader/pull/14371
 if last_migration_date < 20250929 then
     logger.info("Performing one-time migration for 20250929")
 

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -928,17 +928,17 @@ if last_migration_date < 20250929 then
             local new_position_key = prefix .. "screensaver_message_vertical_position"
 
             if old_position == "top" then
-                -- Top -> Banner at 0% from top
+                -- Top -> Banner at 110% from bottom
                 G_reader_settings:saveSetting(new_container_key, "banner")
-                G_reader_settings:saveSetting(new_position_key, 0)
+                G_reader_settings:saveSetting(new_position_key, 100)
             elseif old_position == "middle" then
                 -- Middle -> Box at 50% (center)
                 G_reader_settings:saveSetting(new_container_key, "box")
                 G_reader_settings:saveSetting(new_position_key, 50)
             elseif old_position == "bottom" then
-                -- Bottom -> Banner at 100% from top
+                -- Bottom -> Banner at 0% from bottom
                 G_reader_settings:saveSetting(new_container_key, "banner")
-                G_reader_settings:saveSetting(new_position_key, 100)
+                G_reader_settings:saveSetting(new_position_key, 0)
             end
             G_reader_settings:delSetting(old_position_key)
         end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -928,7 +928,7 @@ if last_migration_date < 20250929 then
             local new_position_key = prefix .. "screensaver_message_vertical_position"
 
             if old_position == "top" then
-                -- Top -> Banner at 110% from bottom
+                -- Top -> Banner at 100% from bottom
                 G_reader_settings:saveSetting(new_container_key, "banner")
                 G_reader_settings:saveSetting(new_position_key, 100)
             elseif old_position == "middle" then

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -205,7 +205,7 @@ return {
                 end,
             },
             {
-                text = _("Message's container and position"),
+                text = _("Container and position"),
                 sub_item_table = {
                     genMenuItem(_("Banner"), "screensaver_message_container", "banner"),
                     genMenuItem(_("Box"), "screensaver_message_container", "box", nil, true),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -214,20 +214,20 @@ return {
                     genMenuItem(_("Box"), "screensaver_message_container", "box", nil, true),
                     {
                         text_func = function()
-                            local percent = G_reader_settings:readSetting("screensaver_message_vertical_position") .. "%"
+                            local percent = G_reader_settings:readSetting("screensaver_message_vertical_position")
                             local value
-                            if percent == "100%" then
+                            if percent == 100 then
                                 value = _("top")
-                            elseif percent == "50%" then
+                            elseif percent == 50 then
                                 value = _("middle")
-                            elseif percent == "0%" then
+                            elseif percent == 0 then
                                 value = _("bottom")
                             else
-                                value = percent
+                                value = percent .. "\xE2\x80\xAF%" -- narrow no-break space
                             end
-                            return T(_("Custom vertical position: %1"), value)
+                            return T(_("Vertical position: %1"), value)
                         end,
-                        help_text = _("Set a custom vertical position for the sleep screen message"),
+                        help_text = _("Set exactly where the sleep screen message appears by setting a vertical position value."),
                         keep_menu_open = true,
                         callback = function(touchmenu_instance)
                             Screensaver:setCustomPosition(touchmenu_instance)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -227,7 +227,7 @@ return {
                             end
                             return T(_("Vertical position: %1"), value)
                         end,
-                        help_text = _("Set exactly where the sleep screen message appears by setting a vertical position value."),
+                        help_text = _("Set a custom vertical position for the sleep screen message."),
                         keep_menu_open = true,
                         callback = function(touchmenu_instance)
                             Screensaver:setCustomPosition(touchmenu_instance)

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -233,6 +233,17 @@ return {
                             Screensaver:setCustomPosition(touchmenu_instance)
                         end,
                     },
+                    {
+                        text_func = function()
+                            local alpha = G_reader_settings:readSetting("screensaver_message_alpha", 100)
+                            return T(_("Message opacity: %1"), alpha) .. "\xE2\x80\xAF%"
+                        end,
+                        help_text = _("Set the opacity level of the sleep screen message."),
+                        keep_menu_open = true,
+                        callback = function(touchmenu_instance)
+                            Screensaver:setMessageOpacity(touchmenu_instance)
+                        end,
+                    },
                 },
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -206,6 +206,9 @@ return {
             },
             {
                 text = _("Container and position"),
+                enabled_func = function()
+                    return G_reader_settings:isTrue("screensaver_show_message")
+                end,
                 sub_item_table = {
                     genMenuItem(_("Banner"), "screensaver_message_container", "banner"),
                     genMenuItem(_("Box"), "screensaver_message_container", "box", nil, true),

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -205,14 +205,31 @@ return {
                 end,
             },
             {
-                text = _("Message position"),
-                enabled_func = function()
-                    return G_reader_settings:isTrue("screensaver_show_message")
-                end,
+                text = _("Message's container and position"),
                 sub_item_table = {
-                    genMenuItem(_("Top"), "screensaver_message_position", "top"),
-                    genMenuItem(_("Middle"), "screensaver_message_position", "middle"),
-                    genMenuItem(_("Bottom"), "screensaver_message_position", "bottom"),
+                    genMenuItem(_("Banner"), "screensaver_message_container", "banner"),
+                    genMenuItem(_("Box"), "screensaver_message_container", "box", nil, true),
+                    {
+                        text_func = function()
+                            local percent = G_reader_settings:readSetting("screensaver_message_vertical_position") .. "%"
+                            local value
+                            if percent == "0%" then
+                                value = _("top")
+                            elseif percent == "50%" then
+                                value = _("middle")
+                            elseif percent == "100%" then
+                                value = _("bottom")
+                            else
+                                value = percent
+                            end
+                            return T(_("Custom vertical position: %1"), value)
+                        end,
+                        help_text = _("Set a custom vertical position for the sleep screen message"),
+                        keep_menu_open = true,
+                        callback = function(touchmenu_instance)
+                            Screensaver:setCustomPosition(touchmenu_instance)
+                        end,
+                    },
                 },
             },
             {

--- a/frontend/ui/elements/screensaver_menu.lua
+++ b/frontend/ui/elements/screensaver_menu.lua
@@ -213,11 +213,11 @@ return {
                         text_func = function()
                             local percent = G_reader_settings:readSetting("screensaver_message_vertical_position") .. "%"
                             local value
-                            if percent == "0%" then
+                            if percent == "100%" then
                                 value = _("top")
                             elseif percent == "50%" then
                                 value = _("middle")
-                            elseif percent == "100%" then
+                            elseif percent == "0%" then
                                 value = _("bottom")
                             else
                                 value = percent

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -275,10 +275,7 @@ end
 function Screensaver:setCustomPosition(touchmenu_instance)
     UIManager:show(SpinWidget:new{
         title_text = _("Adjust message position"),
-        info_text = _("Set the message's position as a percentage from the bottom of the screen.").. "\n\n100% = "..
-                    _("top") .. "\n50% = " ..
-                    _("middle") .. "\n0% = " ..
-                    _("bottom"),
+        info_text = _("Set the message's position as a percentage from the bottom of the screen. \n\n100% = top \n50% = middle \n0% =  bottom"),
         value = G_reader_settings:readSetting("screensaver_message_vertical_position", 50),
         value_min = 0,
         value_max = 100,

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -5,7 +5,6 @@ local CustomPositionContainer = require("ui/widget/container/custompositionconta
 local Device = require("device")
 local DocumentRegistry = require("document/documentregistry")
 local Font = require("ui/font")
-local Geom = require("ui/geometry")
 local InfoMessage = require("ui/widget/infomessage")
 local ImageWidget = require("ui/widget/imagewidget")
 local OverlapGroup = require("ui/widget/overlapgroup")

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -272,9 +272,9 @@ end
 
 function Screensaver:setCustomPosition(touchmenu_instance)
     UIManager:show(SpinWidget:new{
-        title_text = _("Message vertical position"),
-        info_text = _("Set the vertical position of the message as a percentage from the bottom of the screen.").. "\n\n100% = "..
-                    _("top").. "\n50% = " ..
+        title_text = _("Adjust message position"),
+        info_text = _("Set the message's position as a percentage from the bottom of the screen.").. "\n\n100% = "..
+                    _("top") .. "\n50% = " ..
                     _("middle") .. "\n0% = " ..
                     _("bottom"),
         value = G_reader_settings:readSetting("screensaver_message_vertical_position", 50),
@@ -282,16 +282,12 @@ function Screensaver:setCustomPosition(touchmenu_instance)
         value_max = 100,
         value_step = 5,
         value_hold_step = 1,
+        default_value = 50,
         precision = "%.1f",
         unit = "%",
         ok_text = _("Set position"),
         callback = function(spin)
             G_reader_settings:saveSetting("screensaver_message_vertical_position", spin.value)
-            if touchmenu_instance then touchmenu_instance:updateItems() end
-        end,
-        extra_text = _("Reset to default (50%)"),
-        extra_callback = function()
-            G_reader_settings:saveSetting("screensaver_message_vertical_position", 50)
             if touchmenu_instance then touchmenu_instance:updateItems() end
         end,
     })

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -273,9 +273,9 @@ end
 function Screensaver:setCustomPosition(touchmenu_instance)
     UIManager:show(SpinWidget:new{
         title_text = _("Message vertical position"),
-        info_text = _("Set the vertical position of the message as a percentage from the top of the screen.").. "\n\n0% = "..
+        info_text = _("Set the vertical position of the message as a percentage from the bottom of the screen.").. "\n\n100% = "..
                     _("top").. "\n50% = " ..
-                    _("middle") .. "\n100% = " ..
+                    _("middle") .. "\n0% = " ..
                     _("bottom"),
         value = G_reader_settings:readSetting("screensaver_message_vertical_position", 50),
         value_min = 0,
@@ -582,11 +582,12 @@ function Screensaver:show()
                 alignment = "center",
             }
         end
-        -- Create a custom container that places the Message at the requested vertical coordinate
+        -- Create a custom container that places the Message at the requested vertical coordinate.
         message_widget = CustomPositionContainer:new{
             dimen = Geom:new{w = screen_w, h = screen_h},
             widget = content_widget,
-            vertical_position = vertical_percentage / 100,
+            -- although the computer expects 0 to be the top, users expect 0 to be the bottom
+            vertical_position = 1 - (vertical_percentage / 100),
         }
         -- Forward the height of the top message to the overlay widget
         if vertical_percentage < 20 then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -273,7 +273,10 @@ end
 function Screensaver:setCustomPosition(touchmenu_instance)
     UIManager:show(SpinWidget:new{
         title_text = _("Message vertical position"),
-        info_text = _("Set the vertical position of the message as a percentage from the top of the screen.\n\n0% = top\n50% = middle\n100% = bottom"),
+        info_text = _("Set the vertical position of the message as a percentage from the top of the screen.").. "\n\n0% = "..
+                    _("top").. "\n50% = " ..
+                    _("middle") .. "\n100% = " ..
+                    _("bottom"),
         value = G_reader_settings:readSetting("screensaver_message_vertical_position", 50),
         value_min = 0,
         value_max = 100,

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -275,7 +275,7 @@ end
 function Screensaver:setCustomPosition(touchmenu_instance)
     UIManager:show(SpinWidget:new{
         title_text = _("Adjust message position"),
-        info_text = _("Set the message's position as a percentage from the bottom of the screen. \n\n100% = top \n50% = middle \n0% =  bottom"),
+        info_text = _("Set the message's position as a percentage from the bottom of the screen.\n\n100% = top\n50% = middle\n0% = bottom"),
         value = G_reader_settings:readSetting("screensaver_message_vertical_position", 50),
         value_min = 0,
         value_max = 100,

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -3,6 +3,8 @@ CustomPositionContainer contains its content (1 widget) at a custom position wit
 dimensions
 --]]
 
+local Blitbuffer = require("ffi/blitbuffer")
+local Screen = require("device").screen
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local CustomPositionContainer = WidgetContainer:extend{
@@ -15,8 +17,8 @@ function CustomPositionContainer:paintTo(bb, x, y)
     if not self.widget then return end
 
     local content_size = self.widget:getSize()
-    local container_w = self.dimen.w or content_size.w
-    local container_h = self.dimen.h or content_size.h
+    local container_w = (self.dimen and self.dimen.w) or Screen:getWidth()
+    local container_h = (self.dimen and self.dimen.h) or Screen:getHeight()
 
     -- calculate desired position
     local desired_x = math.floor((container_w - content_size.w) * self.horizontal_position)
@@ -26,7 +28,41 @@ function CustomPositionContainer:paintTo(bb, x, y)
     local x_pos = x + math.max(0, math.min(desired_x, container_w - content_size.w))
     local y_pos = y + math.max(0, math.min(desired_y, container_h - content_size.h))
 
-    self.widget:paintTo(bb, x_pos, y_pos)
+
+    -- Handle transparency (similar to MovableContainer but simpler)
+    if self.alpha and self.alpha < 1.0 then
+        -- Create/recreate compose canvas if needed
+        if not self.compose_bb
+            or self.compose_bb:getWidth() ~= bb:getWidth()
+            or self.compose_bb:getHeight() ~= bb:getHeight()
+        then
+            if self.compose_bb then
+                self.compose_bb:free()
+            end
+            self.compose_bb = Blitbuffer.new(bb:getWidth(), bb:getHeight(), bb:getType())
+        end
+
+        -- Copy the relevant portion of the background from the target buffer to compose buffer
+        -- This gives us the actual background (cover image, solid color, etc.) so rounded corners
+        -- don't show artifacts.
+        self.compose_bb:blitFrom(bb, x_pos, y_pos, x_pos, y_pos, content_size.w, content_size.h)
+
+        -- Paint widget to compose canvas
+        self.widget:paintTo(self.compose_bb, x_pos, y_pos)
+
+        -- Blit with alpha to target
+        bb:addblitFrom(self.compose_bb, x_pos, y_pos, x_pos, y_pos, content_size.w, content_size.h, self.alpha)
+    else
+        -- No alpha, direct paint
+        self.widget:paintTo(bb, x_pos, y_pos)
+    end
+end
+
+function CustomPositionContainer:onCloseWidget()
+    if self.compose_bb then
+        self.compose_bb:free()
+        self.compose_bb = nil
+    end
 end
 
 function CustomPositionContainer:getSize()

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -1,0 +1,44 @@
+--[[
+CustomPositionContainer contains its content (1 widget) at a custom position within its own
+dimensions
+--]]
+
+local Geom = require("ui/geometry")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+
+local CustomPositionContainer = WidgetContainer:extend{
+    vertical_position = 0.5,  -- 0.0 = topmost, 1.0 = bottommost
+    horizontal_position = 0.5,  -- 0.0 = leftmost, 1.0 = rightmost
+    widget = nil,
+}
+
+function CustomPositionContainer:paintTo(bb, x, y)
+    if not self.widget then return end
+
+    local content_size = self.widget:getSize()
+    local container_w = self.dimen.w or content_size.w
+    local container_h = self.dimen.h or content_size.h
+
+    -- calculate desired position
+    local desired_x = math.floor((container_w - content_size.w) * self.horizontal_position)
+    local desired_y = math.floor((container_h - content_size.h) * self.vertical_position)
+
+    -- clamp to container bounds
+    local x_pos = x + math.max(0, math.min(desired_x, container_w - content_size.w))
+    local y_pos = y + math.max(0, math.min(desired_y, container_h - content_size.h))
+
+    self.widget:paintTo(bb, x_pos, y_pos)
+end
+
+function CustomPositionContainer:getSize()
+    if self.dimen then
+        return self.dimen
+    end
+    -- return widget size if no dimen set
+    if self.widget then
+        return self.widget:getSize()
+    end
+    return { w = 0, h = 0 }
+end
+
+return CustomPositionContainer

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -3,7 +3,6 @@ CustomPositionContainer contains its content (1 widget) at a custom position wit
 dimensions
 --]]
 
-local Geom = require("ui/geometry")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local CustomPositionContainer = WidgetContainer:extend{

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -30,7 +30,7 @@ function CustomPositionContainer:paintTo(bb, x, y)
     local x_pos = x + math.max(0, math.min(desired_x, container_w - content_size.w))
     local y_pos = y + math.max(0, math.min(desired_y, container_h - content_size.h))
 
-    -- Handle transparency (similar to MovableContainer but simpler)
+    -- Handle transparency similar to MovableContainer
     if self.alpha and self.alpha < 1.0 then
         -- Create/recreate compose canvas if needed
         if not self.compose_bb

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -28,7 +28,6 @@ function CustomPositionContainer:paintTo(bb, x, y)
     local x_pos = x + math.max(0, math.min(desired_x, container_w - content_size.w))
     local y_pos = y + math.max(0, math.min(desired_y, container_h - content_size.h))
 
-
     -- Handle transparency (similar to MovableContainer but simpler)
     if self.alpha and self.alpha < 1.0 then
         -- Create/recreate compose canvas if needed

--- a/frontend/ui/widget/container/custompositioncontainer.lua
+++ b/frontend/ui/widget/container/custompositioncontainer.lua
@@ -11,6 +11,8 @@ local CustomPositionContainer = WidgetContainer:extend{
     vertical_position = 0.5,  -- 0.0 = topmost, 1.0 = bottommost
     horizontal_position = 0.5,  -- 0.0 = leftmost, 1.0 = rightmost
     widget = nil,
+    alpha = nil,  -- 1 = fully opaque, 0 = fully transparent
+    compose_bb = nil,  -- cache for alpha composition
 }
 
 function CustomPositionContainer:paintTo(bb, x, y)


### PR DESCRIPTION
Have you ever found yourself in a situation where your book has a beautiful illustration, that sadly gets blocked by the sleep screen message? or the title happens to be dead centre and (because you prefer the infomessage) so, that spicy señorita at the coffee shop can't see how smart you are because the bloody title is now hidden? well fear not...

This pull request refactors how the screensaver message's position is configured and displayed. Instead of using the previous "top/middle/bottom" options, it introduces a more flexible system with "banner" and "box" containers and allows custom vertical positioning. 

### what's new

* Migrated existing settings from `screensaver_message_position` ("top/middle/bottom") to new settings: `screensaver_message_container` ("banner"/"box") and `screensaver_message_vertical_position` (percentage).
* Updated default settings logic to use the new container and position keys, ensuring new installs or resets use the new system.
* Reworked the screensaver message rendering to use the new `CustomPositionContainer`, which places the message widget at the specified vertical coordinate, supporting both "banner" and "box" containers. 
* Modified the screensaver menu to let users choose between "banner" and "box" containers and set a custom vertical position, replacing the old top/middle/bottom options.
* Added a new function to display a spin widget for precise vertical position selection.

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/7fb81c14-de7e-40a4-8dbd-292711764e59" width=40%> 
<img src="https://github.com/user-attachments/assets/78d5da46-3816-460f-b465-092c966efd30" width=40%> 
</p> 

<p align="center">
<img src="https://github.com/user-attachments/assets/41d96bd4-6102-4f2f-83bb-52a783ed8b85" width=40%> 
<img src="https://github.com/user-attachments/assets/209601de-cc78-4684-925a-d593e1aacda1" width=40%> 
<img src="https://github.com/user-attachments/assets/02bf0e3b-3baa-4805-95c1-02f9104ddef9" width=40%> 
</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14371)
<!-- Reviewable:end -->
