### PR TITLE
remarkable: fix startup script relocalization

### DIFF
--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -12,7 +12,8 @@ fi
 export LC_ALL="en_US.UTF-8"
 
 # working directory of koreader
-export KOREADER_DIR="${0%/*}"
+# NOTE: We need to remember the *actual* KOREADER_DIR, not the relocalized version in /tmp...
+export KOREADER_DIR="${KOREADER_DIR:-${0%/*}}"
 UNPACK_DIR="${KOREADER_DIR%/*}"
 
 # we're always starting from our working directory


### PR DESCRIPTION
Ensure `$KOREADER_DIR` remains correct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14724)
<!-- Reviewable:end -->
