### PR TITLE
CoverImage: fix inconsistent vertical alignment of cover image

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -197,12 +197,8 @@ function CoverImage:createCoverImage(doc_settings)
         elseif self.cover_image_background == "gray" then
             image:fill(Blitbuffer.COLOR_GRAY)
         end
-        -- copy scaled image to buffer
-        if s_w > scaled_w then -- move right
-            image:blitFrom(cover_image, math.floor((s_w - scaled_w) / 2), 0, 0, 0, scaled_w, scaled_h)
-        else -- move down
-            image:blitFrom(cover_image, 0, math.floor((s_h - scaled_h) / 2), 0, 0, scaled_w, scaled_h)
-        end
+        -- center scaled image on both axes
+        image:blitFrom(cover_image, math.floor((s_w - scaled_w) / 2), math.floor((s_h - scaled_h) / 2), 0, 0, scaled_w, scaled_h)
     end
 
     cover_image:free()


### PR DESCRIPTION
Fixes #14986.

Center the scaled cover image on both axes unconditionally instead of branching on which dimension is the limiting factor. When a dimension has no margin, `math.floor(0 / 2)` evaluates to 0, so the centering is a no-op on that axis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14987)
<!-- Reviewable:end -->
