### PR TITLE
Keep settings and annotations of deleted books

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1147,10 +1147,10 @@ function FileManager.addOrphanCheckButton(confirmbox)
     confirmbox:addWidget(CheckButton:new{
         text = _("keep book annotations"),
         enabled = enabled,
-        checked = enabled and G_reader_settings:isTrue("annotations_orphans_enabled"),
+        checked = enabled and G_reader_settings:isTrue("annotations_orphans_on_deletion"),
         parent = confirmbox,
         callback = function()
-            G_reader_settings:flipNilOrFalse("annotations_orphans_enabled")
+            G_reader_settings:flipNilOrFalse("annotations_orphans_on_deletion")
         end,
     })
 end

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -548,14 +548,17 @@ function FileManager:getPlusDialogButtons()
                     text = _("Delete"),
                     enabled = actions_enabled,
                     callback = function()
-                        UIManager:show(ConfirmBox:new{
-                            text = _("Delete selected files?\nIf you delete a file, it is permanently lost."),
+                        local confirmbox
+                        confirmbox = ConfirmBox:new{
+                            text = _("Delete selected files?\nIf you delete a file, it is permanently lost.") .. "\n",
                             ok_text = _("Delete"),
                             ok_callback = function()
                                 UIManager:close(self.plus_dialog)
                                 self:deleteSelectedFiles()
                             end,
-                        })
+                        }
+                        self.addOrphanCheckButton(confirmbox)
+                        UIManager:show(confirmbox)
                     end,
                 },
                 {
@@ -1117,11 +1120,10 @@ function FileManager:showDeleteFileDialog(filepath, post_delete_callback, pre_de
         return
     end
     local is_file = isFile(file)
-    local text = (is_file and _("Delete file permanently?") or _("Delete folder permanently?")) .. "\n\n" .. BD.filepath(file)
-    if is_file and BookList.hasBookBeenOpened(file) then
-        text = text .. "\n\n" .. _("Book settings, highlights and notes will be deleted.")
-    end
-    UIManager:show(ConfirmBox:new{
+    local text = (is_file and _("Delete file permanently?") or _("Delete folder permanently?"))
+        .. "\n\n" .. BD.filepath(file) .. "\n"
+    local confirmbox
+    confirmbox = ConfirmBox:new{
         text = text,
         ok_text = _("Delete"),
         ok_callback = function()
@@ -1131,6 +1133,24 @@ function FileManager:showDeleteFileDialog(filepath, post_delete_callback, pre_de
             if self:deleteFile(file, is_file) and post_delete_callback then
                 post_delete_callback()
             end
+        end,
+    }
+    if not is_file or (BookList.hasBookBeenOpened(file) and BookList.getBookInfo(file).has_annotations) then
+        self.addOrphanCheckButton(confirmbox)
+    end
+    UIManager:show(confirmbox)
+end
+
+function FileManager.addOrphanCheckButton(confirmbox)
+    local folder = G_reader_settings:readSetting("annotations_orphans_folder")
+    local enabled = folder ~= nil and lfs.attributes(folder, "mode") == "directory"
+    confirmbox:addWidget(CheckButton:new{
+        text = _("keep book annotations"),
+        enabled = enabled,
+        checked = enabled and G_reader_settings:isTrue("annotations_orphans_enabled"),
+        parent = confirmbox,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("annotations_orphans_enabled")
         end,
     })
 end

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -90,7 +90,7 @@ function BookInfo:show(doc_settings_or_file, book_props)
     local attr = lfs.attributes(file)
     local is_file = attr and true or nil
     table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
-    if is_file then -- show doc_settings info only for deleted books
+    if is_file then
         local __, filetype = filemanagerutil.splitFileNameType(filename)
         local file_size = attr.size or 0
         local size_f = util.getFriendlySize(file_size)
@@ -99,8 +99,8 @@ function BookInfo:show(doc_settings_or_file, book_props)
         table.insert(kv_pairs, { _("Size:"), string.format("%s (%s bytes)", size_f, size_b) })
         table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
         table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(folder)), separator = true })
-    else
-        table.insert(kv_pairs, { _("Deleted:"), doc_settings_or_file:readSetting("deleted"), separator = true })
+    else -- for deleted books show orphan doc_settings info only
+        table.insert(kv_pairs, { _("Deleted:"), doc_settings_or_file:readSetting("orphan_datetime"), separator = true })
     end
 
     -- Book section
@@ -128,10 +128,14 @@ function BookInfo:show(doc_settings_or_file, book_props)
     -- metadata
     local n_a = _("N/A")
     local custom_props
-    local custom_metadata_file = is_file and DocSettings:findCustomMetadataFile(file)
-    if custom_metadata_file then
-        self.custom_doc_settings = DocSettings.openSettingsFile(custom_metadata_file)
-        custom_props = self.custom_doc_settings:readSetting("custom_props")
+    if is_file then
+        local custom_metadata_file = DocSettings:findCustomMetadataFile(file)
+        if custom_metadata_file then
+            self.custom_doc_settings = DocSettings.openSettingsFile(custom_metadata_file)
+            custom_props = self.custom_doc_settings:readSetting("custom_props")
+        end
+    else
+        custom_props = doc_settings_or_file:readSetting("custom_props")
     end
     local values_lang, callback
     for _i, prop_key in ipairs(self.props) do

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -87,16 +87,21 @@ function BookInfo:show(doc_settings_or_file, book_props)
         has_sidecar = true
     end
     local folder, filename = util.splitFilePathName(file)
-    local __, filetype = filemanagerutil.splitFileNameType(filename)
     local attr = lfs.attributes(file)
-    local file_size = attr.size or 0
-    local size_f = util.getFriendlySize(file_size)
-    local size_b = util.getFormattedSize(file_size)
+    local is_file = attr and true or nil
     table.insert(kv_pairs, { _("Filename:"), BD.filename(filename) })
-    table.insert(kv_pairs, { _("Format:"), filetype:upper() })
-    table.insert(kv_pairs, { _("Size:"), string.format("%s (%s bytes)", size_f, size_b) })
-    table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
-    table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(folder)), separator = true })
+    if is_file then -- show doc_settings info only for deleted books
+        local __, filetype = filemanagerutil.splitFileNameType(filename)
+        local file_size = attr.size or 0
+        local size_f = util.getFriendlySize(file_size)
+        local size_b = util.getFormattedSize(file_size)
+        table.insert(kv_pairs, { _("Format:"), filetype:upper() })
+        table.insert(kv_pairs, { _("Size:"), string.format("%s (%s bytes)", size_f, size_b) })
+        table.insert(kv_pairs, { _("File date:"), os.date("%Y-%m-%d %H:%M:%S", attr.modification) })
+        table.insert(kv_pairs, { _("Folder:"), BD.dirpath(filemanagerutil.abbreviate(folder)), separator = true })
+    else
+        table.insert(kv_pairs, { _("Deleted:"), doc_settings_or_file:readSetting("deleted"), separator = true })
+    end
 
     -- Book section
     -- book_props may be provided if caller already has them available
