### PR TITLE
android: drop no longer working make target

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -38,7 +38,7 @@ endif
 
 # Update. {{{
 
-PHONY += androiddev update
+PHONY += update
 
 ANDROID_DIR = $(PLATFORM_DIR)/android
 ANDROID_LAUNCHER_DIR = $(ANDROID_DIR)/luajit-launcher
@@ -84,9 +84,6 @@ LICENSE*
 *license.txt
 NOTICE
 endef
-
-androiddev: update
-	$(MAKE) -C $(ANDROID_LAUNCHER_DIR) dev
 
 update: all
 	# Note: do not remove the module directory so there's no need


### PR DESCRIPTION
Leftover from 2019, the `dev` target was removed in koreader/android-luajit-launcher@0bd2f4b.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14673)
<!-- Reviewable:end -->
