### PR TITLE
fix(calibre-plugin): ensure size is correctly parsed as a number in book info in search

### DIFF
--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -141,7 +141,7 @@ local function getBookInfo(book)
         end
         return id
     end
-    -- all entries can be empty, except size, which is always filled by calibre.
+    -- All entries can be empty.
     local title = _("Title:") .. " " .. (book.title or "-")
     local authors = _("Author(s):") .. " " .. (getEntries(book.authors) or "-")
     local size = _("Size:") .. " " .. (util.getFriendlySize(book.size) or _("Unknown"))


### PR DESCRIPTION
This function was causing a crash on koreader if a value was `nil`. It happened to me multiple times over the last few months when using calibre with fanfictions, which alter book files when updating.

Here is a simple fix to prevent the crash by parsing before accessing the value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14881)
<!-- Reviewable:end -->
