### PR TITLE
feat: ExternalKeyboard: allow plugin to load on Kindle

### DIFF
--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -87,6 +87,8 @@ end
 local has_otg_role = false
 -- The mount point probably doesn't exist on kernels built w/o CONFIG_DEBUG_FS
 if lfs.attributes("/sys/kernel/debug", "mode") == "directory" then
+    -- This should be in init() but the check must come first. So this part
+    -- of initialization is here. It is quick and harmless enough for a check.
     setupDebugFS()
     if lfs.attributes(OTG_CHIPIDEA_ROLE_PATH, "mode") == "file" or
        lfs.attributes(OTG_SUNXI_ROLE_PATH,    "mode") == "file" then

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -85,6 +85,7 @@ end
 -- (e.g., kindle-hid-passthrough keyboards), so the plugin can work without
 -- OTG role management.
 local has_otg_role = false
+-- The mount point probably doesn't exist on kernels built w/o CONFIG_DEBUG_FS
 if lfs.attributes("/sys/kernel/debug", "mode") == "directory" then
     setupDebugFS()
     if lfs.attributes(OTG_CHIPIDEA_ROLE_PATH, "mode") == "file" or

--- a/plugins/externalkeyboard.koplugin/main.lua
+++ b/plugins/externalkeyboard.koplugin/main.lua
@@ -79,18 +79,24 @@ local function setupDebugFS()
     return true
 end
 
--- The mount point probably doesn't exist on kernels built w/o CONFIG_DEBUG_FS
+-- Check whether we can manage OTG role switching (Kobo) or at least receive
+-- input hotplug events (Kindle). On Kindle, the uevent listener in
+-- input-kindle.h generates EvdevInputInsert/Remove events for UHID devices
+-- (e.g., kindle-hid-passthrough keyboards), so the plugin can work without
+-- OTG role management.
+local has_otg_role = false
 if lfs.attributes("/sys/kernel/debug", "mode") == "directory" then
-    -- This should be in init() but the check must come first. So this part of initialization is here.
-    -- It is quick and harmless enough to be in a check.
-    if not setupDebugFS() then
-        return { disabled = true }
+    setupDebugFS()
+    if lfs.attributes(OTG_CHIPIDEA_ROLE_PATH, "mode") == "file" or
+       lfs.attributes(OTG_SUNXI_ROLE_PATH,    "mode") == "file" then
+        has_otg_role = true
     end
-    if lfs.attributes(OTG_CHIPIDEA_ROLE_PATH, "mode") ~= "file" and
-       lfs.attributes(OTG_SUNXI_ROLE_PATH,    "mode") ~= "file" then
-        return { disabled = true }
-    end
-else
+end
+
+-- On Kindle, we don't need OTG role switching — UHID devices are created by
+-- userspace daemons and the uevent listener handles hotplug. On Kobo, OTG
+-- role files must exist.
+if not has_otg_role and not Device:isKindle() then
     return { disabled = true }
 end
 
