### PR TITLE
Add option to set UI font

### DIFF
--- a/frontend/ui/elements/common_settings_menu_table.lua
+++ b/frontend/ui/elements/common_settings_menu_table.lua
@@ -740,6 +740,11 @@ common_settings.keyboard_layout = {
 
 common_settings.font_ui_fallbacks = dofile("frontend/ui/elements/font_ui_fallbacks.lua")
 
+common_settings.ui_fonts = {
+    text = _("UI fonts"),
+    sub_item_table = require("ui/elements/ui_fonts"):getSettingsMenuTable(),
+}
+
 common_settings.units = {
     text_func = function()
         local unit = G_reader_settings:readSetting("dimension_units", "mm")

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -48,6 +48,7 @@ local order = {
         "keyboard_layout",
         "external_keyboard",
         "font_ui_fallbacks",
+        "ui_fonts",
         "----------------------------",
         "time",
         "units",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -96,6 +96,7 @@ local order = {
         "keyboard_layout",
         "external_keyboard",
         "font_ui_fallbacks",
+        "ui_fonts",
         "----------------------------",
         "time",
         "units",

--- a/frontend/ui/elements/ui_fonts.lua
+++ b/frontend/ui/elements/ui_fonts.lua
@@ -1,0 +1,80 @@
+local Font = require("ui/font")
+local FontList = require("fontlist")
+local UIManager = require("ui/uimanager")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local UIFonts = {}
+
+-- Helper to get font name from filename
+local function getFontName(filename)
+    FontList:getFontList()
+    for path, info in pairs(FontList.fontinfo) do
+        if path:match("([^/]+)$") == filename then
+            return info[1] and info[1].name or filename
+        end
+    end
+    if filename == "NotoSans-Regular.ttf" then return "Noto Sans" end
+    if filename == "NotoSans-Bold.ttf" then return "Noto Sans Bold" end
+    return filename
+end
+
+-- Helper for menu text with brackets
+local function getMenuText(label, font_file)
+    local name = getFontName(font_file)
+    return T("%1 (%2)", label, name)
+end
+
+function UIFonts:getFontTable(setting_name, default_file)
+    local menu_items = {
+        {
+            text_func = function()
+                local name = getFontName(default_file)
+                return T(_("Default (%1)"), name)
+            end,
+            checked_func = function() return not G_reader_settings:has(setting_name) end,
+            callback = function()
+                G_reader_settings:delSetting(setting_name)
+                UIManager:askForRestart()
+            end,
+        },
+    }
+
+    for _, font_path in ipairs(FontList:getFontList()) do
+        local font_info = FontList.fontinfo[font_path]
+        if font_info and font_info[1] then
+            local font_file = font_path:match("([^/]+)$")
+            local display_file = #font_file > 20 and ("..." .. font_file:sub(-17)) or font_file
+            table.insert(menu_items, {
+                text = T("%1 (%2)", font_info[1].name, display_file),
+                checked_func = function() return G_reader_settings:readSetting(setting_name) == font_file end,
+                callback = function()
+                    G_reader_settings:saveSetting(setting_name, font_file)
+                    UIManager:askForRestart()
+                end,
+            })
+        end
+    end
+    return menu_items
+end
+
+function UIFonts:getSettingsMenuTable()
+    local reg_def = Font.DEFAULT_UI_FONT_REGULAR
+    local bold_def = Font.DEFAULT_UI_FONT_BOLD
+    return {
+        {
+            text_func = function()
+                return getMenuText(_("Regular font"), G_reader_settings:readSetting("ui_font_regular") or reg_def)
+            end,
+            sub_item_table_func = function() return self:getFontTable("ui_font_regular", reg_def) end,
+        },
+        {
+            text_func = function()
+                return getMenuText(_("Bold font"), G_reader_settings:readSetting("ui_font_bold") or bold_def)
+            end,
+            sub_item_table_func = function() return self:getFontTable("ui_font_bold", bold_def) end,
+        },
+    }
+end
+
+return UIFonts

--- a/frontend/ui/font.lua
+++ b/frontend/ui/font.lua
@@ -8,13 +8,17 @@ local Screen = require("device").screen
 local logger = require("logger")
 local util = require("util")
 
+local DEFAULT_UI_FONT_REGULAR = "NotoSans-Regular.ttf"
+local DEFAULT_UI_FONT_BOLD = "NotoSans-Bold.ttf"
+
 -- Known regular (and italic) fonts with an available bold font file
-local _bold_font_variant = {}
-_bold_font_variant["NotoSans-Regular.ttf"] = "NotoSans-Bold.ttf"
-_bold_font_variant["NotoSans-Italic.ttf"] = "NotoSans-BoldItalic.ttf"
-_bold_font_variant["NotoSansArabicUI-Regular.ttf"] = "NotoSansArabicUI-Bold.ttf"
-_bold_font_variant["NotoSerif-Regular.ttf"] = "NotoSerif-Bold.ttf"
-_bold_font_variant["NotoSerif-Italic.ttf"] = "NotoSerif-BoldItalic.ttf"
+local _bold_font_variant = {
+    [DEFAULT_UI_FONT_REGULAR] = DEFAULT_UI_FONT_BOLD,
+    ["NotoSans-Italic.ttf"] = "NotoSans-BoldItalic.ttf",
+    ["NotoSansArabicUI-Regular.ttf"] = "NotoSansArabicUI-Bold.ttf",
+    ["NotoSerif-Regular.ttf"] = "NotoSerif-Bold.ttf",
+    ["NotoSerif-Italic.ttf"] = "NotoSerif-BoldItalic.ttf",
+}
 
 -- Build the reverse mapping, so we can know a font is bold
 local _regular_font_variant = {}
@@ -22,7 +26,17 @@ for regular, bold in pairs(_bold_font_variant) do
     _regular_font_variant[bold] = regular
 end
 
+local function getUIFont(setting_name, default)
+    return G_reader_settings:readSetting(setting_name) or default
+end
+
+local UI_REGULAR = getUIFont("ui_font_regular", DEFAULT_UI_FONT_REGULAR)
+local UI_BOLD = getUIFont("ui_font_bold", DEFAULT_UI_FONT_BOLD)
+
 local Font = {
+    DEFAULT_UI_FONT_REGULAR = DEFAULT_UI_FONT_REGULAR,
+    DEFAULT_UI_FONT_BOLD = DEFAULT_UI_FONT_BOLD,
+
     -- Make these available in the Font object, so other code
     -- can complete them if needed.
     bold_font_variant = _bold_font_variant,
@@ -39,22 +53,22 @@ local Font = {
 
     fontmap = {
         -- default font for menu contents
-        cfont = "NotoSans-Regular.ttf",
+        cfont = UI_REGULAR,
         -- default font for title
         --tfont = "NimbusSanL-BoldItal.cff",
-        tfont = "NotoSans-Bold.ttf",
-        smalltfont = "NotoSans-Bold.ttf",
-        x_smalltfont = "NotoSans-Bold.ttf",
+        tfont = UI_BOLD,
+        smalltfont = UI_BOLD,
+        x_smalltfont = UI_BOLD,
         -- default font for footer
-        ffont = "NotoSans-Regular.ttf",
-        smallffont = "NotoSans-Regular.ttf",
-        largeffont = "NotoSans-Regular.ttf",
+        ffont = UI_REGULAR,
+        smallffont = UI_REGULAR,
+        largeffont = UI_REGULAR,
 
         -- default font for reading position info
-        rifont = "NotoSans-Regular.ttf",
+        rifont = UI_REGULAR,
 
         -- default font for pagination display
-        pgfont = "NotoSans-Regular.ttf",
+        pgfont = UI_REGULAR,
 
         -- selectmenu: font for item shortcut
         scfont = "DroidSansMono.ttf",
@@ -62,7 +76,7 @@ local Font = {
         -- help page: font for displaying keys
         hpkfont = "DroidSansMono.ttf",
         -- font for displaying help messages
-        hfont = "NotoSans-Regular.ttf",
+        hfont = UI_REGULAR,
 
         -- font for displaying input content
         -- we have to use mono here for better distance controlling
@@ -71,16 +85,16 @@ local Font = {
         smallinfont = "DroidSansMono.ttf",
 
         -- font for info messages
-        infofont = "NotoSans-Regular.ttf",
+        infofont = UI_REGULAR,
 
         -- small font for info messages
-        smallinfofont = "NotoSans-Regular.ttf",
+        smallinfofont = UI_REGULAR,
         -- small bold font for info messages
-        smallinfofontbold = "NotoSans-Bold.ttf",
+        smallinfofontbold = UI_BOLD,
         -- extra small font for info messages
-        x_smallinfofont = "NotoSans-Regular.ttf",
+        x_smallinfofont = UI_REGULAR,
         -- extra extra small font for info messages
-        xx_smallinfofont = "NotoSans-Regular.ttf",
+        xx_smallinfofont = UI_REGULAR,
     },
     sizemap = {
         cfont = 24,


### PR DESCRIPTION
* Found under `Setting > Device > UI Font`
* Will fall back to default font (bold and none-bold)
* Offers user optiont or restart KOReader immediately or defer
* Full disclaimer, coded with help of an LLM, but tested pretty extensively

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14778)
<!-- Reviewable:end -->
