### PR TITLE
Add python to build dependencies

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -26,6 +26,7 @@ To get and compile the source you must have:
 - `pkg-config` or `pkgconf`
 - `unzip`
 - `wget`
+- `python`
 
 For running the emulator / tests:
 - `SDL2`


### PR DESCRIPTION
./kodev build fails without python available

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14652)
<!-- Reviewable:end -->
