### PR TITLE
Feature: Implement the ability to delete plugins

### DIFF
--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -17,6 +17,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local ffiUtil = require("ffi/util")
 local _ = require("gettext")
+local T = ffiUtil.template
 
 local DEFAULT_PLUGIN_PATH = "plugins"
 

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -326,7 +326,7 @@ function PluginLoader:genPluginManagerSubItem()
             hold_callback = function(touchmenu_instance)
                 local ConfirmBox = require("ui/widget/confirmbox")
                 UIManager:show(ConfirmBox:new{
-                    text = plugin.description .. "\n\n" .. string.format(_("Are you sure you want to delete the plugin '%s'?"), plugin.fullname),
+                    text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),
                     ok_callback = function()
                         local instance = self:getPluginInstance(plugin.name)
                         local stopPluginFn = instance and instance.stopPlugin
@@ -352,7 +352,7 @@ function PluginLoader:genPluginManagerSubItem()
                         else
                             local InfoMessage = require("ui/widget/infomessage")
                             UIManager:show(InfoMessage:new{
-                                text = string.format(_("Failed to delete plugin:\n%s"), tostring(err)),
+                                text = _("Failed to delete plugin:") .. "\n" .. err,
                             })
                         end
                     end,

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -11,6 +11,7 @@ Plugins are controlled by the following settings.
 - plugins_disabled
 - extra_plugin_paths
 ]]
+local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
@@ -59,6 +60,7 @@ end
 local function getMenuTable(plugin)
     local t = {}
     t.name = plugin.name
+    t.path = plugin.path
     t.fullname = string.format("%s%s", plugin.fullname or plugin.name,
         plugin.deprecated and " (" .. _("outdated") .. ")" or "")
 
@@ -250,6 +252,24 @@ function PluginLoader:loadPlugins()
     return self.enabled_plugins, self.disabled_plugins
 end
 
+local function removeDir(path)
+    local attr = lfs.attributes(path, "mode")
+    if attr ~= "directory" then
+        return os.remove(path)
+    end
+    for f in lfs.dir(path) do
+        if f ~= "." and f ~= ".." then
+            local fullpath = path .. "/" .. f
+            if lfs.attributes(fullpath, "mode") == "directory" then
+                removeDir(fullpath)
+            else
+                os.remove(fullpath)
+            end
+        end
+    end
+    return lfs.rmdir(path)
+end
+
 function PluginLoader:genPluginManagerSubItem()
     if not self.all_plugins then
         local enabled_plugins, disabled_plugins = self:loadPlugins()
@@ -278,7 +298,6 @@ function PluginLoader:genPluginManagerSubItem()
                 return plugin.enable
             end,
             callback = function()
-                local UIManager = require("ui/uimanager")
                 local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
                 plugin.enable = not plugin.enable
                 if plugin.enable then
@@ -304,7 +323,41 @@ function PluginLoader:genPluginManagerSubItem()
                     UIManager:askForRestart()
                 end
             end,
-            help_text = plugin.description,
+            hold_callback = function(touchmenu_instance)
+                local ConfirmBox = require("ui/widget/confirmbox")
+                UIManager:show(ConfirmBox:new{
+                    text = plugin.description .. "\n\n" .. string.format(_("Are you sure you want to delete the plugin '%s'?"), plugin.fullname),
+                    ok_callback = function()
+                        local instance = self:getPluginInstance(plugin.name)
+                        local stopPluginFn = instance and instance.stopPlugin
+                        if type(stopPluginFn) == "function" then
+                            local ok, err = self:stopPluginInstance(instance)
+                            if not ok then
+                                logger.err("PluginLoader: Failed to stop plugin instance", plugin.name, err)
+                                ok, err = self:stopPluginInstance(instance, true)
+                                if not ok then
+                                    logger.err("PluginLoader: Failed to force-stop plugin instance", plugin.name, err)
+                                end
+                            end
+                        end
+                        local success, err = removeDir(plugin.path)
+                        if success then
+                            local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
+                            if plugins_disabled[plugin.name] then
+                                plugins_disabled[plugin.name] = nil
+                                G_reader_settings:saveSetting("plugins_disabled", plugins_disabled)
+                            end
+                            self.all_plugins = nil
+                            UIManager:askForRestart()
+                        else
+                            local InfoMessage = require("ui/widget/infomessage")
+                            UIManager:show(InfoMessage:new{
+                                text = string.format(_("Failed to delete plugin:\n%s"), tostring(err)),
+                            })
+                        end
+                    end,
+                })
+            end,
         })
     end
     return plugin_table

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -305,6 +305,7 @@ function PluginLoader:genPluginManagerSubItem()
                         self:stopPluginInstanceByName(plugin.name)
                         local success, err = ffiUtil.purgeDir(plugin.path)
                         if success then
