### PR TITLE
Decode Serverfilename on OPDS Download

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -495,7 +495,7 @@ function OPDSBrowser:getServerFileName(item_url, filetype)
             filename = filename .. "." .. filetype:lower()
         end
     end
-
+    filename = util.urlDecode(filename)
     return filename
 end
 


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/14679 

Just adds a util.urlDecode call to the filename extraction when "use serverfile names" is active for OPDS Servers. 

On a first glance that fixes my Problem. All Unittests ran through locally (though i didnt check if there are plugin tests for opds) . I've tested downloading from other Sources, that still works as it did before, but i doubt that covers all cases.

Example: "https://manybooks.net/sites/default/files/2025-03/The%20Eye%20of%20Nefertiti_%20A%20Pharaoh%27s%20Cat%20Nove%20-%20Maria%20Luisa%20Lang_1_0_0_0_0.epub" -> "The Eye of Nefertiti_ A Pharaoh's Cat Nove - Maria Luisa Lang_1_0_0_0_0.epub"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14732)
<!-- Reviewable:end -->
