### PR TITLE
[DocSettingTweak] add doc tweaks to kindle NT

### DIFF
--- a/plugins/docsettingtweak.koplugin/main.lua
+++ b/plugins/docsettingtweak.koplugin/main.lua
@@ -1,6 +1,6 @@
 local Device = require("device")
 
-if not Device:isTouchDevice() then
+if Device:hasFewKeys() and not Device:isTouchDevice() then
     return { disabled = true }
 end
 


### PR DESCRIPTION
### what's new

Small adjustment to the plugin initialisation logic, ensuring that the plugin is no longer disabled on non-touch kindles. This has been properly fixed now (make kindle great again!)

### related issues

* fixes #8596
* fixes #7356

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14412)
<!-- Reviewable:end -->
