### PR TITLE
Statistics: screen pages only

### DIFF
--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -149,7 +149,6 @@ function ReaderStatistics:initData()
     self.is_doc = true
     self.is_doc_not_finished = self.ui.doc_settings:readSetting("summary").status ~= "complete"
     self.is_doc_not_frozen = self.is_doc_not_finished or not self.settings.freeze_finished_books
-    self.use_pagemap_for_stats = self.ui.pagemap and self.ui.pagemap:wantsPageLabels()
 
     -- first execution
     local book_properties = self.ui.doc_props
@@ -164,12 +163,7 @@ function ReaderStatistics:initData()
         end
     end
     self.data.series = series or "N/A"
-
-    if self.use_pagemap_for_stats then
-        self.data.pages = select(3, self.ui.pagemap:getCurrentPageLabel())
-    else
-        self.data.pages = self.document:getPageCount()
-    end
+    self.data.pages = self.document:getPageCount()
     -- Update these numbers to what's actually stored in the settings
     self.data.highlights, self.data.notes = self.ui.annotation:getNumberOfHighlightsAndNotes()
     self.id_curr_book = self:getIdBookDB()
@@ -219,13 +213,7 @@ function ReaderStatistics:onDocumentRerendered()
     --   - we only then update self.data.pages=254 as the new page count
     -- - 5 minutes later, on the next insertDB(), (153, now-5mn, 42, 254) will be inserted in DB
 
-    local new_pagecount
-    if self.use_pagemap_for_stats then
-        new_pagecount = select(3, self.ui.pagemap:getCurrentPageLabel())
-    else
-        new_pagecount = self.document:getPageCount()
-    end
-
+    local new_pagecount = self.document:getPageCount()
     if new_pagecount ~= self.data.pages then
         logger.dbg("ReaderStatistics: Pagecount change, flushing volatile book statistics")
         -- Flush volatile stats to DB for current book, and update pagecount and average time per page stats
@@ -246,18 +234,6 @@ function ReaderStatistics:onDocumentPartiallyRerendered(first_partial_rerender)
         end
         return
     end
-end
-
-function ReaderStatistics:onUsePageLabelsUpdated()
-    self.use_pagemap_for_stats = not self.use_pagemap_for_stats
-    local new_current_page
-    if self.use_pagemap_for_stats then
-        new_current_page = select(2, self.ui.pagemap:getCurrentPageLabel())
-    else
-        new_current_page = self.ui:getCurrentPage()
-    end
-    self:onPageUpdate(new_current_page)
-    self:onDocumentRerendered()
 end
 
 function ReaderStatistics:onPreserveCurrentSession()
@@ -1053,11 +1029,7 @@ function ReaderStatistics:onToggleStatistics(arg)
         if self.settings.is_enabled then
             self:initData()
             self.start_current_period = os.time()
-            if self.use_pagemap_for_stats then
-                self.curr_page = select(2, self.ui.pagemap:getCurrentPageLabel())
-            else
-                self.curr_page = self.ui:getCurrentPage()
-            end
+            self.curr_page = self.ui:getCurrentPage()
             self:resetVolatileStats(self.start_current_period)
         end
         self.view.footer:maybeUpdateFooter()
@@ -1619,28 +1591,22 @@ function ReaderStatistics:getCurrentStat()
     total_time_book = tonumber(total_time_book) or 0
     total_read_pages = tonumber(total_read_pages) or 0
     first_open = first_open or now_ts
-    if self.use_pagemap_for_stats then
-        self.data.pages = select(3, self.ui.pagemap:getCurrentPageLabel())
-    else
-        self.data.pages = self.document:getPageCount()
-    end
+    self.data.pages = self.document:getPageCount()
 
-    local current_page
-    local total_pages
-    local page_progress_string
-    local percent_read
-    if self.use_pagemap_for_stats then
-        local current_page_label
-        current_page_label, current_page, total_pages = self.ui.pagemap:getCurrentPageLabel()
+    local current_page, total_pages, page_progress_string
+    if self.ui.pagemap and self.ui.pagemap:wantsPageLabels() then
+        current_page = self.ui:getCurrentPage()
+        total_pages = self.data.pages
+        local current_page_label, current_page_idx, total_pages_idx = self.ui.pagemap:getCurrentPageLabel()
         local last_page_label = self.ui.pagemap:getLastPageLabel()
-        percent_read = Math.round(100*current_page/total_pages)
+        local percent_read = Math.round(100*current_page_idx/total_pages_idx)
         page_progress_string = ("%s / %s (%d%%)"):format(current_page_label, last_page_label, percent_read)
     elseif self.document:hasHiddenFlows() then
         current_page = self.ui:getCurrentPage()
         local flow = self.document:getPageFlow(current_page)
         current_page = self.document:getPageNumberInFlow(current_page)
         total_pages = self.document:getTotalPagesInFlow(flow)
-        percent_read = Math.round(100*current_page/total_pages)
+        local percent_read = Math.round(100*current_page/total_pages)
         if flow == 0 then
             page_progress_string = ("%d // %d (%d%%)"):format(current_page, total_pages, percent_read)
         else
@@ -1649,7 +1615,7 @@ function ReaderStatistics:getCurrentStat()
     else
         current_page = self.ui:getCurrentPage()
         total_pages = self.data.pages
-        percent_read = Math.round(100*current_page/total_pages)
+        local percent_read = Math.round(100*current_page/total_pages)
         page_progress_string = ("%d / %d (%d%%)"):format(current_page, total_pages, percent_read)
     end
 
@@ -2630,22 +2596,14 @@ end
 
 
 function ReaderStatistics:onPosUpdate(pos, pageno)
-    local pn = pageno
-    if self.use_pagemap_for_stats then
-        pageno = select(2, self.ui.pagemap:getCurrentPageLabel())
-    end
     if self.curr_page ~= pageno then
-        self:onPageUpdate(pn)
+        self:onPageUpdate(pageno)
     end
 end
 
 function ReaderStatistics:onPageUpdate(pageno)
     if not self:isEnabledAndNotFrozen() then
         return
-    end
-
-    if self.use_pagemap_for_stats and pageno ~= false then
-        pageno = select(2, self.ui.pagemap:getCurrentPageLabel())
     end
 
     if self._reading_paused_ts then


### PR DESCRIPTION
- #14388 causes issues in BookMap
- discussed in #14426

So, revert storing reference pages in the statistics database, back to screen pages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14434)
<!-- Reviewable:end -->
