### PR TITLE
Improve Japanese text selection

### DIFF
--- a/plugins/japanese.koplugin/main.lua
+++ b/plugins/japanese.koplugin/main.lua
@@ -220,8 +220,6 @@ function Japanese:onWordSelection(args)
     -- Calling sdcv is fairly expensive, so reduce the cost by trying every
     -- candidate in one shot and then picking the longest one which gave us a
     -- result.
-    --- @todo Given there is a limit to how many command-line arguments you can
-    --       pass, we should split up the candidate list if it's too long.
     local all_words = {}
     for i = 1, #all_candidates do all_words[i] = all_candidates[i].text end
     local cancelled, all_results = self.dictionary:rawSdcv(all_words)


### PR DESCRIPTION
I'm not sure if this is just a problem for me or if it bothers other people too, but I have large thumbs and frequently have trouble with accidentally tapping the second character of a word instead of the first one and then getting a nonsensical single character translation. I changed it so that it now searches in both directions meaning you can tap any character that's part of the word and it will select the whole word for the translation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14485)
<!-- Reviewable:end -->
