### PR TITLE
BookInfo: minor fixes

### DIFF
--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -101,9 +101,8 @@ function BookInfo:show(doc_settings_or_file, book_props)
     -- Book section
     -- book_props may be provided if caller already has them available
     -- but it may lack "pages", that we may get from sidecar file
-    if not book_props or not book_props.pages then
-        book_props = self:getDocProps(file, book_props)
-    end
+    book_props = book_props or self:getDocProps(file, book_props)
+    book_props.pages = book_props.pages or BookList.getBookInfo(file).pages
     -- cover image
     self.custom_book_cover = DocSettings:findCustomCoverFile(file)
     local key_text = self.prop_text["cover"]
@@ -120,6 +119,7 @@ function BookInfo:show(doc_settings_or_file, book_props)
         separator = true,
     })
     -- metadata
+    local n_a = _("N/A")
     local custom_props
     local custom_metadata_file = DocSettings:findCustomMetadataFile(file)
     if custom_metadata_file then
@@ -130,7 +130,7 @@ function BookInfo:show(doc_settings_or_file, book_props)
     for _i, prop_key in ipairs(self.props) do
         local prop = book_props[prop_key]
         if prop == nil or prop == "" then
-            prop = _("N/A")
+            prop = n_a
         elseif prop_key == "title" then
             prop = BD.auto(prop)
         elseif prop_key == "authors" or prop_key == "keywords" then
@@ -166,7 +166,9 @@ function BookInfo:show(doc_settings_or_file, book_props)
         })
     end
     -- pages
-    table.insert(kv_pairs, { self.prop_text["pages"], book_props["pages"] or _("N/A"), separator = true })
+    local pages = self.is_current_doc
+        and self.ui.pagemap and self.ui.pagemap:wantsPageLabels() and self.ui.pagemap:getLastPageLabel(true)
+    table.insert(kv_pairs, { self.prop_text["pages"], pages or book_props.pages or n_a, separator = true })
 
     -- Current page
     if self.document then
@@ -184,7 +186,7 @@ function BookInfo:show(doc_settings_or_file, book_props)
     end
     table.insert(kv_pairs, { _("Rating:"), ("★"):rep(rating) .. ("☆"):rep(self.rating_max - rating),
         hold_callback = summary_hold_callback })
-    table.insert(kv_pairs, { _("Review:"), summary.note or _("N/A"),
+    table.insert(kv_pairs, { _("Review:"), summary.note or n_a,
         hold_callback = summary_hold_callback, separator = true })
 
     -- Notebook file
@@ -975,11 +977,11 @@ function BookInfo:expandString(str, file, timestamp)
         return str
     end
 
-    local na = _("N/A")
+    local n_a = _("N/A")
     local doc_patterns, is_doc_required = "%T%A%S%t%c%p%H%C%l%P%h"
     local patterns = {}
     for p in str:gmatch("%%%a") do
-        patterns[p] = na -- calculate only needed items
+        patterns[p] = n_a -- calculate only needed items
         if not is_doc_required and doc_patterns:find(p, 1, true) then
             is_doc_required = true
         end
@@ -992,17 +994,21 @@ function BookInfo:expandString(str, file, timestamp)
             local doc = self.document and self.document.file == file and self.document
             if doc then -- Reader, currently opened file
                 props = self.ui.doc_props
-                local pageno = self.ui.view.footer.pageno
+                local footer = self.ui.view.footer
+                local pageno = footer.pageno
                 if patterns["%t"] or patterns["%c"] then
-                    if doc:hasHiddenFlows() then
+                    if self.ui.pagemap and self.ui.pagemap:wantsPageLabels() then
+                        patterns["%t"] = patterns["%t"] and self.ui.pagemap:getLastPageLabel(true)
+                        patterns["%c"] = patterns["%c"] and self.ui.pagemap:getCurrentPageLabel(true)
+                    elseif doc:hasHiddenFlows() then
                         patterns["%t"] = patterns["%t"] and doc:getTotalPagesInFlow(doc:getPageFlow(pageno))
                         patterns["%c"] = patterns["%c"] and doc:getPageNumberInFlow(pageno)
                     else
-                        patterns["%t"] = patterns["%t"] and self.ui.view.footer.pages
+                        patterns["%t"] = patterns["%t"] and footer.pages
                         patterns["%c"] = patterns["%c"] and pageno
                     end
                 end
-                patterns["%p"] = patterns["%p"] and Math.round(self.ui.view.footer:getBookProgress() * 100)
+                patterns["%p"] = patterns["%p"] and Math.round(footer:getBookProgress() * 100)
                 if patterns["%C"] then
                     local title = self.ui.toc:getTocTitleByPage(pageno)
                     if title and title ~= "" then
@@ -1012,13 +1018,13 @@ function BookInfo:expandString(str, file, timestamp)
                 if patterns["%l"] then
                     local pages_left_in_chapter = self.ui.toc:getChapterPagesLeft(pageno) or doc:getTotalPagesLeft(pageno)
                     if pages_left_in_chapter then
-                        if self.ui.view.footer.settings.pages_left_includes_current_page then
+                        if footer.settings.pages_left_includes_current_page then
                              pages_left_in_chapter = pages_left_in_chapter + 1
                         end
                         patterns["%l"] = pages_left_in_chapter
                     end
                 end
-                patterns["%P"] = patterns["%P"] and Math.round(self.ui.view.footer:getChapterProgress(true) * 100)
+                patterns["%P"] = patterns["%P"] and Math.round(footer:getChapterProgress(true) * 100)
                 if (patterns["%H"] or patterns["%h"]) and self.ui.statistics then
                     local pages = doc:getTotalPagesLeft(pageno)
                     if patterns["%H"] then


### PR DESCRIPTION
(1) Show number of pages of reflowable documents in "Book information" called from the file browser.
(2) Show number of **reference** pages (if used) in "Book information" of the currently opened file.
(3) Show total/current **reference** pages (if used) in messages extended by patterns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14373)
<!-- Reviewable:end -->
