### PR TITLE
ci/circle: speed up lint phase

### DIFF
--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -39,6 +39,6 @@ if [ "${untagged_todo}" ]; then
 fi
 
 echo -e "\n${ANSI_GREEN}Luacheck results${ANSI_RESET}"
-luacheck -q {reader,setupkoenv,datastorage}.lua frontend plugins spec || exit_code=1
+luacheck ${PARALLEL_JOBS:+-j "${PARALLEL_JOBS}"} -q {reader,setupkoenv,datastorage}.lua frontend plugins spec || exit_code=1
 
 exit ${exit_code}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ jobs:
       CLICOLOR_FORCE: "1"
       EMULATE_READER: "1"
       KODEBUG: ""
-      MAKEFLAGS: "PARALLEL_JOBS=3 OUTPUT_DIR=build INSTALL_DIR=install"
+      MAKEFLAGS: "OUTPUT_DIR=build INSTALL_DIR=install"
+      PARALLEL_JOBS: "3"
     steps:
       # Checkout / fetch. {{{
       - checkout


### PR DESCRIPTION
Honor `PARALLEL_JOBS` so the number of luacheck jobs is capped to 3 (we don't want to end-up using 36 jobs).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14472)
<!-- Reviewable:end -->
