### PR TITLE
SSH: add top menu checkbox

### DIFF
--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -246,7 +246,7 @@ function SSH:addToMainMenu(menu_items)
             },
             {
                 text_func = function()
-                    return T(_("SSH port (%1)"), self.SSH_port)
+                    return T(_("SSH port: %1"), self.SSH_port)
                 end,
                 keep_menu_open = true,
                 enabled_func = function() return not self:isRunning() end,


### PR DESCRIPTION
Useful to see the status and toggle SSH server with long-pressing.
- No. 1 in #14625

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14631)
<!-- Reviewable:end -->
