### PR TITLE
feat(calibre) - add collection creation from tags

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -279,6 +279,24 @@ function Calibre:getWirelessMenuTable()
             end,
         },
         {
+            text = _("Create collections from tags"),
+            enabled_func = isEnabled,
+            checked_func = function()
+                return G_reader_settings:isTrue("calibre_collections_from_tags")
+            end,
+            callback = function()
+                G_reader_settings:toggle("calibre_collections_from_tags")
+            end,
+        },
+        {
+            text = _("Sync collections from tags now"),
+            enabled_func = isEnabled,
+            keep_menu_open = true,
+            callback = function()
+                CalibreWireless:syncCollectionsFromTags()
+            end,
+        },
+        {
             text_func = function()
                 local address = _("automatic")
                 if G_reader_settings:has("calibre_wireless_url") then


### PR DESCRIPTION
Allows users to enable the option to create koreader collections from their calibre tags

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14865)
<!-- Reviewable:end -->
