### PR TITLE
Fix crash on Kindle when both AutoSuspend and KeepAlive are on

### DIFF
--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -136,7 +136,7 @@ if Device:isKindle() then
             logger.dbg("AutoSuspend: KeepAlive is active, skipping t1 timeout reset")
             return
         end
-        
+
         local now = UIManager:getElapsedTimeSinceBoot()
         local kindle_t1_reset_seconds = default_kindle_t1_timeout_reset_seconds - time.to_number(now - self.last_t1_reset_time)
         -- NOTE: Unlike us, powerd doesn't care about charging, so we always use the delta since the last user input.


### PR DESCRIPTION
KeepAlive disable t1 timeout by disabling screensaver in powerd, so we must not reset it then.

Fixes #14548.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14594)
<!-- Reviewable:end -->
