### PR TITLE
DjVu: preserve text-layer reading order in selection

### DIFF
--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -57,7 +57,6 @@ function DjvuDocument:comparePositions(pos1, pos2)
 end
 
 -- Performance is better pre-allocated than as table.sort(tbl, function() … end).
-local function compareByX(a, b) return a.x0 < b.x0 end
 local function compareByYThenX(a, b)
     if a.y0 - b.y0 == 0 then return a.x0 < b.x0 end
     return a.y0 < b.y0
@@ -73,21 +72,6 @@ local function collectWords(node, words)
         collectWords(node[i], words)
     end
     return words
-end
-
---- X-only sort that tries to avoid sorting when already ordered.
-local function sortWordsByX(words)
-    local n = #words
-    if n < 2 then return end
-    local prev = words[1].x0
-    for i = 2, n do
-        local x = words[i].x0
-        if prev > x then
-            table.sort(words, compareByX)
-            return
-        end
-        prev = x
-    end
 end
 
 --- Collect only direct word children (no recursion).
@@ -108,15 +92,18 @@ local function hasDirectWordChildren(node)
     return false
 end
 
-local function groupWordsIntoLines(words)
-    if #words == 0 then return {} end
-    -- Sort by y (top to bottom), then x (left to right)
-    table.sort(words, compareByYThenX)
-    -- Estimate a dynamic threshold based on word heights
+local function getLineGroupingThreshold(words)
     local sum_h = 0
-    for i = 1, #words do sum_h = sum_h + math.floor((words[i].y1 - words[i].y0) + 0.5) end
+    for i = 1, #words do
+        sum_h = sum_h + math.floor((words[i].y1 - words[i].y0) + 0.5)
+    end
     local avg_h = sum_h / #words
-    local threshold = math.max(2, math.floor(avg_h * 0.5 + 0.5))
+    return math.max(2, math.floor(avg_h * 0.5 + 0.5))
+end
+
+local function groupWordsIntoLinesInOrder(words)
+    if #words == 0 then return {} end
+    local threshold = getLineGroupingThreshold(words)
     local lines = {}
     local current = { words[1] }
     local current_y = (words[1].y0 + words[1].y1) / 2
