### PR TITLE
[ReaderFooter] Adds a fixed-width setting for progress bar alongside items

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -1226,21 +1226,6 @@ function ReaderFooter:addToMainMenu(menu_items)
                 separator = true,
             },
             {
-                text = _("Lock width at minimum"),
-                help_text = _("Anchors the width of the progress bar at the selected minimum."),
-                enabled_func = function()
-                    return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
-                        and self.settings.all_at_once
-                end,
-                checked_func = function()
-                    return self.settings.progress_bar_lock_width
-                end,
-                callback = function()
-                    self.settings.progress_bar_lock_width = not self.settings.progress_bar_lock_width or nil
-                    self:refreshFooter(true, true)
-                end,
-            },
-            {
                 text_func = function()
                     if self.settings.progress_style_thin then
                         return _("Thickness and height: thin")
@@ -1393,6 +1378,21 @@ function ReaderFooter:addToMainMenu(menu_items)
                     UIManager:show(items)
                 end,
                 keep_menu_open = true,
+            },
+            {
+                text = _("Lock width at minimum"),
+                help_text = _("Anchors the width of the progress bar at the selected minimum."),
+                enabled_func = function()
+                    return self.settings.progress_bar_position == "alongside" and not self.settings.disable_progress_bar
+                        and self.settings.all_at_once
+                end,
+                checked_func = function()
+                    return self.settings.progress_bar_lock_width
+                end,
+                callback = function()
+                    self.settings.progress_bar_lock_width = not self.settings.progress_bar_lock_width or nil
+                    self:refreshFooter(true, true)
+                end,
                 separator = true,
             },
             {


### PR DESCRIPTION
Added a Fixed-width setting for the progress bar, available when displayed alongside the text items.

![013006](https://github.com/user-attachments/assets/02c96ee7-1ce9-4ed3-b7c8-be6c33bc2e39)

Without fixed width setting the progress bar size can vary widely, making the tracking of one's position more difficult : 

https://github.com/user-attachments/assets/153e4c49-d52b-484d-9f92-4e1fdc45c5f4

With fixed with setting (new): 

https://github.com/user-attachments/assets/e5a031ca-6665-4e3d-9b7a-44816e833bec

I also increased the available range for the minimum width in the UI from 50% of the screen width to 90%, since with the fixed setting it could otherwise never get larger than 50%, but a wider size will be useful if only few and short items fill up less than 50% of the remaining space.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14980)
<!-- Reviewable:end -->
