### PR TITLE
KoptInterface: prevent crash when word is nil 2

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -801,7 +801,9 @@ function KoptInterface:getReflewOCRWord(doc, pageno, rect)
             kc.getTOCRWord, kc, "dst",
             rect.x, rect.y, rect.w, rect.h,
             self.tessocr_data, self.ocr_lang, self.ocr_type, 0, 1)
-        DocCache:insert(hash, CacheItem:new{ rfocrword = word, size = #word + 64 }) -- estimation
+        if word then
+            DocCache:insert(hash, CacheItem:new{ rfocrword = word, size = #word + 64 }) -- estimation
+        end
         return word
     else
         return cached.rfocrword


### PR DESCRIPTION
Followup to https://github.com/koreader/koreader/commit/d2d39c503d2d3f6cd1960c22de9f8420ff794f1d for reflow mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14705)
<!-- Reviewable:end -->
