### PR TITLE
Reference pages: add synthetic pagemap

### DIFF
--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -202,13 +202,20 @@ function filemanagerutil.genResetSettingsButton(doc_settings_or_file, caller_cal
                         custom_cover_file    = check_button_cover.checked and custom_cover_file,
                         custom_metadata_file = check_button_metadata.checked and custom_metadata_file,
                     }
-                    (doc_settings or DocSettings:open(file)):purge(nil, data_to_purge)
-                    if data_to_purge.custom_cover_file or data_to_purge.custom_metadata_file then
-                        UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
-                    end
+                    doc_settings = doc_settings or DocSettings:open(file)
                     if data_to_purge.doc_settings then
+                        if doc_settings:has("pagemap_synthetic_chars_per_page") then
+                            local cache_file_path = doc_settings:readSetting("cache_file_path")
+                            if cache_file_path then
+                                os.remove(cache_file_path)
+                            end
+                        end
                         BookList.setBookInfoCacheProperty(file, "been_opened", false)
                         require("readhistory"):fileSettingsPurged(file)
+                    end
+                    doc_settings:purge(nil, data_to_purge)
+                    if data_to_purge.custom_cover_file or data_to_purge.custom_metadata_file then
+                        UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
                     end
                     caller_callback()
                 end,


### PR DESCRIPTION
Discussed in and closes #9020.

A book with built-in reference pages.
<img width="400" height="540" alt="1" src="https://github.com/user-attachments/assets/984a130c-283c-4526-ad38-1b86426f9d7d" />

-----

A book without built-in and without synthetic reference pages.
<img width="400" height="540" alt="2" src="https://github.com/user-attachments/assets/8d82da31-df87-4dd3-8ec1-82f5ed8c17b5" />

-----

A book with synthetic reference pages.
<img width="400" height="540" alt="3" src="https://github.com/user-attachments/assets/2bd93723-c311-4586-a853-594235e30093" />

-----
Default settings menu (for newly opened books).
<img width="400" height="201" alt="4" src="https://github.com/user-attachments/assets/77b5d5e2-ea06-44a4-985a-34a4e525efc4" />
