### PR TITLE
newsdownloader - new feature: continue processing feed on download error

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -790,7 +790,7 @@ function NewsDownloader:createFromDescription(feed, title, content, feed_output_
         local byline = getByline(feed)
         local footer
         if download_full_failed then
-            footer = _("Downloading the full article failed, this might only be a summary. To retry, delete this file and sync again.")
+            footer = _("Downloading the full article failed. To retry, delete this file and sync again.")
         else
             footer = _("If this is only a summary, the full article can be downloaded by going to the News Downloader settings and changing 'Download full article' to 'true'.")
         end


### PR DESCRIPTION
## The problem

Currently, when using the "Download full article" feature of the news downloader plugin, the plugin stops processing the other items (posts) in the feed if a download fails.
In practice, this happens occasionally when a single feed item link is wrong, or the server's bot / user-agent detection blocks koreader.

## The new implementation

If the full download of the news item fails, the plugin falls back to creating the post as if the "Download full article" feature is `false` (using the RSS/atom item's description/content fields) and adds a notice in the footer that the full download failed.
It then processes the rest of the items in the feed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14650)
<!-- Reviewable:end -->
