### PR TITLE
fix/remarkable: event_map remapping fix

### DIFF
--- a/frontend/device/remarkable/device.lua
+++ b/frontend/device/remarkable/device.lua
@@ -226,7 +226,7 @@ function Remarkable:init()
 
     self.input = require("device/input"):new{
         device = self,
-        event_map = dofile("frontend/device/remarkable/event_map.lua"),
+        event_map = event_map,
         event_map_adapter = {
             SleepCover = function(ev)
                 if ev.value == 1 then


### PR DESCRIPTION
Use the modified event_map from above instead of reloading the event_map file, reverting unmapped event.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14415)
<!-- Reviewable:end -->
