### PR TITLE
appimage: fix possible issue with the appimagetool binary

### DIFF
--- a/make/appimage.mk
+++ b/make/appimage.mk
@@ -14,7 +14,16 @@ plugins/timesync.koplugin
 $(filter-out tools/trace_require.lua tools/wbuilder.lua,$(wildcard tools/*))
 endef
 
-update: all
+appimagetool $(APPIMAGETOOL):
+	wget -O $(APPIMAGETOOL).part '$(APPIMAGETOOL_URL)'
+	# Zero-out AppImage magic bytes from the ELF header extended ABI version so
+	# binfmt+qemu can be used (e.g. when executed from `docker run --platform …`).
+	# Cf. https://github.com/AppImage/AppImageKit/issues/1056.
+	printf '\0\0\0' | dd conv=notrunc obs=1 seek=8 of=$(APPIMAGETOOL).part
+	chmod +x ./$(APPIMAGETOOL).part
+	mv $(APPIMAGETOOL).part $(APPIMAGETOOL)
+
+update: all $(APPIMAGETOOL)
 	cd $(INSTALL_DIR)/koreader && '$(abspath tools/mkrelease.sh)' ../appimage/ . $(release_excludes)
 	cp $(APPIMAGE_DIR)/{AppRun,koreader.desktop} resources/koreader.png $(INSTALL_DIR)/appimage/
 	sed -e 's/%%VERSION%%/$(VERSION)/' -e 's/%%DATE%%/$(RELEASE_DATE)/' $(PLATFORM_DIR)/common/koreader.metainfo.xml >$(INSTALL_DIR)/appimage/koreader.appdata.xml
@@ -25,12 +34,8 @@ ifeq (,$(wildcard $(UBUNTU_LIBBSD)))
 else
 	cp $(UBUNTU_LIBBSD) $(INSTALL_DIR)/appimage/libs/
 endif
-ifeq (,$(wildcard $(APPIMAGETOOL)))
-	# Download appimagetool.
-	wget '$(APPIMAGETOOL_URL)'
-	chmod a+x ./$(APPIMAGETOOL)
-endif
 	# Generate AppImage.
 	ARCH='$(APPIMAGE_ARCH)' ./$(APPIMAGETOOL) --appimage-extract-and-run $(INSTALL_DIR)/appimage $(KOREADER_APPIMAGE)
 
-PHONY += update
+PHONY += appimagetool update
+SOUND += $(APPIMAGETOOL)


### PR DESCRIPTION
Patch the ARMhf binary ELF magic so binfmt+qemu can be used (e.g. under docker from another architecture).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14717)
<!-- Reviewable:end -->
