### PR TITLE
fix: import embedded PDF annotations properly

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -999,11 +999,11 @@ function ReaderBookmark:onShowBookmark()
             if bookmark.document.is_pdf then
                 table.insert(buttons, {
                     {
-                        text = _("Import embedded highlights"),
+                        text = _("Import embedded annotations"),
                         enabled = bookmark.document.configurable.text_wrap == 0,
                         callback = function()
                             UIManager:close(bm_dialog)
-                            bookmark:importEmbeddedHighlights()
+                            bookmark:importEmbeddedAnnotations()
                         end,
                     },
                 })
@@ -1640,15 +1640,23 @@ function ReaderBookmark:filterByHighlightColor()
     self.ui.highlight:showHighlightColorDialog(filter_by_color_callback)
 end
 
-function ReaderBookmark:importEmbeddedHighlights()
-    local boxes = self.document:getEmbeddedAnnotationsBoxes()
-    if boxes then
-        local count = self.ui.highlight:saveHighlightsFromBoxes(boxes)
-        self.bookmark_menu[1].close_callback()
-        self:onShowBookmark()
-        UIManager:show(InfoMessage:new{ text = T(N_("1 highlight added", "%1 highlights added", count), count) })
+function ReaderBookmark:importEmbeddedAnnotations()
+    local annotations = self.document:getEmbeddedAnnotations()
+    if annotations then
+        local count, skipped = self.ui.highlight:importEmbeddedAnnotations(annotations)
+        if count > 0 then
+            self.bookmark_menu[1].close_callback()
+            self:onShowBookmark()
+            local msg = T(N_("1 annotation imported.", "%1 annotations imported.", count), count)
+            if skipped > 0 then
+                msg = msg .. "\n" .. T(N_("1 duplicate skipped.", "%1 duplicates skipped.", skipped), skipped)
+            end
+            UIManager:show(InfoMessage:new{ text = msg })
+        else
+            UIManager:show(InfoMessage:new{ text = _("All embedded annotations are already imported.") })
+        end
     else
-        UIManager:show(InfoMessage:new{ text = _("No embedded highlights found") })
+        UIManager:show(InfoMessage:new{ text = _("No embedded annotations found.") })
     end
 end
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2628,48 +2628,97 @@ function ReaderHighlight:getSavedExtendedHighlightPage(highlight, page, index)
     return item
 end
 
