### PR TITLE
OPDS: fix Search

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -780,7 +780,8 @@ function OPDSBrowser:searchCatalog(item_url)
                         self.catalog_title = _("Search results")
                         local search_str = util.urlEncode(dialog:getInputText())
                         -- Use function replacement to avoid % being treated as capture refs
-                        self:updateCatalog(item_url:gsub("%%s", function() return search_str end))
+                        item_url = item_url:gsub("%%s", function() return search_str end)
+                        self:updateCatalog(item_url)
                     end,
                 },
             },


### PR DESCRIPTION
Follow-up to #14248.

The second result of `gsub` (total number of substitutions made) was passed as the second arg to
https://github.com/koreader/koreader/blob/7c677bf2ae391bf7f8a43b32ed9fecccb89f978a/plugins/opds.koplugin/opdsbrowser.lua#L714

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14425)
<!-- Reviewable:end -->
