### PR TITLE
Kindle: Autodetect & handle the fancy `gesture_tap` input device

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -615,7 +615,7 @@ function Kindle:init()
     -- Auto-detect & open input devices
     self:openInputDevices()
 
-    -- Deal with the fancy "double-tap on the device frame" thingy
+    -- Deal with the fancy "double-tap on the device frame" thingy, c.f., #14461
     if self:hasFancyTaps() then
         -- Make sure we setup key handlers, in case the device is otherwise touch-only
         self.hasKeys = yes


### PR DESCRIPTION
As found on the latest PW6 & CS2

Depends on https://github.com/koreader/koreader-base/pull/2203
Fix #14461

(Squash me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14506)
<!-- Reviewable:end -->
