### PR TITLE
doc: another update to build requirements

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -13,18 +13,23 @@ You can skip most of the following instructions if desired, and use our premade 
 
 To get and compile the source you must have:
 - `autoconf`: version > 2.64
+- `automake`
+- `awk`
 - `bash`: version >= 4.0
 - `cmake`: version >= 3.17.5
+- `curl`
+- `find`
 - `gcc/g++` or `clang/clang++`: with C11 & C++17 support
 - `gettext`
 - `git`
+- `libtool`
 - `make`: version >= 4.1 (recommended: >= 4.4 for transparent `-j` / `-l` handling)
 - `meson`: version >= 1.2.0 on Linux, >= 1.8.3 on macOS
 - `nasm`
 - `ninja` (recommended: >= 1.13.2 for make job server support)
 - `patch`
-- `perl`: version >= 5
 - `pkg-config` or `pkgconf`
+- `python`: version >= 3.10
 - `unzip`
 - `wget`
 
@@ -43,7 +48,7 @@ Install the prerequisites using apk:
 ```
 sudo apk add autoconf automake bash cmake coreutils curl diffutils \
     findutils g++ gcc gettext-dev git grep gzip libtool linux-headers \
-    make meson nasm ninja-build patch perl pkgconf procps-ng sdl3 tar \
+    make meson nasm ninja-build patch pkgconf procps-ng sdl3 tar \
     unzip wget
 ```
 
@@ -61,7 +66,7 @@ Install the prerequisites using pacman:
 
 ```
 run0 pacman -S base-devel ca-certificates cmake gcc-libs git \
-    meson nasm ninja perl sdl3 unzip wget
+    meson nasm ninja sdl3 unzip wget
 ```
 
 Optional:
@@ -74,39 +79,41 @@ run0 pacman -S 7zip ccache luacheck luajit shellcheck shfmt
 Install the prerequisites using APT:
 
 ```
-sudo apt install autoconf automake build-essential ca-certificates cmake \
-    gcc-multilib gettext git libtool libtool-bin meson nasm \
-    ninja-build patch perl pkg-config unzip wget
+sudo apt install --no-install-recommends autoconf automake build-essential \
+    ca-certificates cmake curl gcc-multilib gettext git libtool libtool-bin \
+    meson nasm ninja-build patch pkg-config unzip wget
 ```
 
 To install SDL3, on recent enough distributions:
 ```
-sudo apt install libsdl3-0
+sudo apt install --no-install-recommends libsdl3-0
 ```
 
 For building SDL3 on distributions that don't provide a recent enough version:
 ```
 # Minimal Wayland support.
-sudo apt install libegl-dev libwayland-dev
+sudo apt install --no-install-recommends libegl-dev libwayland-dev libxkbcommon-dev
 # Minimal X11 support.
-sudo apt install libx11-dev libxext-dev
+sudo apt install --no-install-recommends libx11-dev libxcursor-dev libxext-dev libxi-dev \
+    libxrandr-dev libxss-dev libxtst-dev
 ```
 
 **Note:** Debian distributions might need `meson` to be installed from `bookworm-backports`
 because the version provided by the default repositories is too old:
 ```
-sudo apt install meson/bookworm-backports
+sudo apt install --no-install-recommends meson/bookworm-backports
 ```
 The bookworm-backports repository was already included on Linux Mint Debian Edition 6.
 Otherwise, follow full up-to-date instructions from here: https://wiki.debian.org/Backports.
 
 Optional:
 ```
-sudo apt install ccache libluajit-5.1-dev lua-check luajit p7zip-full shellcheck shfmt
+sudo apt install --no-install-recommends  ccache libluajit-5.1-dev lua-check luajit \
+    p7zip-full shellcheck shfmt
 ```
 And to install GCC plugin support for your installed GCC version, e.g. for `gcc-11`:
 ```
-sudo apt install gcc-11-plugin-dev
+sudo apt install --no-install-recommends gcc-11-plugin-dev
 ```
 
 ### Fedora/Red Hat
@@ -115,7 +122,7 @@ Install the prerequisites using DNF:
 
 ```
 sudo dnf install autoconf automake cmake gcc gcc-c++ gettext git libtool meson \
-    nasm ninja-build patch perl-FindBin procps-ng SDL3 unzip wget
+    nasm ninja-build patch procps-ng SDL3 unzip wget
 ```
 
 Optional:
@@ -134,7 +141,8 @@ Install the prerequisites using [Homebrew](https://brew.sh/):
 
 ```
 brew install autoconf automake bash binutils cmake coreutils findutils \
-    gettext gnu-getopt libtool make meson nasm ninja pkg-config util-linux
+    gettext gnu-getopt libtool make meson nasm ninja pkgconf sdl3 \
+    util-linux
 ```
 
 You will also have to ensure Homebrew's findutils, gnu-getopt, make & util-linux are in your path, e.g., via
@@ -159,6 +167,26 @@ Ensure the [nix is installed](https://nixos.org/download/).
 Then simply run the included nix shell:
 ```
 nix-shell tools/shell.nix
+```
+
+### openSUSE
+
+Install the prerequisites using zypper:
+
+```
+sudo zypper install autoconf automake bash cmake find gcc gcc-32bit gcc-c++ gettext \
+    gawk git libSDL3-0 libtool make meson nasm ninja patch pkgconf unzip wget
+```
+
+Optional:
+
+```
+sudo zypper install 7zip ccache luajit-devel luajit-luacheck ShellCheck shfmt
+```
+
+And to install GCC plugin support for your installed GCC version, e.g. for `gcc15`:
+```
+sudo apt install gcc15-devel
 ```
 
 ## Getting the source


### PR DESCRIPTION
- add missing requirements (that would normally be already installer or transitively installed by other requirements on most distributions)
- drop perl (no longer needed since the switch from OpenSSL to LibreSSL)
- fix SDL3 Ubuntu requirements
- add instructions for OpenSUSE

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15191)
<!-- Reviewable:end -->
