### PR TITLE
[ReaderDictionary] clean stress marks from selection for dict search

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -858,6 +858,8 @@ function ReaderDictionary:cleanSelection(text, is_sane)
         text = text:gsub("·", "") -- interpunct
         text = text:gsub("|", "") -- pipe
         text = text:gsub("↑", "") -- and up arrow, used in some dictionaries to indicate related words
+        text = text:gsub("ˈ", "") -- primary stress mark, used in phonetic transcriptions to indicate a stressed syllable
+        text = text:gsub("ˌ", "") -- secondary stress mark, used in phonetic transcriptions to indicate a weaker stressed syllable
         -- Strip some common english grammatical construct
         text = text:gsub("'s$", '') -- english possessive
         -- Strip some common french grammatical constructs


### PR DESCRIPTION
### what's new

* Improved text cleaning in `ReaderDictionary:cleanSelection` by stripping the primary (`ˈ`) and secondary (`ˌ`) stress marks commonly found in phonetic transcriptions.

<p align="center">
<img src="https://github.com/user-attachments/assets/827a233c-8cd7-4a03-bd53-9743b40e1bf4" width=40%> 
</p>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14856)
<!-- Reviewable:end -->
