### PR TITLE
Add error handling to Kindle Wi-Fi functions

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -154,7 +154,13 @@ local function kindleGetScanList()
         local success, cm_state = pcall(function()
             return lipc_handle:get_string_property("com.lab126.wifid", "cmState")
         end)
-        if not success or (cm_state and cm_state ~= "CONNECTED") then
+        if not success then
+            -- cmState may fail when the LIPC backend is temporarily unavailable (e.g., suspend/lock).
+            logger.warn("kindleGetScanList: failed to access cmState")
+        end
+        -- Fall back to scanList if cmState is unavailable or not CONNECTED (cm_state may be nil).
+        local need_scan = (not success) or (cm_state ~= "CONNECTED")
+        if need_scan then
             local ha_input = lipc_handle:new_hasharray()
             local success_scan, ha_results = pcall(function()
                 return lipc_handle:access_hash_property("com.lab126.wifid", "scanList", ha_input)


### PR DESCRIPTION
Wrap LIPC calls in pcall() to prevent crashes when accessing Wi-Fi properties.

This PR adds error handling to five critical functions that interact with the Kindle's LIPC (Lab126 IPC) system for Wi-Fi management. Without proper error handling, these functions can crash KOReader when LIPC calls fail.

Changes:
- kindleGetSavedNetworks: Wrap access_hash_property call in pcall()
- kindleGetCurrentProfile: Wrap access_hash_property call in pcall()
- kindleSaveNetwork: Wrap createProfile call in pcall()
- kindleGetScanList: Wrap both get_string_property and access_hash_property calls in pcall()
- kindleScanThenGetResults: Wrap get_string_property call in pcall()

All modified functions now:
- Catch LIPC errors using pcall() instead of crashing
- Log warnings when LIPC calls fail
- Return safe default values (empty tables or nil) instead of propagating errors

Tested on: Kindle Paperwhite 3 (PW3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14817)
<!-- Reviewable:end -->
