### PR TITLE
calibre: use correct callback when Wi-Fi is off at connect time

### DIFF
--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -241,7 +241,7 @@ function CalibreWireless:connect()
     end
 
     -- Ensure network is online.
-    if NetworkMgr:willRerunWhenConnected(self.re) then
+    if NetworkMgr:willRerunWhenConnected(re) then
         coroutine.yield()
         if not NetworkMgr:isConnected() then
             return


### PR DESCRIPTION
When Wi-Fi is off and the user taps "Connect to calibre", the plugin asks NetworkMgr to bring up Wi-Fi and re-run a callback to resume the connection flow. However, the callback passed is `self.re`, which isn't assigned until later in the function (line 292). At line 244 it is always `nil`, either never set, or explicitly cleared by a previous `disconnect()`.

The `nil` propagates silently through the NetworkMgr chain (`beforeWifiAction` → `enableWifi` → `connectivityCheck`) because `connectivityCheck` guards the callback call with `if callback then`. The result: Wi-Fi comes up successfully, but the Calibre connection coroutine is never resumed. No error is shown to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/14998)
<!-- Reviewable:end -->
