### PR TITLE
fix(coverimage): fix operator precedence and parameter usage in cache functions

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -311,9 +311,9 @@ function CoverImage:cleanCache()
     -- delete the oldest files first
     table.sort(files, function(a, b) return a.mod < b.mod end)
     local index = 1
-    while ((cache_count > self.cover_image_cache_maxfiles and self.cover_image_cache_maxfiles ~= 0)
-        or (cache_size > self.cover_image_cache_maxsize * 1000 * 1000 and self.cover_image_cache_maxsize ~= 0))
-        and index <= #files do
+    while index <= #files
+        and ((cache_count > self.cover_image_cache_maxfiles and self.cover_image_cache_maxfiles ~= 0)
+        or (cache_size > self.cover_image_cache_maxsize * 1000 * 1000 and self.cover_image_cache_maxsize ~= 0)) do
         os.remove(files[index].name)
         cache_count = cache_count - 1
         cache_size = cache_size - files[index].size


### PR DESCRIPTION
1. `cleanCache()`: Fix operator precedence in while loop condition. In Lua, `and` has higher precedence than `or`, so the bounds check `index <= #files` was only applied to the cache size condition, not the file count condition. Added parentheses to ensure the bounds check applies to both conditions.

2. `getCacheFiles()`: Use the function parameters `cache_path` and `cache_prefix` consistently instead of mixing them with `self.cover_image_cache_path` and `self.cover_image_cache_prefix`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15032)
<!-- Reviewable:end -->
