### PR TITLE
Fix sdl3 lib path in nix shell

### DIFF
--- a/tools/shell.nix
+++ b/tools/shell.nix
@@ -31,6 +31,6 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    export LD_LIBRARY_PATH=${pkgs.SDL2}/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=${pkgs.sdl3}/lib:$LD_LIBRARY_PATH
   '';
 }


### PR DESCRIPTION
`./kodev run` from nix-shell failed as it could not locate the sdl3 library. This change fixes it.
Tested on my linux dev environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15142)
<!-- Reviewable:end -->
