### PR TITLE
ReaderFooter: percent_finished in continious mode

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2318,6 +2318,10 @@ end
 function ReaderFooter:onPosUpdate(pos, pageno)
     self.pageno = pageno
     self.initial_pageno = self.initial_pageno or pageno
+    if self.pages then
+        self.percent_finished = self:getBookProgress()
+        BookList.setBookInfoCacheProperty(self.ui.document.file, "percent_finished", self.percent_finished)
+    end
     self:onUpdateFooter()
 end
 


### PR DESCRIPTION
Follow-up to https://github.com/koreader/koreader/pull/14787. Forgot about continious mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14794)
<!-- Reviewable:end -->