--- Saves PDF embedded highlights as KOReader annotations
--- (For pdf documents only, reflow mode must be off)
-function ReaderHighlight:saveHighlightsFromBoxes(boxes)
-    local highlight_write_into_pdf = self.highlight_write_into_pdf
-    self.highlight_write_into_pdf = nil -- prevent writing into PDF once more
-    local rotation = Screen:getRotationMode()
-    local zoom = self.ui.zooming:getZoom(1)
-    local note = _("embedded highlight")
-    local count = 0
-    for page, page_pboxes in pairs(boxes) do
-        for _, hl_pboxes in ipairs(page_pboxes) do
-            local first_box = hl_pboxes[1]
-            local pos0 = {
-                page = page,
-                rotation = rotation,
-                zoom = zoom,
-                x = first_box.x + 1, -- inside the box
-                y = first_box.y + 1, -- ditto
-            }
-            local last_box = hl_pboxes[#hl_pboxes]
-            local pos1 = {
-                page = page,
-                rotation = rotation,
-                zoom = zoom,
-                x = last_box.x + last_box.w - 2, -- ditto
-                y = last_box.y + last_box.h - 2, -- ditto
-            }
-            local text = self.document:getTextFromPositions(pos0, pos1)
-            self.selected_text = {
-                pos0 = pos0,
-                pos1 = pos1,
-                pboxes = hl_pboxes,
-                text = text and text.text or "",
-                note = note,
-            }
-            self:saveHighlight()
-            count = count + 1
+-- PDF annotation type to KOReader drawer mapping
+local ANNOT_TYPE_DRAWER = {
+    [8]  = "lighten",    -- PDF_ANNOT_HIGHLIGHT
+    [9]  = "underscore", -- PDF_ANNOT_UNDERLINE
+    [10] = "underscore", -- PDF_ANNOT_SQUIGGLY (closest equivalent)
+    [11] = "strikeout",  -- PDF_ANNOT_STRIKE_OUT
+}
+
+function ReaderHighlight:_isDuplicateAnnotation(page, pboxes)
+    for _, item in ipairs(self.ui.annotation.annotations) do
+        if item.page == page and item.pboxes and #item.pboxes == #pboxes then
+            local match = true
+            for i, box in ipairs(pboxes) do
+                local existing = item.pboxes[i]
+                if math.abs(box.x - existing.x) > 1
+                or math.abs(box.y - existing.y) > 1
+                or math.abs(box.w - existing.w) > 1
+                or math.abs(box.h - existing.h) > 1 then
+                    match = false
+                    break
+                end
+            end
+            if match then return true end
         end
     end
-    self.highlight_write_into_pdf = highlight_write_into_pdf
+    return false
+end
+
+-- Imports PDF embedded markup annotations as KOReader annotations.
+-- Two-phase approach: delete originals from PDF first, then import.
+-- avoids ambiguity when write-into-pdf re-creates the annotations.
+-- (For pdf documents only, reflow mode must be off)
+function ReaderHighlight:importEmbeddedAnnotations(annotations)
+    local rotation = Screen:getRotationMode()
+    local zoom = self.ui.zooming:getZoom(1)
+    local count = 0
+    local skipped = 0
+
+    -- Phase 1: Identify annotations to import and delete originals from PDF
+    local to_import = {}
+    for page, page_annots in pairs(annotations) do
+        for _, annot in ipairs(page_annots) do
+            if self:_isDuplicateAnnotation(page, annot.boxes) then
+                skipped = skipped + 1
+            else
+                table.insert(to_import, { page = page, annot = annot })
+                self.document:deleteHighlight(page, { pboxes = annot.boxes })
+            end
+        end
+    end
+
+    -- Phase 2: Import collected annotations
+    for _, entry in ipairs(to_import) do
+        local annot = entry.annot
+        local page = entry.page
+        local hl_pboxes = annot.boxes
+        local first_box = hl_pboxes[1]
+        local pos0 = {
+            page = page,
+            rotation = rotation,
+            zoom = zoom,
+            x = first_box.x + 1, -- inside the box
+            y = first_box.y + 1, -- ditto
+        }
+        local last_box = hl_pboxes[#hl_pboxes]
+        local pos1 = {
+            page = page,
+            rotation = rotation,
+            zoom = zoom,
+            x = last_box.x + last_box.w - 2, -- ditto
+            y = last_box.y + last_box.h - 2, -- ditto
+        }
+        local text = self.document:getTextFromPositions(pos0, pos1)
+        local contents = annot.contents
+        if contents == "" then
+            contents = nil
+        end
+        self.selected_text = {
+            pos0 = pos0,
+            pos1 = pos1,
+            pboxes = hl_pboxes,
+            text = text and text.text or "",
+            note = contents,
+            drawer = ANNOT_TYPE_DRAWER[annot.type],
+        }
+        self:saveHighlight()
+        count = count + 1
+    end
+
     self.selected_text = nil
-    return count
+    return count, skipped
 end
 
 function ReaderHighlight:onReadSettings(config)

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -293,14 +293,17 @@ function PdfDocument:updateHighlightContents(pageno, item, contents)
     page:close()
 end
 
-function PdfDocument:getEmbeddedAnnotationsBoxes()
-    local boxes = {}
+function PdfDocument:getEmbeddedAnnotations()
+    local annotations = {}
     for pageno = 1, self.info.number_of_pages do
         local page = self._document:openPage(pageno)
-        boxes[pageno] = page:getMarkupAnnotationBoxesFromPage()
+        local page_annots = page:getEmbeddedAnnotations()
+        if page_annots then
+            annotations[pageno] = page_annots
+        end
         page:close()
     end
-    return next(boxes) and boxes
+    return next(annotations) and annotations
 end
 
 function PdfDocument:writeDocument()


### PR DESCRIPTION
Fixes #15075. Depends on koreader/koreader-base#2287.

### Problems with current import (#15040)

1. **Notes discarded** -- all annotations get hardcoded `note = "embedded highlight"`, overwriting actual `/Contents`
2. **No type filtering** -- iterates all annotations including Links, Popups, Widgets
3. **Double rendering** -- originals stay in PDF while KOReader draws its own on top
4. **No deduplication** -- running import twice creates duplicates
5. **Type not preserved** -- all imports become "lighten" regardless of original type

### Changes

- **pdfdocument.lua**: Add `getEmbeddedAnnotations()` wrapper for the new koreader-base function that returns type, boxes, and contents per markup annotation
- **readerhighlight.lua**: Replace `saveHighlightsFromBoxes()` with `importEmbeddedAnnotations()`:
  - Map annotation type to correct drawer (Highlight -> lighten, Underline -> underscore, StrikeOut -> strikeout)
  - Preserve original `/Contents` as KOReader note
  - Delete imported annotations from PDF (two-phase: delete first, then import)
  - Deduplicate against existing annotations by quadpoint coordinate matching
  - Respect `highlight_write_into_pdf` naturally (no more disable/restore hack)
- **readerbookmark.lua**: Rename menu item to "Import embedded annotations", show import/skip counts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15076)
<!-- Reviewable:end -->
