### PR TITLE
[Calibre] preserve uuid field in calibre metadata serialisation

### DIFF
--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -45,7 +45,7 @@ local function slim(book, is_search)
         elseif k == "tags" or k == "authors" then
             slim_book[k] = book[k] or rapidjson.array({})
         else
-            slim_book[k] = book[k]
+            slim_book[k] = book[k] or rapidjson.null
         end
     end
     return slim_book


### PR DESCRIPTION
### bug fix

In `slim()`, fields without explicit handling fall through to a bare `slim_book[k] = book[k]` assignment. In Lua, assigning `nil` to a table key removes it entirely, so any book with a missing `uuid` produces a JSON payload with no field at all.
Calibre's Smart Device driver expects the `uuid` to be present on every book so a single missing one raises a `KeyError`

```
calibre, version 9.4.0
ERROR: Error: Error communicating with device

'uuid'

Traceback (most recent call last):
  File "calibre/gui2/device.py", line 110, in run
  File "calibre/gui2/device.py", line 581, in _books
  File "calibre/devices/smart_device_app/driver.py", line 58, in _synchronizer
  File "calibre/devices/smart_device_app/driver.py", line 1316, in books
KeyError: 'uuid'
```

and aborts the entire book enumeration. The connection succeeds and file transfer works, but the library appears empty on the calibre side.
* Fixed by handling `uuid` consistently with series and series_index, falling back to `rapidjson.null` rather than silently dropping the key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15088)
<!-- Reviewable:end -->
