### PR TITLE
Update OPDS sync to download books in inverse order

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1549,6 +1549,7 @@ function OPDSBrowser:fillPendingSyncs(server)
         for i, entry in ipairs(sync_list) do
             -- for project gutenberg
             local sub_table = {}
+            local item
             if entry.url then
                 sub_table = self:getSyncDownloadList(entry.url)
             end


### PR DESCRIPTION
I wrote this awhile ago since books in the current version have books most recently added to the list downloaded first so sorting by newest in the file browser has them by default in what I would consider a backwards order

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14610)
<!-- Reviewable:end -->
