### PR TITLE
DictQuickLookup: fix Japanese text selection in dictionary

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -77,6 +77,15 @@ local CreDocument = Document:extend{
     last_linear_page = nil,
 }
 
+function CreDocument:getLanguageSupportCallbacks()
+    return {
+        get_prev_char_pos = function(pos) return self:getPrevVisibleChar(pos) end,
+        get_next_char_pos = function(pos) return self:getNextVisibleChar(pos) end,
+        get_text_in_range = function(pos0, pos1) return self:getTextFromXPointers(pos0, pos1) end,
+        get_selection_sboxes = function(pos0, pos1) return self:getScreenBoxesFromPositions(pos0, pos1, true) end,
+    }
+end
+
 function CreDocument.cacheInit()
     -- remove legacy cr3cache directory
     if lfs.attributes("./cr3cache", "mode") == "directory" then

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -594,6 +594,10 @@ function Document:updateHighlightContents(pageno, item, contents)
     return nil
 end
 
+function Document:getLanguageSupportCallbacks()
+    return nil
+end
+
 --[[
 helper functions
 --]]

--- a/frontend/languagesupport.lua
+++ b/frontend/languagesupport.lua
@@ -230,6 +230,28 @@ function LanguageSupport:improveWordSelection(selection)
     }
 end
 
+--- Called from widgets that hold text buffer (like TextBoxWidget) to improve selection.
+-- @param selection Table with { text, pos0, pos1, callbacks }
+-- @param language_code String
+-- @return new_pos0, new_pos1 (or nil if no improvement)
+function LanguageSupport:improveBufferSelection(selection, language_code)
+    if not self:hasActiveLanguagePlugins() then return end
+
+    language_code = language_code or "unknown"
+
+    local new_pos0, new_pos1 = unpack(self:_findAndCallPlugin(
+        language_code, "WordSelection",
+        selection
+    ) or {})
+
+    if not new_pos0 or not new_pos1 or
+        (new_pos0 == selection.pos0 and new_pos1 == selection.pos1) then
+        return
+    end
+
+    return new_pos0, new_pos1
+end
+
 --- Called from ReaderHighlight:startSdcv after the selected has text has been
 -- OCR'd, cleaned, and otherwise made ready for sdcv.
 -- @tparam string text Original text being searched by the user.

--- a/frontend/languagesupport.lua
+++ b/frontend/languagesupport.lua
@@ -151,105 +151,60 @@ function LanguageSupport:_findAndCallPlugin(language_code, handler_name, ...)
     end
 end
 
-local function createDocumentCallbacks(document)
-    if not document or document.info.has_pages then
-        -- We need document:get{Prev,Next}VisibleChar at a minimum and there
-        -- isn't an alternative for PDFs at the moment (not to mention for
-        -- quite a few CJK PDFs, MuPDF seems to be unable to create selections
-        -- at a character level even using hold-and-pan).
-        logger.dbg("language support currently cannot expand document selections in non-EPUB formats")
-        return
-    end
-    return {
-        get_prev_char_pos = function(pos) return document:getPrevVisibleChar(pos) end,
-        get_next_char_pos = function(pos) return document:getNextVisibleChar(pos) end,
-        get_text_in_range = function(pos0, pos1) return document:getTextFromXPointers(pos0, pos1) end,
-    }
-end
-
 --- Called from ReaderHighlight:onHold after the document-specific handler has
--- successfully grabbed a "word" from the document. If the selection is to
--- updated, improveWordSelection will also update the document's internal
--- selection state (for crengine) to correctly display the right selection.
+-- successfully grabbed a "word" from the document (or widget). If the selection is to
+-- updated, improveWordSelection will return the new selection data.
 -- @param selection Text selection table to improve if possible.
+-- @param object (Optional) The object (Document or Widget) containing the text. Defaults to self.document.
+-- @param language_code (Optional) The language code to use. Defaults to document language.
 -- @return New updated selected_text table which should be used (or nil).
-function LanguageSupport:improveWordSelection(selection)
-    if not self:hasActiveLanguagePlugins() then return end -- nothing to do
+function LanguageSupport:improveWordSelection(selection, object, language_code)
+    if not self:hasActiveLanguagePlugins() then return end
 
-    if not self.document then
-        logger.dbg("language support: cannot improve word selection outside document")
+    object = object or self.document
+    if not object then
+        logger.dbg("language support: cannot improve word selection without object")
         return
     end
 
-    local language_code = self.ui.doc_props.language or "unknown"
-    logger.dbg("language support: improving", language_code, "selection", selection)
-
-    -- Rather than requiring each language plugin to use document: methods
-    -- correctly, return a set of callbacks that are document-agnostic (and
-    -- have the document handle as an upvalue of the closure) and could be used
-    -- for non-EPUB formats in the future.
-    local callbacks = createDocumentCallbacks(self.document)
+    local callbacks = object:getLanguageSupportCallbacks()
     if not callbacks then
+        logger.dbg("language support: object does not support language plugins")
         return
     end
