### PR TITLE
feat: track and navigate to furthest read position

### DIFF
--- a/frontend/apps/reader/modules/readergoto.lua
+++ b/frontend/apps/reader/modules/readergoto.lua
@@ -22,6 +22,15 @@ function ReaderGoto:addToMainMenu(menu_items)
             self:onShowGotoDialog()
         end,
     }
+    menu_items.go_to_furthest_read = {
+        text = _("Go to furthest read position"),
+        enabled_func = function()
+            return self.ui.rolling ~= nil or self.ui.paging ~= nil
+        end,
+        callback = function()
+            self:onGoToFurthestReadPage()
+        end,
+    }
     menu_items.skim_to = {
         text = _("Skim document"),
         callback = function()
@@ -325,6 +334,24 @@ function ReaderGoto:getPinnedPageNumber()
             return self.document:getPageFromXPointer(pn_or_xp)
         end
     end
+end
+
+function ReaderGoto:onGoToFurthestReadPage()
+    if self.ui.rolling then
+        local furthest_xp = self.ui.rolling.furthest_xpointer
+        if not furthest_xp then return true end
+        local cmp = self.ui.document:compareXPointers(self.ui.document:getXPointer(), furthest_xp)
+        if cmp ~= 1 then return true end
+        self.ui.link:addCurrentLocationToStack()
+        self.ui.rolling:onGotoXPointer(furthest_xp)
+    elseif self.ui.paging then
+        local furthest_page = self.ui.paging.furthest_page
+        if not furthest_page then return true end
+        if self.ui.paging.current_page >= furthest_page then return true end
+        self.ui.link:addCurrentLocationToStack()
+        self.ui.paging:onGotoPage(furthest_page)
+    end
+    return true
 end
 
 return ReaderGoto

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -149,14 +149,24 @@ end
 function ReaderPaging:onReadSettings(config)
     self.page_positions = config:readSetting("page_positions") or {}
     self:_gotoPage(config:readSetting("last_page") or 1)
+    self.furthest_page = config:readSetting("furthest_page")
     self.flipping_zoom_mode = config:readSetting("flipping_zoom_mode") or "page"
     self.flipping_scroll_mode = config:isTrue("flipping_scroll_mode")
+end
+
+function ReaderPaging:_updateFurthestPage()
+    if not self.furthest_page or self.current_page > self.furthest_page then
+        self.furthest_page = self.current_page
+    end
 end
 
 function ReaderPaging:onSaveSettings()
     --- @todo only save current_page page position
     self.ui.doc_settings:saveSetting("page_positions", self.page_positions)
     self.ui.doc_settings:saveSetting("last_page", self:getTopPage())
+
+    self:_updateFurthestPage()
+    self.ui.doc_settings:saveSetting("furthest_page", self.furthest_page)
     self.ui.doc_settings:saveSetting("percent_finished", self.view.footer.percent_finished)
     self.ui.doc_settings:saveSetting("flipping_zoom_mode", self.flipping_zoom_mode)
     self.ui.doc_settings:saveSetting("flipping_scroll_mode", self.flipping_scroll_mode)
@@ -1148,6 +1158,7 @@ function ReaderPaging:onGotoPage(number, pos)
         -- gotoPage emits this event only if the page changes
         self.ui:handleEvent(Event:new("PageUpdate", self.current_page))
     end
+    self:_updateFurthestPage()
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -198,6 +198,8 @@ function ReaderRolling:onReadSettings(config)
         end
     end
 
+    self.furthest_xpointer = config:readSetting("furthest_xpointer")
+
     local last_xp = config:readSetting("last_xpointer")
     local last_per = config:readSetting("last_percent")
     if last_xp then
@@ -336,6 +338,10 @@ function ReaderRolling:onSaveSettings()
     self.ui.doc_settings:saveSetting("percent_finished", self.view.footer.percent_finished)
     self.ui.doc_settings:delSetting("last_percent") -- deprecated
     self.ui.doc_settings:saveSetting("last_xpointer", self.xpointer)
+
+    self:_updateFurthestXpointer()
+    self.ui.doc_settings:saveSetting("furthest_xpointer", self.furthest_xpointer)
+
     self.ui.doc_settings:saveSetting("hide_nonlinear_flows", self.hide_nonlinear_flows)
     self.ui.doc_settings:saveSetting("partial_rerendering", self.partial_rerendering)
 end
@@ -744,10 +750,25 @@ function ReaderRolling:onNotCharging()
     self:updateBatteryState()
 end
 
+function ReaderRolling:_updateFurthestXpointer()
+    local current_xp = self.xpointer
+    if current_xp and self.ui.document then
+        if not self.furthest_xpointer then
+            self.furthest_xpointer = current_xp
+        else
+            local cmp = self.ui.document:compareXPointers(self.furthest_xpointer, current_xp)
+            if cmp == 1 then
+                self.furthest_xpointer = current_xp
+            end
+        end
+    end
+end
+
 function ReaderRolling:onGotoPercent(percent)
     logger.dbg("goto document offset in percent:", percent)
     self:_gotoPercent(percent)
     self.xpointer = self.ui.document:getXPointer()
+    self:_updateFurthestXpointer()
     return true
 end
 
@@ -756,6 +777,7 @@ function ReaderRolling:onGotoPage(number)
         self:_gotoPage(number)
     end
     self.xpointer = self.ui.document:getXPointer()
+    self:_updateFurthestXpointer()
     return true
 end
 
@@ -764,6 +786,7 @@ function ReaderRolling:onGotoRelativePage(number)
         self:_gotoPage(self.current_page + number)
     end
     self.xpointer = self.ui.document:getXPointer()
+    self:_updateFurthestXpointer()
     return true
 end
 
@@ -943,6 +966,7 @@ function ReaderRolling:onGotoViewRel(diff)
     end
     if self.ui.document ~= nil then
         self.xpointer = self.ui.document:getXPointer()
+        self:_updateFurthestXpointer()
     end
     return true
 end
@@ -955,6 +979,7 @@ function ReaderRolling:onPanning(args, _)
     end
     self:_gotoPos(self.current_pos + dy * self.panning_steps.normal)
     self.xpointer = self.ui.document:getXPointer()
+    self:_updateFurthestXpointer()
     return true
 end
 

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -174,6 +174,7 @@ local settingsList = {
     skim = {category="none", event="ShowSkimtoDialog", title=_("Skim document"), reader=true},
     pin_current_page = {category="none", event="PinPage", title=_("Pin current page"), reader=true},
     go_to_pinned_page = {category="none", event="GoToPinnedPage", title=_("Go to pinned page"), reader=true, separator=true},
+    go_to_furthest_read = {category="none", event="GoToFurthestReadPage", title=_("Go to furthest read position"), reader=true},
     ----
     prev_bookmark = {category="none", event="GotoPreviousBookmarkFromPage", title=_("Previous bookmark"), reader=true},
     next_bookmark = {category="none", event="GotoNextBookmarkFromPage", title=_("Next bookmark"), reader=true},
@@ -429,6 +430,7 @@ local dispatcher_menu_order = {
     "skim",
     "pin_current_page",
     "go_to_pinned_page",
+    "go_to_furthest_read",
     ----
     "prev_bookmark",
     "next_bookmark",

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -23,6 +23,7 @@ local order = {
         "page_browser", -- if Device:isTouchDevice() or useDPadAsActionKeys()
         "----------------------------",
         "go_to",
+        "go_to_furthest_read",
         "skim_to",
         "autoturn",
         "----------------------------",

--- a/spec/unit/readerpaging_spec.lua
+++ b/spec/unit/readerpaging_spec.lua
@@ -37,6 +37,28 @@ describe("Readerpaging module", function()
             assert.is.truthy(called)
             readerui.onEndOfBook = nil
         end)
+
+        it("should update furthest_page only when advancing", function()
+            paging.furthest_page = nil
+            paging.ui.doc_settings:delSetting("furthest_page")
+            paging:onGotoPage(1)
+            paging:onSaveSettings()
+
+            -- go forward
+            paging:onGotoPage(4)
+            paging:onSaveSettings()
+            assert.are.same(4, paging.ui.doc_settings:readSetting("furthest_page"))
+
+            -- go backward
+            paging:onGotoPage(2)
+            paging:onSaveSettings()
+            assert.are.same(4, paging.ui.doc_settings:readSetting("furthest_page"))
+
+            -- go forward again to a new furthest page
+            paging:onGotoPage(23)
+            paging:onSaveSettings()
+            assert.are.same(23, paging.ui.doc_settings:readSetting("furthest_page"))
+        end)
     end)
 
     describe("Scroll mode", function()

--- a/spec/unit/readerrolling_spec.lua
+++ b/spec/unit/readerrolling_spec.lua
@@ -123,6 +123,34 @@ describe("Readerrolling module", function()
             assert.is.truthy(called)
             readerui:onClose()
         end)
+
+        it("should update furthest_xpointer only when advancing", function()
+            rolling.furthest_xpointer = nil
+            rolling.ui.doc_settings:delSetting("furthest_xpointer")
+            rolling:onGotoPage(1)
+            rolling:onSaveSettings()
+
+            -- go forward some
+            rolling:onGotoPage(12)
+            local xp_mid = rolling.ui.document:getXPointer()
+            rolling:onSaveSettings()
+            -- check that pointer was updated
+            assert.are.same(xp_mid, rolling.ui.doc_settings:readSetting("furthest_xpointer"))
+
+            -- go back some
+            rolling:onGotoPage(3)
+            rolling:onSaveSettings()
+            -- check that pointer is STILL on furthest page read so far
+            assert.are.same(xp_mid, rolling.ui.doc_settings:readSetting("furthest_xpointer"))
+
+            -- go to page 30
+            rolling:onGotoPage(30)
+            local xp_far = rolling.ui.document:getXPointer()
+            rolling:onSaveSettings()
+
+            -- furthest should now be page 30
+            assert.are.same(xp_far, rolling.ui.doc_settings:readSetting("furthest_xpointer"))
+        end)
     end)
 
     describe("test in landscape screen mode", function()


### PR DESCRIPTION
Implements #5798. Tracks the furthest position ever reached in a book and adds a "Go to furthest read position" menu item under Navigation, so users can jump back after navigating away (e.g. following footnotes or cross-references).

## Changes

- **Rolling reader (EPUB):** tracks `furthest_xpointer` in `readerrolling.lua`, updated on every page turn/navigation using `compareXPointers()`
- **Paging reader (PDF/DjVu):** tracks `furthest_page` in `readerpaging.lua`, updated via integer comparison
- **Navigation UI:** adds `onGoToFurthestReadPage()` handler in `readergoto.lua` with menu item in the Navigation tab
- **Dispatcher:** registers `GoToFurthestReadPage` event for gesture/key binding
- **Tests:** unit tests for both engines verifying the position only advances forward

## How it works

- The furthest position is stored per-book in the sidecar (`.sdr`) file and loaded on book open
- The position updates live during reading (page turns, jumps, scrolling) and persists on close
- Jumping to furthest pushes the current location onto the back-navigation stack
- The menu item is enabled whenever a document is open; the handler is a no-op if already at or past the furthest position

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15110)
<!-- Reviewable:end -->
