### PR TITLE
[KeyValuePage] Fix keyboard hold events targeting wrong item

### DIFF
--- a/frontend/ui/widget/keyvaluepage.lua
+++ b/frontend/ui/widget/keyvaluepage.lua
@@ -321,6 +321,7 @@ function KeyValuePage:init()
         self.key_events.PrevPage = { { Input.group.PgBack } }
         if Device:hasScreenKB() or Device:hasKeyboard() then
             local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.HoldNonTouch = { { modifier, "Press" } }
             self.key_events.FirstPage = { { modifier, Input.group.PgFwd }, event = "GoToPage", args = 1 }
             self.key_events.LastPage = { { modifier, Input.group.PgBack }, event = "GoToPage", args = self.pages}
         end
@@ -859,6 +860,15 @@ function KeyValuePage:onReturn()
         UIManager:close(self)
         UIManager:setDirty(nil, "ui")
     end
+end
+
+function KeyValuePage:onHoldNonTouch()
+    -- Handle keyboard-triggered hold events by acting on the focused item directly
+    local focused_item = self:getFocusItem()
+    if not focused_item then
+        return true
+    end
+    return focused_item:onHold()
 end
 
 return KeyValuePage


### PR DESCRIPTION
### what's new

* Registered a new `HoldNonTouch` key event in `KeyValuePage:init()` to support "hold" actions via keyboard or screen keyboard.
* Added the `onHoldNonTouch()` method to handle the `HoldNonTouch` event by invoking the `onHold()` method on the currently focused item.

### related issues

* same as #14252
* same as #14314

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15305)
<!-- Reviewable:end -->