+
+    language_code = language_code or self.ui.doc_props.language or "unknown"
+    logger.dbg("language support: improving", language_code, "selection", selection)
 
     local new_pos0, new_pos1 = unpack(self:_findAndCallPlugin(
         language_code, "WordSelection",
         { text = selection.text, pos0 = selection.pos0, pos1 = selection.pos1, callbacks = callbacks }
     ) or {})
-    -- If no plugin could update the selection (or after "expansion" the
-    -- selection is the same) then we can safely skip all of the subsequent
-    -- re-selection work.
+
     if not new_pos0 or not new_pos1 or
         (new_pos0 == selection.pos0 and new_pos1 == selection.pos1) then
-        logger.dbg("language support: no plugin could improve the selection")
         return
     end
     logger.dbg("language support: updating selection\nfrom",
         selection.pos0, ":", selection.pos1, "\nto", new_pos0, ":", new_pos1)
 
-    -- We want to use native crengine text selection here, but we cannot use
-    -- getTextFromPositions because the conversion to and from screen
-    -- coordinates leads to issues with text selection of <ruby> text. In
-    -- addition, using getTextFromXPointers means we can select text not on the
-    -- screen. But this means we need to manually create the text selection
-    -- object returned by getTextFromPositions (though this is not a big deal
-    -- because we'd have to generate the sboxes anyway).
-    local new_text = self.document:getTextFromXPointers(new_pos0, new_pos1, true)
+    local new_text = callbacks.get_text_in_range(new_pos0, new_pos1)
     if not new_text then
-        -- This really shouldn't happen since we started with some text.
         logger.warn("language support: no text found in selection", new_pos0, ":", new_pos1)
         return
+    end
+
+    local sboxes
+    if callbacks.get_selection_sboxes then
+        sboxes = callbacks.get_selection_sboxes(new_pos0, new_pos1)
     end
 
     return {
         text = util.cleanupSelectedText(new_text),
         pos0 = new_pos0,
         pos1 = new_pos1,
-        sboxes = self.document:getScreenBoxesFromPositions(new_pos0, new_pos1, true),
+        sboxes = sboxes,
     }
-end
-
---- Called from widgets that hold text buffer (like TextBoxWidget) to improve selection.
--- @param selection Table with { text, pos0, pos1, callbacks }
--- @param language_code String
--- @return new_pos0, new_pos1 (or nil if no improvement)
-function LanguageSupport:improveBufferSelection(selection, language_code)
-    if not self:hasActiveLanguagePlugins() then return end
-
-    language_code = language_code or "unknown"
-
-    local new_pos0, new_pos1 = unpack(self:_findAndCallPlugin(
-        language_code, "WordSelection",
-        selection
-    ) or {})
-
-    if not new_pos0 or not new_pos1 or
-        (new_pos0 == selection.pos0 and new_pos1 == selection.pos1) then
-        return
-    end
-
-    return new_pos0, new_pos1
 end
 
 --- Called from ReaderHighlight:startSdcv after the selected has text has been

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -186,22 +186,19 @@ function DictQuickLookup:init()
                         end
 
                         if textbox and textbox.charlist then
-                            local callbacks = textbox:getLanguageSupportCallbacks()
-
-                            local new_pos0, new_pos1 = self.ui.languagesupport:improveBufferSelection({
+                            local result = self.ui.languagesupport:improveWordSelection({
                                 text = text,
                                 pos0 = pos0,
                                 pos1 = pos1,
-                                callbacks = callbacks
-                            }, lang)
+                            }, textbox, lang)
 
-                            if new_pos0 then
-                                textbox.highlight_start_idx = new_pos0
-                                textbox.highlight_end_idx = new_pos1
+                            if result then
+                                textbox.highlight_start_idx = result.pos0
+                                textbox.highlight_end_idx = result.pos1
                                 textbox:updateHighlight()
                                 textbox:redrawHighlight()
 
-                                text = callbacks.get_text_in_range(new_pos0, new_pos1)
+                                text = result.text
                             end
                         end
                     end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -178,7 +178,7 @@ function DictQuickLookup:init()
                 },
                 -- callback function when HoldReleaseText is handled as args
                 args = function(text, hold_duration, pos0, pos1)
-                    if self.ui and self.ui.languagesupport and pos0 and pos1 then
+                    if self.ui and self.ui.languagesupport and self.ui.languagesupport:hasActiveLanguagePlugins() and pos0 and pos1 then
                         local lang = self.lang
                         local textbox = nil
                         if self.stw_widget then

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -177,7 +177,35 @@ function DictQuickLookup:init()
                     range = range,
                 },
                 -- callback function when HoldReleaseText is handled as args
