### PR TITLE
OPDS: load settings when needed only

### DIFF
--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -12,10 +12,13 @@ local T = require("ffi/util").template
 
 local OPDS = WidgetContainer:extend{
     name = "opds",
-    opds_settings_file = DataStorage:getSettingsDir() .. "/opds.lua",
+    settings_file = DataStorage:getSettingsDir() .. "/opds.lua",
     settings = nil,
+    opds_settings = nil,
     servers = nil,
     downloads = nil,
+    pending_syncs = nil,
+    updated = nil,
     default_servers = {
         {
             title = "Project Gutenberg",
@@ -45,16 +48,20 @@ local OPDS = WidgetContainer:extend{
 }
 
 function OPDS:init()
-    self.opds_settings = LuaSettings:open(self.opds_settings_file)
-    if next(self.opds_settings.data) == nil then
-        self.updated = true -- first run, force flush
-    end
-    self.servers = self.opds_settings:readSetting("servers", self.default_servers)
-    self.downloads = self.opds_settings:readSetting("downloads", {})
-    self.settings = self.opds_settings:readSetting("settings", {})
-    self.pending_syncs = self.opds_settings:readSetting("pending_syncs", {})
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
+end
+
+function OPDS:loadSettings()
+    if self.settings then return end
+    self.settings = LuaSettings:open(self.settings_file)
+    if next(self.settings.data) == nil then
+        self.updated = true -- first run, force flush
+    end
+    self.opds_settings = self.settings:readSetting("settings", {})
+    self.servers = self.settings:readSetting("servers", self.default_servers)
+    self.downloads = self.settings:readSetting("downloads", {})
+    self.pending_syncs = self.settings:readSetting("pending_syncs", {})
 end
 
 function OPDS:onDispatcherRegisterActions()
@@ -75,10 +82,11 @@ function OPDS:addToMainMenu(menu_items)
 end
 
 function OPDS:onShowOPDSCatalog()
+    self:loadSettings()
     self.opds_browser = OPDSBrowser:new{
+        settings = self.opds_settings,
         servers = self.servers,
         downloads = self.downloads,
-        settings = self.settings,
         pending_syncs = self.pending_syncs,
         title = _("OPDS catalog"),
         is_popout = false,
@@ -129,7 +137,7 @@ end
 
 function OPDS:onFlushSettings()
     if self.updated then
-        self.opds_settings:flush()
+        self.settings:flush()
         self.updated = nil
     end
 end


### PR DESCRIPTION
Avoid opening the settings file if OPDS isn't used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15283)
<!-- Reviewable:end -->
