### PR TITLE
calibre: escape dot in gsub pattern for series index cleanup

### DIFF
--- a/plugins/calibre.koplugin/search.lua
+++ b/plugins/calibre.koplugin/search.lua
@@ -316,7 +316,7 @@ function CalibreSearch:bookCatalog(t, option)
     end
     if series and not subseries then
         for index, entry in ipairs(catalog) do
-            catalog[index].text = entry.text:gsub(".00", "", 1)
+            catalog[index].text = entry.text:gsub("%.00", "", 1)
         end
     end
     return catalog


### PR DESCRIPTION
In `bookCatalog()`, the `.00` suffix is stripped via:

```lua
catalog[index].text = entry.text:gsub(".00", "", 1)
```

Because `.` in Lua patterns matches any character, the following happens:

| series_index | before gsub | actual result | expected result |
|---|---|---|---|
| 1 | `00001.00` | `01.00` | `00001` |
| 42 | `00042.00` | `42.00` | `00042` |
| 100 | `00100.00` | `00.00` | `00100` |

This PR fixes it by escaping the dot: `"%.00"` matches a literal period followed by two zeros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15037)
<!-- Reviewable:end -->
