### PR TITLE
kindle: fix restart on special offers devices

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1893,7 +1893,7 @@ function KindleTouch:exit()
         -- fake a touch event
         if self.touch_dev then
             local width, height = self.screen:getScreenWidth(), self.screen:getScreenHeight()
-            require("ffi/input").fakeTapInput(self.touch_dev,
+            require("libs/libkoreader-input").fakeTapInput(self.touch_dev,
                 math.min(width, height)/2,
                 math.max(width, height)-30
             )


### PR DESCRIPTION
Fix leftover use of `ffi/input` (removed in #12486). Close #14833.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14837)
<!-- Reviewable:end -->
