### PR TITLE
coverimage: only update on rotation if rotate image enabled

### DIFF
--- a/plugins/coverimage.koplugin/main.lua
+++ b/plugins/coverimage.koplugin/main.lua
@@ -233,7 +233,9 @@ end
 
 function CoverImage:onSetRotationMode(rotation)
     logger.dbg("CoverImage: onSetRotationMode", rotation)
-    self:createCoverImage(self.ui.doc_settings)
+    if self.cover_image_rotate then
+        self:createCoverImage(self.ui.doc_settings)
+    end
 end
 
 function CoverImage:fallbackEnabled()


### PR DESCRIPTION
Creating the cover image delays rotation a little bit (half a second, even if cached), although it could be several seconds on some PocketBook devices since #14985 which synchronously invokes `sync` after creating the cover.

To work around this, skip creating the image in the onSetRotationMode event hook if "Rotate image" is disabled as the resulting image would be exactly the same. The speedup is noticeable even if the cover cache gets hit.

The issue with synchronous `sync` taking several seconds will be fixed later once we figure out whether any PocketBook devices actually need the `sync` or not.
See https://github.com/koreader/koreader/issues/15177 for details. (Note that this PR doesn't completely fix that issue! It's just a partial workaround and requires disabling "Rotate image".)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15179)
<!-- Reviewable:end -->
