### PR TITLE
Wikipedia: revamp languages handling

### DIFF
--- a/frontend/ui/widget/container/scrollablecontainer.lua
+++ b/frontend/ui/widget/container/scrollablecontainer.lua
@@ -621,6 +621,14 @@ function ScrollableContainer:onScrollablePanRelease(_, ges)
     if not self._is_scrollable then
         return false
     end
+    if ges.from_mousewheel and not self._scrolling and ges.relative and ges.relative.y then
+        if ges.relative.y < 0 then
+            self:onScrollPageDown()
+        elseif ges.relative.y > 0 then
+            self:onScrollPageUp()
+        end
+        return true
+    end
     logger.dbg("ScrollableContainer:onScrollablePanRelease", ges)
     if self._scrolling then
         self:_scrollBy(-self._scroll_relative_x, -self._scroll_relative_y)

--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -338,6 +338,12 @@ function KeyValuePage:init()
                 range = self.dimen,
             }
         }
+        self.ges_events.Pan = { -- (for mousewheel scrolling support)
+            GestureRange:new{
+                ges = "pan",
+                range = self.dimen,
+            }
+        }
     end
 
     -- return button
@@ -813,6 +819,17 @@ function KeyValuePage:onMultiSwipe(arg, ges_ev)
     -- used to close and where we then allow any multiswipe to close, allow any
     -- multiswipe to close this widget too.
     self:onClose()
+    return true
+end
+
+function KeyValuePage:onPan(arg, ges_ev)
+    if ges_ev.mousewheel_direction then
+        if ges_ev.direction == "north" then
+            self:onNextPage()
+        elseif ges_ev.direction == "south" then
+            self:onPrevPage()
+        end
+    end
     return true
 end
 

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -194,6 +194,8 @@ end
 function ScrollTextWidget:resetScroll()
     local low, high = self.text_widget:getVisibleHeightRatios()
     self.v_scroll_bar:set(low, high)
+    self.prev_low = nil
+    self.prev_high = nil
 
     local visible_line_count = self.text_widget:getVisLineCount()
     local total_line_count = self.text_widget:getAllLineCount()

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -15,8 +15,8 @@ local T = ffiutil.template
 -- https://en.wikipedia.org/w/api.php?action=query&prop=extracts&format=jsonfm&explaintext=&redirects=&titles=E-reader
 --
 -- To get parsed HTML :
--- https://en.wikipedia.org/w/api.php?action=parse&page=E-book
--- https://en.wikipedia.org/w/api.php?action=parse&page=E-book&prop=text|sections|displaytitle|revid&disablelimitreport=&disableeditsection
+-- https://en.wikipedia.org/w/api.php?action=parse&page=Ebook
+-- https://en.wikipedia.org/w/api.php?action=parse&page=Ebook&prop=text|tocdata|displaytitle|revid&disablelimitreport=&disableeditsection
 -- https://www.mediawiki.org/wiki/API:Parsing_wikitext#parse
 --]]
 
