### PR TITLE
KoptInterface: fix panel zooming when dewatermark is on

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -450,10 +450,10 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, hi
         kc:optimizePage()
         local fullwidth, fullheight = kc:getPageDim()
         -- prepare cache item with contained blitbuffer
-        local tile = TileCacheItem:new {
+        local tile = TileCacheItem:new{
             persistent = persistent,
             doc_path = doc.file,
-            excerpt = Geom:new {
+            excerpt = Geom:new{
                 x = 0, y = 0,
                 w = fullwidth,
                 h = fullheight,


### PR DESCRIPTION
Currently, panel zoom does not work when `dewatermark` is on.
This PR fixes the issue by calculating and using the correct bbox. `part_tile` is not cached yet; I'm not sure if caching is necessary.
Tested on Kindle Paperwhite (12th Generation).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15067)
<!-- Reviewable:end -->