@@ -104,24 +109,26 @@ function BookInfo:show(doc_settings_or_file, book_props)
     book_props = book_props or self:getDocProps(file, book_props)
     book_props.pages = book_props.pages or BookList.getBookInfo(file).pages
     -- cover image
-    self.custom_book_cover = DocSettings:findCustomCoverFile(file)
-    local key_text = self.prop_text["cover"]
-    if self.custom_book_cover then
-        key_text = "\u{F040} " .. key_text
+    if is_file then
+        self.custom_book_cover = DocSettings:findCustomCoverFile(file)
+        local key_text = self.prop_text["cover"]
+        if self.custom_book_cover then
+            key_text = "\u{F040} " .. key_text
+        end
+        table.insert(kv_pairs, { key_text, _("Tap to display"),
+            callback = function()
+                self:onShowBookCover(file)
+            end,
+            hold_callback = function()
+                self:showCustomDialog(file, book_props)
+            end,
+            separator = true,
+        })
     end
-    table.insert(kv_pairs, { key_text, _("Tap to display"),
-        callback = function()
-            self:onShowBookCover(file)
-        end,
-        hold_callback = function()
-            self:showCustomDialog(file, book_props)
-        end,
-        separator = true,
-    })
     -- metadata
     local n_a = _("N/A")
     local custom_props
