### PR TITLE
[Dispatcher] remove Gesture overview from non-touch devices

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -54,7 +54,7 @@ local Dispatcher = {
 -- See above for description.
 local settingsList = {
     -- General
-    gesture_overview = {category="none", event="ShowGestureOverview", title=_("Gesture overview"), general=true},
+    gesture_overview = {category="none", event="ShowGestureOverview", title=_("Gesture overview"), general=true, condition=Device:isTouchDevice()},
     filemanager = {category="none", event="Home", title=_("File browser"), general=true},
     open_previous_document = {category="none", event="OpenLastDoc", title=_("Open previous document"), general=true},
     history = {category="none", event="ShowHist", title=_("History"), general=true},


### PR DESCRIPTION
### what's new

  * Added a `condition` field to the `gesture_overview` entry in `settingsList` within `frontend/dispatcher.lua`, restricting its visibility to touch devices using `Device:isTouchDevice()`.
  * https://github.com/koreader/koreader/pull/13909#discussion_r2778428902

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15059)
<!-- Reviewable:end -->
