### PR TITLE
Update device.lua to support Tolino Vision Color (monzaKobo)

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1778,7 +1778,7 @@ elseif codename == "goldfinch" then
     return KoboGoldfinch
 elseif codename == "condor" then
     return KoboCondor
-elseif codename == "monza" or codename == "monzaTolino" or codename == "monzaKobo" then
+elseif codename == "monza" or codename == "monzaKobo" or codename == "monzaTolino" then
     return KoboMonza
 elseif codename == "spaBW" or codename == "spaTolinoBW" or codename == "spaBWTPV" then
     return KoboSpaBW


### PR DESCRIPTION
added monzaKobo for Tolino Vision Color in Kobo mode

```
Original fb rotation is set @ 1
Original fb bitdepth is set @ 32bpp
Switching fb bitdepth to 32bpp & rotation to Portrait
[FBInk] Detected a Kobo Libra Colour (390 => Monza @ Mark 13)
[FBInk] This device does not support HW inversion
[FBInk] Enabled MediaTek quirks
[FBInk] Clock tick frequency appears to be 100 Hz
[FBInk] Screen density set to 300 dpi
[FBInk] Variable fb info: 1264x1680, 32bpp @ rotation: 1 (Clockwise, 90°)
[FBInk] Fixed fb info: ID is "hwtcon", length of fb mem: 8494080 bytes & line length: 5056 bytes
[FBInk] Canonical rotation: 0 (Upright, 0°)
[FBInk] Fontsize set to 32x32 (IBM (Default) base glyph size: 8x8)
[FBInk] Line length: 39 cols, Page size: 52 rows
[FBInk] Vertical fit isn't perfect, shifting rows down by 8 pixels
[FBInk] Framebuffer pixel format: RGBA
[FBDepth] Screen is 1264x1680 (1264x1680 addressable, fb says 1264x1680)
[FBDepth] Buffer is mapped for 8494080 bytes with a scanline stride of 5056 bytes
[FBDepth] Current bitdepth is already 32bpp!
[FBDepth] Requested canonical rota 0 translates to 1 for this device
[FBDepth] Current rotation is already 1!
---------------------------------------------
             launching...
  _  _____  ____                _
 | |/ / _ \|  _ \ ___  __ _  __| | ___ _ __
 | ' / | | | |_) / _ \/ _` |/ _` |/ _ \ '__|
 | . \ |_| |  _ <  __/ (_| | (_| |  __/ |
 |_|\_\___/|_| \_\___|\__,_|\__,_|\___|_|

 It's a scroll... It's a codex... It's KOReader!

 [*] Current time: 01/08/26-19:58:41
has monolibtic? no (libs/libkoreader-monolibtic.so: cannot open shared object file: No such file or directory)
lib_search_path: libs/?
lib_basic_format: lib%s.so
lib_version_format: lib%s.so.%s
 [*] Version: v2025.10-81-g1944c2687_2026-01-03

ffi.load: rt.so.1 (RTLD_GLOBAL)
ffi.findlib: utf8proc [3]
ffi.load: libs/libutf8proc.so.3
ffi.findlib: blitbuffer
ffi.load: libs/libblitbuffer.so
ffi.findlib: archive [13]
ffi.load: libs/libarchive.so.13
./luajit: frontend/device/kobo/device.lua:1796: unrecognized Kobo model monzaKobo with device id 390
stack traceback:
	[C]: in function 'error'
	frontend/device/kobo/device.lua:1796: in main chunk
	[C]: in function 'probeDevice'
	frontend/device.lua:53: in main chunk
	[C]: in function 'require'
	./reader.lua:151: in main chunk
	[C]: at 0x00013e95
!!!!
Uh oh, something went awry... (Crash n°1: 01/08/26 @ 19:58:41)
Running FW 5.7.212781 on Linux 4.9.77 (#1 SMP PREEMPT b33568f-20250306T161124-B0307074922)
Attempting to restart KOReader . . .
!!!!

```

and from kfmon:

```
[FBInk] Detected a Kobo Libra Colour (390 => Monza @ Mark 13)
**** PRODUCT 'monzaKobo' on PLATFORM 'mt8113t-ntx' ****
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14801)
<!-- Reviewable:end -->
