### PR TITLE
CloudStorage: fix onClose

### DIFF
--- a/frontend/apps/cloudstorage/cloudstorage.lua
+++ b/frontend/apps/cloudstorage/cloudstorage.lua
@@ -878,7 +878,7 @@ end
 
 function CloudStorage:onClose()
     local download_dir = self.cs_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
-    local fc = self.ui.file_chooser
+    local fc = self.ui and self.ui.file_chooser
     if fc and fc.path == download_dir then
         fc:refreshPath()
     end


### PR DESCRIPTION
No need to refresh the file list when called by SyncService (for syncing Statistics and VocabBuilder).
- Closes #14709

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14711)
<!-- Reviewable:end -->
