### PR TITLE
fix/remarkable: remove duplicated RM2FB check in koreader.sh

### DIFF
--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -9,10 +9,6 @@ cd "${KOREADER_DIR}" || exit
 # reMarkable 2 check
 IFS= read -r MACHINE_TYPE <"/sys/devices/soc0/machine"
 if [ "reMarkable 2.0" = "${MACHINE_TYPE}" ]; then
-    if [ -z "${RM2FB_SHIM}" ]; then
-        echo "reMarkable 2 requires RM2FB to work, visit https://github.com/ddvk/remarkable2-framebuffer for instructions how to setup"
-        exit 1
-    fi
     export KO_DONT_GRAB_INPUT=1
 fi
 


### PR DESCRIPTION
It's already getting checked in Lua side (and bash script is cumbersome to check for multiple conditions/substrings/etc) so remove  it in koreader.sh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14421)
<!-- Reviewable:end -->
