### PR TITLE
[Hotkeys] NT: BUG correct function call

### DIFF
--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -89,7 +89,7 @@ end
 function HotKeys:onHotkeyAction(hotkey)
     -- Note: we could have started text selection and then trigger a reflow through hotkeys (e.g., increase
     --       font-size) which will cause pandemonium to ensue (invalid coordinates).
-    if self.ui.highlight then self.ui.highlight:stopHighlightIndicator(true) end
+    if self.ui.highlight then self.ui.highlight:onStopHighlightIndicator(true) end
     local hotkey_action_list = self.hotkeys[hotkey]
     local context = self.is_docless and "FileManager" or "Reader"
     if hotkey_action_list == nil then


### PR DESCRIPTION
### bug

* Changed the method call from `stopHighlightIndicator` to `onStopHighlightIndicator` on the `highlight` object in `HotKeys:onHotkeyAction` to ensure the correct handler is invoked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15009)
<!-- Reviewable:end -->
