### PR TITLE
creopt: fix toggle order for Invert Images to be consistent

### DIFF
--- a/frontend/ui/data/creoptions.lua
+++ b/frontend/ui/data/creoptions.lua
@@ -731,10 +731,10 @@ Whether enabled or disabled, KOReader's own status bar at the bottom of the scre
             {   -- ReaderTypeset
                 name = "nightmode_images",
                 name_text = _("Invert Images"),
-                toggle = {C_("Invert images", "on"), C_("Invert images", "off")},
-                values = {1, 0},
+                toggle = {C_("Invert images", "off"), C_("Invert images", "on")},
+                values = {0, 1},
                 default_value = 1,
-                args = {true, false},
+                args = {false, true},
                 event = "ToggleNightmodeImages",
                 show_func = function() return Screen.night_mode end,
                 name_text_hold_callback = optionsutil.showValues,


### PR DESCRIPTION
Rearranges the order for the option "Invert Images" so that off is on the left and on is on the right.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/2d9c6311-5f6f-4fd7-9c06-5b6c65521751" />

Related: #13041

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15112)
<!-- Reviewable:end -->
