### PR TITLE
Exporter: Correct MyClipping Page value parsing

### DIFF
--- a/plugins/exporter.koplugin/clip.lua
+++ b/plugins/exporter.koplugin/clip.lua
@@ -200,7 +200,6 @@ function MyClipping:getTime(line)
 end
 
 function MyClipping:getInfo(line)
-    local info = {}
     line = line or ""
 
     local parts = {}
@@ -211,6 +210,8 @@ function MyClipping:getInfo(line)
     if #parts < 2 then
         return {}
     end
+
+    local info = {}
 
     for sort, words in pairs(keywords) do
         for _, word in ipairs(words) do


### PR DESCRIPTION
Better page and location parsing from MyClipping item's info line.

Closes #14582

Maybe it is possible to completely drop ancient info string of type `sort page-or-loc | ts` and say that myclippings come only in modern format of `sort page | location | ts`.
My current code supports both options.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14583)
<!-- Reviewable:end -->
