### PR TITLE
fix(opds): redraw OPDS download confirmation popup on Kindle/e-ink

### DIFF
--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -108,7 +108,7 @@ end
 
 function OPDS:showFileDownloadedDialog(file)
     self.last_downloaded_file = file
-    local cb = ConfirmBox:new{
+    local confirm_box = ConfirmBox:new{
         text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file)),
         ok_text = _("Read now"),
         ok_callback = function()
@@ -121,10 +121,10 @@ function OPDS:showFileDownloadedDialog(file)
             end
         end,
     }
-    UIManager:show(cb)
+    UIManager:show(confirm_box)
     -- Kindle/e-ink: OPDS download completion ConfirmBox may be partially rendered; force a light redraw on next tick.
     UIManager:nextTick(function()
-        UIManager:setDirty("ui", "ui")
+        UIManager:setDirty(confirm_box, "ui")
         UIManager:forceRePaint()
     end)
 end

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -121,6 +121,7 @@ function OPDS:showFileDownloadedDialog(file)
             end
         end,
     }
+    -- As the InfoMessage "Downloading" is getting closed, show this ConfirmBox on the next UI tick to avoid e-Ink rendering congestion
     UIManager:nextTick(function()
         UIManager:show(confirm_box)
     end)

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -108,7 +108,7 @@ end
 
 function OPDS:showFileDownloadedDialog(file)
     self.last_downloaded_file = file
-    UIManager:show(ConfirmBox:new{
+    local cb = ConfirmBox:new{
         text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file)),
         ok_text = _("Read now"),
         ok_callback = function()
@@ -120,7 +120,13 @@ function OPDS:showFileDownloadedDialog(file)
                 self.ui:openFile(file)
             end
         end,
-    })
+    }
+    UIManager:show(cb)
+    -- Kindle/e-ink: OPDS download completion ConfirmBox may be partially rendered; force a light redraw on next tick.
+    UIManager:nextTick(function()
+        UIManager:setDirty("ui", "ui")
+        UIManager:forceRePaint()
+    end)
 end
 
 function OPDS:onFlushSettings()

--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -121,11 +121,8 @@ function OPDS:showFileDownloadedDialog(file)
             end
         end,
     }
-    UIManager:show(confirm_box)
-    -- Kindle/e-ink: OPDS download completion ConfirmBox may be partially rendered; force a light redraw on next tick.
     UIManager:nextTick(function()
-        UIManager:setDirty(confirm_box, "ui")
-        UIManager:forceRePaint()
+        UIManager:show(confirm_box)
     end)
 end
 


### PR DESCRIPTION
### Problem
On Kindle e-ink devices, the OPDS “File saved to…” confirmation popup can be
partially rendered when it is shown after a download completes.

Screenshot:
<img width="357" height="188" alt="image" src="https://github.com/user-attachments/assets/8f9218c4-57cb-4abe-a7bb-b2f9a4a8f3b3" />

This popup is displayed from an asynchronous download completion callback,
not directly from a user input event, which can result in an incomplete
partial refresh on e-ink devices.

Moving the popup immediately redraws it correctly.

### Solution

After showing the ConfirmBox, a light UI redraw is forced on the next UI tick
using `UIManager:setDirty("ui","ui")` and `UIManager:forceRePaint()`.

### Tested on

- Kindle Paperwhite 3 (PW3)
- Kindle Paperwhite 5 (PW5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14836)
<!-- Reviewable:end -->
