### PR TITLE
feat: add alternative mime type for fb2

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1562,8 +1562,8 @@ function CreDocument:register(registry)
     registry:addProvider("epub", "application/epub", self, 100) -- Alternative mimetype for OPDS.
     registry:addProvider("epub3", "application/epub+zip", self, 100)
     registry:addProvider("fb2", "application/fb2", self, 90)
-    registry:addProvider("fb2", "text/fb2+xml", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("fb2", "application/x-fictionbook+xml", self, 90) -- Alternative mimetype for OPDS.
+    registry:addProvider("fb2", "text/fb2+xml", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("fb2.zip", "application/zip", self, 90)
     registry:addProvider("fb2.zip", "application/fb2+zip", self, 90) -- Alternative mimetype for OPDS.
     registry:addProvider("fb3", "application/fb3", self, 90)


### PR DESCRIPTION
When I configured OPDS server on my selfhosted grimmory instance I wasn't able to download fb2 books, because mime type "application/x-fictionbook+xml" was missing from koreader list. This pull request adds it.

P.S. Thank you for a great reader, I've been really enjoying it on my pocketbook!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15231)
<!-- Reviewable:end -->