@@ -135,6 +122,11 @@ local function groupWordsIntoLines(words)
     end
     lines[#lines + 1] = current
     return lines
+end
+
+local function groupWordsIntoLinesByGeometry(words)
+    table.sort(words, compareByYThenX)
+    return groupWordsIntoLinesInOrder(words)
 end
 
 local function computeBboxFromWords(words)
@@ -167,7 +159,6 @@ function DjvuDocument:getPageTextBoxes(pageno)
         if node.line then
             local words = collectWords(node, {})
             if #words > 0 then
-                sortWordsByX(words)
                 setLineBbox(words)
                 lines[#lines + 1] = words
             end
@@ -177,7 +168,7 @@ function DjvuDocument:getPageTextBoxes(pageno)
             -- Only handle direct words here to avoid double-processing nested structures.
             local words = collectDirectWords(node, {})
             if #words > 0 then
-                local groups = groupWordsIntoLines(words)
+                local groups = groupWordsIntoLinesInOrder(words)
                 for i = 1, #groups do
                     setLineBbox(groups[i])
                     lines[#lines + 1] = groups[i]
@@ -204,7 +195,7 @@ function DjvuDocument:getPageTextBoxes(pageno)
     end
     -- No explicit line nodes: group all words heuristically by y.
     local all_words = collectWords(page_text, {})
-    local grouped = groupWordsIntoLines(all_words)
+    local grouped = groupWordsIntoLinesByGeometry(all_words)
     for i = 1, #grouped do setLineBbox(grouped[i]) end
     return grouped
 end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -994,6 +994,16 @@ local function getWordBoxIndices(boxes, pos)
     return m, n
 end
 
+local function compareWordBoxIndices(i1, j1, i2, j2)
+    if i1 == i2 then
+        if j1 == j2 then
+            return 0
+        end
+        return j1 < j2 and 1 or -1
+    end
+    return i1 < i2 and 1 or -1
+end
+
 --[[--
 Get word and word box around `pos`.
 --]]
@@ -1024,7 +1034,7 @@ function KoptInterface:getTextFromBoxes(boxes, pos0, pos1)
     local line_boxes = {}
     local i_start, j_start = getWordBoxIndices(boxes, pos0)
     local i_stop, j_stop = getWordBoxIndices(boxes, pos1)
-    if i_start == i_stop and j_start > j_stop or i_start > i_stop then
+    if compareWordBoxIndices(i_start, j_start, i_stop, j_stop) == -1 then
         i_start, i_stop = i_stop, i_start
         j_start, j_stop = j_stop, j_start
     end
@@ -1067,12 +1077,12 @@ function KoptInterface:getTextFromBoxes(boxes, pos0, pos1)
                     if prev_word:sub(-1, -1) == " " or word:sub(1, 1) == " " then
                         -- Already a space between these words
                         add_space = false
-                    elseif dist_from_prev_word < box_height * 0.03 then
+                    elseif dist_from_prev_word >= 0 and dist_from_prev_word < box_height * 0.03 then
                         -- If the space between previous word box and this word box
                         -- is smaller than 5% of box height, assume these boxes
                         -- should be stuck
                         add_space = false
-                    elseif dist_from_prev_word < box_height * 0.8 then
+                    elseif dist_from_prev_word >= 0 and dist_from_prev_word < box_height * 0.8 then
                         local prev_word_end = prev_word:match(util.UTF8_CHAR_PATTERN.."$")
                         local word_start = word:match(util.UTF8_CHAR_PATTERN)
                         if util.isCJKChar(prev_word_end) and util.isCJKChar(word_start) then
@@ -1449,18 +1459,13 @@ function KoptInterface:comparePositions(doc, ppos1, ppos2)
     elseif ppos1.page > ppos2.page then
         return -1
     end
-    local box1 = self:getWordFromPosition(doc, ppos1).pbox
-    local box2 = self:getWordFromPosition(doc, ppos2).pbox
-    if box1.y == box2.y then
-        if box1.x == box2.x then
-            return 0
-        elseif box1.x > box2.x then
-            return -1
-        end
-    elseif box1.y > box2.y then
-        return -1
+    local text_boxes = self:getTextBoxes(doc, ppos1.page)
+    if not text_boxes then
+        return 0
     end
-    return 1
+    local i1, j1 = getWordBoxIndices(text_boxes, ppos1)
+    local i2, j2 = getWordBoxIndices(text_boxes, ppos2)
+    return compareWordBoxIndices(i1, j1, i2, j2)
 end
 
 --[[--

--- a/spec/unit/djvudocument_spec.lua
+++ b/spec/unit/djvudocument_spec.lua
@@ -1,0 +1,78 @@
+describe("DjVu document module", function()
+    local DjvuDocument
+
+    setup(function()
+        require("commonrequire")
+        DjvuDocument = require("document/djvudocument")
+    end)
+
+    local function get_words(lines)
+        local words = {}
+        for i = 1, #lines do
+            words[i] = {}
+            for j = 1, #lines[i] do
+                words[i][j] = lines[i][j].word
+            end
+        end
+        return words
+    end
+
+    local function make_doc(page_text)
+        return {
+            _document = {
+                getPageText = function(_, pageno)
+                    assert.is_equal(1, pageno)
+                    return page_text
+                end,
+            },
+        }
+    end
+
+    it("should flatten nested line nodes without reordering words by x", function()
+        local page_text = {
+            {
+                {
+                    line = true,
+                    { word = "Strategie", x0 = 50, y0 = 10, x1 = 90, y1 = 20 },
+                    { word = "del", x0 = 10, y0 = 10, x1 = 30, y1 = 20 },
+                    { word = "terrore", x0 = 100, y0 = 10, x1 = 150, y1 = 20 },
+                },
+            },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({ { "Strategie", "del", "terrore" } }, get_words(lines))
+    end)
+
+    it("should preserve source order for direct word children", function()
+        local page_text = {
+            {
+                word = false,
+                { word = "draw", x0 = 45, y0 = 10, x1 = 70, y1 = 20 },
+                { word = "attention,", x0 = 10, y0 = 10, x1 = 40, y1 = 20 },
+                { word = "in", x0 = 75, y0 = 10, x1 = 85, y1 = 20 },
+            },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({ { "draw", "attention,", "in" } }, get_words(lines))
+    end)
+
+    it("should still fall back to geometric grouping when only loose words exist", function()
+        local page_text = {
+            { word = "first", x0 = 40, y0 = 30, x1 = 60, y1 = 40 },
+            { word = "line", x0 = 70, y0 = 30, x1 = 90, y1 = 40 },
+            { word = "second", x0 = 10, y0 = 60, x1 = 40, y1 = 70 },
+            { word = "line", x0 = 45, y0 = 60, x1 = 65, y1 = 70 },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({
+            { "first", "line" },
+            { "second", "line" },
+        }, get_words(lines))
+    end)
+end)

--- a/spec/unit/djvudocument_spec.lua
+++ b/spec/unit/djvudocument_spec.lua
@@ -1,0 +1,78 @@
+describe("DjVu document module", function()
+    local DjvuDocument
+
+    setup(function()
+        require("commonrequire")
+        DjvuDocument = require("document/djvudocument")
+    end)
+
+    local function get_words(lines)
+        local words = {}
+        for i = 1, #lines do
+            words[i] = {}
+            for j = 1, #lines[i] do
+                words[i][j] = lines[i][j].word
+            end
+        end
+        return words
+    end
+
+    local function make_doc(page_text)
+        return {
+            _document = {
+                getPageText = function(_, pageno)
+                    assert.is_equal(1, pageno)
+                    return page_text
+                end,
+            },
+        }
+    end
+
+    it("should flatten nested line nodes", function()
+        local page_text = {
+            {
+                {
+                    line = true,
+                    { word = "Strategie", x0 = 50, y0 = 10, x1 = 90, y1 = 20 },
+                    { word = "del", x0 = 10, y0 = 10, x1 = 30, y1 = 20 },
+                    { word = "terrore", x0 = 100, y0 = 10, x1 = 150, y1 = 20 },
+                },
+            },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({ { "Strategie", "del", "terrore" } }, get_words(lines))
+    end)
+
+    it("should preserve source order for direct word children", function()
+        local page_text = {
+            {
+                word = false,
+                { word = "draw", x0 = 45, y0 = 10, x1 = 70, y1 = 20 },
+                { word = "attention,", x0 = 10, y0 = 10, x1 = 40, y1 = 20 },
+                { word = "in", x0 = 75, y0 = 10, x1 = 85, y1 = 20 },
+            },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({ { "draw", "attention,", "in" } }, get_words(lines))
+    end)
+
+    it("should fall back to geometric grouping when only loose words exist", function()
+        local page_text = {
+            { word = "first", x0 = 40, y0 = 30, x1 = 60, y1 = 40 },
+            { word = "line", x0 = 70, y0 = 30, x1 = 90, y1 = 40 },
+            { word = "second", x0 = 10, y0 = 60, x1 = 40, y1 = 70 },
+            { word = "line", x0 = 45, y0 = 60, x1 = 65, y1 = 70 },
+        }
+
+        local lines = DjvuDocument.getPageTextBoxes(make_doc(page_text), 1)
+
+        assert.are_same({
+            { "first", "line" },
+            { "second", "line" },
+        }, get_words(lines))
+    end)
+end)

--- a/spec/unit/koptinterface_spec.lua
+++ b/spec/unit/koptinterface_spec.lua
@@ -170,3 +170,49 @@ describe("Koptinterface module", function()
     end)
 
 end)
+
+describe("Koptinterface ordering", function()
+    local Koptinterface
+
+    setup(function()
+        require("commonrequire")
+        Koptinterface = require("document/koptinterface")
+    end)
+
+    it("should preserve reading-order spacing when line geometry goes backwards", function()
+        local boxes = {
+            {
+                { word = "Strategie", x0 = 50, y0 = 10, x1 = 90, y1 = 20 },
+                { word = "del", x0 = 10, y0 = 10, x1 = 30, y1 = 20 },
+                { word = "terrore", x0 = 100, y0 = 10, x1 = 150, y1 = 20 },
+                x0 = 10, y0 = 10, x1 = 150, y1 = 20,
+            },
+        }
+
+        local selection = Koptinterface:getTextFromBoxes(boxes, { x = 55, y = 15 }, { x = 120, y = 15 })
+
+        assert.is_same("Strategie del terrore", selection.text)
+    end)
+
+    it("should compare same-line positions by reading order instead of x coordinates", function()
+        local boxes = {
+            {
+                { word = "Strategie", x0 = 50, y0 = 10, x1 = 90, y1 = 20 },
+                { word = "del", x0 = 10, y0 = 10, x1 = 30, y1 = 20 },
+                { word = "terrore", x0 = 100, y0 = 10, x1 = 150, y1 = 20 },
+                x0 = 10, y0 = 10, x1 = 150, y1 = 20,
+            },
+        }
+        local doc = {
+            configurable = { text_wrap = 0 },
+        }
+        local fake_kopt = {
+            getTextBoxes = function()
+                return boxes
+            end,
+        }
+
+        assert.is_same(1, Koptinterface.comparePositions(fake_kopt, doc, { page = 1, x = 55, y = 15 }, { page = 1, x = 15, y = 15 }))
+        assert.is_same(-1, Koptinterface.comparePositions(fake_kopt, doc, { page = 1, x = 15, y = 15 }, { page = 1, x = 55, y = 15 }))
+    end)
+end)


### PR DESCRIPTION
Disclaimer: I used codex-cli for this patch.  Hopefully it fixes #15286. I can successfully copy non-scrambled text now from my djvu files.

  This fixes scrambled copied text from some DjVu highlights by preserving the DjVu text
  layer's reading order during flattening instead of reordering words geometrically.

  It also makes downstream selection logic consistent with that reading order:
  - compare same-page positions by text-box order rather than raw x/y coordinates
  - avoid collapsing spaces when logical word order goes backwards in x

  Tests:
  - ./kodev test front djvudocument
  - ./kodev test front koptinterface

  Manual verification:
  - reproduced and verified in the local emulator with the DjVu sample from #15286

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15298)
<!-- Reviewable:end -->