+                            self:deletePluginSettingsByName(plugin.name)
                             local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
                             if plugins_disabled[plugin.name] then
                                 plugins_disabled[plugin.name] = nil
@@ -356,6 +357,37 @@ function PluginLoader:stopPluginInstanceByName(name)
     if not ok then
         logger.err("PluginLoader: Failed to force-stop plugin instance", name, err)
     end
+    return false, err
+end
+
+--- Calls the deletePluginSettings() method on a plugin instance of a given name if it's currently loaded.
+--- This is only intended for plugins that manage settings in G_reader_settings or koreader/settings.
+--- @param name string The name of the plugin whose settings should be deleted.
+--- @return boolean Success, string|nil
+function PluginLoader:deletePluginSettingsByName(name)
+    local instance = self:getPluginInstance(name)
+    local deletePluginSettingsFn = instance and instance.deletePluginSettings
+    if type(deletePluginSettingsFn) ~= "function" then
+        return true, nil
+    end
+    local ok, err = self:deletePluginSettings(instance)
+    if not ok then
+        logger.err("PluginLoader: Failed to delete plugin settings", name, err)
+    end
+    return ok, err
+end
+
+--- Calls the deletePluginSettings() method on a plugin instance if it's currently loaded.
+--- This is only intended for plugins that manage settings in G_reader_settings or koreader/settings.
+--- @param instance table The plugin instance whose settings should be deleted.
+--- @return boolean Success, string|nil
+function PluginLoader:deletePluginSettings(instance)
+    local ok, err = false, "no deletePluginSettings method"
+    local fn = instance.deletePluginSettings
+    if type(fn) == "function" then
+        ok, err = pcall(fn, instance)
+    end
+    if ok then return true, nil end
     return false, err
 end
 

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -15,6 +15,7 @@ local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
+local util = require("util")
 local _ = require("gettext")
 
 local DEFAULT_PLUGIN_PATH = "plugins"
@@ -252,24 +253,6 @@ function PluginLoader:loadPlugins()
     return self.enabled_plugins, self.disabled_plugins
 end
 
-local function removeDir(path)
-    local attr = lfs.attributes(path, "mode")
-    if attr ~= "directory" then
-        return os.remove(path)
-    end
-    for f in lfs.dir(path) do
-        if f ~= "." and f ~= ".." then
-            local fullpath = path .. "/" .. f
-            if lfs.attributes(fullpath, "mode") == "directory" then
-                removeDir(fullpath)
-            else
-                os.remove(fullpath)
-            end
-        end
-    end
-    return lfs.rmdir(path)
-end
-
 function PluginLoader:genPluginManagerSubItem()
     if not self.all_plugins then
         local enabled_plugins, disabled_plugins = self:loadPlugins()
@@ -340,7 +323,7 @@ function PluginLoader:genPluginManagerSubItem()
                                 end
                             end
                         end
-                        local success, err = removeDir(plugin.path)
+                        local success, err = util.purgeDir(plugin.path)
                         if success then
                             local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
                             if plugins_disabled[plugin.name] then

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -287,18 +287,7 @@ function PluginLoader:genPluginManagerSubItem()
                     plugins_disabled[plugin.name] = nil
                 else
                     plugins_disabled[plugin.name] = true
-                    local instance = self:getPluginInstance(plugin.name)
-                    local stopPluginFn = instance and instance.stopPlugin
-                    if type(stopPluginFn) == "function" then
-                        local ok, err = self:stopPluginInstance(instance)
-                        if not ok then
-                            logger.err("PluginLoader: Failed to stop plugin instance", plugin.name, err)
-                            ok, err = self:stopPluginInstance(instance, true)
-                            if not ok then
-                                logger.err("PluginLoader: Failed to force-stop plugin instance", plugin.name, err)
-                            end
-                        end
-                    end
+                    self:stopPluginInstanceByName(plugin.name)
                 end
                 G_reader_settings:saveSetting("plugins_disabled", plugins_disabled)
                 if self.show_info then
