### PR TITLE
Fix crash when clicking button (Kobo popup flash)

### DIFF
--- a/frontend/ui/widget/button.lua
+++ b/frontend/ui/widget/button.lua
@@ -397,9 +397,10 @@ end
 function Button:_doFeedbackHighlight()
     -- NOTE: self[1] -> self.frame, if you're confused about what this does vs. onFocus/onUnfocus ;).
     if self.text then
+        self._flash_ui_uses_invert = false
         -- We only want the button's *highlight* to have rounded corners (otherwise they're redundant, same color as the bg).
         -- The nil check is to discriminate the default from callers that explicitly request a specific radius.
-        if self[1].radius == nil or self.background then
+        if (self[1].radius == nil or self.background) and self[1].background then
             self[1].radius = Size.radius.button
             -- And here, it's easier to just invert the bg/fg colors ourselves,
             -- so as to preserve the rounded corners in one step.
@@ -408,6 +409,7 @@ function Button:_doFeedbackHighlight()
             -- We do *NOT* set the invert flag, because it just adds an invertRect step at the end of the paintTo process,
             -- and we've already taken care of inversion in a way that won't mangle the rounded corners.
         else
+            self._flash_ui_uses_invert = true
             self[1].invert = true
         end
 
@@ -422,13 +424,14 @@ end
 
 function Button:_undoFeedbackHighlight(is_translucent)
     if self.text then
-        if self[1].radius == Size.radius.button then
+        if not self._flash_ui_uses_invert and self[1].radius == Size.radius.button and self[1].background then
             self[1].radius = nil
             self[1].background = self[1].background:invert()
             self.label_widget.fgcolor = self.label_widget.fgcolor:invert()
         else
             self[1].invert = false
         end
+        self._flash_ui_uses_invert = nil
         UIManager:widgetRepaint(self[1], self[1].dimen.x, self[1].dimen.y)
     else
         self[1].invert = false


### PR DESCRIPTION
## Summary

Fix a crash in `Button:_doFeedbackHighlight()` when `flash_ui` is enabled and a text button has no background.

Previously, the highlight path could attempt to call `self[1].background:invert()` even when `self[1].background` was `nil`, causing:

`attempt to index field 'background' (a nil value)`

This change preserves the existing rounded highlight behavior when a background is present, and falls back to the standard invert-based highlight when it is not.

## Before

- With `flash_ui` enabled  
- Tapping certain text buttons could crash KOReader  
- Stack trace pointed to `frontend/ui/widget/button.lua`

## After

- Buttons with a background keep the rounded flash behavior  
- Buttons without a background use the invert fallback  
- No crash when `background` is `nil`

## Notes

This keeps the feature functional instead of working around the issue by disabling `flash_ui`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15287)
<!-- Reviewable:end -->
