### PR TITLE
Profiles: keep settings in the base class

### DIFF
--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -24,20 +24,23 @@ local Profiles = WidgetContainer:extend{
     prefix = "profile_exec_",
     settings_file = DataStorage:getSettingsDir() .. "/profiles.lua",
     data = nil, -- direct access to the settings table
-    updated = false,
+    updated = nil,
 }
 
 function Profiles:init()
     Dispatcher:init()
     self.autoexec = G_reader_settings:readSetting("profiles_autoexec", {})
     self.ui.menu:registerToMainMenu(self)
-    self:onDispatcherRegisterActions()
+    self:onDispatcherRegisterActions() -- will call loadSettings()
     self:onStart()
 end
 
-function Profiles:loadProfiles()
+function Profiles:loadSettings()
     if not Profiles.settings then
         Profiles.settings = LuaSettings:open(self.settings_file)
+        if not next(Profiles.settings.data) then
+            self.updated = true -- first run, force flush
+        end
         -- ensure profile name
         for k, v in pairs(Profiles.settings.data) do
             v.settings = v.settings or {}
@@ -46,7 +49,6 @@ function Profiles:loadProfiles()
                 self.updated = true
             end
         end
-        self:onFlushSettings()
     end
     self.data = Profiles.settings.data
 end
@@ -54,7 +56,7 @@ end
 function Profiles:onFlushSettings()
     if self.updated then
         Profiles.settings:flush()
-        self.updated = false
+        self.updated = nil
     end
 end
 
@@ -68,7 +70,7 @@ local function dispatcherUnregisterProfile(name)
 end
 
 function Profiles:onDispatcherRegisterActions()
-    self:loadProfiles()
+    self:loadSettings()
     for k, v in pairs(self.data) do
         if v.settings.registered then
             dispatcherRegisterProfile(k)

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -22,9 +22,8 @@ local autostart_done
 local Profiles = WidgetContainer:extend{
     name = "profiles",
     prefix = "profile_exec_",
-    profiles_file = DataStorage:getSettingsDir() .. "/profiles.lua",
-    profiles = nil,
-    data = nil,
+    settings_file = DataStorage:getSettingsDir() .. "/profiles.lua",
+    data = nil, -- direct access to the settings table
     updated = false,
 }
 
@@ -37,27 +36,24 @@ function Profiles:init()
 end
 
 function Profiles:loadProfiles()
-    if self.profiles then
-        return
-    end
-    self.profiles = LuaSettings:open(self.profiles_file)
-    self.data = self.profiles.data
-    -- ensure profile name
-    for k, v in pairs(self.data) do
-        if not v.settings then
-            v.settings = {}
+    if not Profiles.settings then
+        Profiles.settings = LuaSettings:open(self.settings_file)
+        -- ensure profile name
+        for k, v in pairs(Profiles.settings.data) do
+            v.settings = v.settings or {}
+            if not v.settings.name then
+                v.settings.name = k
+                self.updated = true
+            end
         end
-        if not v.settings.name then
-            v.settings.name = k
-            self.updated = true
-        end
+        self:onFlushSettings()
     end
-    self:onFlushSettings()
+    self.data = Profiles.settings.data
 end
 
 function Profiles:onFlushSettings()
-    if self.profiles and self.updated then
-        self.profiles:flush()
+    if self.updated then
+        Profiles.settings:flush()
         self.updated = false
     end
 end
@@ -90,7 +86,6 @@ function Profiles:addToMainMenu(menu_items)
 end
 
 function Profiles:getSubMenuItems()
-    self:loadProfiles()
     local sub_item_table = {
         {
             text = _("New"),


### PR DESCRIPTION
To avoid reopening the settings file on switching FM - Reader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15270)
<!-- Reviewable:end -->
