### PR TITLE
Replace checkboxes with Radio buttons

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -951,6 +951,7 @@ function FileManagerMenu:getSortingMenuTable()
             callback = function()
                 self.ui:onSetSortBy(k)
             end,
+            radio = true,
         })
     end
     table.sort(sub_item_table, function(a, b) return a.menu_order < b.menu_order end)
@@ -981,6 +982,7 @@ function FileManagerMenu:getStartWithMenuTable()
             callback = function()
                 G_reader_settings:saveSetting("start_with", v[2])
             end,
+            radio = true,
         })
     end
     return {

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1218,6 +1218,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             self:setTocMarkers()
                             self:refreshFooter(true, true)
                         end,
+                        radio = true,
                     },
                     {
                         text = _("Thin"),
@@ -1230,6 +1231,7 @@ function ReaderFooter:addToMainMenu(menu_items)
                             self.progress_bar:updateStyle(false, bar_height)
                             self:refreshFooter(true, true)
                         end,
+                        radio = true,
                         separator = true,
                     },
                     {
@@ -1770,6 +1772,7 @@ function ReaderFooter:genProgressBarPositionMenuItems(value)
             self.settings.progress_bar_position = value
             self:refreshFooter(true, true)
         end,
+        radio = true,
     }
 end
 
@@ -1792,6 +1795,7 @@ function ReaderFooter:genProgressBarChapterMarkerWidthMenuItems(value)
             self:setTocMarkers()
             self:refreshFooter(true)
         end,
+        radio = true,
     }
 end
 
@@ -1824,6 +1828,7 @@ function ReaderFooter:genProgressPercentageFormatMenuItems(value)
             self.settings.progress_pct_format = value
             self:refreshFooter(true)
         end,
+        radio = true,
     }
 end
 
@@ -1854,6 +1859,7 @@ function ReaderFooter:genItemSymbolsMenuItems(value)
             end
             self:refreshFooter(true)
         end,
+        radio = true,
     }
 end
 
@@ -1877,6 +1883,7 @@ function ReaderFooter:genItemSeparatorMenuItems(value)
             self.separator_width = nil
             self:refreshFooter(true)
         end,
+        radio = true,
     }
 end
 
@@ -1927,6 +1934,7 @@ function ReaderFooter:genAlignmentMenuItems(value)
             self.settings.align = value
             self:refreshFooter(true)
         end,
+        radio = true,
     }
 end
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -565,6 +565,7 @@ local function genAutoSaveMenuItem(value)
         callback = function()
             G_reader_settings:saveSetting(setting_name, value)
         end,
+        radio = true,
     }
 end
 

--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -400,13 +400,13 @@ local back_to_exit_str = {
     always = {_("Always"), _("always")},
     disable ={_("Disable"), _("disable")},
 }
-local function genGenericMenuEntry(title, setting, value, default, radiomark)
+local function genGenericMenuEntry(title, setting, value, default)
     return {
         text = title,
         checked_func = function()
             return G_reader_settings:readSetting(setting, default) == value
         end,
-        radio = radiomark,
+        radio = true,
         callback = function()
             G_reader_settings:saveSetting(setting, value)
         end,
@@ -446,6 +446,7 @@ common_settings.back_in_filemanager = {
             callback = function()
                 G_reader_settings:saveSetting("back_in_filemanager", "default")
             end,
+            radio = true,
         },
         genGenericMenuEntry(_("Go to parent folder"), "back_in_filemanager", "parent_folder"),
     },
@@ -478,6 +479,7 @@ common_settings.back_in_reader = {
             callback = function()
                 G_reader_settings:saveSetting("back_in_reader", "default")
             end,
+            radio = true,
         },
         genGenericMenuEntry(_("Go to file browser"), "back_in_reader", "filebrowser"),
         genGenericMenuEntry(_("Go to previous location"), "back_in_reader", "previous_location"),
@@ -699,10 +701,10 @@ common_settings.document_end_action = {
             end,
             separator = true,
         },
