### PR TITLE
feat (reader): Add option to add custom bottom padding to footnote popup

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -299,6 +299,10 @@ local function isPreferFootnoteEnabled()
     return G_reader_settings:isTrue("link_prefer_footnote")
 end
 
+local function isFootnoteLinkInPopupExtraBottomPaddingEnabled()
+    return G_reader_settings:isTrue("footnote_popup_add_bottom_padding")
+end
+
 local function isSwipeToGoBackEnabled()
     return G_reader_settings:isTrue("swipe_to_go_back")
 end
@@ -351,6 +355,59 @@ From the footnote popup, you can jump to the footnote location in the book by sw
                         not isPreferFootnoteEnabled())
                 end,
                 help_text = _([[Loosen footnote detection rules to show more links as footnotes.]]),
+                separator = Device:isTouchDevice() and true or false,
+            },
+            {
+                text = _("Add footnote popup bottom padding"),
+                enabled_func = function()
+                    return isFootnoteLinkInPopupEnabled() and
+                        (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
+                end,
+                checked_func = function()
+                    return G_reader_settings:isTrue("footnote_popup_add_bottom_padding")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("footnote_popup_add_bottom_padding")
+                end,
+                help_text = _([[
+Add adjustable bottom padding to the footnote popup, so that the footnote content is moved further from the bottom edge of the screen. Especially useful for screens with rounded corners.]]),
+            },
+            {
+                text = _("Set footnote popup bottom padding size"),
+                enabled_func = function()
+                    return isFootnoteLinkInPopupExtraBottomPaddingEnabled() and
+                        (isTapToFollowLinksOn() or isSwipeToFollowNearestLinkEnabled())
+                end,
+                keep_menu_open = true,
+                callback = function()
+                    local spin_widget
+                    local get_bottom_padding_size_widget
+                    get_bottom_padding_size_widget = function(show_bottom_padding_size_widget)
+                        local SpinWidget = require("ui/widget/spinwidget")
+                        if show_bottom_padding_size_widget then
+                            spin_widget = SpinWidget:new{
+                                width = math.floor(Screen:getWidth() * 0.75),
+                                value = G_reader_settings:readSetting("footnote_popup_bottom_padding_size")
+                                                or Screen:scaleBySize(0),
+                                value_min = 0,
+                                value_max = 255,
+                                precision = "%d",
+                                ok_text = _("Set bottom padding size"),
+                                title_text =  _("Set footnote popup bottom padding size"),
+                                info_text = _([[
+The padding for the bottom of the footnote popup can be increased to move the text further from the bottom edge, which is especially useful for screens with rounded corners.]]),
+                                callback = function(spin)
+                                    G_reader_settings:saveSetting("footnote_popup_bottom_padding_size", spin.value)
+                                end,
+                            }
+                        end
+                        return spin_widget
+                    end
+                    local show_bottom_padding_size_widget = G_reader_settings:has("footnote_popup_add_bottom_padding")
+                    spin_widget = get_bottom_padding_size_widget(show_bottom_padding_size_widget)
+                    UIManager:show(spin_widget)
+                end,
+                help_text = _([[The footnote popup bottom padding can be adjusted to move the content further from the screen edge.]]),
                 separator = Device:isTouchDevice() and true or false,
             },
             {

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -308,6 +308,11 @@ function FootnoteWidget:init()
     local padding_top = Size.padding.large
     local padding_bottom = Size.padding.large
     local htmlwidget_height = self.height - padding_top - padding_bottom
+    if G_reader_settings:isTrue("footnote_popup_add_bottom_padding") then
+        local padding_bottom_extra =  Screen:scaleBySize(G_reader_settings:readSetting("footnote_popup_bottom_padding_size"))
+        padding_bottom = padding_bottom + padding_bottom_extra
+        htmlwidget_height = self.height - padding_top - padding_bottom + padding_bottom_extra
+    end
 
     -- We always get balanced XHTML from crengine for HTML snippets, so we
     -- pass is_xhtml=true to avoid side effects from MuPDF's HTML5 parser.


### PR DESCRIPTION
Quite a lot of phones now have rounded screen corners, meaning that content all the way in the corner risks ending up outside of the physical screen. This happens with footnote popups, where a character or two in the two bottom corners ends up not being shown on screen, or only partially.

This problem can be solved by adding an adjustable bottom margin to the popup widget, so that all the content is pushed a given amount away from the screen edge.

I have made a proof of concept, as there are some things I am not very familiar with in the codebase, so I'd appreciate if someone has any pointers to what could be improved. For instance, I'm not exactly sure the units used are the best ones for the purpose, and if that logic is implemented correctly, although it seems to work as a concept at least. Also, the help texts etc. could probably be improved?

I have no experience building koreader from source though, so I have only tried the frontend changes on the source code in the zip file in release 2025.10.

The added settings:
<img width="566" height="279" alt="New menu entries" src="https://github.com/user-attachments/assets/37ec0230-51e8-46fd-9390-b7269eda6d32" />

Widget to set the custom value:
<img width="566" height="528" alt="Widget" src="https://github.com/user-attachments/assets/7f59a3d6-d1dd-4b34-8eb9-5a62db3544c4" />

Before (no extra padding):
<img width="565" height="777" alt="Before" src="https://github.com/user-attachments/assets/687a0931-7783-4bdf-84e8-da313367650b" />

After:
<img width="566" height="776" alt="After" src="https://github.com/user-attachments/assets/330f3d37-d1dc-4add-91d9-b72cb749983a" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14866)
<!-- Reviewable:end -->
