### PR TITLE
NewsDownloader: Add URL path encoding to improve request handling

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -10,8 +10,8 @@ local socket = require("socket")
 local socket_url = require("socket.url")
 local socketutil = require("socketutil")
 local time = require("ui/time")
-local _ = require("gettext")
 local util = require("util")
+local _ = require("gettext")
 local T = ffiutil.template
 
 local function removeSubstring(str, substr)


### PR DESCRIPTION
# Original problem
I use the News/Feed Downloader to download webcomics. As I am using it, there are some images that could not be downloaded if it contains blank spaces in its path, i.e. [https://fandogamia.com/fanternet/content/nadadelotromundo/Curso de cocina para exdioses - 034.jpg](https://fandogamia.com/fanternet/content/nadadelotromundo/Curso de cocina para exdioses - 034.jpg).

# Solution
I have implemented a small function that, according to the [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), converts invalid path characters to their percent-encoded equivalent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14870)
<!-- Reviewable:end -->