@@ -44,19 +44,20 @@ local Wikipedia = {
    -- Full article, parsed to output text (+ main thumbnail image)
    wiki_full_params = {
        action = "query",
-       prop = "extracts|pageimages",
+       prop = "extracts|pageimages|langlinks",
        format = "json",
        -- exintro = nil, -- get more than only the intro
        explaintext = "",
        redirects = "",
        -- title = nil, -- text to lookup, will be added below
+       lllimit = 500, -- (default nb of langlinks returned is 10)
    },
    -- Full article, parsed to output HTML, for Save as EPUB
    wiki_phtml_params = {
        action = "parse",
        format = "json",
        -- we only need the following pieces of information
-       prop = "text|sections|displaytitle|revid",
+       prop = "text|tocdata|displaytitle|revid",
        -- page = nil, -- text to lookup, will be added below
        -- disabletoc = "", -- if we want to remove toc IN html
             -- 20230722: there is no longer the TOC in the html no matter this param
@@ -715,7 +716,7 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
     local wiki_base_url = self:getWikiServer(lang)
 
     -- Get infos from wikipedia result
-    -- (see example at https://en.wikipedia.org/w/api.php?action=parse&page=E-book&prop=text|sections|displaytitle|revid&disablelimitreport=&disableeditsection)
+    -- (see example at https://en.wikipedia.org/w/api.php?action=parse&page=Ebook&prop=text|tocdata|displaytitle|revid&disablelimitreport=&disableeditsection)
     local cancelled = false
     local html = phtml.text["*"] -- html content
     local page_cleaned = page:gsub("_", " ") -- page title
@@ -726,7 +727,8 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
     -- encodes. (We don't escape < or > as these JSON strings may contain HTML tags)
     page_cleaned = util.htmlEntitiesToUtf8(page_cleaned):gsub("&", "&#38;")
     page_htmltitle = util.htmlEntitiesToUtf8(page_htmltitle):gsub("&", "&#38;")
-    local sections = phtml.sections -- Wikipedia provided TOC
+    -- Wikipedia provided TOC (might be "null", that JSON.decode() converts to a function)
+    local sections = type(phtml.tocdata) == "table" and phtml.tocdata.sections or {}
     local bookid = string.format("wikipedia_%s_%s_%s", lang, phtml.pageid, phtml.revid)
     -- Not sure if this bookid may ever be used by indexing software/calibre, but if it is,
     -- should it changes if content is updated (as now, including the wikipedia revisionId),
@@ -1343,7 +1345,7 @@ abbr.abbr {
         -- We need to do as for page_htmltitle above. But headings can contain
         -- html entities for < and > that we need to put back as html entities
         s_title = util.htmlEntitiesToUtf8(s_title):gsub("&", "&#38;"):gsub(">", "&gt;"):gsub("<", "&lt;")
-        local s_level = s.toclevel
+        local s_level = s.tocLevel
         if s_level > depth then
             depth = s_level -- max depth required in toc.ncx
         end
@@ -1415,7 +1417,7 @@ abbr.abbr {
         -- for the links to be valid.
         local s_anchor = s.anchor:gsub("&", "&amp;"):gsub('"', "&quot;"):gsub(">", "&gt;"):gsub("<", "&lt;")
         local s_title = string.format("%s %s", s.number, s.line)
-        local s_level = s.toclevel
+        local s_level = s.tocLevel
         if s_level == cur_level then
             table.insert(toc_html_parts, "</li>")
         elseif s_level < cur_level then


### PR DESCRIPTION
#### KeyValuePage, scrollablecontainer: allow mousewheel scrolling

(Doing this incrementally, each time I expect to have it work on the emulator and not getting it :))

#### ScrollTextWidget: fix resetScroll()

Could cause some refreshes (actually triggered when the scrollbar changes) in DictQuickLookup to be ignored in some rare circonstances (2 consecutive results from a text dictionary having the exact same nb of lines).

#### Wikipedia: revamp languages handling

Replace the cumbersome implementation of language rotation with a more natural language selection:
- replace the <kbd>en > fr</kbd> button with a <kbd>Language ≡</kbd> button, which on tap shows a popup with the user languages allowing direct selection (instead of having to rotate through all the intermediate languages and wait for each result)
- we don't touch anymore the user-set wikipedia_languages array when switching language
- the newly selected language is stored in doc_settings, and will be used for next queries on this book. It is also stored in G_reader_settings as the language to be used for next newly opened books and for lookups done when in FileBrowser
- 
<img width="534" height="114" alt="image" src="https://github.com/user-attachments/assets/b1a3ed8c-531f-4dd3-b0c5-a1e9157a0e2c" />

<img width="530" height="404" alt="image" src="https://github.com/user-attachments/assets/73a055c7-4039-4bf9-8908-a9a282eae75b" />

_
Also:
On Wikipedia full articles, the top left hamburger menu shows a popup with the other Wikipedia languages the current article is available for, and allows reading them.

<img width="591" height="157" alt="image" src="https://github.com/user-attachments/assets/66a14e3c-170e-4876-8385-9552b4dbb8db" />

<img width="596" height="612" alt="image" src="https://github.com/user-attachments/assets/bfe43cc1-8b01-43d3-b36a-9e41ef8ddebe" />

Closes #14777.
_
Also:
Wikipedia article ToC: the 'sections' properties of the Wikipedia API is now deprecated: use its replacement 'tocdata'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14791)
<!-- Reviewable:end -->
