### PR TITLE
[Readtimer] bug fix: fix focus when setting a timer.

### DIFF
--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -37,7 +37,7 @@ function ReadTimer:init()
     self.timer_symbol = "\u{23F2}"  -- ⏲ timer symbol
     self.timer_letter = "T"
     self.settings = G_reader_settings:readSetting("readtimer", {})
-    self.non_touch = Device:hasDPad() and Device:useDPadAsActionKeys() and not Device:isTouchDevice()
+    self.non_touch_with_action_dpad = Device:hasDPad() and Device:useDPadAsActionKeys() and not Device:isTouchDevice()
 
     self.alarm_callback = function()
         -- Don't do anything if we were unscheduled
@@ -421,9 +421,7 @@ function ReadTimer:onShowAlarm(touchmenu_instance)
         end
     }
     self:addCheckboxes(time_widget)
-    if self.non_touch then
-        fixNonTouchFocus(time_widget)
-    end
+    if self.non_touch_with_action_dpad then fixNonTouchFocus(time_widget) end
     UIManager:show(time_widget)
     return true
 end
@@ -473,9 +471,7 @@ function ReadTimer:onShowTimer(touchmenu_instance)
     }
 
     self:addCheckboxes(time_widget, true)
-    if self.non_touch then
-        fixNonTouchFocus(time_widget)
-    end
+    if self.non_touch_with_action_dpad then fixNonTouchFocus(time_widget) end
     UIManager:show(time_widget)
     return true
 end


### PR DESCRIPTION
### bug fix

* Implemented the `fixNonTouchFocus` function to programmatically move focus to the OK button in the `DateTimeWidget` when checkboxes are present, resolving cursor key unresponsiveness.

### related issues

* fixes #14236
