### PR TITLE
[PB623] fix crashing due to NetMgrPing() missing

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -25,7 +25,6 @@ local PocketBook = Generic:extend{
     isPocketBook = yes,
     hasOTAUpdates = yes,
     hasWifiToggle = yes,
-    hasNetMgrPing = yes,
     isTouchDevice = yes,
     hasKeys = yes,
     hasFrontlight = yes,
@@ -364,7 +363,8 @@ function PocketBook:initNetworkManager(NetworkMgr)
         UIManager:unschedule(keepWifiAlive)
 
         if NetworkMgr:isWifiOn() then
-            if self.hasNetMgrPing() then
+            -- check if NetMgrPing is available on the device and skip keepalive if not
+            if pcall(function() return inkview.NetMgrPing and true end) then
                 logger.dbg("ping wifi keep alive and reschedule")
 
                 inkview.NetMgrPing()
@@ -579,7 +579,6 @@ local PocketBook622 = PocketBook:extend{
 local PocketBook623 = PocketBook:extend{
     model = "PBTouchLux",
     display_dpi = 212,
-    hasNetMgrPing = no,
 }
 
 -- PocketBook Basic Touch (624)


### PR DESCRIPTION
The latest firmware version of the PocketBook Touch Lux (623), `W623.4.4.614`, does not provide the `inkview.NetMgrPing()` function. This leads to the application crashing after WiFi is activated and the keepalive is to be scheduled.

Indicating function availability via the new member `hasNetMgrPing` and only calling the function if it is marked as available, circumvents the crash, which looks originally like this:

```
./luajit: frontend/device/pocketbook/device.lua:364: /usr/lib/libinkview.so: undefined symbol: NetMgrPing
stack traceback:
	[C]: in function '__index'
	frontend/device/pocketbook/device.lua:364: in function 'keepWifiAlive'
	frontend/device/pocketbook/device.lua:374: in function 'requestToTurnOnWifi'
	frontend/ui/network/manager.lua:339: in function 'enableWifi'
	frontend/ui/network/manager.lua:406: in function 'toggleWifiOn'
	frontend/ui/network/manager.lua:860: in function 'callback'
	frontend/ui/widget/touchmenu.lua:874: in function 'onMenuSelect'
	frontend/ui/widget/touchmenu.lua:218: in function 'handleEvent'
	frontend/ui/widget/container/inputcontainer.lua:266: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	...
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/ui/uimanager.lua:896: in function 'sendEvent'
	frontend/ui/uimanager.lua:53: in function '__default__'
	frontend/ui/uimanager.lua:1423: in function 'handleInputEvent'
	frontend/ui/uimanager.lua:1523: in function 'handleInput'
	frontend/ui/uimanager.lua:1567: in function 'run'
	./reader.lua:280: in main chunk
	[C]: at 0x00013ee1
Segmentation fault
```

The default value for the new member is `yes` and thus does not affect other devices - except for the 623 model, for which the function is marked `no`. Maybe other, older PocketBook devices are also affects, but I have only the 623 at hand for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14961)
<!-- Reviewable:end -->
