### PR TITLE
Fix two bugs with statusbar presets

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1962,7 +1962,6 @@ function ReaderFooter:loadPreset(preset)
     self.mode_index = self.settings.order or self.mode_index
     self.custom_text = preset.reader_footer_custom_text
     self.custom_text_repetitions = tonumber(preset.reader_footer_custom_text_repetitions)
-
     if not self.settings.disable_progress_bar then
         local thick = not self.settings.progress_style_thin
         local height = thick and self.settings.progress_style_thick_height or self.settings.progress_style_thin_height


### PR DESCRIPTION
Hi koreader-team, 
congrats on the recent release.
This PR addresses two bugs that occurred when loading status bar presets:

### Problem 1: Footer visibility with progress bar-only presets
**Description**: When loading a preset with all status bar items disabled but the progress bar enabled, the footer would not be displayed.
**What happened**: The reader_footer_mode setting controls footer visibility, where mode 0 means the footer is hidden. When all items are disabled, the preset saves mode 0. However, when the progress bar is enabled (disable_progress_bar = false), the footer should still be visible to show the progress bar alone.
**To reproduce**: Create two statusbar presets. The first preset only shows the progressbar (all oither items disabled). The second shows progressbar + one or more item. Toggle between the presets. 
**Solution**: When loading such a preset, override the mode to 1 (page_progress) to ensure the footer remains visible, matching the behavior of the "Show progress bar" toggle in the UI. This is how it is done at several other places.

### Problem 2: Progress bar style not applied on preset load
**Description**: When loading a preset, the progress bar style (thin/thick) and height were not being updated to match the preset's settings.
**To reproduce**: Create two statusbar presets. The first preset only shows the progressbar with mode thin. The second shows progressbar in mode thick. Toggle between the presets. 
**Solution**: Call `progress_bar:updateStyle()` in `loadPreset()` with the appropriate thickness and height values from the preset settings before applying the footer mode.

Best, 
Andreas

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14556)
<!-- Reviewable:end -->
