### PR TITLE
[PocketBook] Respect input_ignore_gsensor setting

### DIFF
--- a/frontend/device/pocketbook/powerd.lua
+++ b/frontend/device/pocketbook/powerd.lua
@@ -104,7 +104,7 @@ function PocketBookPowerD:afterResume()
 
         -- Create a synthetic MSC_GYRO event and let the existing handler process it
         local synthetic_event = { value = gyro_value }
-        local Event = self.device.input:handleMiscGyroEv(synthetic_event)
+        local Event = self.device.input:handleGyroEv(synthetic_event)
 
         if Event then
             local UIManager = require("ui/uimanager")


### PR DESCRIPTION
I just briefly skimmed through the gyro code once more but haven't had the time to verify the fix ye. 

The `input_ignore_gsensor` setting sets `handleGyroEv` to be `voidEv` which skips the rotation fix in case the user wants to ignore the GSensor settings. Using `handleMiscGyroEv` bypasses the GSensor ignore check and leads to the rotation.

Related to #15168

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15304)
<!-- Reviewable:end -->
