### PR TITLE
HTMLBoxWidget: add setRawContent()

### DIFF
--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -277,7 +277,7 @@ function HtmlBoxWidget:setRawContent(body, magic, default_font_size, resource_di
     local ok
     ok, self.document = pcall(Mupdf.openDocumentFromText, body, magic, resource_directory)
     if not ok then
-        logger.warn("SVG loading error:", self.document)
+        logger.warn("Raw content loading error:", self.document)
         return nil, self.document
     end
 


### PR DESCRIPTION
The functionality I'm looking for is really just a way to pass through the pure string without any of the current manipulation in setContent (which would sometimes be good for HTML too) and maybe a custom "magic", but I'm not quite seeing an elegant way to do that right now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14480)
<!-- Reviewable:end -->
