### PR TITLE
Bug fix: Change condition for message height calculation

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -600,7 +600,7 @@ function Screensaver:show()
             alpha = alpha_value / 100,
         }
         -- Forward the height of the top message to the overlay widget
-        if vertical_percentage < 20 then
+        if vertical_percentage > 80 then -- top of the screen
             message_height = message_widget.widget:getSize().h
         end
 


### PR DESCRIPTION
### bug fix

* Changed the conditional in `Screensaver:show()` to check if `vertical_percentage > 80` (top of the screen) instead of `< 20` (bottom of the screen) before forwarding the message height to the overlay widget. 

Mistakes were made when swapping top/bottom values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14403)
<!-- Reviewable:end -->
