### PR TITLE
[InputText, ReaderStyleTweak] add copy/paste to NT devices

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -162,21 +162,6 @@ function TweakInfoWidget:init()
     }
 
     if Device:hasDPad() then
-        self.css_frame.onFocus = function(this)
-            if not this._focused then
-                this._orig_inner_bordersize = this.inner_bordersize
-                this.inner_bordersize = this.focus_border_size
-                this._focused = true
-            end
-            UIManager:setDirty(this, "ui")
-        end
-        self.css_frame.onUnfocus = function(this)
-            if this._focused then
-                this.inner_bordersize = this._orig_inner_bordersize
-                this._focused = false
-            end
-            UIManager:setDirty(this, "ui")
-        end
         self.css_frame.onPress = function()
             local item = self:getFocusItem()
             if item == self.css_frame and Device:hasClipboard() then

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -13,7 +13,7 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local InfoMessage = require("ui/widget/infomessage")
-local InputContainer = require("ui/widget/container/inputcontainer")
+local FocusManager = require("ui/widget/focusmanager")
 local MovableContainer = require("ui/widget/container/movablecontainer")
 local Notification = require("ui/widget/notification")
 local Size = require("ui/size")
@@ -31,7 +31,7 @@ local Screen = Device.screen
 local T = require("ffi/util").template
 
 -- Simple widget for showing tweak info
