### PR TITLE
ci/macos: update upload-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,8 +216,9 @@ jobs:
         run: make skeleton update --assume-old=base
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
+          archive: false
           name: koreader-macos-${{ matrix.platform }}
           path: '*.7z'
 


### PR DESCRIPTION
Not creating a zip is finally supported!

Except it does not work with all mime types… Cf. https://github.com/actions/upload-artifact/issues/765.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15046)
<!-- Reviewable:end -->
