### PR TITLE
Fix language matching logic

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -342,7 +342,7 @@ function ReaderWikipedia:initLanguages(word)
         local addLanguage = function(lang)
             if lang and lang ~= "" then
                 -- convert "zh-CN" and "zh-TW" to "zh"
-                lang = lang:match("(.*)-") or lang
+                lang = lang:match("([^_-]+)") or lang
                 if lang == "C" then lang="en" end
                 lang = lang:lower()
                 if not self.seen_lang[lang] then


### PR DESCRIPTION
This morning, I picked up my Kindle to perform a Wikipedia lookup within KOReader. Initially, my search was being directed to Wikipedia ES, the Spanish version of Wikipedia, even though the result I wanted was on the Portuguese version.

Not knowing how to change the search language directly, I went into the settings and changed the KOReader interface language to "Português do Brasil" (Brazilian Portuguese). After restarting KOReader, the search shifted to "Wikipedia PT-BR", and I could see in the dropdown menu that the "pt_br" language was now selected.

However, no matter what word I searched for, every query on "Wikipedia PT-BR" returned an error.

<img width="300" alt="image-1" src="https://github.com/user-attachments/assets/1c0acf21-6a2d-425f-ae1a-fc04ead5e3f2" />

**Figure 1: It says "Falha ao pesquisar na Wikipedia" which means "Failed to search Wikipedia"**

I eventually found where to change the languages used in Wikipedia search, and noticed that one of the options was indeed "pt_br".

<img width="300" alt="image-2d" src="https://github.com/user-attachments/assets/da5760b3-eb78-44b3-917a-6bca69aa2fc6" />


When I changed it from "pt_br" to "pt," the searches started working.

I decided to look into the KOReader source code to understand what was happening. From what I gathered, KOReader is probably using `https://pt_br.wikipedia.org/`, which is an invalid domain, whereas it should be `https://pt.wikipedia.org/`, the correct domain.

It all starts with the `language.lua` file:

```
local Language = {
    language_names = {
        C = "English",
        en = "English",
        ...
        pt_PT = "Português",
        pt_BR = "Português do Brasil",
    },
```

"pt_BR" should be transformed into "pt" at some point to be used in Wikipedia searches. As far as I could trace it, this should be happening in the `readerwikipedia.lua` file, which contains this:

```
-- convert "zh-CN" and "zh-TW" to "zh"
lang = lang:match("(.*)-") or lang
```

The existing normalization only handles hyphenated tags (zh-CN → zh), not those with underscores (pt_BR), as they appear on `language.lua`.

I changed the regex to account for the underscore while keeping the hyphen for compatibility:

```
lang = lang:match("([^_-]+)") or lang
```

After building from source with this change, the issue was resolved in my tests.

<img width="300" alt="image-3" src="https://github.com/user-attachments/assets/18015f5c-1145-4df3-86f2-3d7a90115b04" />


It would be helpful if someone else could verify this behavior to confirm there are no regressions.

## Steps to reproduce

1. Change the KOReader language to "Português do Brasil".
2. Perform a Wikipedia lookup.
3. Confirm that the search is being executed against "Wikipedia PT-BR", which results in errors for all queries.

## Validation after fix

1. Repeat steps 1 and 2.
2. Confirm that the search is now executed against "Wikipedia PT" and that results are returned correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15267)
<!-- Reviewable:end -->
