### PR TITLE
TouchMenu: fix menu height with/without separators

### DIFF
--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -733,6 +733,7 @@ function TouchMenu:updateItems(target_page, target_item_id)
     self.dimen.w = self.width
     self.dimen.h = self.item_group:getSize().h + self.bordersize*2 + self.padding -- (no padding at top)
     self:moveFocusTo(self.cur_tab, 1, FocusManager.NOT_FOCUS) -- reset the position of the focusmanager
+
     -- NOTE: We use a slightly ugly hack to detect a brand new menu vs. a tab switch,
     --       in order to optionally flash on initial menu popup...
     -- NOTE: Also avoid repainting what's underneath us on initial popup.


### PR DESCRIPTION
Currently adding separators increases touch menu height and causes slight but visible moving of the bottom edge.

<img width="400" height="260" alt="11" src="https://github.com/user-attachments/assets/ac265420-efdf-4083-b6e8-df9c2bc61ff7" />

<img width="400" height="270" alt="12" src="https://github.com/user-attachments/assets/395a39e7-c4f5-4db2-b278-181e356fcbc6" />

Combined screenshots
<img width="402" height="233" alt="13" src="https://github.com/user-attachments/assets/ff6b5617-b080-4a15-906d-e5fb9ffb4fb2" />

Fixed by inserting vertical span between items when there is no separator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14627)
<!-- Reviewable:end -->
