### PR TITLE
fix(android): work around broken touchscreen reporting on Mobiscribe Wave

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -266,6 +266,7 @@ function Device:init()
     -- check if we have a touchscreen
     if android.lib.AConfiguration_getTouchscreen(android.app.config)
        ~= C.ACONFIGURATION_TOUCHSCREEN_NOTOUCH
+       or android.prop.brokenTouchReport
     then
         self.isTouchDevice = yes
     end


### PR DESCRIPTION
Some Android devices (e.g., Mobiscribe Wave) incorrectly report `ACONFIGURATION_TOUCHSCREEN_NOTOUCH` despite having a functioning touchscreen. This prevents touch zone registration in the reader view, making documents unusable via touch input.

This checks the new brokenTouchReport quirk exposed by android-luajit-launcher as a fallback
when the AConfiguration check reports no touch.

Depends on: koreader/android-luajit-launcher#589 -- a submodule bump will be needed once that merges.
Fixes #12349

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15273)
<!-- Reviewable:end -->
