### PR TITLE
TouchMenu: submenu level indicator

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -20,6 +20,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local LeftContainer = require("ui/widget/container/leftcontainer")
 local LineWidget = require("ui/widget/linewidget")
+local OverlapGroup = require("ui/widget/overlapgroup")
 local RadioMark = require("ui/widget/radiomark")
 local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
@@ -587,7 +588,7 @@ function TouchMenu:init()
         icon = "chevron.up",
         show_parent = self.show_parent,
         padding_left = math.floor(footer_width*0.33*0.1),
-        padding_right = math.floor(footer_width*0.33*0.01),
+        padding_right = math.floor(footer_width*0.33*0.1),
         callback = function()
             self:backToUpperMenu()
         end,
@@ -600,9 +601,12 @@ function TouchMenu:init()
     self.footer = HorizontalGroup:new{
         LeftContainer:new{
             dimen = Geom:new{ w = math.floor(footer_width*0.33), h = footer_height},
-            HorizontalGroup:new{
+            OverlapGroup:new{
                 up_button,
-                self.submenu_level_info,
+                HorizontalGroup:new{
+                    HorizontalSpan:new{ width = math.floor(up_button:getSize().w * 0.8) },
+                    self.submenu_level_info,
+                },
             },
         },
         CenterContainer:new{

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -472,6 +472,7 @@ local TouchMenu = FocusManager:extend{
     cur_tab = -1,
     close_callback = nil,
     is_fresh = true,
+    submenu_level_indicator = "•\u{202F}", -- Narrow No-Break Space
 }
 
 function TouchMenu:init()
@@ -586,16 +587,23 @@ function TouchMenu:init()
         icon = "chevron.up",
         show_parent = self.show_parent,
         padding_left = math.floor(footer_width*0.33*0.1),
-        padding_right = math.floor(footer_width*0.33*0.1),
+        padding_right = math.floor(footer_width*0.33*0.01),
         callback = function()
             self:backToUpperMenu()
         end,
+    }
+    self.submenu_level_info = TextWidget:new{
+        text = "",
+        face = self.fface,
     }
     local footer_height = up_button:getSize().h + Size.line.thick
     self.footer = HorizontalGroup:new{
         LeftContainer:new{
             dimen = Geom:new{ w = math.floor(footer_width*0.33), h = footer_height},
-            up_button,
+            HorizontalGroup:new{
+                up_button,
+                self.submenu_level_info,
+            },
         },
         CenterContainer:new{
             dimen = Geom:new{ w = math.floor(footer_width*0.33), h = footer_height},
@@ -699,6 +707,7 @@ function TouchMenu:updateItems(target_page, target_item_id)
 
     table.insert(self.item_group, self.footer_top_margin)
     table.insert(self.item_group, self.footer)
+    self.submenu_level_info:setText(self.submenu_level_indicator:rep(#self.item_table_stack))
     if self.page_num > 1 then
         -- @translators %1 is the current page. %2 is the total number of pages. In some languages a good translation might need to reverse this order, for instance: "Total %2, page %1".
         self.page_info_text:setText(T(_("Page %1 of %2"), self.page, self.page_num))


### PR DESCRIPTION
- Closes #14492 

Easy user-patchable for those who don't like it:
```lua
local TouchMenu = require("ui/widget/touchmenu")
TouchMenu.submenu_level_indicator = ""
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14539)
<!-- Reviewable:end -->
