### PR TITLE
bugfix: check for current directory in webdav listing

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -53,6 +53,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
     if webdav_url:sub(-1) ~= "/" then
         webdav_url = webdav_url .. "/"
     end
+    local webdav_url_path = self.trim_slashes(webdav_url:match("^https?://[^/]*(.*)$") or webdav_url)
 
     local sink = {}
     local data = [[<?xml version="1.0"?><a:propfind xmlns:a="DAV:"><a:prop><a:resourcetype/><a:getcontentlength/></a:prop></a:propfind>]]
@@ -92,7 +93,7 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             -- <d:href> is the path and filename of the entry.
             local item_fullpath = item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>")
             local item_name = ffiUtil.basename(util.htmlEntitiesToUtf8(util.urlDecode(item_fullpath)))
-            local is_current_dir = self.trim_slashes(item_fullpath) == path
+            local is_current_dir = self.trim_slashes(item_fullpath) == webdav_url_path
             local is_not_collection = item:find("<[^:]*:resourcetype%s*/>") or
                                       item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
             local item_path = path .. "/" .. item_name

--- a/plugins/cloudstorage.koplugin/providers/webdav.lua
+++ b/plugins/cloudstorage.koplugin/providers/webdav.lua
@@ -58,6 +58,7 @@ function WebDavApi.listFolder(address, user, pass, folder_path, include_folders)
     if webdav_url:sub(-1) ~= "/" then
         webdav_url = webdav_url .. "/"
     end
+    local webdav_url_path = WebDavApi.trim_slashes(util.urlDecode(webdav_url:match("^https?://[^/]*(.*)$") or webdav_url))
 
     local sink = {}
     local data = [[<?xml version="1.0"?><a:propfind xmlns:a="DAV:"><a:prop><a:resourcetype/><a:getcontentlength/><a:getlastmodified/></a:prop></a:propfind>]]
@@ -122,7 +123,7 @@ function WebDavApi.listFolder(address, user, pass, folder_path, include_folders)
             end
         elseif item:find("<[^:]*:collection[^<]*/>") then
             if include_folders then
-                local is_not_current_dir = WebDavApi.trim_slashes(item_fullpath) ~= path
+                local is_not_current_dir = WebDavApi.trim_slashes(item_fullpath) ~= webdav_url_path
                 if is_not_current_dir then
                     table.insert(item_list, {
                         is_folder = true,


### PR DESCRIPTION
## bug
🐞 The name of the current directory in webdav storage is showing up in the contents list and placed in alphabetical order.
<img width="608" height="820" alt="Screenshot 2026-03-27 at 0 25 43" src="https://github.com/user-attachments/assets/ab59bc1c-d23f-44a2-a23e-f14025ce01bb" />

## fix
Update the comparisson logic for the current dir to use a path value without the full server address.
<img width="652" height="864" alt="Screenshot 2026-03-27 at 0 26 24" src="https://github.com/user-attachments/assets/803a2db4-aa90-4580-b04b-0465906a4f1b" />

## notes
I noticed this issue while using Nextcloud's WebDAV.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15192)
<!-- Reviewable:end -->
