### PR TITLE
Recurrent 429 error due to Wikipedia change

### DIFF
--- a/frontend/socketutil.lua
+++ b/frontend/socketutil.lua
@@ -8,6 +8,8 @@ local http = require("socket.http")
 local https = require("ssl.https")
 local ltn12 = require("ltn12")
 local socket = require("socket")
+local ffiUtil = require("ffi/util")
+local T = ffiUtil.template
 
 local socketutil = {
     -- Init to the default LuaSocket/LuaSec values
@@ -15,9 +17,10 @@ local socketutil = {
     total_timeout = -1,
 }
 
---- Builds a sensible UserAgent that fits Wikipedia's UA policy <https://meta.wikimedia.org/wiki/User-Agent_policy>
+--- Builds a sensible UserAgent that fits Wikipedia's UA policy <https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy>
 local socket_ua = http.USERAGENT
-socketutil.USER_AGENT = "KOReader/" .. Version:getShortVersion() .. " (" .. Device.model .. "; " .. jit.os .. "; " .. jit.arch .. ") " .. socket_ua:gsub(" ", "/")
+socketutil.USER_AGENT = T("KOReader/%1 (%2; %3; %4; https://github.com/koreader/koreader) %5",
+    Version:getShortVersion(), Device.model, jit.os, jit.arch, socket_ua:gsub(" ", "/"))
 -- Monkey-patch it in LuaSocket, as it already takes care of inserting the appropriate header to its requests.
 http.USERAGENT = socketutil.USER_AGENT
 


### PR DESCRIPTION
@poire-z raised in https://github.com/koreader/koreader/pull/14766#issue-3765465474 that the 429 errors started appearing again

I looked into it some more, I am seeing [this change from Wikipedia](https://gerrit.wikimedia.org/r/plugins/gitiles/operations/puppet/+/5ed2909eccdc3d92a9a702479d93b944482eb61f%5E%21/modules/varnish/templates/upload-frontend.inc.vcl.erb) a few weeks ago. Basically koreader requests started returning `Varnish` as the server in the response header, but we should see `Thumbor/7.3.2`. 

When you go to the linked wiki commit, they added logic to enforce that the user agent is compliant with their robot policy (the koreader user agent didn't have a contact). It seems koreader got sniped by a wiki rate limit again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14981)
<!-- Reviewable:end -->