-        genGenericMenuEntry(_("Ask with popup dialog"), "end_document_action", "pop-up", "pop-up", true),
-        genGenericMenuEntry(_("Do nothing"), "end_document_action", "nothing", nil, true),
-        genGenericMenuEntry(_("Book status"), "end_document_action", "book_status", nil, true),
-        genGenericMenuEntry(_("Delete file"), "end_document_action", "delete_file", nil, true),
+        genGenericMenuEntry(_("Ask with popup dialog"), "end_document_action", "pop-up", "pop-up"),
+        genGenericMenuEntry(_("Do nothing"), "end_document_action", "nothing", nil),
+        genGenericMenuEntry(_("Book status"), "end_document_action", "book_status", nil),
+        genGenericMenuEntry(_("Delete file"), "end_document_action", "delete_file", nil),
         {
             text = _("Open next file"),
             enabled_func = function()
@@ -717,10 +719,10 @@ common_settings.document_end_action = {
                 G_reader_settings:saveSetting("end_document_action", "next_file")
             end,
         },
-        genGenericMenuEntry(_("Go to beginning"), "end_document_action", "goto_beginning", nil, true),
-        genGenericMenuEntry(_("Return to file browser"), "end_document_action", "file_browser", nil, true),
-        genGenericMenuEntry(_("Mark book as finished"), "end_document_action", "mark_read", nil, true),
-        genGenericMenuEntry(_("Book status and return to file browser"), "end_document_action", "book_status_file_browser", nil, true),
+        genGenericMenuEntry(_("Go to beginning"), "end_document_action", "goto_beginning", nil),
+        genGenericMenuEntry(_("Return to file browser"), "end_document_action", "file_browser", nil),
+        genGenericMenuEntry(_("Mark book as finished"), "end_document_action", "mark_read", nil),
+        genGenericMenuEntry(_("Book status and return to file browser"), "end_document_action", "book_status_file_browser", nil),
     }
 }
 
@@ -756,9 +758,9 @@ common_settings.units = {
             end,
             separator = true,
         },
-        genGenericMenuEntry(_("Metric system"),   "dimension_units", "mm", nil, true),
-        genGenericMenuEntry(_("Imperial system"), "dimension_units", "in", nil, true),
-        genGenericMenuEntry(_("Pixels"),          "dimension_units", "px", nil, true),
+        genGenericMenuEntry(_("Metric system"),   "dimension_units", "mm", nil),
+        genGenericMenuEntry(_("Imperial system"), "dimension_units", "in", nil),
+        genGenericMenuEntry(_("Pixels"),          "dimension_units", "px", nil),
     }
 }
 

--- a/frontend/ui/language.lua
+++ b/frontend/ui/language.lua
@@ -107,7 +107,8 @@ function Language:genLanguageSubItem(lang_locale)
         end,
         callback = function()
             self:changeLanguage(lang_locale)
-        end
+        end,
+        radio = true,
     }
 end
 

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -969,6 +969,7 @@ function NetworkMgr:getBeforeWifiActionMenuTable()
             wifi_enable_action_setting = wifi_enable_action
             G_reader_settings:saveSetting("wifi_enable_action", wifi_enable_action)
         end,
+        radio = true,
     }
     end
 
@@ -1007,6 +1008,7 @@ function NetworkMgr:getAfterWifiActionMenuTable()
             wifi_disable_action_setting = wifi_disable_action
             G_reader_settings:saveSetting("wifi_disable_action", wifi_disable_action)
         end,
+        radio = true,
     }
     end
     return {

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -115,6 +115,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             callback = function()
                 self:setDisplayMode(mode)
             end,
+            radio = true,
         }
         history_sub_item_table[i] = {
             text = text,
@@ -124,6 +125,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             callback = function()
                 CoverBrowser.setupWidgetDisplayMode("history", mode)
             end,
+            radio = true,
         }
         collection_sub_item_table[i] = {
             text = text,
@@ -133,6 +135,7 @@ function CoverBrowser:addToMainMenu(menu_items)
             callback = function()
                 CoverBrowser.setupWidgetDisplayMode("collections", mode)
             end,
+            radio = true,
         }
     end
     sub_item_table[#self.modes].separator = true


### PR DESCRIPTION
### what's new

* Standardise the use of radio buttons in menu item definitions across the UI. By consistently setting the `radio = true` property, the UI will correctly indicate mutually exclusive menu options, improving user experience and code maintainability.

in short, checkboxes are now exclusively on/off switches and radio buttons represent multiple mutually exclusive, one-option-must-be-active settings.

### related issues 

* #12826
* #8167

