### PR TITLE
refactor(configdialog): improve API for 3rd party use

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -137,7 +137,7 @@ function ReaderConfig:onShowConfigMenu()
     }
     self.ui:handleEvent(Event:new("DisableHinting"))
     -- show last used panel when opening config dialog
-    self.config_dialog:onShowConfigPanel(self.last_panel_index)
+    self.config_dialog:onShowConfigPanel(self.last_panel_index, true)
     UIManager:show(self.config_dialog)
     self.ui:handleEvent(Event:new("HandledAsSwipe")) -- cancel any pan scroll made
 

--- a/frontend/ui/widget/configdialog.lua
+++ b/frontend/ui/widget/configdialog.lua
@@ -864,7 +864,6 @@ local ConfigDialog = FocusManager:extend{
     --is_borderless = false,
     name = "ConfigDialog",
     panel_index = 1,
-    is_fresh = true,
 }
 
 function ConfigDialog:init()
@@ -958,7 +957,7 @@ function ConfigDialog:onCloseWidget()
     end)
 end
 
-function ConfigDialog:onShowConfigPanel(index)
+function ConfigDialog:onShowConfigPanel(index, force_keep_bg)
     self.panel_index = index
     local old_dimen = self.dialog_frame.dimen and self.dialog_frame.dimen:copy()
     local old_layout_h = self.layout and #self.layout
@@ -969,11 +968,10 @@ function ConfigDialog:onShowConfigPanel(index)
     --       This is trickier than in touchmenu, because dimen appear to fluctuate before/after painting...
     --       So we've settled instead for the amount of lines in the panel, as line-height is constant.
     local keep_bg = old_layout_h and #self.layout >= old_layout_h
-    UIManager:setDirty((self.is_fresh or keep_bg) and self or "all", function()
+    UIManager:setDirty((force_keep_bg or keep_bg) and self or "all", function()
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dialog_frame.dimen)
             or self.dialog_frame.dimen
-        self.is_fresh = false
         return "ui", refresh_dimen
     end)
     return true


### PR DESCRIPTION
The `is_fresh` flag is highly tied to the reader app (to avoid 2nd bg draw on index restore after init). For all other purposes (e.g., use by plugins w/o index restore), the ConfigPanel should not behave differently on the first tab change for no obvious reason.

Refers: https://github.com/oleasteo/koreader-screenlockpin/issues/31

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14769)
<!-- Reviewable:end -->
