### PR TITLE
[DictQuickLookup] NT: fix utf8 byte drift during text selection

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -179,7 +179,7 @@ function DictQuickLookup:init()
                 -- callback function when HoldReleaseText is handled as args
                 args = function(text, hold_duration)
                     -- short hold: same domain; long hold (>=3s): switch domain
-                    self:searchDictionaryOrWikipedia(text, hold_duration >= time.s(3))
+                    self:lookupDictionaryOrWikipedia(text, hold_duration >= time.s(3))
                 end
             },
             SetTemporaryLargeWindowMode = {
@@ -1994,7 +1994,7 @@ function DictQuickLookup:onTextSelectorPress()
         function(text) selected_text = text end,
         self:_createTextSelectionGesture("hold_release")
     )
-    self:searchDictionaryOrWikipedia(selected_text, false)
+    self:lookupDictionaryOrWikipedia(selected_text, false)
     self:onStopTextSelectorIndicator()
     return true
 end
@@ -2010,7 +2010,7 @@ function DictQuickLookup:onTextSelectorModifierPress()
             function(text) selected_text = text end,
             self:_createTextSelectionGesture("hold_release")
         )
-        self:searchDictionaryOrWikipedia(selected_text, true) -- switch_domain, "i'm master of my domain" ¯\_(ツ)_/¯
+        self:lookupDictionaryOrWikipedia(selected_text, true) -- switch_domain, "i'm master of my domain" ¯\_(ツ)_/¯
         self:onStopTextSelectorIndicator()
         return true
     end
@@ -2033,7 +2033,7 @@ function DictQuickLookup:onStartOrMoveTextSelectorIndicator(args)
     return true
 end
 
-function DictQuickLookup:searchDictionaryOrWikipedia(selected_text, switch_domain)
+function DictQuickLookup:lookupDictionaryOrWikipedia(selected_text, switch_domain)
     if not selected_text then return false end
     local new_dict_close_callback = function() self:clearDictionaryHighlight() end
     local use_wiki = self.is_wiki


### PR DESCRIPTION
In `TextBoxWidget`, `highlight_start_idx` / `highlight_end_idx` are character indices.
In `DictQuickLookup:_performLookupOnSelection`, we use:

```lua
selection_widget.text:sub(start_idx, end_idx)
```
but `string.sub` uses byte indices. So with UTF-8 content (the IPA `/mænˈkaɪnd/` etc.), extraction shifts left and returns the wrong token (e.g. "with Sc").

<p align="center">
<img src="https://github.com/user-attachments/assets/cc215c78-8d71-4267-a86c-c127c81e768f" width=60%> 
</p> 


### bug fix

* Refactored `onTextSelectorPress` and `onTextSelectorModifierPress` to extract the selected text via a callback from `onHoldReleaseText`, and pass it directly to `_performLookupOnSelection`. 
* Changed `_performLookupOnSelection` to accept the selected text as its argument, rather than the selection widget, simplifying its interface and removing internal logic for extracting text from the widget.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15015)
<!-- Reviewable:end -->
