### PR TITLE
tools/logcat: improve handling of input encoding

### DIFF
--- a/tools/logcat.py
+++ b/tools/logcat.py
@@ -331,6 +331,7 @@ def main():
                 stdin = sys.stdin
             else:
                 stdin = stack.enter_context(open(args.filter, 'r', encoding=encoding))
+            stdin.reconfigure(errors='replace')
         else:
             # Logcat mode.
             if args.clear:


### PR DESCRIPTION
For example, avoid a decoding exception on this line:
```
20:58:28.534 14160            reader.launche  F  thread.cc:1326] Check failed: FindStackTop() > reinterpret_cast<void*>(tlsPtr_.stack_end) (FindStackTop()=X���`���X���, reinterpret_cast<void*>(tlsPtr_.stack_end)=0xbe10c000)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14629)
<!-- Reviewable:end -->
