### PR TITLE
handle multiple args in common/koreader.sh

### DIFF
--- a/platform/common/koreader.sh
+++ b/platform/common/koreader.sh
@@ -7,22 +7,25 @@ KOREADER_DIR="$(dirname "$(realpath "$0")")"
 
 # export @KOREADER_FLAVOR@
 
-# FIXME: handle multiple arguments.
-if [ $# -eq 1 ] && [ -e "$(pwd)/$1" ]; then
-    ARGS="$(pwd)/$1"
-else
-    ARGS="$*"
-fi
+# Canonicalize non-option arguments so we can change dir.
+# (Pop left, push right - each arg once so we end with the orig order.)
+for arg; do
+    shift
+    if [ -e "${PWD}/${arg}" ]; then
+        arg="${PWD}/${arg}"
+    fi
+    set -- "$@" "${arg}"
+done
 
 # We're always starting from our working directory.
 cd "${KOREADER_DIR}" || exit
 
 RETURN_VALUE=85
 while [ ${RETURN_VALUE} -eq 85 ]; do
-    ./reader.lua "${ARGS}"
+    ./reader.lua "$@"
     RETURN_VALUE=$?
     # Do not restart with saved arguments.
-    ARGS="${HOME}"
+    set -- "${HOME}"
 done
 
 exit ${RETURN_VALUE}


### PR DESCRIPTION
The previous handling had two problems:

- current dir only appended if argc == 1
- multiple args passed as one to reader.lua

As a result:

- `bin/koreader -v -d` doesn't work (reader.lua sees it as one arg)
- `bin/koreader -d abc.epub` doesn't work either (for the same reason)

The fix is to go through args one by one and use `set -- …` to keep them as an
array of args (preserves white-space and avoid unintended expansions that
might happen if we attempted to do some eval trickery instead).

Note that reader.lua doesn't currently handle multiple file/dir args, so we
could instead just look at the last arg and add pwd to that one. Unfortunately
doing this in POSIX sh isn't any simpler than processing all args. :-)

(While at it, use `$PWD` which is required by POSIX to always be present.)

Tested with bash 5.3.9, busybox 1.37.0 and dash 0.5.12.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15271)
<!-- Reviewable:end -->
