### PR TITLE
Wikipedia EPUBs: use 1.5x image when 2x not available

### DIFF
--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -804,6 +804,9 @@ function Wikipedia:createEpub(epub_path, page, lang, with_images)
             if srcset then
                 srcset = " "..srcset.. ", " -- for next pattern to possibly match 1st or last item
                 src2x = srcset:match([[ (%S+) 2x, ]])
+                if not src2x then -- if no 2x, we may have 1.5x
+                    src2x = srcset:match([[ (%S+) 1.5x, ]])
+                end
                 if src2x then
                     if src2x:sub(1,2) == "//" then
                         src2x = "https:" .. src2x


### PR DESCRIPTION
Looks like there are more images with srcset 1.5x than with 2x.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14984)
<!-- Reviewable:end -->
