### PR TITLE
Add support for "Disable key repeat" setting on Pocketbooks

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -282,7 +282,7 @@ function PocketBook:toggleKeyRepeat(toggle)
             if ev.type == C.EV_KEY and ev.value == 1 then -- KEY_PRESS = 1
                 local now = time.now()
                 local time_diff = time.to_ms(now - self.last_key_time)
-                if time_diff <= 100 and ev.code == self.last_key_code then
+                if time_diff <= 500 and ev.code == self.last_key_code then
                     logger.info("Skipping sticky key", ev.code, time_diff)
                     ev.value = -1 -- Set to an invalid value that will be ignored
                 end


### PR DESCRIPTION
See https://github.com/koreader/koreader/discussions/14429 for more details.

Tested on Pocketbook Inkpad Color 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14432)
<!-- Reviewable:end -->
