### PR TITLE
[FileChooser] ignore home folder lock when navigating file structure from menu

### DIFF
--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -24,6 +24,7 @@ local FileChooser = BookList:extend{
     show_hidden      = G_reader_settings:readSetting("show_hidden", false), -- folders/files starting with "."
     show_unsupported = G_reader_settings:readSetting("show_unsupported", false), -- set to true to ignore file_filter
     file_filter = nil, -- function defined in the caller, returns true for files to be shown
+    ignore_home_folder_lock = false, -- if true, home folder lock has no effect in FileChooser (e.g., PathChooser)
     -- NOTE: Input is *always* a relative entry name
     exclude_dirs = { -- const
         -- KOReader / Kindle

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -231,6 +231,10 @@ function FileChooser:genItemTableFromPath(path)
     return self:genItemTable(dirs, files, path)
 end
 
+function FileChooser:isHomeFolderLockActive()
+    return not self.ignore_home_folder_lock and G_reader_settings:isTrue("lock_home_folder")
+end
+
 function FileChooser:genItemTable(dirs, files, path)
     local collate = self:getCollate()
     local collate_mixed = G_reader_settings:isTrue("collate_mixed")
@@ -253,7 +257,7 @@ function FileChooser:genItemTable(dirs, files, path)
     end
 
     if path then -- file browser or PathChooser
-        if path ~= "/" and not (G_reader_settings:isTrue("lock_home_folder") and
+        if path ~= "/" and not (self:isHomeFolderLockActive() and
                                 path == G_reader_settings:readSetting("home_dir")) then
             table.insert(item_table, 1, {
                 text = BD.mirroredUILayout() and BD.ltr("../ ⬆") or "⬆ ../",
@@ -372,7 +376,7 @@ function FileChooser:goHome()
 end
 
 function FileChooser:onFolderUp()
-    if not (G_reader_settings:isTrue("lock_home_folder") and
+    if not (self:isHomeFolderLockActive() and
             self.path == G_reader_settings:readSetting("home_dir")) then
         self:changeToPath(string.format("%s/..", self.path), self.path)
     end

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -14,6 +14,7 @@ local PathChooser = FileChooser:extend{
     title = true, -- or a string
         -- if let to true, a generic title will be set in init()
     no_title = false,
+    ignore_home_folder_lock = true,
     select_directory = true, -- allow selecting directories
     select_file = true,      -- allow selecting files
     show_files = true, -- show files, even if select_file=false


### PR DESCRIPTION
Currently when Home folder is locked and a user tries to say, change the path for the sleep screen images, if the starting point if said Home folder, there is no way to move out of it without first having to deactivate it.

### what's new

* Added a new method `isHomeFolderLockActive` to `FileChooser` to encapsulate the logic for determining if the home folder lock is active, improving code readability and maintainability.
* Updated the navigation logic in `genItemTable` and `onFolderUp` to use the new `isHomeFolderLockActive` method instead of directly checking the setting, ensuring consistent behaviour. 
* Set `ignore_home_folder_lock = true` in the `PathChooser` extension, allowing this component to bypass the home folder lock if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15205)
<!-- Reviewable:end -->
