### PR TITLE
feat(archiveviewer): extract all files button

### DIFF
--- a/plugins/archiveviewer.koplugin/main.lua
+++ b/plugins/archiveviewer.koplugin/main.lua
@@ -69,11 +69,7 @@ function ArchiveViewer:openFile(file)
     self.booklist = BookList:new({
         title = filename,
         item_table = self:getItemTable(),
-        covers_fullscreen = true,
-        is_borderless = true,
-        is_popout = false,
         title_multilines = true,
-        title_bar_fm_style = true,
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function()
             self:showMenu()
@@ -213,22 +209,10 @@ end
 function ArchiveViewer:showFileDialog(filepath)
     local dialog
     local buttons = {
-        {
-            {
-                text = _("Choose folder"),
-                callback = function()
-                    require("ui/downloadmgr")
-                        :new({
-                            onConfirm = function(path)
-                                self.extract_dir = path
-                                UIManager:close(dialog)
-                                self:showFileDialog(filepath)
-                            end,
-                        })
-                        :chooseDir(self.extract_dir)
-                end,
-            },
-        },
+        self:getChooseFolderButton(function()
+            UIManager:close(dialog)
+            self:showFileDialog(filepath)
+        end),
         {
             {
                 text = _("View"),
@@ -260,22 +244,10 @@ end
 function ArchiveViewer:extractAllDialog()
     local dialog
     local buttons = {
-        {
-            {
-                text = _("Choose folder"),
-                callback = function()
-                    require("ui/downloadmgr")
-                        :new({
-                            onConfirm = function(path)
-                                self.extract_dir = path
-                                UIManager:close(dialog)
-                                self:extractAllDialog()
-                            end,
-                        })
-                        :chooseDir(self.extract_dir)
-                end,
-            },
-        },
+        self:getChooseFolderButton(function()
+            UIManager:close(dialog)
+            self:extractAllDialog()
+        end),
         {
             {
                 text = _("Cancel"),
@@ -302,12 +274,33 @@ function ArchiveViewer:extractAllDialog()
     UIManager:show(dialog)
 end
 
+function ArchiveViewer:getChooseFolderButton(callback)
+    return {
+        {
+            text = _("Choose folder"),
+            callback = function()
+                require("ui/downloadmgr")
+                    :new({
+                        onConfirm = function(path)
+                            if path:sub(-1) ~= "/" then
+                                path = path .. "/"
+                            end
+                            self.extract_dir = path
+                            callback()
+                        end,
+                    })
+                    :chooseDir(self.extract_dir)
+            end,
+        },
+    }
+end
+
 function ArchiveViewer:viewFile(filepath)
     if DocumentRegistry:isImageFile(filepath) then
         local index = 0
         local curr_index
         local images_list = {}
-        for i, item in ipairs(self.menu.item_table) do
+        for i, item in ipairs(self.booklist.item_table) do
             local item_path = item.path
             if item.is_file and DocumentRegistry:isImageFile(item_path) then
                 table.insert(images_list, item_path)
@@ -350,10 +343,6 @@ end
 function ArchiveViewer:extractFile(filepath)
     local directory = self.extract_dir
 
-    if directory:sub(-1) ~= "/" then
-        directory = directory .. "/"
-    end
-
     self.fm_updated = self.arc:extractToPath(filepath, directory .. filepath)
 
     UIManager:show(InfoMessage:new({
@@ -364,10 +353,6 @@ end
 
 function ArchiveViewer:extractAll()
     local archive_dir = self.extract_dir
-
-    if archive_dir:sub(-1) ~= "/" then
-        archive_dir = archive_dir .. "/"
-    end
 
     for entry in self.arc:iterate() do
         if entry.mode == "file" then


### PR DESCRIPTION
This commit adds an option to extract all files inside an archive from the Archive viewer. Currently implemented as an item in the file menu list. Future work could move it to a dedicated button next to the navigation buttons, if deemed appropriate. I opted for the item list approach as it does not conflict with how a user is used to interacting with the engine.

<details>
<summary>Screenshots</Summary>
<img width="529" height="712" alt="image" src="https://github.com/user-attachments/assets/cf346944-f28a-48f0-beae-68e2f33bddd8" />
<img width="530" height="710" alt="image" src="https://github.com/user-attachments/assets/a5e7d09b-e6df-4411-abc8-f9db79d8c922" />

</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14770)
<!-- Reviewable:end -->
