### PR TITLE
(opds): remove redundant UTF-8 fixup

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -999,7 +999,7 @@ function OPDSBrowser:getLocalDownloadPath(filename, filetype, remote_url)
     filename = filename and filename .. "." .. filetype:lower() or self:getServerFileName(remote_url, filetype)
     filename = util.getSafeFilename(filename, download_dir)
     filename = (download_dir ~= "/" and download_dir or "") .. '/' .. filename
-    return util.fixUtf8(filename, "_")
+    return filename
 end
 
 -- Downloads a book (with "File already exists" dialog)


### PR DESCRIPTION
…names

The getLocalDownloadPath function was calling fixUtf8 with '_' replacement on the full path (directory + filename), after the filename had already been properly sanitized by getSafeFilename which calls fixUtf8 with ''.

This double processing with different replacement characters caused:
- Non-UTF8 bytes (from URL decoding or header issues) to be replaced with '_'
- Encoding artifacts like '=' characters combined with '_' replacements
- File extensions corrupted (e.g., .cbz becomes .cbz_=)

The fix removes the redundant fixUtf8 call on the full path. The filename is already properly validated by getSafeFilename, and applying fixUtf8 again on the combined path is unnecessary and harmful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15122)
<!-- Reviewable:end -->