-    local custom_metadata_file = DocSettings:findCustomMetadataFile(file)
+    local custom_metadata_file = is_file and DocSettings:findCustomMetadataFile(file)
     if custom_metadata_file then
         self.custom_doc_settings = DocSettings.openSettingsFile(custom_metadata_file)
         custom_props = self.custom_doc_settings:readSetting("custom_props")
@@ -154,13 +161,13 @@ function BookInfo:show(doc_settings_or_file, book_props)
                 self:showBookProp("description", prop)
             end
         end
-        key_text = self.prop_text[prop_key]
+        local key_text = self.prop_text[prop_key]
         if custom_props and custom_props[prop_key] then -- customized
             key_text = "\u{F040} " .. key_text
         end
         table.insert(kv_pairs, { key_text, prop,
             callback = callback,
-            hold_callback = function()
+            hold_callback = is_file and function()
                 self:showCustomDialog(file, book_props, prop_key)
             end,
         })
@@ -240,7 +247,7 @@ Source (print edition):
     -- Summary section
     local summary = has_sidecar and doc_settings_or_file:readSetting("summary") or {}
     local rating = summary.rating or 0
-    local summary_hold_callback = function()
+    local summary_hold_callback = is_file and function()
         self:editSummary(doc_settings_or_file, book_props)
     end
     table.insert(kv_pairs, { _("Rating:"), ("★"):rep(rating) .. ("☆"):rep(self.rating_max - rating),
@@ -249,12 +256,14 @@ Source (print edition):
         hold_callback = summary_hold_callback, separator = true })
 
     -- Notebook file
-    local notebook_file = self:getNotebookFile(doc_settings_or_file)
-    local notebook_file_callback = function()
-        self:showNotebookFileDialog(notebook_file, doc_settings_or_file, book_props)
+    if is_file then
+        local notebook_file = self:getNotebookFile(doc_settings_or_file)
+        local notebook_file_callback = function()
+            self:showNotebookFileDialog(notebook_file, doc_settings_or_file, book_props)
+        end
+        table.insert(kv_pairs, { _("Notebook file:"), notebook_file:gsub(".*/", ""),
+            callback = notebook_file_callback })
     end
-    table.insert(kv_pairs, { _("Notebook file:"), notebook_file:gsub(".*/", ""),
-        callback = notebook_file_callback })
 
     local KeyValuePage = require("ui/widget/keyvaluepage")
     self.kvp_widget = KeyValuePage:new{

--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -249,6 +249,7 @@ function ReaderAnnotation:onSaveSettings()
     self:updatePageNumbers()
     self.ui.doc_settings:saveSetting("annotations", self.annotations)
     self:onExportAnnotations(true)
+    DocSettings.saveOrphanSettings(self.ui.doc_settings, nil, true)
 end
 
 function ReaderAnnotation:getExportAnnotationsFilepath()

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -309,6 +309,15 @@ function ReaderBookmark:addToMainMenu(menu_items)
                 separator = true,
             },
             {
+                text = _("Save orphan annotations on book closing"),
+                checked_func = function()
+                    return G_reader_settings:isTrue("annotations_orphans_on_closing")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("annotations_orphans_on_closing")
+                end,
+            },
+            {
                 text_func = function()
                     return T(_("Orphan annotations folder: %1"),
                         G_reader_settings:readSetting("annotations_orphans_folder") or _("not set"))

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -306,6 +306,36 @@ function ReaderBookmark:addToMainMenu(menu_items)
                     end
                     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path, default_path)
                 end,
