### PR TITLE
[ReaderHighlight] preserve highlight when using highlight dialogue

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -47,6 +47,10 @@ DOVERLAPPIXELS = 30,
 -- set to 0 to disable showing rectangle and follow link immediately
 FOLLOW_LINK_TIMEOUT = 0.5,
 
+-- delay before clearing highlighted text after dictionary queries
+-- default to 0.5 second
+DELAY_CLEAR_HIGHLIGHT_S = 0.5,
+
 -- customizable tap zones(rectangles)
 -- x: x coordinate of top left corner in proportion to screen width
 -- y: y coordinate of top left corner in proportion to screen height

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1186,7 +1186,7 @@ function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, 
         Device:doExternalDictLookup(word, G_reader_settings:readSetting("external_dict_lookup_method"), function()
             if self.highlight then
                 local clear_id = self.highlight:getClearId()
-                UIManager:scheduleIn(0.5, function()
+                UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function()
                     self.highlight:clear(clear_id)
                 end)
             end
@@ -1356,9 +1356,7 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
             id = "close",
             callback = function(dialog)
                 UIManager:close(dialog)
-                -- this should be self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, but in FM we don't have access to self.ui
-                local delay_clear_highlight_s = 0.5
-                UIManager:scheduleIn(delay_clear_highlight_s, function() lookupCancelled() end)
+                UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function() lookupCancelled() end)
             end,
         },
         primary_action,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -27,7 +27,6 @@ local T = ffiUtil.template
 local Screen = Device.screen
 
 local ReaderHighlight = InputContainer:extend{
-    DELAY_CLEAR_HIGHLIGHT_S = 0.5, -- since this is out of bounds in FM, we declare a local var delay_clear_highlight_s in those cases.
     -- Matches what is available in BlitBuffer.HIGHLIGHT_COLORS
     highlight_colors = {
         {_("Red"), "red"},
@@ -102,7 +101,7 @@ function ReaderHighlight:init()
                     UIManager:show(Notification:new{
                         text = _("Selection copied to clipboard."),
                     })
-                    UIManager:scheduleIn(self.DELAY_CLEAR_HIGHLIGHT_S, function()
+                    UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function()
                         this:clear()
                     end)
                 end,

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1548,7 +1548,7 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
                 -- it and know where to start reading again
                 local footnote_top_y = Screen:getHeight() - footnote_height
                 if link.link_y > footnote_top_y then
-                    UIManager:scheduleIn(self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, clear_highlight)
+                    UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), clear_highlight)
                 else
                     clear_highlight()
                 end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1301,7 +1301,7 @@ function DictQuickLookup:onClose(no_clear)
             -- delay unhighlight of selection, so we can see where we stopped when
             -- back from our journey into dictionary or wikipedia
             local clear_id = self.highlight:getClearId()
-            UIManager:scheduleIn(self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, function()
+            UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function()
                 self.highlight:clear(clear_id)
             end)
         end

--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -532,9 +532,7 @@ function HtmlBoxWidget:scheduleClearHighlightAndRedraw()
             self:redrawHighlight()
         end
     end
-    -- this should be self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, but in FM we don't have access to self.ui
-    local delay_clear_highlight_s = 0.5
-    UIManager:scheduleIn(delay_clear_highlight_s, self.highlight_clear_and_redraw_action)
+    UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), self.highlight_clear_and_redraw_action)
 end
 
 function HtmlBoxWidget:unscheduleClearHighlightAndRedraw()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -2381,9 +2381,7 @@ function TextBoxWidget:scheduleClearHighlightAndRedraw()
             self:redrawHighlight()
         end
     end
-    -- this should be self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, but in FM we don't have access to self.ui
-    local delay_clear_highlight_s = 0.5
-    UIManager:scheduleIn(delay_clear_highlight_s, self.highlight_clear_and_redraw_action)
+    UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), self.highlight_clear_and_redraw_action)
 end
 
 function TextBoxWidget:unscheduleClearHighlightAndRedraw()

--- a/plugins/qrclipboard.koplugin/main.lua
+++ b/plugins/qrclipboard.koplugin/main.lua
@@ -39,7 +39,7 @@ function QRClipboard:addToHighlightDialog()
                     dismiss_callback = function()
                         -- delay clearing highlighted text a bit, so the user can see
                         -- what was used to generate the QR code
-                        UIManager:scheduleIn(self.ui.highlight.DELAY_CLEAR_HIGHLIGHT_S, function()
+                        UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function()
                             this:clear()
                         end)
                     end,


### PR DESCRIPTION
This pull request introduces small improvements to the highlighting and clipboard features in the reader module, focusing on better user experience when copying text and performing dictionary lookups from the highlight dialogue. The changes ensure the dialogue is closed whilst preserving the highlighted text.

### what's new

* The `onClose` method in `ReaderHighlight` now accepts a `keep_highlight` parameter, allowing the highlight to persist when needed.
* After copying selected text to the clipboard, the highlight is kept briefly and cleared after a 0.5 second delay, giving users time to see what was copied.
* When performing a dictionary lookup, the highlight is preserved, and the `lookupDict` function now receives the highlight as an argument for better context management.
* In the QR clipboard plugin, the dismiss callback now keeps the highlight and also delays clearing it by 0.5 seconds, improving user feedback for QR code generation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14437)
<!-- Reviewable:end -->
