### PR TITLE
OPDS: fix off-by-one in sync sub_table access

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1570,7 +1570,7 @@ function OPDSBrowser:fillPendingSyncs(server)
             end
             if #sub_table > 0 then
                 -- The first element seems to be most compatible. Second element has most options
-                item = sub_table[2]
+                item = sub_table[2] or sub_table[1]
             else
                 item = entry
             end


### PR DESCRIPTION
This PR fixes crash during OPDS sync download when a catalog entry's URL resolves to a `sub_table` with exactly one element. In that case, `sub_table[2]` returns `nil`, causing "attempt to index a nil value" on `item.acquisitions`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15073)
<!-- Reviewable:end -->