@@ -311,18 +300,7 @@ function PluginLoader:genPluginManagerSubItem()
                 UIManager:show(ConfirmBox:new{
                     text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),
                     ok_callback = function()
-                        local instance = self:getPluginInstance(plugin.name)
-                        local stopPluginFn = instance and instance.stopPlugin
-                        if type(stopPluginFn) == "function" then
-                            local ok, err = self:stopPluginInstance(instance)
-                            if not ok then
-                                logger.err("PluginLoader: Failed to stop plugin instance", plugin.name, err)
-                                ok, err = self:stopPluginInstance(instance, true)
-                                if not ok then
-                                    logger.err("PluginLoader: Failed to force-stop plugin instance", plugin.name, err)
-                                end
-                            end
-                        end
+                        self:stopPluginInstanceByName(plugin.name)
                         local success, err = util.purgeDir(plugin.path)
                         if success then
                             local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
@@ -357,10 +335,32 @@ function PluginLoader:createPluginInstance(plugin, attr)
     end
 end
 
+--- Calls the stopPlugin() method on a plugin instance of a given name if it's currently loaded.
+--- This is only intended for plugins that manage external resources or processes.
+--- @param name string The name of the plugin to stop.
+--- @return boolean Success, string|nil
+function PluginLoader:stopPluginInstanceByName(name)
+    local instance = self:getPluginInstance(name)
+    local stopPluginFn = instance and instance.stopPlugin
+    if type(stopPluginFn) ~= "function" then
+        return true, nil
+    end
+    local ok, err = self:stopPluginInstance(instance)
+    if ok then
+        return true, nil
+    end
+    logger.err("PluginLoader: Failed to stop plugin instance", name, err)
+    ok, err = self:stopPluginInstance(instance, true)
+    if not ok then
+        logger.err("PluginLoader: Failed to force-stop plugin instance", name, err)
+    end
+    return false, err
+end
+
 --- Calls the stopPlugin() method on a plugin instance if it's currently loaded.
 --- This is only intended for plugins that manage external resources or processes.
 --- @param instance table The plugin instance to stop.
---- @param force boolean If true, forces the plugin to stop even if it encounters errors.
+--- @param force boolean|nil If true, forces the plugin to stop even if it encounters errors.
 --- @return boolean Success, string|nil
 function PluginLoader:stopPluginInstance(instance, force)
     local ok, err = false, "no stopPlugin method"

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -297,15 +297,22 @@ function PluginLoader:genPluginManagerSubItem()
                 end
             end,
             hold_callback = function()
+                local CheckButton = require("ui/widget/checkbutton")
                 local ConfirmBox = require("ui/widget/confirmbox")
-                UIManager:show(ConfirmBox:new{
+                local instance = self:getPluginInstance(plugin.name)
+                local deletePluginSettingsFn = instance and instance.deletePluginSettings
+                local delete_plugin_settings = false
+                local delete_plugin_settings_checkbox
+                local confirmbox = ConfirmBox:new{
                     text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),
                     ok_text = _("Delete"),
                     ok_callback = function()
                         self:stopPluginInstanceByName(plugin.name)
                         local success, err = ffiUtil.purgeDir(plugin.path)
                         if success then
-                            self:deletePluginSettingsByName(plugin.name)
+                            if delete_plugin_settings then
+                                self:deletePluginSettingsByName(plugin.name)
+                            end
                             local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
                             if plugins_disabled[plugin.name] then
                                 plugins_disabled[plugin.name] = nil
@@ -320,7 +327,17 @@ function PluginLoader:genPluginManagerSubItem()
                             })
                         end
                     end,
-                })
+                }
+                delete_plugin_settings_checkbox = CheckButton:new{
+                    parent = confirmbox,
+                    text = _("Also delete plugin settings"),
+                    enabled = type(deletePluginSettingsFn) == "function",
+                    callback = function()
+                        delete_plugin_settings = not delete_plugin_settings
+                    end,
+                }
+                confirmbox:addWidget(delete_plugin_settings_checkbox)
+                UIManager:show(confirmbox)
             end,
         })
     end

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -300,6 +300,7 @@ function PluginLoader:genPluginManagerSubItem()
                 local ConfirmBox = require("ui/widget/confirmbox")
                 UIManager:show(ConfirmBox:new{
                     text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),
+                    ok_text = _("Delete"),
                     ok_callback = function()
                         self:stopPluginInstanceByName(plugin.name)
                         local success, err = ffiUtil.purgeDir(plugin.path)

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -15,7 +15,7 @@ local UIManager = require("ui/uimanager")
 local dbg = require("dbg")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
-local util = require("util")
+local ffiUtil = require("ffi/util")
 local _ = require("gettext")
 
 local DEFAULT_PLUGIN_PATH = "plugins"
@@ -301,7 +301,7 @@ function PluginLoader:genPluginManagerSubItem()
                     text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),
                     ok_callback = function()
                         self:stopPluginInstanceByName(plugin.name)
