### PR TITLE
Tweak bug report template: nightly test not required, avoid automatic reference to nightly ticket

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,10 +13,10 @@ body:
       options:
         - label: Reproduced the issue with external plugins and user-patches disabled.
           required: true
-        - label: Tested on the latest nightly build ([more information](https://github.com/koreader/koreader/issues/11068)).
-          required: true
         - label: Searched existing issues for similar reports.
           required: true
+        - label: Tested on the latest nightly build ([more information](/koreader/koreader/issues/11068)).
+          required: false
 
   - type: dropdown
     id: device-type


### PR DESCRIPTION
See <https://github.com/koreader/koreader/pull/15072#issuecomment-4016113442>.

Supposedly automatic references can be avoided by not including `github.com`, as well as by using `redirect.github.com`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15084)
<!-- Reviewable:end -->
