### PR TITLE
kopt: fix Invert Document regression with Reflow/Auto Straighten

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -597,28 +597,13 @@ Inherited from common document interface.
 --]]
 function KoptInterface:drawContextPage(doc, target, x, y, rect, pageno, zoom, rotation, nightmode_invert)
     local tile = self:renderPage(doc, pageno, rect, zoom, rotation, 1.0)
-    local offs_x = rect.x - tile.excerpt.x
-    local offs_y = rect.y - tile.excerpt.y
+    target:blitFrom(tile.bb,
+        x, y,
+        rect.x - tile.excerpt.x,
+        rect.y - tile.excerpt.y,
+        rect.w, rect.h)
     if nightmode_invert then
-        if doc.configurable.page_opt == 1 then
-            -- Dewatermark enabled: draw tile, then invert the drawn area
-            target:blitFrom(tile.bb,
-                x, y,
-                offs_x, offs_y,
-                rect.w, rect.h)
-            target:invertRect(x, y, rect.w, rect.h)
-        else
-            -- Dewatermark disabled: invert tile directly
-            target:invertblitFrom(tile.bb,
-                x, y,
-                offs_x, offs_y,
-                rect.w, rect.h)
-        end
-    else
-        target:blitFrom(tile.bb,
-            x, y,
-            offs_x, offs_y,
-            rect.w, rect.h)
+        target:invertRect(x, y, rect.w, rect.h)
     end
 end
 


### PR DESCRIPTION
Due to changes to `renderOptimizedPage(...)` made by #15067, which was merged after #14954 was made, a regression was introduced that causes instability and even crashes on mobile devices and e-readers when Invert Document is enabled along with Reflow or Auto Straighten.

This PR fixes the regression and simplifies the `drawContextPage(...)` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15123)
<!-- Reviewable:end -->
