### PR TITLE
fix(pocketbook): Networking and DNS resolution during early boot

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -11,6 +11,11 @@ local _ = require("gettext")
 
 require("ffi/linux_input_h")
 
+ffi.cdef[[
+    int res_init(void);
+    int __res_init(void);
+]]
+
 local function yes() return true end
 local function no() return false end
 
@@ -392,17 +397,57 @@ function PocketBook:initNetworkManager(NetworkMgr)
         end
     end
 
-    function NetworkMgr:isConnected()
+    function NetworkMgr:isWifiOn()
         return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
-    NetworkMgr.isWifiOn = NetworkMgr.isConnected
+
+    local route_seen = false
+    function NetworkMgr:isConnected()
+        if not self:isWifiOn() then
+            route_seen = false
+            return false
+        end
+        if self:hasDefaultRoute() then
+            if not route_seen then
+                -- Workaround for glibc bug where /etc/resolv.conf is parsed
+                -- only once. We force a reload when the route first appears.
+                local ok = pcall(function() ffi.C.res_init() end)
+                if not ok then pcall(function() ffi.C.__res_init() end) end
+                route_seen = true
+            end
+            return true
+        end
+        return false
+    end
 
     function NetworkMgr:isOnline()
         -- Fail early if we don't even have a default route, otherwise we're
         -- unlikely to be online and canResolveHostnames would never succeed
         -- again because PocketBook's glibc parses /etc/resolv.conf on first
         -- use only. See https://sourceware.org/bugzilla/show_bug.cgi?id=984
-        return NetworkMgr:hasDefaultRoute() and NetworkMgr:canResolveHostnames()
+        return self:isConnected() and self:canResolveHostnames()
+    end
+
+    -- Ensure NetworkConnected is eventually broadcasted if KOReader boots
+    -- while the system network stack is still coming up.
+    local orig_init = NetworkMgr.init
+    function NetworkMgr:init()
+        local is_link_up = self:isWifiOn()
+        local res = orig_init(self)
+
+        if is_link_up and not self.is_connected then
+            local function waitForRoute()
+                if not self:isWifiOn() then return end
+                if self:isConnected() then
+                    self.is_connected = true
+                    UIManager:broadcastEvent(require("ui/event"):new("NetworkConnected"))
+                else
+                    UIManager:scheduleIn(0.5, waitForRoute)
+                end
+            end
+            UIManager:scheduleIn(0.5, waitForRoute)
+        end
+        return res
     end
 end
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -411,6 +411,7 @@ function PocketBook:initNetworkManager(NetworkMgr)
             if not route_seen then
                 -- Workaround for glibc bug where /etc/resolv.conf is parsed
                 -- only once. We force a reload when the route first appears.
+                -- See https://sourceware.org/bugzilla/show_bug.cgi?id=984
                 local ok = pcall(function() ffi.C.res_init() end)
                 if not ok then pcall(function() ffi.C.__res_init() end) end
                 route_seen = true
@@ -421,10 +422,8 @@ function PocketBook:initNetworkManager(NetworkMgr)
     end
 
     function NetworkMgr:isOnline()
-        -- Fail early if we don't even have a default route, otherwise we're
-        -- unlikely to be online and canResolveHostnames would never succeed
-        -- again because PocketBook's glibc parses /etc/resolv.conf on first
-        -- use only. See https://sourceware.org/bugzilla/show_bug.cgi?id=984
+        -- Override to call isConnected before canResolveHostnames
+        -- to work around glibc bug. See https://sourceware.org/bugzilla/show_bug.cgi?id=984
         return self:isConnected() and self:canResolveHostnames()
     end
 

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -401,24 +401,26 @@ function PocketBook:initNetworkManager(NetworkMgr)
         return band(inkview.QueryNetwork(), C.NET_CONNECTED) ~= 0
     end
 
-    local route_seen = false
+    local res_init_done = false
     function NetworkMgr:isConnected()
-        if not self:isWifiOn() then
-            route_seen = false
-            return false
-        end
-        if self:hasDefaultRoute() then
-            if not route_seen then
+        local is_connected = self:isWifiOn() and self:hasDefaultRoute()
+
+        if is_connected then
+            if not res_init_done then
+                -- Re-init resolver once connected
                 -- Workaround for glibc bug where /etc/resolv.conf is parsed
                 -- only once. We force a reload when the route first appears.
                 -- See https://sourceware.org/bugzilla/show_bug.cgi?id=984
                 local ok = pcall(function() ffi.C.res_init() end)
                 if not ok then pcall(function() ffi.C.__res_init() end) end
