### PR TITLE
Minor Wikipedia & highlighting fixes, add "Toggle hanging punctuation" to dispatcher

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -589,6 +589,10 @@ function ReaderDictionary:onLookupWord(word, is_sane, boxes, highlight, link, di
     -- escape quotes and other funny characters in word
     word = self:cleanSelection(word, is_sane)
     logger.dbg("dict stripped word:", word)
+    -- (If word ends up empty, we still do the lookup, which will give us
+    -- a window with no result. This will ensure the normal cleanup of the
+    -- highlight when closing this "no result" window, which is easier than
+    -- trying to do it here if we were skipping the lookup.)
 
     self.highlight = highlight
     local disable_fuzzy_search
@@ -1168,10 +1172,6 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
 end
 
 function ReaderDictionary:stardictLookup(word, dict_names, fuzzy_search, boxes, link, dict_close_callback)
-    if word == "" then
-        return
-    end
-
     local book_title = self.ui.doc_props and self.ui.doc_props.display_title or _("Dictionary lookup")
 
     -- Event for plugin to catch lookup with book title

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1812,6 +1812,13 @@ function ReaderHighlight:onHold(arg, ges)
         end
         return true
     end
+    -- It has happened it failed because the text range was detected on the
+    -- previous page and highlighted by crengine, but no word was returned
+    -- (because the boxes were not on the current page).
+    -- Be sure we clear any such selection
+    self.ui.document:clearSelection()
+    -- And that we don't get stuck in a hold state
+    self.hold_pos = nil
     return false
 end
 

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -558,8 +558,7 @@ These settings will apply to all books with any hyphenation dictionary.
         text = _("Hanging punctuation"),
         checked_func = function() return self.floating_punctuation == 1 end,
         callback = function()
-            self.floating_punctuation = self.floating_punctuation == 1 and 0 or 1
-            self:onToggleFloatingPunctuation(self.floating_punctuation)
+            self:onToggleFloatingPunctuation()
         end,
         hold_callback = function() self:makeDefaultFloatingPunctuation() end,
     })
@@ -603,14 +602,14 @@ function ReaderTypography.getLangTags() -- for Dispatcher
 end
 
 function ReaderTypography:onToggleFloatingPunctuation(toggle)
-    -- for some reason the toggle value read from history files may stay boolean
-    -- and there seems no more elegant way to convert boolean values to numbers
-    if toggle == true then
-        toggle = 1
-    elseif toggle == false then
-        toggle = 0
+    if toggle == nil then
+        self.floating_punctuation = self.floating_punctuation == 1 and 0 or 1
+    elseif toggle == 0 or toggle == false then
+        self.floating_punctuation = 0
+    else -- 1 or true (or anything else)
+        self.floating_punctuation = 1
     end
-    self.ui.document:setFloatingPunctuation(toggle)
+    self.ui.document:setFloatingPunctuation(self.floating_punctuation)
     self.ui:handleEvent(Event:new("UpdatePos"))
 end
 
@@ -764,11 +763,10 @@ function ReaderTypography:onReadSettings(config)
     -- (Stored as 0/1 in docsetting for historical reasons, but as true/false
     -- in global settings.)
     if config:has("floating_punctuation") then
-        self.floating_punctuation = config:readSetting("floating_punctuation")
+        self:onToggleFloatingPunctuation(config:readSetting("floating_punctuation"))
     else
-        self.floating_punctuation = G_reader_settings:isTrue("floating_punctuation") and 1 or 0
+        self:onToggleFloatingPunctuation(G_reader_settings:isTrue("floating_punctuation"))
     end
-    self:onToggleFloatingPunctuation(self.floating_punctuation)
 
     -- Decide and set the text main lang tag according to settings
     if config:has("text_lang") then

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -225,7 +225,8 @@ local settingsList = {
     export_annotations = {category="none", event="ExportAnnotations", title=_("Export annotations"), reader=true},
 
     -- Reflowable documents
-    set_typography_lang = {category="string", event="SetTypographyLanguage", title=_("Set typography language"), args_func=ReaderTypography.getLangTags, rolling=true, separator=true},
+    set_typography_lang = {category="string", event="SetTypographyLanguage", title=_("Set typography language"), args_func=ReaderTypography.getLangTags, rolling=true},
+    toggle_hanging_punctuation = {category="none", event="ToggleFloatingPunctuation", title=_("Toggle hanging punctuation"), rolling=true, separator=true},
     set_font = {category="string", event="SetFont", title=_("Font"), rolling=true, args_func=require("fontlist").getFontArgFunc,},
     increase_font = {category="incrementalnumber", event="IncreaseFontSize", min=0.5, max=255, step=0.5, title=_("Increase font size"), rolling=true},
     decrease_font = {category="incrementalnumber", event="DecreaseFontSize", min=0.5, max=255, step=0.5, title=_("Decrease font size"), rolling=true},
@@ -482,6 +483,7 @@ local dispatcher_menu_order = {
 
     -- Reflowable documents
     "set_typography_lang",
+    "toggle_hanging_punctuation",
     ----
     "set_font",
     "increase_font",

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1903,7 +1903,7 @@ function DictQuickLookup:showWikiFullOtherLangsMenu()
     local font_size = 18
     local button_dialog
     local buttons = {}
-    local lang_links = self.results[1].lang_links
+    local lang_links = self.results[1].lang_links or {}
     -- We'll show the articles in the wikipedia languages set by the user first (and in bold)
     local user_wiki_languages = {}
     for _, lang in ipairs(self.wiki_languages) do
@@ -1930,6 +1930,15 @@ function DictQuickLookup:showWikiFullOtherLangsMenu()
                 -- popup menu opened so we get to it when done to try another lang
                 self:lookupWikipedia(true, page, true, lang)
             end,
+        }}
+        table.insert(buttons, row)
+    end
+    if #lang_links == 0 then
+        local row = {{
+            text = C_("Wikipedia", "No article in any other language"),
+            font_size = font_size,
+            font_bold = false,
+            align = "left",
         }}
         table.insert(buttons, row)
     end


### PR DESCRIPTION
#### Wikipedia full: avoid crash when not available in other languages

Solves the crash when tap'ing on the hambuger menu on a full article when the topic is not avialable in any other language, noticed at https://github.com/koreader/koreader/pull/14791#issuecomment-4159105837.

#### Highlighting/lookup: avoid getting stuck when nothing selected

Fixes 2 cases where we could get stuck in an exepected state:
- if onHold would get us nothing to act on, we would stay stuck in "hold" state (until a next hold) and taps for page turn would not work
Noticed with the test case at https://github.com/koreader/crengine/issues/659#issuecomment-4236035443, when doing it with long-press: we would just get stuck as the selected text was on the previous page (tap not working, and if PgUp, we would see the text highlighted on that previous page)
- if text selection would get us some text (ie. some punctuation) that would be stripped to an empty string, we would just not do the lookup, but the selection would stay: best to do that lookup and get a "no result" window, that when closed would do the normal cleanup.
See https://github.com/koreader/koreader/pull/14979#issuecomment-4262627827

#### Dispatcher: add "Toggle hanging punctuation"

Also: minor revamp of the setting handling by having onToggleFloatingPunctuation() accepting nil/true/false/0/1 and being the sole manager of self.floating_punctuation.
(Felt it was nice to have when testing https://github.com/koreader/crengine/pull/660 -  easier to see the changes without having to go to that menu which hides half of the screen.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15285)
<!-- Reviewable:end -->
