### PR TITLE
Add portrait-only gyro auto-rotation mode

### DIFF
--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -247,6 +247,31 @@ if Device:hasGSensor() then
         end
         Notification:notify(new_text)
     end
+
+    function DeviceListener:onPortraitOnlyGSensor()
+        G_reader_settings:flipNilOrFalse("input_gsensor_portrait_only")
+        self:setPortraitOnlyGsensor(G_reader_settings:isTrue("input_gsensor_portrait_only"))
+        return true
+    end
+
+    -- @param flag bool on/off
+    function DeviceListener:onSetPortraitOnlyGSensor(flag)
+        self:setPortraitOnlyGsensor(flag)
+        return true
+    end
+
+    -- @param flag bool on/off
+    function DeviceListener:setPortraitOnlyGsensor(flag)
+        G_reader_settings:saveSetting("input_gsensor_portrait_only", flag)
+        Device:portraitOnlyGSensor(flag)
+        local new_text
+        if G_reader_settings:isTrue("input_gsensor_portrait_only") then
+            new_text = _("Auto rotation limited to portrait only.")
+        else
+            new_text = _("Auto rotation unrestricted.")
+        end
+        Notification:notify(new_text)
+    end
 end
 
 if not Device:isAlwaysFullscreen() then

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -76,6 +76,7 @@ local Device = {
     canShareText = no,
     hasGSensor = no,
     isGSensorLocked = no,
+    isGSensorPortraitOnly = no,
     canToggleMassStorage = no,
     canToggleChargingLED = no,
     _updateChargingLED = nil,
@@ -275,6 +276,11 @@ function Device:init()
         -- Honor the gyro lock
         if G_reader_settings:isTrue("input_lock_gsensor") then
             self:lockGSensor(true)
+        end
+
+        -- Honor the portrait-only gyro setting
+        if G_reader_settings:isTrue("input_gsensor_portrait_only") then
+            self:portraitOnlyGSensor(true)
         end
     end
 
@@ -564,6 +570,25 @@ function Device:lockGSensor(toggle)
             self.isGSensorLocked = no
         else
             self.isGSensorLocked = yes
+        end
+    end
+end
+
+-- Whether or not the GSensor should only honor portrait rotations (i.e., discard landscape events)
+function Device:portraitOnlyGSensor(toggle)
+    if not self:hasGSensor() then
+        return
+    end
+
+    if toggle == true then
+        self.isGSensorPortraitOnly = yes
+    elseif toggle == false then
+        self.isGSensorPortraitOnly = no
+    else
+        if self:isGSensorPortraitOnly() then
+            self.isGSensorPortraitOnly = no
+        else
+            self.isGSensorPortraitOnly = yes
         end
     end
 end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -1212,6 +1212,11 @@ function Input:handleMiscGyroEv(ev)
         return
     end
 
+    -- If portrait-only mode is enabled, discard landscape rotation events
+    if self.device:isGSensorPortraitOnly() and bit.band(rotation, 1) == 1 then
+        return
+    end
+
     local old_rotation = self.device.screen:getRotationMode()
     if self.device:isGSensorLocked() then
         local matching_orientation = bit.band(rotation, 1) == bit.band(old_rotation, 1)

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -102,6 +102,8 @@ local settingsList = {
     temp_gsensor_on = {category="none", event="TempGSensorOn", title=_("Enable accelerometer for 5 seconds"), device=true, condition=Device:hasGSensor()},
     lock_gsensor = {category="none", event="LockGSensor", title=_("Toggle lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor()},
     set_lock_gsensor = {category="string", event="SetLockGSensor", title=_("Set lock auto rotation to current orientation"), device=true, condition=Device:hasGSensor(), args = {true, false}, toggle = { _("true"), _("false")}},
+    portrait_only_gsensor = {category="none", event="PortraitOnlyGSensor", title=_("Toggle portrait-only auto rotation"), device=true, condition=Device:hasGSensor()},
+    set_portrait_only_gsensor = {category="string", event="SetPortraitOnlyGSensor", title=_("Set portrait-only auto rotation"), device=true, condition=Device:hasGSensor(), args = {true, false}, toggle = { _("true"), _("false")}},
     rotation_mode = {category="string", device=true}, -- title=_("Rotation"), parsed from CreOptions
     toggle_rotation = {category="none", event="SwapRotation", title=_("Toggle orientation"), device=true},
     invert_rotation = {category="none", event="InvertRotation", title=_("Invert rotation"), device=true},

--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -60,6 +60,24 @@ If you need to do so, you'll have to use the UI toggles.]]),
                     UIManager:broadcastEvent(Event:new("LockGSensor"))
                 end,
             })
+
+            table.insert(rotation_table, {
+                text = _("Auto rotate only in portrait"),
+                help_text = _([[
+When checked, the gyro will only honor portrait rotations (Upright and Inverted Portrait).
+Landscape rotation events will be silently discarded.
+This is useful if you only read in portrait mode and want to prevent accidental landscape rotations.
+Note: if orientation is also locked, both constraints apply — e.g., if locked while in landscape, no gyro rotation will occur at all.]]),
+                enabled_func = function()
+                    return G_reader_settings:nilOrFalse("input_ignore_gsensor")
+                end,
+                checked_func = function()
+                    return G_reader_settings:isTrue("input_gsensor_portrait_only")
+                end,
+                callback = function()
+                    UIManager:broadcastEvent(Event:new("PortraitOnlyGSensor"))
+                end,
+            })
         end
 
         table.insert(rotation_table, {


### PR DESCRIPTION
## Summary

Adds a new **"Auto rotate only in portrait"** option under Settings → Rotation. When enabled, the accelerometer only rotates between the two portrait orientations (0° and 180°), silently discarding landscape rotation events (90° and 270°).

- New setting `input_gsensor_portrait_only` with device-level flag, mirroring the existing `input_lock_gsensor` pattern
- Filter in `handleMiscGyroEv` discards landscape events before further processing
- Menu item with help text, grayed out when accelerometer is disabled
- Dispatcher entries for gesture/button binding support

Closes #5106, closes #13590

## Test plan

- [x] Tested on **Kobo Libra H2O** (firmware 4.x) — only device tested
- [x] Enable portrait-only → hold device in landscape → no rotation occurs
- [x] Enable portrait-only → flip upside-down in portrait → rotates to inverted portrait
- [x] Disable accelerometer → portrait-only menu item is grayed out
- [x] `luacheck` passes with 0 warnings / 0 errors
- [ ] CI (emulator build + frontend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15208)
<!-- Reviewable:end -->
