### PR TITLE
[DictQuickLookup] detection and key-event injection for SDL devices

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -806,7 +806,7 @@ function DictQuickLookup:registerKeyEvents()
             self.key_events.FastLeftTextSelectorIndicator  = { { modifier, "Left" },  event = "FindInTextOrMoveSelectorIndicator", args = { -1, 0, true } }
             self.key_events.FastRightTextSelectorIndicator = { { modifier, "Right" }, event = "FindInTextOrMoveSelectorIndicator", args = { 1,  0, true } }
             if Device:hasKeyboard() then
-                self.key_events.LookupInputWordClear = { { Input.group.Alphabet }, { "Shift", Input.group.Alphabet }, event = "LookupInputWord" }
+                self.key_events.LookupInputWordClear = { { Input.group.AlphaNumeric }, { "Shift", Input.group.AlphaNumeric }, event = "LookupInputWord" }
                 if G_reader_settings:nilOrFalse("backspace_as_back") then
                     -- We need to concat here so that the 'del' event press, which propagates to inputText (desirable for previous key_event,
                     -- i.e., LookupInputWordClear) does not remove the last char of self.word


### PR DESCRIPTION
### what's new

* Expanded the `LookupInputWordClear` key event to include both unmodified and Shift-modified alphabet keys, allowing for more flexible input handling.
* Updated the `onLookupInputWord` function to support direct key-event injection for SDL devices, ensuring that the input dialog opens and the pressed key (with correct casing for Shift) is injected on the next tick.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15158)
<!-- Reviewable:end -->