-                        local success, err = util.purgeDir(plugin.path)
+                        local success, err = ffiUtil.purgeDir(plugin.path)
                         if success then
                             local plugins_disabled = G_reader_settings:readSetting("plugins_disabled") or {}
                             if plugins_disabled[plugin.name] then

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -296,7 +296,7 @@ function PluginLoader:genPluginManagerSubItem()
                     UIManager:askForRestart()
                 end
             end,
-            hold_callback = function(touchmenu_instance)
+            hold_callback = function()
                 local ConfirmBox = require("ui/widget/confirmbox")
                 UIManager:show(ConfirmBox:new{
                     text = plugin.description .. "\n\n" .. T(_("Are you sure you want to delete the plugin '%1'?"), plugin.fullname),

--- a/spec/unit/pluginloader_spec.lua
+++ b/spec/unit/pluginloader_spec.lua
@@ -14,6 +14,7 @@ describe("PluginLoader module", function()
         local lfs_mock = {
             dir_results = {},
             attributes_results = {},
+            mkdir = original_lfs.mkdir,
         }
 
         function lfs_mock.dir(path)
@@ -202,8 +203,8 @@ describe("PluginLoader module", function()
         shown_widget.ok_callback()
 
         assert.is_true(shown_widget._added_widgets[1].enabled)
-        assert.stub(PluginLoader.stopPluginInstanceByName).was.called_with(PluginLoader, "test")
-        assert.stub(PluginLoader.deletePluginSettingsByName).was.called_with(PluginLoader, "test")
+        assert.stub(PluginLoader.stopPluginInstanceByName).was.called()
+        assert.stub(PluginLoader.deletePluginSettingsByName).was.called()
         assert.is_nil(G_reader_settings:readSetting("plugins_disabled").test)
 
         UIManager.askForRestart:revert()
@@ -247,22 +248,23 @@ describe("PluginLoader module", function()
     end)
 
     it("calls deletePluginSettings on the loaded plugin instance by internal plugin id", function()
+        local called_instance
         local instance = {
-            deletePluginSettings = function() end,
+            deletePluginSettings = function(self)
+                called_instance = self
+            end,
         }
 
         stub(PluginLoader, "getPluginInstance", function()
             return instance
         end)
-        stub(instance, "deletePluginSettings")
 
         local ok, err = PluginLoader:deletePluginSettingsByName("test")
 
         assert.is_true(ok)
         assert.is_nil(err)
-        assert.stub(instance.deletePluginSettings).was.called_with(instance)
+        assert.are.equal(instance, called_instance)
 
-        instance.deletePluginSettings:revert()
         PluginLoader.getPluginInstance:revert()
     end)
 end)

--- a/spec/unit/pluginloader_spec.lua
+++ b/spec/unit/pluginloader_spec.lua
@@ -164,6 +164,9 @@ describe("PluginLoader module", function()
 
     it("deletes plugin settings by internal plugin id", function()
         local shown_widget
+        local instance = {
+            deletePluginSettings = function() end,
+        }
 
         stub(PluginLoader, "loadPlugins", function()
             return {
@@ -174,6 +177,9 @@ describe("PluginLoader module", function()
                     path = "plugins/test.koplugin",
                 },
             }, {}
+        end)
+        stub(PluginLoader, "getPluginInstance", function()
+            return instance
         end)
         stub(PluginLoader, "stopPluginInstanceByName")
         stub(PluginLoader, "deletePluginSettingsByName")
@@ -191,8 +197,11 @@ describe("PluginLoader module", function()
 
         local plugin_items = PluginLoader:genPluginManagerSubItem()
         plugin_items[1].hold_callback()
+        shown_widget._added_widgets[1].checked = true
+        shown_widget._added_widgets[1].callback()
         shown_widget.ok_callback()
 
+        assert.is_true(shown_widget._added_widgets[1].enabled)
         assert.stub(PluginLoader.stopPluginInstanceByName).was.called_with(PluginLoader, "test")
         assert.stub(PluginLoader.deletePluginSettingsByName).was.called_with(PluginLoader, "test")
         assert.is_nil(G_reader_settings:readSetting("plugins_disabled").test)
@@ -202,6 +211,38 @@ describe("PluginLoader module", function()
         ffiUtil.purgeDir:revert()
         PluginLoader.deletePluginSettingsByName:revert()
         PluginLoader.stopPluginInstanceByName:revert()
+        PluginLoader.getPluginInstance:revert()
+        PluginLoader.loadPlugins:revert()
+    end)
+
+    it("shows the delete settings checkbox disabled when the plugin does not provide that hook", function()
+        local shown_widget
+
+        stub(PluginLoader, "loadPlugins", function()
+            return {
+                {
+                    name = "test",
+                    fullname = "Pretty Test",
+                    description = "from meta",
+                    path = "plugins/test.koplugin",
+                },
+            }, {}
+        end)
+        stub(PluginLoader, "getPluginInstance", function()
+            return nil
+        end)
+        stub(UIManager, "show", function(_, widget)
+            shown_widget = widget
+        end)
+
+        local plugin_items = PluginLoader:genPluginManagerSubItem()
+        plugin_items[1].hold_callback()
+
+        assert.is_not_nil(shown_widget._added_widgets)
+        assert.is_false(shown_widget._added_widgets[1].enabled)
+
+        UIManager.show:revert()
+        PluginLoader.getPluginInstance:revert()
         PluginLoader.loadPlugins:revert()
     end)
 

--- a/spec/unit/pluginloader_spec.lua
+++ b/spec/unit/pluginloader_spec.lua
@@ -1,10 +1,12 @@
 describe("PluginLoader module", function()
     local PluginLoader, UIManager
+    local ffiUtil
     local original_lfs
 
     setup(function()
         require("commonrequire")
         UIManager = require("ui/uimanager")
+        ffiUtil = require("ffi/util")
         original_lfs = require("libs/libkoreader-lfs")
     end)
 
@@ -158,5 +160,68 @@ describe("PluginLoader module", function()
         UIManager.askForRestart:revert()
         PluginLoader.getPluginInstance:revert()
         PluginLoader.loadPlugins:revert()
+    end)
+
+    it("deletes plugin settings by internal plugin id", function()
+        local shown_widget
+
+        stub(PluginLoader, "loadPlugins", function()
+            return {
+                {
+                    name = "test",
+                    fullname = "Pretty Test",
+                    description = "from meta",
+                    path = "plugins/test.koplugin",
+                },
+            }, {}
+        end)
+        stub(PluginLoader, "stopPluginInstanceByName")
+        stub(PluginLoader, "deletePluginSettingsByName")
+        stub(ffiUtil, "purgeDir", function()
+            return true
+        end)
+        stub(UIManager, "show", function(_, widget)
+            shown_widget = widget
+        end)
+        stub(UIManager, "askForRestart")
+
+        G_reader_settings:saveSetting("plugins_disabled", {
+            test = true,
+        })
+
+        local plugin_items = PluginLoader:genPluginManagerSubItem()
+        plugin_items[1].hold_callback()
+        shown_widget.ok_callback()
+
+        assert.stub(PluginLoader.stopPluginInstanceByName).was.called_with(PluginLoader, "test")
+        assert.stub(PluginLoader.deletePluginSettingsByName).was.called_with(PluginLoader, "test")
+        assert.is_nil(G_reader_settings:readSetting("plugins_disabled").test)
+
+        UIManager.askForRestart:revert()
+        UIManager.show:revert()
+        ffiUtil.purgeDir:revert()
+        PluginLoader.deletePluginSettingsByName:revert()
+        PluginLoader.stopPluginInstanceByName:revert()
+        PluginLoader.loadPlugins:revert()
+    end)
+
+    it("calls deletePluginSettings on the loaded plugin instance by internal plugin id", function()
+        local instance = {
+            deletePluginSettings = function() end,
+        }
+
+        stub(PluginLoader, "getPluginInstance", function()
+            return instance
+        end)
+        stub(instance, "deletePluginSettings")
+
+        local ok, err = PluginLoader:deletePluginSettingsByName("test")
+
+        assert.is_true(ok)
+        assert.is_nil(err)
+        assert.stub(instance.deletePluginSettings).was.called_with(instance)
+
+        instance.deletePluginSettings:revert()
+        PluginLoader.getPluginInstance:revert()
     end)
 end)


### PR DESCRIPTION
This pull request adds the ability for users to delete plugins directly from KoReader's UI.

It prevents the need to either connect the Kindle to the computer and delete the plugin's folder or do it through the file explorer which can be cumbersome.

Disclaimer: the code was generated by Gemini but was unsloppified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15240)
<!-- Reviewable:end -->