+                separator = true,
+            },
+            {
+                text_func = function()
+                    return T(_("Orphan annotations folder: %1"),
+                        G_reader_settings:readSetting("annotations_orphans_folder") or _("not set"))
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local title_header = _("Orphan annotations folder:")
+                    local current_path = G_reader_settings:readSetting("annotations_orphans_folder")
+                    local caller_callback = function(path)
+                        local ok = true
+                        if current_path then
+                            local FileManager = require("apps/filemanager/filemanager")
+                            util.findFiles(current_path, function(fullpath, filename)
+                                if filename:match("%.lua$") then
+                                    ok = FileManager:moveFile(fullpath, path .. "/" .. filename)
+                                elseif filename:match("%.old$") then
+                                    os.remove(fullpath)
+                                end
+                            end, false)
+                        end
+                        if ok then
+                            G_reader_settings:saveSetting("annotations_orphans_folder", path)
+                            touchmenu_instance:updateItems()
+                        end
+                    end
+                    filemanagerutil.showChooseDialog(title_header, caller_callback, current_path)
+                end,
             },
         },
     }

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -628,7 +628,7 @@ function DocSettings.saveOrphanSettings(doc_settings, custom_metadata_file, on_c
         custom_metadata_file = DocSettings:findCustomMetadataFile(doc_settings:readSetting("doc_path"))
     else -- on deletion
         if G_reader_settings:hasNot("annotations_orphans_on_deletion") then
-            if isFile(orphan_file) then
+            if orphan_file and isFile(orphan_file) then
                 os.remove(orphan_file)
                 os.remove(orphan_file .. ".old")
             end

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -462,6 +462,7 @@ function DocSettings.updateLocation(doc_path, new_doc_path, copy)
         end
     else -- delete
         if has_sidecar_file then
+            DocSettings.saveOrphan(doc_settings)
             local cache_file_path = doc_settings:readSetting("cache_file_path")
             if cache_file_path then
                 os.remove(cache_file_path)
@@ -602,6 +603,30 @@ function DocSettings.findSidecarFilesInHashLocation()
     end
     util.findFiles(DOCSETTINGS_HASH_DIR, callback)
     return res
+end
+
+function DocSettings.saveOrphan(doc_settings)
+    if G_reader_settings:isTrue("annotations_orphans_enabled") then
+        local folder = G_reader_settings:readSetting("annotations_orphans_folder")
+        if folder then
+            local md5_checksum = doc_settings:readSetting("partial_md5_checksum")
+            if md5_checksum then
+                local o_settings = LuaSettings:open(folder .. "/" .. md5_checksum .. ".lua")
+                local settings_to_keep = {
+                    "annotations",
+                    "doc_path",
+                    "doc_props",
+                    "partial_md5_checksum",
+                    "summary",
+                }
+                for _, setting in ipairs(settings_to_keep) do
+                    o_settings:saveSetting(setting, doc_settings:readSetting(setting))
+                end
+                o_settings:saveSetting("deleted", os.date("%Y-%m-%d %H:%M:%S"))
+                o_settings:flush()
+            end
+        end
+    end
 end
 
 return DocSettings

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -462,7 +462,7 @@ function DocSettings.updateLocation(doc_path, new_doc_path, copy)
         end
     else -- delete
         if has_sidecar_file then
-            DocSettings.saveOrphan(doc_settings)
+            DocSettings.saveOrphanSettings(doc_settings, custom_metadata_file)
             local cache_file_path = doc_settings:readSetting("cache_file_path")
             if cache_file_path then
                 os.remove(cache_file_path)
@@ -605,28 +605,54 @@ function DocSettings.findSidecarFilesInHashLocation()
     return res
 end
 
-function DocSettings.saveOrphan(doc_settings)
-    if G_reader_settings:isTrue("annotations_orphans_enabled") then
-        local folder = G_reader_settings:readSetting("annotations_orphans_folder")
-        if folder then
-            local md5_checksum = doc_settings:readSetting("partial_md5_checksum")
-            if md5_checksum then
-                local o_settings = LuaSettings:open(folder .. "/" .. md5_checksum .. ".lua")
-                local settings_to_keep = {
-                    "annotations",
-                    "doc_path",
-                    "doc_props",
-                    "partial_md5_checksum",
-                    "summary",
-                }
-                for _, setting in ipairs(settings_to_keep) do
-                    o_settings:saveSetting(setting, doc_settings:readSetting(setting))
-                end
-                o_settings:saveSetting("deleted", os.date("%Y-%m-%d %H:%M:%S"))
-                o_settings:flush()
+function DocSettings.getOrphanSettingsFilename(doc_settings, does_exist)
+    local folder = G_reader_settings:readSetting("annotations_orphans_folder")
+    if folder then
+        local md5_checksum = doc_settings:readSetting("partial_md5_checksum")
+        if md5_checksum then
+            local file = folder .. "/" .. md5_checksum .. ".lua"
+            if does_exist then
+                return file and isFile(file) and file
             end
+            return file
         end
     end
+end
+
+function DocSettings.saveOrphanSettings(doc_settings, custom_metadata_file, on_closing)
+    local orphan_file = DocSettings.getOrphanSettingsFilename(doc_settings)
+    if on_closing then
+        if G_reader_settings:hasNot("annotations_orphans_on_closing") then
+            return
+        end
+        custom_metadata_file = DocSettings:findCustomMetadataFile(doc_settings:readSetting("doc_path"))
+    else -- on deletion
+        if G_reader_settings:hasNot("annotations_orphans_on_deletion") then
+            if isFile(orphan_file) then
+                os.remove(orphan_file)
+                os.remove(orphan_file .. ".old")
+            end
+            return
+        end
+    end
+
+    local o_settings = LuaSettings:open(orphan_file)
+    local settings_to_keep = {
+        "annotations",
+        "doc_path",
+        "doc_props",
+        "partial_md5_checksum",
+        "summary",
+    }
+    for _, setting in ipairs(settings_to_keep) do
+        o_settings:saveSetting(setting, doc_settings:readSetting(setting))
+    end
+    if custom_metadata_file then
+        local custom_settings = DocSettings.openSettingsFile(custom_metadata_file)
+        o_settings:saveSetting("custom_props", custom_settings:readSetting("custom_props"))
+    end
+    o_settings:saveSetting("orphan_datetime", os.date("%Y-%m-%d %H:%M:%S"))
+    o_settings:flush()
 end
 
 return DocSettings

--- a/frontend/ui/widget/bookmarkbrowser.lua
+++ b/frontend/ui/widget/bookmarkbrowser.lua
@@ -4,6 +4,7 @@ local BookList = require("ui/widget/booklist")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonSelector = require("ui/widget/buttonselector")
 local CheckButton = require("ui/widget/checkbutton")
+local ConfirmBox = require("ui/widget/confirmbox")
 local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
 local InfoMessage = require("ui/widget/infomessage")
@@ -17,6 +18,7 @@ local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local ffiUtil = require("ffi/util")
 local filemanagerutil = require("apps/filemanager/filemanagerutil")
+local lfs = require("libs/libkoreader-lfs")
 local util = require("util")
 local _ = require("gettext")
 local Screen = require("device").screen
@@ -335,6 +337,9 @@ function BookmarkBrowser:getBookList(files)
             is_deleted = file:match("%.lua$")
             if is_deleted then
                 doc_settings = DocSettings.openSettingsFile(file)
+                if lfs.attributes(doc_settings:readSetting("doc_path"), "mode") == "file" then
+                    doc_settings = nil -- the book is not deleted yet
+                end
             else
                 doc_settings = BookList.hasBookBeenOpened(file) and BookList.getDocSettings(file)
             end
@@ -389,7 +394,7 @@ function BookmarkBrowser:getItemTable()
     local no_filter = self.filters_nb == 0
     self.visible_books_nb = 0 -- may differ from the enabled books number due to bookmarks filtering
     local item_table = {}
-    for __, book in ipairs(self.books) do
+    for self_books_idx, book in ipairs(self.books) do
         if book.enabled then
             local book_item_table_idx = #item_table + 1
             local bookmark_idx = 0
@@ -438,6 +443,7 @@ function BookmarkBrowser:getItemTable()
                     text = T(_("%1 • %2"), book.authors, book.doc_props.display_title),
                     bold = true,
                     mandatory = "(" .. annotations_nb .. ")",
+                    self_books_idx = self_books_idx,
                     file = book.file,
                     is_current_file = book.is_current_file,
                     is_deleted = book.is_deleted,
@@ -481,9 +487,21 @@ function BookmarkBrowser:showBookDialog(item)
     local buttons = {
         {
             {
-                text = _("Open"),
-                enabled = not item.is_deleted,
-                callback = function()
+                text = item.is_deleted and _("Delete orphan") or _("Open"),
+                callback = item.is_deleted and function()
+                    UIManager:show(ConfirmBox:new{
+                        text = _("Delete orphan annotations?"),
+                        ok_text = _("Delete"),
+                        ok_callback = function()
+                            UIManager:close(book_dialog)
+                            local orphan_file = DocSettings.getOrphanSettingsFilename(item.doc_settings)
+                            os.remove(orphan_file)
+                            os.remove(orphan_file .. ".old")
+                            table.remove(self.books, item.self_books_idx)
+                            self:updateBookmarkList()
+                        end,
+                    })
+                end or function()
                     UIManager:close(book_dialog)
                     self.bm_list:onClose()
                     if self.ui.document then

--- a/frontend/ui/widget/bookmarkbrowser.lua
+++ b/frontend/ui/widget/bookmarkbrowser.lua
@@ -4,6 +4,7 @@ local BookList = require("ui/widget/booklist")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonSelector = require("ui/widget/buttonselector")
 local CheckButton = require("ui/widget/checkbutton")
+local DocSettings = require("docsettings")
 local DocumentRegistry = require("document/documentregistry")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
@@ -100,6 +101,19 @@ function BookmarkBrowser:showSourceDialog(ui, force_show_dialog)
                     for file in pairs(ui.selected_files) do
                         books[file] = true
                     end
+                end)
+            end,
+        },
+        deleted_books = {
+            text = _("Deleted books"),
+            enabled = G_reader_settings:has("annotations_orphans_folder"),
+            callback = function()
+                fetch_and_show_bookmarks("deleted_books", function(books)
+                    util.findFiles(G_reader_settings:readSetting("annotations_orphans_folder"), function(fullpath, filename)
+                        if filename:match("%.lua$") then
+                            books[fullpath] = true
+                        end
+                    end, false)
                 end)
             end,
         },
@@ -204,6 +218,7 @@ function BookmarkBrowser:showSourceDialog(ui, force_show_dialog)
             gen_source_button("history"),
             gen_source_button("collections"),
             gen_source_button("selected_files"),
+            gen_source_button("deleted_books"),
             gen_source_button("home_folder"),
             gen_source_button("home_folder_subfolders"),
             gen_source_button("folder"),
@@ -310,14 +325,19 @@ function BookmarkBrowser:getBookList(files)
     local current_file = self.ui.document and self.ui.document.file
     local books = {}
     for file in pairs(files) do
+        local is_deleted, doc_settings, doc_props, annotations
         local is_current_file = file == current_file or nil
-        local doc_settings, doc_props, annotations
         if is_current_file then
             doc_settings = self.ui.doc_settings
             doc_props = self.ui.doc_props
             annotations = self.ui.annotation.annotations
         else
-            doc_settings = BookList.hasBookBeenOpened(file) and BookList.getDocSettings(file)
+            is_deleted = file:match("%.lua$")
+            if is_deleted then
+                doc_settings = DocSettings.openSettingsFile(file)
+            else
+                doc_settings = BookList.hasBookBeenOpened(file) and BookList.getDocSettings(file)
+            end
             if doc_settings then
                 doc_props = doc_settings:readSetting("doc_props")
                 annotations = doc_settings:readSetting("annotations")
@@ -333,6 +353,7 @@ function BookmarkBrowser:getBookList(files)
                 enabled = true, -- start with showing all books from the source
                 file = file,
                 is_current_file = is_current_file,
+                is_deleted = is_deleted,
                 doc_settings = doc_settings,
                 doc_props = doc_props,
                 annotations = annotations,
@@ -419,6 +440,7 @@ function BookmarkBrowser:getItemTable()
                     mandatory = "(" .. annotations_nb .. ")",
                     file = book.file,
                     is_current_file = book.is_current_file,
+                    is_deleted = book.is_deleted,
                     doc_props = book.doc_props,
                     doc_settings = book.doc_settings,
                     authors = book.authors,
@@ -460,6 +482,7 @@ function BookmarkBrowser:showBookDialog(item)
         {
             {
                 text = _("Open"),
+                enabled = not item.is_deleted,
                 callback = function()
                     UIManager:close(book_dialog)
                     self.bm_list:onClose()
@@ -475,8 +498,8 @@ function BookmarkBrowser:showBookDialog(item)
             filemanagerutil.genBookInformationButton(item.doc_settings, item.doc_props, close_dialog_callback),
         },
         {
-            filemanagerutil.genBookCoverButton(file, item.doc_props, close_dialog_callback),
-            filemanagerutil.genBookDescriptionButton(file, item.doc_props, close_dialog_callback),
+            filemanagerutil.genBookCoverButton(file, item.doc_props, close_dialog_callback, item.is_deleted),
+            filemanagerutil.genBookDescriptionButton(file, item.doc_props, close_dialog_callback, item.is_deleted),
         },
         {}, -- separator
         {
@@ -546,6 +569,7 @@ function BookmarkBrowser:showBookmarkDetails(item)
         {
             {
                 text = _("View in book"),
+                enabled = not book.is_deleted,
                 callback = function()
                     textviewer:onClose()
                     self.bm_list:onClose()
@@ -600,7 +624,6 @@ function BookmarkBrowser:showBookmarkListMenu()
             {
                 text = are_disabled_books
                     and T(_("Books: %1 / %2"), self.filter_table.enabled_books_nb, #self.books) or _("Books"),
-                enabled = #self.books > 1,
                 callback = function()
                     UIManager:close(bm_list_menu)
                     self:showBookList(true)
@@ -930,7 +953,7 @@ end
 function BookmarkBrowser:genShowBookListButton(caller_callback)
     return {
         text = _("Book list"),
-        enabled = self.visible_books_nb > 1,
+        enabled = self.visible_books_nb > 0,
         callback = function()
             caller_callback()
             self:showBookList()


### PR DESCRIPTION
(1) Choose a folder for orphan annotations in the Bookmark settings menu:
<img width="400" height="508" alt="1" src="https://github.com/user-attachments/assets/6dc049a0-3e0f-49cf-8f78-3e3b4ed94ea3" />

-----

(2) Check the checkbox in the Delete confirmation dialog:
<img width="400" height="508" alt="2" src="https://github.com/user-attachments/assets/20ef132c-287a-4970-989b-890b7638b183" />

-----

(3) Choose "Deleted books" in the bookmark browser source dialog:
<img width="400" height="508" alt="3" src="https://github.com/user-attachments/assets/508696e8-34d6-4d1a-b00e-a8b226af573f" />

-----

(4) While viewing annotations, tap on a book:
<img width="400" height="508" alt="4" src="https://github.com/user-attachments/assets/6cc0118d-fada-4169-a81c-c67aad66ecab" />

-----

(5) View deleted book info:
<img width="400" height="508" alt="5" src="https://github.com/user-attachments/assets/a0f4dc91-db67-4d96-9e71-0a200f138268" />

- Closes #11387 
- Closes #14959

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15254)
<!-- Reviewable:end -->
