### PR TITLE
[TextViewer] bug fix, don't crash on Menu press

### DIFF
--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -711,7 +711,7 @@ function TextViewer:setTextBold(start_pos, len)
 end
 
 function TextViewer:onShowMenu()
-    if not self.titlebar.left_icon then return end -- Menu could be triggered with a key event.
+    if not self.show_menu then return end -- Menu could be triggered with a key event.
     local dialog
     local buttons = {
         {{
@@ -764,9 +764,7 @@ function TextViewer:onShowMenu()
         shrink_unneeded_width = true,
         buttons = buttons,
         anchor = function()
-            if self.titlebar.left_button then
-                return self.titlebar.left_button.image.dimen
-            end
+            return self.titlebar.left_button.image.dimen
         end,
     }
     UIManager:show(dialog)


### PR DESCRIPTION
### bug fix

  * Added a check in `onShowMenu()` to ensure `self.titlebar.left_icon` exists before proceeding, preventing errors if the menu is triggered via a key event and the icon is missing.
  * Updated the anchor logic for the menu dialog to only access `self.titlebar.left_button` if it exists, avoiding potential nil reference errors.


```
./luajit: frontend/ui/widget/textviewer.lua:770: attempt to index field 'left_button' (a nil value)
stack traceback:
        frontend/ui/widget/textviewer.lua:770: in function 'anchor'
        frontend/ui/widget/container/movablecontainer.lua:128: in function 'ensureAnchor'
        frontend/ui/widget/container/movablecontainer.lua:192: in function 'paintTo'
        frontend/ui/widget/container/centercontainer.lua:31: in function 'paintTo'
        frontend/ui/widget/container/inputcontainer.lua:91: in function 'paintTo'
        frontend/ui/widget/buttondialog.lua:355: in function 'paintTo'
        frontend/ui/uimanager.lua:1258: in function '_repaint'
        frontend/ui/uimanager.lua:1481: in function 'handleInput'
        frontend/ui/uimanager.lua:1581: in function 'run'
        reader.lua:280: in main chunk
        [C]: at 0x010db2f890
make: *** [make/emulator.mk:20: run] Error 1
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14936)
<!-- Reviewable:end -->
