### PR TITLE
[ReaderDictionary] offer search with presets when dict fails to find match

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1315,6 +1315,15 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
     local has_presets = preset_names and #preset_names > 0
     if fuzzy_search and not has_presets then return false end -- fall through to showing empty results
 
+    local preset_button = has_presets and {
+        text = _("Search with preset"),
+        callback = function(dialog)
+            local new_word = dialog:getInputText()
+            if new_word == "" or new_word:match("^%s*$") then return end
+            self:showSearchWithPresetDialog(preset_names, dialog, new_word, boxes, link, dict_close_callback)
+        end,
+    } or nil
+
     -- Determine the primary action based on what's available
     local description, primary_action
     if not fuzzy_search then
@@ -1332,30 +1341,14 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
         }
     elseif has_presets then
         description = _("Would you like to search with a preset?")
-        primary_action = {
-            text = _("Search with preset"),
-            is_enter_default = true,
-            callback = function(dialog)
-                local new_word = dialog:getInputText()
-                if new_word == "" or new_word:match("^%s*$") then return end
-                self:showSearchWithPresetDialog(preset_names, dialog, new_word, boxes, link, dict_close_callback)
-            end,
-        }
+        primary_action = preset_button
+        primary_action.is_enter_default = true
     end
 
     local buttons = {}
     -- Add preset button as an additional option (when fuzzy is the primary action)
     if not fuzzy_search and has_presets then
-        table.insert(buttons, {
-            {
-                text = _("Search with preset"),
-                callback = function(dialog)
-                    local new_word = dialog:getInputText()
-                    if new_word == "" or new_word:match("^%s*$") then return end
-                    self:showSearchWithPresetDialog(preset_names, dialog, new_word, boxes, link, dict_close_callback)
-                end,
-            }
-        })
+        table.insert(buttons, { preset_button })
     end
     table.insert(buttons, {
         {


### PR DESCRIPTION
### what's new

This pull request refactors and enhances the previous work done in #14343, improving user experience when no results are found. The main changes include the introduction of a unified dialog for alternative search actions, avoidance of code duplication, and better handling of search presets and fuzzy search options.

* Added a new `showNoResultsDialog` method to present users with alternative search actions (fuzzy search or preset search) when a dictionary lookup yields no results, streamlining the interaction and reducing duplicated dialog code.
* Enhanced the preset search flow by extracting dialog construction logic into a reusable `showSearchWithPresetDialog` method, improving code maintainability and clarity.
* Refactored the dictionary lookup logic to delegate alternative search options to the new dialog, replacing previous inline dialog construction and callbacks.
* Updated the dictionary lookup UI handler to use the extracted preset dialog method, further reducing code duplication.

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/a4a0e0b0-f127-4158-ab52-d8f386679888" width=40%> 
<img src="https://github.com/user-attachments/assets/537018a8-78a8-4749-b574-8bfececee3a6" width=40%> 
</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14399)
<!-- Reviewable:end -->
