### PR TITLE
docs: update macOS build requirements

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -19,7 +19,7 @@ To get and compile the source you must have:
 - `gettext`
 - `git`
 - `make`: version >= 4.1 (recommended: >= 4.4 for transparent `-j` / `-l` handling)
-- `meson`: version >= 1.2.0
+- `meson`: version >= 1.2.0 on Linux, >= 1.8.3 on macOS
 - `nasm`
 - `ninja` (recommended: >= 1.13.2 for make job server support)
 - `patch`


### PR DESCRIPTION
Need meson >= 1.8.3 to work around koreader/koreader-base#2258.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14894)
<!-- Reviewable:end -->
