### PR TITLE
Fix Kindle crash on AutoSuspend while charging

### DIFF
--- a/plugins/autosuspend.koplugin/main.lua
+++ b/plugins/autosuspend.koplugin/main.lua
@@ -57,6 +57,7 @@ function AutoSuspend:_schedule(shutdown_only)
     end
 
     local suspend_delay_seconds, shutdown_delay_seconds
+    local is_charging
     -- On devices with an auxiliary battery, we only care about the auxiliary battery being charged...
     if Device:hasAuxBattery() and PowerD:isAuxBatteryConnected() then
         is_charging = PowerD:isAuxCharging() and not PowerD:isAuxCharged()


### PR DESCRIPTION
This fixes #14591.

I'm not necessarily in love with the idea of putting `is_charging` as an attribute of AutoSuspend, but it seemed better than the alternative of duplicating the logic from `_schedule`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14604)
<!-- Reviewable:end -->