-local TweakInfoWidget = InputContainer:extend{
+local TweakInfoWidget = FocusManager:extend{
     tweak = nil,
     is_global_default = nil,
     toggle_global_default_callback = function() end,
@@ -158,6 +158,28 @@ function TweakInfoWidget:init()
         show_parent = self,
     }
 
+    if Device:hasDPad() then
+        self.css_frame.onFocus = function(this)
+            this.bordersize = Size.border.thick
+            UIManager:setDirty(this, "ui")
+        end
+        self.css_frame.onUnfocus = function(this)
+            this.bordersize = Size.border.thin
+            UIManager:setDirty(this, "ui")
+        end
+        self.css_frame.onPress = function()
+            local item = self:getFocusItem()
+            if item == self.css_frame and Device:hasClipboard() then
+                self:copyTextToClipboard(self.css_text)
+                return true
+            end
+        end
+        self.layout = {}
+        table.insert(self.layout, 1, { self.css_frame })
+        self:mergeLayoutInVertical(button_table)
+        self:refocusWidget()
+    end
+
     self.movable = MovableContainer:new{
         FrameContainer:new{
             background = Blitbuffer.COLOR_WHITE,
@@ -207,10 +229,7 @@ function TweakInfoWidget:onTap(arg, ges)
         -- Tap inside CSS text copies it into clipboard (so it
         -- can be pasted into the book-specific tweak editor)
         -- (Add \n on both sides for easier pasting)
-        Device.input.setClipboardText("\n"..self.css_text.."\n")
-        UIManager:show(Notification:new{
-            text = _("CSS text copied to clipboard"),
-        })
+        self:copyTextToClipboard(self.css_text)
         return true
     elseif ges.pos:notIntersectWith(self.movable.dimen) then
         -- Tap outside closes widget
@@ -218,6 +237,14 @@ function TweakInfoWidget:onTap(arg, ges)
         return true
     end
     return false
+end
+
+function TweakInfoWidget:copyTextToClipboard(text)
+    Device.input.setClipboardText("\n"..text.."\n")
+    UIManager:show(Notification:new{
+        text = _("CSS text copied to clipboard"),
+    })
+    return true
 end
 
 function TweakInfoWidget:onSelect()

--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -161,10 +161,12 @@ function TweakInfoWidget:init()
         show_parent = self,
     }
 
-    if Device:hasDPad() then
+    -- Note: for devices with DPad but no clipboard, button_table is a FocusManager
+    --       so the widget should work correctly nonetheless.
+    if Device:hasDPad() and Device:hasClipboard() then
         self.css_frame.onPress = function()
             local item = self:getFocusItem()
-            if item == self.css_frame and Device:hasClipboard() then
+            if item == self.css_frame then
                 self:copyTextToClipboard(self.css_text)
                 return true
             end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -173,6 +173,7 @@ local function initTouchEvents()
         end
 
         function InputText:onHoldTextBox(arg, ges)
+            -- Logic moved below as it is also used when not isTouchDevice
             self:holdTextBox(arg, ges)
             return true
         end

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -173,117 +173,7 @@ local function initTouchEvents()
         end
 
         function InputText:onHoldTextBox(arg, ges)
-            if self.parent.onSwitchFocus then
-                self.parent:onSwitchFocus(self)
-            end
-            -- clipboard dialog
-            self._hold_handled = nil
-            if Device:hasClipboard() then
-                if self.do_select then -- select mode on
-                    if self.selection_start_pos then -- select end
-                        local selection_end_pos = self.charpos - 1
-                        if self.selection_start_pos > selection_end_pos then
-                            self.selection_start_pos, selection_end_pos = selection_end_pos + 1, self.selection_start_pos - 1
-                        end
-                        local txt = table.concat(self.charlist, "", self.selection_start_pos, selection_end_pos)
-                        Device.input.setClipboardText(txt)
-                        UIManager:show(Notification:new{
-                            text = _("Selection copied to clipboard."),
-                        })
-                        self.selection_start_pos = nil
-                        self.do_select = false
-                        self:initTextBox()
-                    else -- select start
-                        self.selection_start_pos = self.charpos
-                        UIManager:show(Notification:new{
-                            text = _("Set cursor to end of selection, then long-press in text box."),
-                        })
-                    end
-                    self._hold_handled = true
-                    return true
-                end
-                local clipboard_value = Device.input.getClipboardText()
-                local is_clipboard_empty = clipboard_value == ""
-                local clipboard_dialog
-                clipboard_dialog = require("ui/widget/textviewer"):new{
-                    title = _("Clipboard"),
-                    show_menu = false,
-                    text = is_clipboard_empty and _("(empty)") or clipboard_value,
-                    fgcolor = is_clipboard_empty and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_BLACK,
-                    width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8),
-                    height = math.floor(math.max(Screen:getWidth(), Screen:getHeight()) * 0.4),
-                    justified = false,
-                    modal = true,
-                    stop_events_propagation = true,
-                    buttons_table = {
-                        {
-                            {
-                                text = _("Copy all"),
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    Device.input.setClipboardText(table.concat(self.charlist))
-                                    UIManager:show(Notification:new{
-                                        text = _("All text copied to clipboard."),
-                                    })
-                                end,
-                            },
-                            {
-                                text = _("Copy line"),
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    local txt = table.concat(self.charlist, "", self:getStringPos())
-                                    Device.input.setClipboardText(txt)
-                                    UIManager:show(Notification:new{
-                                        text = _("Line copied to clipboard."),
-                                    })
-                                end,
-                            },
-                            {
-                                text = _("Copy word"),
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    local txt = table.concat(self.charlist, "", self:getStringPos(true))
-                                    Device.input.setClipboardText(txt)
-                                    UIManager:show(Notification:new{
-                                        text = _("Word copied to clipboard."),
-                                    })
-                                end,
-                            },
-                        },
-                        {
-                            {
-                                text = _("Delete all"),
-                                enabled = #self.charlist > 0,
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    self:delAll()
-                                end,
-                            },
-                            {
-                                text = _("Select"),
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    UIManager:show(Notification:new{
-                                        text = _("Set cursor to start of selection, then long-press in text box."),
-                                    })
-                                    self.do_select = true
-                                    self:initTextBox()
-                                end,
-                            },
-                            {
-                                text = _("Paste"),
-                                enabled = not is_clipboard_empty,
-                                callback = function()
-                                    UIManager:close(clipboard_dialog)
-                                    self:addChars(clipboard_value)
-                                end,
-                            },
-                        },
-                    },
-                }
-                UIManager:show(clipboard_dialog)
-            end
-            self._hold_handled = true
+            self:holdTextBox(arg, ges)
             return true
         end
 
@@ -715,6 +605,8 @@ function InputText:onKeyPress(key)
             self:upLine()
         elseif key["Down"] then
             self:downLine()
+        elseif key["Press"] then
+            self:holdTextBox()
         elseif key["Home"] then
             if self.keyboard:isVisible() then
                 self:onCloseKeyboard()
@@ -796,6 +688,121 @@ function InputText:onShowKeyboard(ignore_first_hold_release)
     if self.keyboard then
         self.keyboard:showKeyboard(ignore_first_hold_release)
     end
+    return true
+end
+
+function InputText:holdTextBox(arg, ges)
+    if self.parent.onSwitchFocus then
+        self.parent:onSwitchFocus(self)
+    end
+    -- clipboard dialog
+    self._hold_handled = nil
+    if Device:hasClipboard() then
+        if self.do_select then -- select mode on
+            if self.selection_start_pos then -- select end
+                local selection_end_pos = self.charpos - 1
+                if self.selection_start_pos > selection_end_pos then
+                    self.selection_start_pos, selection_end_pos = selection_end_pos + 1, self.selection_start_pos - 1
+                end
+                local txt = table.concat(self.charlist, "", self.selection_start_pos, selection_end_pos)
+                Device.input.setClipboardText(txt)
+                UIManager:show(Notification:new{
+                    text = _("Selection copied to clipboard."),
+                })
+                self.selection_start_pos = nil
+                self.do_select = false
+                self:initTextBox()
+            else -- select start
+                self.selection_start_pos = self.charpos
+                UIManager:show(Notification:new{
+                    text = _("Set cursor to end of selection, then long-press in text box."),
+                })
+            end
+            self._hold_handled = true
+            return true
+        end
+        local clipboard_value = Device.input.getClipboardText()
+        local is_clipboard_empty = clipboard_value == ""
+        local clipboard_dialog
+        clipboard_dialog = require("ui/widget/textviewer"):new{
+            title = _("Clipboard"),
+            show_menu = false,
+            text = is_clipboard_empty and _("(empty)") or clipboard_value,
+            fgcolor = is_clipboard_empty and Blitbuffer.COLOR_DARK_GRAY or Blitbuffer.COLOR_BLACK,
+            width = math.floor(math.min(Screen:getWidth(), Screen:getHeight()) * 0.8),
+            height = math.floor(math.max(Screen:getWidth(), Screen:getHeight()) * 0.4),
+            justified = false,
+            modal = true,
+            stop_events_propagation = true,
+            buttons_table = {
+                {
+                    {
+                        text = _("Copy all"),
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            Device.input.setClipboardText(table.concat(self.charlist))
+                            UIManager:show(Notification:new{
+                                text = _("All text copied to clipboard."),
+                            })
+                        end,
+                    },
+                    {
+                        text = _("Copy line"),
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            local txt = table.concat(self.charlist, "", self:getStringPos())
+                            Device.input.setClipboardText(txt)
+                            UIManager:show(Notification:new{
+                                text = _("Line copied to clipboard."),
+                            })
+                        end,
+                    },
+                    {
+                        text = _("Copy word"),
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            local txt = table.concat(self.charlist, "", self:getStringPos(true))
+                            Device.input.setClipboardText(txt)
+                            UIManager:show(Notification:new{
+                                text = _("Word copied to clipboard."),
+                            })
+                        end,
+                    },
+                },
+                {
+                    {
+                        text = _("Delete all"),
+                        enabled = #self.charlist > 0,
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            self:delAll()
+                        end,
+                    },
+                    {
+                        text = _("Select"),
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            UIManager:show(Notification:new{
+                                text = _("Set cursor to start of selection, then long-press in text box."),
+                            })
+                            self.do_select = true
+                            self:initTextBox()
+                        end,
+                    },
+                    {
+                        text = _("Paste"),
+                        enabled = not is_clipboard_empty,
+                        callback = function()
+                            UIManager:close(clipboard_dialog)
+                            self:addChars(clipboard_value)
+                        end,
+                    },
+                },
+            },
+        }
+        UIManager:show(clipboard_dialog)
+    end
+    self._hold_handled = true
     return true
 end
 


### PR DESCRIPTION
### what's new

* Replaced `InputContainer` with `FocusManager` in `TweakInfoWidget`, enabling better focus handling and D-pad navigation for the CSS tweak info widget (`frontend/apps/reader/modules/readerstyletweak.lua`). 
* Added D-pad support and focus callbacks in the CSS tweak widget, so users can copy CSS text to clipboard using D-pad and receive visual feedback on focus state (`frontend/apps/reader/modules/readerstyletweak.lua`).
* Refactored clipboard copy logic into a new `copyTextToClipboard` method, used both for tap and D-pad press events, reducing code duplication (`frontend/apps/reader/modules/readerstyletweak.lua`). 

* Moved clipboard dialog and selection logic from `onHoldTextBox` to a new reusable `holdTextBox` method in `InputText`, simplifying event handling and enabling invocation from both touch and keyboard events (`frontend/ui/widget/inputtext.lua`). 
* Enabled triggering the clipboard dialog via keyboard "Press" events, improving accessibility for keyboard users (`frontend/ui/widget/inputtext.lua`).

### related issues

* closes https://github.com/koreader/koreader/issues/12772

### screen recording

 <details>
  <summary>expand to see</summary>
  
<div align="center">
  <img src="https://github.com/user-attachments/assets/2fe6722e-9846-4fe3-9f8c-5155ba355b2a" alt="name" width="400" />
</div>
  
</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14941)
<!-- Reviewable:end -->