-                route_seen = true
+                res_init_done = true
             end
-            return true
+        else
+            -- Connection lost; reset flag to trigger re-init on next success
+            res_init_done = false
         end
-        return false
+
+        return is_connected
     end
 
     function NetworkMgr:isOnline()

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -436,16 +436,19 @@ function PocketBook:initNetworkManager(NetworkMgr)
         local res = orig_init(self)
 
         if is_link_up and not self.is_connected then
-            local function waitForRoute()
+            local function waitForRoute(iter)
+                iter = iter or 0
                 if not self:isWifiOn() then return end
                 if self:isConnected() then
                     self.is_connected = true
                     UIManager:broadcastEvent(require("ui/event"):new("NetworkConnected"))
+                elseif iter < 120 then
+                    UIManager:scheduleIn(0.5, function() waitForRoute(iter + 1) end)
                 else
-                    UIManager:scheduleIn(0.5, waitForRoute)
+                    logger.warn("NetworkMgr: Network route not established after 60s, giving up.")
                 end
             end
-            UIManager:scheduleIn(0.5, waitForRoute)
+            UIManager:scheduleIn(0.5, function() waitForRoute(0) end)
         end
         return res
     end

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -442,7 +442,7 @@ function PocketBook:initNetworkManager(NetworkMgr)
                 if self:isConnected() then
                     self.is_connected = true
                     UIManager:broadcastEvent(require("ui/event"):new("NetworkConnected"))
-                elseif iter < 120 then
+                elseif iter < 90 then
                     UIManager:scheduleIn(0.5, function() waitForRoute(iter + 1) end)
                 else
                     logger.warn("NetworkMgr: Network route not established after 60s, giving up.")


### PR DESCRIPTION
## Value Proposition
This PR significantly improves network robustness on PocketBook devices and officially makes it viable to use KOReader as the primary system launcher (by replacing `bookshelf.app`). 
Previously, launching KOReader immediately at boot caused a permanent networking/DNS failure for that session. This patch safely defers network initialization and busts the device's internal DNS cache, ensuring reliable Wi-Fi connections, sync, and OTA updates without requiring users to manually restart KOReader after boot.
## The Problem
On PocketBook devices, there is a known limitation with the older `glibc` implementation (related to [glibc bugzilla #984](https://sourceware.org/bugzilla/show_bug.cgi?id=984)): `/etc/resolv.conf` is parsed only *once* upon the first DNS resolution attempt.
When users set KOReader as their system launcher, KOReader boots extremely fast - faster than the system's DHCP client can acquire an IP address and populate `/etc/resolv.conf`. 
However, `frontend/device/pocketbook/device.lua` previously equated the hardware link state (`inkview.QueryNetwork() & C.NET_CONNECTED`) with being fully connected (`isConnected()`). As soon as the Wi-Fi radio turned on, KOReader would broadcast the `NetworkConnected` event. Background plugins would immediately attempt to resolve hostnames, causing `glibc` to cache the empty/incomplete `/etc/resolv.conf`. From that point on, DNS resolution was permanently broken for the entire KOReader session.
## The Solution
This patch introduces the following changes to `frontend/device/pocketbook/device.lua`:
1. **Decouples Link State from Network State:** 
   `NetworkMgr:isWifiOn()` now accurately reflects the hardware link state, while `NetworkMgr:isConnected()` has been upgraded to ensure a valid routing table exists (`hasDefaultRoute()`) before returning true.
   
2. **Explicit DNS Cache Busting (`res_init`):**
   We added an FFI binding to `res_init` (and `__res_init` as a fallback). The very first time `isConnected()` detects a valid default route, it explicitly calls `res_init()` to force `glibc` to reload `/etc/resolv.conf`. This guarantees that even if a premature DNS call was made, the resolver state is fixed once DHCP completes.
   
3. **Deferred Boot Events:**
   We hook into `NetworkMgr:init()` to check if KOReader was launched while the Wi-Fi link is up but the route is not yet established (typical launcher scenario). If so, we delay broadcasting the `NetworkConnected` event via a polling loop until the route is actually confirmed. This prevents plugins from firing network requests into the void during early boot.
## Testing Performed
- Verified syntax with `luajit -b`.
- Verified that on a cold boot, KOReader waits for the network route seamlessly and DNS resolution (OPDS, Wikipedia) succeeds without requiring a manual restart on my PocketBook Inkpad 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15244)
<!-- Reviewable:end -->
