### PR TITLE
android: fix possible run target error

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -28,7 +28,7 @@ endif
 	# install
 	adb install $(ADB_INSTALL_FLAGS) '$(ANDROID_APK)'
 	# speed up testing, auto-grant permission
-	adb shell appops set --uid $(ANDROID_APP_ID) MANAGE_EXTERNAL_STORAGE allow
+	-adb shell appops set --uid $(ANDROID_APP_ID) MANAGE_EXTERNAL_STORAGE allow
 	# there's no adb run so we do this…
 	adb shell monkey -p $(ANDROID_APP_ID) -c android.intent.category.LAUNCHER 1
 	# monitor logs


### PR DESCRIPTION
Auto-granting the external storage permission does not work in all cases, so ignore errors:

```
Error: Unknown operation string: MANAGE_EXTERNAL_STORAGE
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14608)
<!-- Reviewable:end -->
