### PR TITLE
refactor duplication in  #15088  

### DIFF
--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -40,9 +40,7 @@ local search_used_metadata = {
 local function slim(book, is_search)
     local slim_book = rapidjson.object({})
     for _, k in ipairs(is_search and search_used_metadata or used_metadata) do
-        if k == "series" or k == "series_index" then
-            slim_book[k] = book[k] or rapidjson.null
-        elseif k == "tags" or k == "authors" then
+        if k == "tags" or k == "authors" then
             slim_book[k] = book[k] or rapidjson.array({})
         else
             slim_book[k] = book[k] or rapidjson.null


### PR DESCRIPTION
### refactor #15088

* Simplified the logic in the `slim` function so that `series` and `series_index` fields are no longer handled separately and are treated like other fields, defaulting to `rapidjson.null` if missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15094)
<!-- Reviewable:end -->
