### PR TITLE
feat(input): add stylus callback API for plugin integration

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -186,6 +186,10 @@ local Input = {
     ev_slots = nil, -- table
     gesture_detector = nil,
 
+    -- tool type constants (for stylus support)
+    TOOL_TYPE_FINGER = TOOL_TYPE_FINGER,  -- 0
+    TOOL_TYPE_PEN = TOOL_TYPE_PEN,        -- 1
+
     -- simple internal clipboard implementation, can be overridden to use system clipboard
     hasClipboardText = function()
         return _internal_clipboard_text ~= ""
@@ -1758,9 +1762,5 @@ function Input:inhibitInputUntil(set_or_seconds)
     UIManager:scheduleIn(delay_s, self._inhibitInputUntil_func)
     self:inhibitInput(true)
 end
-
--- Export tool type constants for plugins
-Input.TOOL_TYPE_FINGER = TOOL_TYPE_FINGER  -- 0
-Input.TOOL_TYPE_PEN = TOOL_TYPE_PEN        -- 1
 
 return Input

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -451,6 +451,57 @@ function Input:gestureAdjustHook(ges)
     -- do nothing by default
 end
 
+--[[--
+Register a callback for stylus/pen events.
+Called before gesture detection with fully-processed slot data.
+The callback receives the Input object and a slot table: {slot, id, x, y, tool, timev}
+Return true from the callback to "dominate" the event (remove from gesture detection).
+@param callback function(input, slot)
+]]
+function Input:registerStylusCallback(callback)
+    self.stylus_callback = callback
+    logger.info("Input: stylus callback registered, pen_slot =", self.pen_slot)
+end
+
+function Input:unregisterStylusCallback()
+    self.stylus_callback = nil
+    logger.info("Input: stylus callback unregistered")
+end
+
+--[[--
+Filter stylus events from MTSlots and route to callback.
+Called before gesture detection. Modifies self.MTSlots in place.
+--]]
+function Input:routeStylusEvents()
+    if not self.stylus_callback or #self.MTSlots == 0 then
+        return
+    end
+
+    local dominated_indices = {}
+
+    for i, slot in ipairs(self.MTSlots) do
+        -- Identify stylus by tool type OR pen slot
+        local is_stylus = (slot.tool == TOOL_TYPE_PEN) or
+                          (slot.slot == self.pen_slot)
+
+        if is_stylus then
+            logger.dbg("Input:routeStylusEvents: stylus detected in slot", slot.slot,
+                       "tool=", slot.tool, "id=", slot.id, "x=", slot.x, "y=", slot.y,
+                       "pen_slot=", self.pen_slot)
+            local dominated = self.stylus_callback(self, slot)
+            if dominated then
+                table.insert(dominated_indices, i)
+                logger.dbg("Input:routeStylusEvents: slot", slot.slot, "dominated, will remove from gesture detection")
+            end
+        end
+    end
+
+    -- Remove dominated slots in reverse order (preserves indices)
+    for i = #dominated_indices, 1, -1 do
+        table.remove(self.MTSlots, dominated_indices[i])
+    end
+end
+
 --- Catalog of predefined hooks.
 -- These are *not* usable directly as hooks, they're just building blocks (c.f., Kobo)
 function Input:adjustABS_SwitchXY(ev)
@@ -963,6 +1014,7 @@ function Input:handleTouchEv(ev)
                 self:setMtSlot(MTSlot.slot, "timev", time.timeval(ev.time))
             end
             -- feed ev in all slots to state machine
+            self:routeStylusEvents()
             local touch_gestures = self.gesture_detector:feedEvent(self.MTSlots)
             self:newFrame()
             local ges_evs = {}
@@ -1004,6 +1056,7 @@ function Input:handleMixedTouchEv(ev)
                 self:setMtSlot(MTSlot.slot, "timev", time.timeval(ev.time))
             end
             -- feed ev in all slots to state machine
+            self:routeStylusEvents()
             local touch_gestures = self.gesture_detector:feedEvent(self.MTSlots)
             self:newFrame()
             local ges_evs = {}
@@ -1069,6 +1122,7 @@ function Input:handleTouchEvSnow(ev)
                 self:setMtSlot(MTSlot.slot, "timev", time.timeval(ev.time))
             end
             -- feed ev in all slots to state machine
+            self:routeStylusEvents()
             local touch_gestures = self.gesture_detector:feedEvent(self.MTSlots)
             self:newFrame()
             local ges_evs = {}
@@ -1129,6 +1183,7 @@ function Input:handleTouchEvPhoenix(ev)
                 self:setMtSlot(MTSlot.slot, "timev", time.timeval(ev.time))
             end
             -- feed ev in all slots to state machine
+            self:routeStylusEvents()
             local touch_gestures = self.gesture_detector:feedEvent(self.MTSlots)
             self:newFrame()
             local ges_evs = {}
@@ -1178,6 +1233,7 @@ function Input:handleTouchEvLegacy(ev)
             end
 
             -- feed ev in all slots to state machine
+            self:routeStylusEvents()
             local touch_gestures = self.gesture_detector:feedEvent(self.MTSlots)
             self:newFrame()
             local ges_evs = {}
@@ -1702,5 +1758,9 @@ function Input:inhibitInputUntil(set_or_seconds)
     UIManager:scheduleIn(delay_s, self._inhibitInputUntil_func)
     self:inhibitInput(true)
 end
+
+-- Export tool type constants for plugins
+Input.TOOL_TYPE_FINGER = TOOL_TYPE_FINGER  -- 0
+Input.TOOL_TYPE_PEN = TOOL_TYPE_PEN        -- 1
 
 return Input

--- a/spec/unit/input_spec.lua
+++ b/spec/unit/input_spec.lua
@@ -9,6 +9,166 @@ describe("input module", function()
         Input = require("device").input
     end)
 
+    describe("stylus callback", function()
+        after_each(function()
+            -- Clean up after each test
+            Input:unregisterStylusCallback()
+            Input.MTSlots = {}
+        end)
+
+        describe("registerStylusCallback", function()
+            it("should register a callback function", function()
+                local callback = function() end
+                Input:registerStylusCallback(callback)
+                assert.is_equal(callback, Input.stylus_callback)
+            end)
+
+            it("should replace existing callback when registering new one", function()
+                local callback1 = function() return "first" end
+                local callback2 = function() return "second" end
+                Input:registerStylusCallback(callback1)
+                Input:registerStylusCallback(callback2)
+                assert.is_equal(callback2, Input.stylus_callback)
+            end)
+        end)
+
+        describe("unregisterStylusCallback", function()
+            it("should remove the registered callback", function()
+                local callback = function() end
+                Input:registerStylusCallback(callback)
+                assert.is_not_nil(Input.stylus_callback)
+                Input:unregisterStylusCallback()
+                assert.is_nil(Input.stylus_callback)
+            end)
+
+            it("should handle unregister when no callback registered", function()
+                Input.stylus_callback = nil
+                -- Should not error
+                Input:unregisterStylusCallback()
+                assert.is_nil(Input.stylus_callback)
+            end)
+        end)
+
+        describe("routeStylusEvents", function()
+            it("should do nothing when no callback registered", function()
+                Input.stylus_callback = nil
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_PEN },
+                }
+                Input:routeStylusEvents()
+                -- Slots should be unchanged
+                assert.is_equal(1, #Input.MTSlots)
+            end)
+
+            it("should do nothing when MTSlots is empty", function()
+                local called = false
+                Input:registerStylusCallback(function() called = true end)
+                Input.MTSlots = {}
+                Input:routeStylusEvents()
+                assert.is_false(called)
+            end)
+
+            it("should call callback for pen tool type", function()
+                local received_slot = nil
+                Input:registerStylusCallback(function(input, slot)
+                    received_slot = slot
+                    return false
+                end)
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_PEN },
+                }
+                Input:routeStylusEvents()
+                assert.is_not_nil(received_slot)
+                assert.is_equal(100, received_slot.x)
+                assert.is_equal(200, received_slot.y)
+                assert.is_equal(Input.TOOL_TYPE_PEN, received_slot.tool)
+            end)
+
+            it("should call callback for pen_slot match", function()
+                local received_slot = nil
+                Input.pen_slot = 1
+                Input:registerStylusCallback(function(input, slot)
+                    received_slot = slot
+                    return false
+                end)
+                Input.MTSlots = {
+                    { slot = 1, id = 1, x = 150, y = 250, tool = Input.TOOL_TYPE_FINGER },
+                }
+                Input:routeStylusEvents()
+                assert.is_not_nil(received_slot)
+                assert.is_equal(150, received_slot.x)
+                assert.is_equal(1, received_slot.slot)
+            end)
+
+            it("should not call callback for finger events", function()
+                local called = false
+                Input.pen_slot = nil
+                Input:registerStylusCallback(function()
+                    called = true
+                    return false
+                end)
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_FINGER },
+                }
+                Input:routeStylusEvents()
+                assert.is_false(called)
+            end)
+
+            it("should remove dominated slots from MTSlots", function()
+                Input:registerStylusCallback(function()
+                    return true  -- dominate
+                end)
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_PEN },
+                }
+                assert.is_equal(1, #Input.MTSlots)
+                Input:routeStylusEvents()
+                assert.is_equal(0, #Input.MTSlots)
+            end)
+
+            it("should keep non-dominated slots in MTSlots", function()
+                Input:registerStylusCallback(function()
+                    return false  -- don't dominate
+                end)
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_PEN },
+                }
+                Input:routeStylusEvents()
+                assert.is_equal(1, #Input.MTSlots)
+            end)
+
+            it("should handle mixed stylus and finger events", function()
+                local stylus_count = 0
+                Input:registerStylusCallback(function()
+                    stylus_count = stylus_count + 1
+                    return true  -- dominate stylus events
+                end)
+                Input.MTSlots = {
+                    { slot = 0, id = 1, x = 100, y = 200, tool = Input.TOOL_TYPE_FINGER },
+                    { slot = 1, id = 2, x = 150, y = 250, tool = Input.TOOL_TYPE_PEN },
+                    { slot = 2, id = 3, x = 200, y = 300, tool = Input.TOOL_TYPE_FINGER },
+                }
+                Input:routeStylusEvents()
+                -- Only pen event should trigger callback
+                assert.is_equal(1, stylus_count)
+                -- Pen slot should be removed, finger slots remain
+                assert.is_equal(2, #Input.MTSlots)
+                assert.is_equal(Input.TOOL_TYPE_FINGER, Input.MTSlots[1].tool)
+                assert.is_equal(Input.TOOL_TYPE_FINGER, Input.MTSlots[2].tool)
+            end)
+        end)
+
+        describe("tool type constants", function()
+            it("should export TOOL_TYPE_FINGER", function()
+                assert.is_equal(0, Input.TOOL_TYPE_FINGER)
+            end)
+
+            it("should export TOOL_TYPE_PEN", function()
+                assert.is_equal(1, Input.TOOL_TYPE_PEN)
+            end)
+        end)
+    end)
+
     describe("handleTouchEvPhoenix", function()
 --[[
 -- a touch looks something like this (from H2Ov1)


### PR DESCRIPTION
Summary
Adds a stylus callback API to the Input module, allowing plugins to intercept stylus/pen events before gesture detection.

Motivation
Plugins that handle stylus input (e.g., annotation/drawing tools) need access to raw stylus events with minimal latency. Currently, stylus events go through the gesture detection
 pipeline, which adds overhead and doesn't expose the data plugins need.

Changes
- Input:registerStylusCallback(callback) / Input:unregisterStylusCallback() - Register a callback to receive stylus events
- Input:routeStylusEvents() - Filters stylus events from MTSlots and routes to callback before gesture detection
- Callbacks can return true to "dominate" events, removing them from the gesture pipeline
- Export TOOL_TYPE_FINGER and TOOL_TYPE_PEN constants for plugin use

Implementation Details
- Stylus events are identified by TOOL_TYPE_PEN or matching pen_slot
- Callback receives the Input object and slot data: {slot, id, x, y, tool, timev}
- Zero impact when no callback registered (early return)
- Added to all touch handlers: handleTouchEv, handleMixedTouchEv, handleTouchEvSnow, handleTouchEvPhoenix, handleTouchEvLegacy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14862)
<!-- Reviewable:end -->
