### PR TITLE
Properly set bootlogo on pocketbook

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -139,6 +139,9 @@ function CoverImage:createCoverImage(doc_settings)
         return
     end
 
+    -- On PocketBook, Screen:getWidth/getHeight returns dimensions that iv2sh
+    -- will not accept. Use Screen:getScreenWidth/getScreenHeight instead so
+    -- the generated boot logo has the correct size.
     local s_w, s_h
     if Device.isPocketBook() then
         s_w, s_h = Screen:getScreenWidth(), Screen:getScreenHeight()


### PR DESCRIPTION
On several Pocketbook devices, the boot logo never gets updated. These changes fix that behavior by calling iv2sh and by creating an image with the correct dimensions so iv2sh accepts it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14985)
<!-- Reviewable:end -->
