### PR TITLE
Screensaver: skip showing without UI instance

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -334,7 +334,7 @@ end
 function Screensaver:setup(event, event_message)
     self.ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
     if not self.ui then
-        logger.dbg("Screensaver called without UI instance, skipped")
+        logger.warn("Screensaver called without UI instance, skipped")
         return
     end
 


### PR DESCRIPTION
Screensaver extensively uses the UI instance (Reader or FM) and cannot be shown without it.
This PR safeguards that.
- Closes #14558

Unfortunately, without the device, I cannot trace the source of calling the Screensaver in the above issue that is done **after** closing the FM.
On "PowerOff", the screensaver is setup and shown **before** the UI instance is closed.
https://github.com/koreader/koreader/blob/8726233277a86575c3139b7bcb1ce735361dafc9/frontend/ui/uimanager.lua#L76-L83
Respective part of the crash.log:
```
11/02/25-11:37:54 INFO  Powering off the device... 
11/02/25-11:37:54 DEBUG close widget: table: 0x437831d0 
11/02/25-11:37:54 DEBUG close widget: filemanager 
11/02/25-11:37:54 DEBUG CoverMenu:onCloseWidget: terminating jobs if needed 
11/02/25-11:37:54 DEBUG close filemanager 
11/02/25-11:37:54 DEBUG close widget: table: 0x43534160 
11/02/25-11:37:54 DEBUG AutoStandby:onCloseWidget() instance= table: 0x43e430b8 
11/02/25-11:37:54 DEBUG Tearing down FileManager table: 0x43534160 
./luajit: frontend/ui/screensaver.lua:415: attempt to index field 'ui' (a nil value)
stack traceback:
	frontend/ui/screensaver.lua:415: in function 'setup'
	frontend/ui/uimanager.lua:82: in function 'action'
	frontend/ui/uimanager.lua:1001: in function '_checkTasks'
	frontend/ui/uimanager.lua:1447: in function 'handleInput'
	frontend/ui/uimanager.lua:1567: in function 'run'
	./reader.lua:280: in main chunk
	[C]: at 0x00013ee1
Process has been terminated by signal {SIGSEGV::SEGV_MAPERR}
Segmentation fault
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14561)
<!-- Reviewable:end -->
