### PR TITLE
Fix max port number typo in Calibre plugin

### DIFF
--- a/plugins/calibre.koplugin/main.lua
+++ b/plugins/calibre.koplugin/main.lua
@@ -344,7 +344,7 @@ function Calibre:getWirelessMenuTable()
                                             local fields = url_dialog:getFields()
                                             if fields[1] ~= "" then
                                                 local port = tonumber(fields[2])
-                                                if not port or port < 1 or port > 65355 then
+                                                if not port or port < 1 or port > 65535 then
                                                     --default port
                                                      port = 9090
                                                 end


### PR DESCRIPTION
65355 -> 65535: the transposed digits caused ports 65356–65535 to be silently rejected and reset to the default (9090).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14991)
<!-- Reviewable:end -->
