### PR TITLE
ci/macos: update jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: '13'
+          - image: '15'
             platform: 'x86-64'
-            xcode_version: '15.2'
+            xcode_version: '16.4'
             deployment_target: '10.15'
             jobs: 5
-          - image: '14'
+          - image: '15'
             platform: 'ARM64'
-            xcode_version: '15.4'
+            xcode_version: '16.4'
             deployment_target: '11.0'
             jobs: 4
 
     name: "macOS ${{ matrix.image }} ${{ matrix.platform }} 🔨${{ matrix.xcode_version }} 🎯${{ matrix.deployment_target }}"
 
-    runs-on: "macos-${{ matrix.image }}"
+    runs-on: "macos-${{ matrix.image }}${{ matrix.platform == 'x86-64' && '-intel' || '' }}"
 
     env:
       # Bump first number to reset all caches.


### PR DESCRIPTION
Match koreader-base' configuration: use macOS 15 (macOS 13 runner images will be retired by December 4th) and XCode 16.4 (the default).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14501)
<!-- Reviewable:end -->
