### PR TITLE
bump base & crengine: CSS enhancements and other fixes

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1919,12 +1919,6 @@ function ReaderHighlight:onHoldPan(_, ges)
 
     local old_text = self.selected_text and self.selected_text.text
     self.selected_text = self.ui.document:getTextFromPositions(self.hold_pos, self.holdpan_pos)
-    if self.selected_text and self.selected_text.sboxes and #self.selected_text.sboxes == 0 then
-        -- abort highlighting if crengine doesn't provide sboxes for current positions
-        -- may happen in TXT files with disabled txt_preformatted
-        self:clear()
-        return true
-    end
     self.is_word_selection = false
 
     if self.selected_text and self.selected_text.pos0 then
@@ -2522,7 +2516,7 @@ function ReaderHighlight:extendSelection()
         -- pos0 and pos1 are in order within highlights
         new_pos0 = self.ui.document:compareXPointers(item1.pos0, item2_pos0) == 1 and item1.pos0 or item2_pos0
         new_pos1 = self.ui.document:compareXPointers(item1.pos1, item2_pos1) == 1 and item2_pos1 or item1.pos1
-        new_pboxes = self.document:getScreenBoxesFromPositions(new_pos0, new_pos1)
+        new_pboxes = self.document:getScreenBoxesFromPositions(new_pos0, new_pos1, true)
         -- true to draw
         new_text = self.ui.document:getTextFromXPointers(new_pos0, new_pos1, true)
     end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -688,7 +688,7 @@ function CreDocument:getTextFromPositions(pos0, pos1, do_not_draw_selection)
         drawSelection, drawSegmentedSelection)
     logger.dbg("CreDocument: get text range", text_range)
     if text_range then
-        local line_boxes = self:getScreenBoxesFromPositions(text_range.pos0, text_range.pos1)
+        local line_boxes = self:getScreenBoxesFromPositions(text_range.pos0, text_range.pos1, true)
         return {
             text = text_range.text,
             pos0 = text_range.pos0,


### PR DESCRIPTION
#### bump base & crengine: CSS enhancements and other fixes

Includes:
- https://github.com/koreader/crengine/pull/647
  - Add support for CSS width: `fit-content`
- https://github.com/koreader/crengine/pull/648
  - fb2def.h: add a few common attributes
    Closes #14829 (not certain it does, but it could, so let's close it)
  - lvtext: includes `src->t.offset` in `word->t.start`
  - CSS: support for pseudo element `::first-letter`
    Closes #6944.
    Closes #9142.
    Closes #14391 (even if not yet ::first-line)
- https://github.com/koreader/crengine/pull/649
  - `::first-letter`: fix when single letter text node
  - `ldomXPointer::getRectEx()`: return optional context
  - `ldomXRange::getSegmentRects()`: fix when BiDi/RTL
- https://github.com/koreader/crengine/pull/651
  - `testAuthorDotTitleFormat`: fix off-by-one error for last character in bookTitle
    Closes #14971.
- https://github.com/koreader/crengine/pull/650
  - Epub ncx TOC: don't skip items with invalid href 
  - Avoid some compiler warnings
  - `ldomDocument::createXPointer(pt)`: better consistency
- https://github.com/koreader/crengine/pull/652
  - CSS: add support for `ruby-position: over/under/alternate`
    Closes #14970.
  - MathML: don't handle anything when no def style set
    Closes #14974.

base/cre.cpp https://github.com/koreader/koreader-base/pull/2270
- add requestRender()
- getTextFromPositions(): improvements
  Closes #12135.

base:
- Fix offs_x/offs_y typo in BB_add_blit_from fast path https://github.com/koreader/koreader-base/pull/2266
- lua-Spore: fix matching plain application/json https://github.com/koreader/koreader-base/pull/2267
  Closes #14972.
- libpng: update to 1.6.55 https://github.com/koreader/koreader-base/pull/2268
- luajit: update to 2.1.1770989063 https://github.com/koreader/koreader-base/pull/2269
- ci/circle: bump docker images https://github.com/koreader/koreader-base/pull/2271

#### ReaderHighlight:onHoldPan(): remove abort on empty selection

We may happen to have an empty selection while panning, no reason to abort the selection yet before release. See https://github.com/koreader/koreader/pull/13392#issuecomment-3739300581.
Also add get_segments=true to remaining calls to getScreenBoxesFromPositions() that we forgot to update to use it. See https://github.com/koreader/koreader/pull/12810#issuecomment-3751062870

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14979)
<!-- Reviewable:end -->