@@ -108,60 +114,72 @@ local ExternalKeyboard = WidgetContainer:extend{
 function ExternalKeyboard:init()
     self.ui.menu:registerToMainMenu(self)
 
-    -- Check if we should go with the sunxi otg manager, or the chipidea driver...
-    if lfs.attributes(OTG_SUNXI_ROLE_PATH, "mode") == "file" then
-        self.getOTGRole = self.sunxiGetOTGRole
-        self.setOTGRole = self.sunxiSetOTGRole
+    if has_otg_role then
+        -- Kobo: set up OTG role management
+        if lfs.attributes(OTG_SUNXI_ROLE_PATH, "mode") == "file" then
+            self.getOTGRole = self.sunxiGetOTGRole
+            self.setOTGRole = self.sunxiSetOTGRole
+        else
+            self.getOTGRole = self.chipideaGetOTGRole
+            self.setOTGRole = self.chipideaSetOTGRole
+        end
+
+        local role = self:getOTGRole()
+        logger.dbg("ExternalKeyboard: role", role)
+
+        if role == USB_ROLE_DEVICE and G_reader_settings:isTrue("external_keyboard_otg_mode_on_start") then
+            self:setOTGRole(USB_ROLE_HOST)
+            role = USB_ROLE_HOST
+        end
+        if role == USB_ROLE_HOST then
+            self:findAndSetupKeyboards()
+        end
     else
-        self.getOTGRole = self.chipideaGetOTGRole
-        self.setOTGRole = self.chipideaSetOTGRole
-    end
-
-    local role = self:getOTGRole()
-    logger.dbg("ExternalKeyboard: role", role)
-
-    if role == USB_ROLE_DEVICE and G_reader_settings:isTrue("external_keyboard_otg_mode_on_start") then
-        self:setOTGRole(USB_ROLE_HOST)
-        role = USB_ROLE_HOST
-    end
-    if role == USB_ROLE_HOST then
-        -- Sweep the full class/input sysfs tree to look for keyboards
+        -- Kindle: no OTG role management, but scan for any keyboards that
+        -- may already be present (e.g., UHID device created before KOReader
+        -- started). New keyboards are handled via EvdevInputInsert events.
         self:findAndSetupKeyboards()
     end
 end
 
 function ExternalKeyboard:addToMainMenu(menu_items)
+    local sub_items = {}
+
+    -- OTG role management is only available on platforms with OTG sysfs knobs (Kobo)
+    if has_otg_role then
+        table.insert(sub_items, {
+            text = _("Enable OTG mode to connect peripherals"),
+            checked_func = function()
+                return self:getOTGRole() == USB_ROLE_HOST
+            end,
+            callback = function(touchmenu_instance)
+                local role = self:getOTGRole()
+                local new_role = (role == USB_ROLE_DEVICE) and USB_ROLE_HOST or USB_ROLE_DEVICE
+                self:setOTGRole(new_role)
+            end,
+        })
+        table.insert(sub_items, {
+            text = _("Always enable OTG mode"),
+            checked_func = function()
+                 return G_reader_settings:isTrue("external_keyboard_otg_mode_on_start")
+            end,
+            callback = function(touchmenu_instance)
+                G_reader_settings:flipNilOrFalse("external_keyboard_otg_mode_on_start")
+            end,
+        })
+    end
+
+    table.insert(sub_items, {
+        text = _("Help"),
+        keep_menu_open = true,
+        callback = function()
+            self:showHelp()
+        end,
+    })
+
     menu_items.external_keyboard = {
         text = _("External Keyboard"),
-        sub_item_table = {
-            {
-                text = _("Enable OTG mode to connect peripherals"),
-                checked_func = function()
-                    return self:getOTGRole() == USB_ROLE_HOST
-                end,
-                callback = function(touchmenu_instance)
-                    local role = self:getOTGRole()
-                    local new_role = (role == USB_ROLE_DEVICE) and USB_ROLE_HOST or USB_ROLE_DEVICE
-                    self:setOTGRole(new_role)
-                end,
-            },
-            {
-                text = _("Always enable OTG mode"),
-                checked_func = function()
-                     return G_reader_settings:isTrue("external_keyboard_otg_mode_on_start")
-                end,
-                callback = function(touchmenu_instance)
-                    G_reader_settings:flipNilOrFalse("external_keyboard_otg_mode_on_start")
-                end,
-            },
-            {
-                text = _("Help"),
-                keep_menu_open = true,
-                callback = function()
-                    self:showHelp()
-                end,
-            },
-        }
+        sub_item_table = sub_items,
     }
 end
 
@@ -217,9 +235,11 @@ function ExternalKeyboard:setOTGRole(role) end
 
 function ExternalKeyboard:onExit()
     logger.dbg("ExternalKeyboard:onExit")
-    local role = self:getOTGRole()
-    if role == USB_ROLE_HOST then
-        self:setOTGRole(USB_ROLE_DEVICE)
+    if has_otg_role then
+        local role = self:getOTGRole()
+        if role == USB_ROLE_HOST then
+            self:setOTGRole(USB_ROLE_DEVICE)
+        end
     end
 end
 


### PR DESCRIPTION
A user (@alllexx88, [kindle-hid-passthrough#40](https://github.com/zampierilucas/kindle-hid-passthrough/issues/40)) pointed out that keyboards connected via [kindle-hid-passthrough](https://github.com/zampierilucas/kindle-hid-passthrough) don't work in KOReader. The root cause is two-fold: input-kindle.h didn't emit hotplug events (fixed in companion koreader-base PR koreader/koreader-base#2327), and the externalkeyboard plugin unconditionally disables itself on Kindle because it gates on Kobo-specific OTG sysfs paths.

The keyboard detection and hotplug handling in the plugin (findAndSetupKeyboards, onEvdevInputInsert, setupKeyboard via fbink_input) is already fully generic. This patch replaces the OTG-only gate with a check that lets the plugin load on Kindle while skipping OTG role management, which doesn't apply there. OTG menu items are hidden on Kindle. Kobo behavior is completely unchanged. Tested on a Kindle PW4 with kindle-hid-passthrough and a BLE keyboard, KOReader correctly shows the "Keyboard connected" banner and accepts input.

Fixes #14359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15248)
<!-- Reviewable:end -->