-                args = function(text, hold_duration)
+                args = function(text, hold_duration, pos0, pos1)
+                    if self.ui and self.ui.languagesupport and pos0 and pos1 then
+                        local lang = self.lang
+                        local textbox = nil
+                        if self.stw_widget then
+                            textbox = self.stw_widget.text_widget
+                        end
+
+                        if textbox and textbox.charlist then
+                            local callbacks = textbox:getLanguageSupportCallbacks()
+
+                            local new_pos0, new_pos1 = self.ui.languagesupport:improveBufferSelection({
+                                text = text,
+                                pos0 = pos0,
+                                pos1 = pos1,
+                                callbacks = callbacks
+                            }, lang)
+
+                            if new_pos0 then
+                                textbox.highlight_start_idx = new_pos0
+                                textbox.highlight_end_idx = new_pos1
+                                textbox:updateHighlight()
+                                textbox:redrawHighlight()
+
+                                text = callbacks.get_text_in_range(new_pos0, new_pos1)
+                            end
+                        end
+                    end
+
                     -- do this lookup in the same domain (dict/wikipedia)
                     local lookup_wikipedia = self.is_wiki
                     if hold_duration >= time.s(3) then

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -134,6 +134,20 @@ local TextBoxWidget = InputContainer:extend{
         -- right) of some lines in the provided text.
 }
 
+function TextBoxWidget:getLanguageSupportCallbacks()
+    return {
+        get_prev_char_pos = function(pos) return pos > 1 and pos - 1 or nil end,
+        get_next_char_pos = function(pos) return pos < #self.charlist and pos + 1 or nil end,
+        get_text_in_range = function(p0, p1)
+            if self._xtext then
+                return self._xtext:getText(p0, p1)
+            else
+                return table.concat(self.charlist, "", p0, p1)
+            end
+        end,
+    }
+end
+
 function TextBoxWidget:init()
     if not self._face_adjusted then
         self._face_adjusted = true -- only do that once

--- a/spec/unit/dictquicklookup_repro_spec.lua
+++ b/spec/unit/dictquicklookup_repro_spec.lua
@@ -1,0 +1,67 @@
+describe("DictQuickLookup interaction", function()
+    local DocumentRegistry, ReaderUI, UIManager, Screen
+    local readerui, dictionary
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        load_plugin("japanese.koplugin")
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        UIManager = require("ui/uimanager")
+        Screen = require("device").screen
+    end)
+
+    setup(function()
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument("spec/front/unit/data/sample.txt"),
+        }
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+        UIManager:quit()
+    end)
+
+    it("should use improveBufferSelection and expand selection when holding text", function()
+        dictionary = readerui.dictionary
+        dictionary:onLookupWord("test")
+        fastforward_ui_events()
+
+        local dict_window = dictionary.dict_window
+        assert.is_not_nil(dict_window)
+
+        local text_widget = dict_window.text_widget.text_widget
+        local text = "これは辞書です"
+        text_widget:setText(text)
+        assert.is_not_nil(text_widget.charlist)
+
+        local s_handleEvent = spy.on(readerui, "handleEvent")
+
+        local japanese_plugin = nil
+        for name, p in pairs(readerui.languagesupport.plugins) do
+            if name == "japanese" then japanese_plugin = p break end
+        end
+        assert.is_not_nil(japanese_plugin)
+
+        stub(japanese_plugin, "onWordSelection").returns({4, 5})
+
+        local hold_release_handler = dict_window.ges_events.HoldReleaseText.args
+        hold_release_handler("辞", 1.0, 4, 4)
+
+        assert.spy(s_handleEvent).was_called()
+
+        local found_lookup = false
+        for i, call in ipairs(s_handleEvent.calls) do
+            local event = call.vals[2]
+            if event and event.handler == "onLookupWord" then
+                found_lookup = true
+                assert.equal("辞書", event.args[1])
+            end
+        end
+        assert.is_true(found_lookup)
+
+        japanese_plugin.onWordSelection:revert()
+    end)
+end)

--- a/spec/unit/dictquicklookup_repro_spec.lua
+++ b/spec/unit/dictquicklookup_repro_spec.lua
@@ -24,7 +24,7 @@ describe("DictQuickLookup interaction", function()
         UIManager:quit()
     end)
 
-    it("should use improveBufferSelection and expand selection when holding text", function()
+    it("should use improveWordSelection and expand selection when holding text", function()
         dictionary = readerui.dictionary
         dictionary:onLookupWord("test")
         fastforward_ui_events()


### PR DESCRIPTION
This PR fixes an issue where selecting text in the dictionary lookup window would not trigger language-specific segmentation logic (e.g., for Japanese), resulting in incorrect selection of single characters instead of full words.

### Strategy
The fix involves three main parts:
1.  **LanguageSupport:** Added a new document-agnostic method `improveBufferSelection` that allows widgets to invoke language plugins by providing their own text access callbacks, removing the hard dependency on `crengine` document methods.
2.  **TextBoxWidget:** Implemented `getLanguageSupportCallbacks()` to provide a standardized way for language plugins to traverse the widget's internal character list. This logic was refactored out of the UI handlers to be reusable and idiomatic.
3.  **DictQuickLookup:** Updated the `HoldReleaseText` handler to invoke `improveBufferSelection` using the widget's new callback API. This allows plugins like `japanese.koplugin` to scan the text and improve the selection.

### Related Issues
- Closes #9408
- Relates to #8270

### Verification
A reproduction test case has been added in `spec/unit/dictquicklookup_repro_spec.lua`. This test mocks a Japanese text buffer and verifies that holding a single character correctly expands the selection to the full semantic word (e.g., expanding '辞' to '辞書') before triggering the dictionary lookup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14851)
<!-- Reviewable:end -->
