### PR TITLE
pocketbook: drop redundant trace

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -406,10 +406,6 @@ function PocketBook:initNetworkManager(NetworkMgr)
     end
 end
 
-function PocketBook:getSoftwareVersion()
-    return ffi.string(inkview.GetSoftwareVersion())
-end
-
 function PocketBook:getDeviceModel()
     return ffi.string(inkview.GetDeviceModel())
 end
@@ -853,8 +849,6 @@ local PocketBook1040 = PocketBook:extend{
     usingForcedRotation = landscape_ccw,
     hasNaturalLight = yes,
 }
-
-logger.info('SoftwareVersion: ', PocketBook:getSoftwareVersion())
 
 local full_codename = PocketBook:getDeviceModel()
 


### PR DESCRIPTION
We already show the actual and targeted PocketBook software versions when initializing our inkview support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15222)
<!-- Reviewable:end -->
