### PR TITLE
KOSync: optionally send document metadata with progress sync

### DIFF
--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -107,6 +107,7 @@ function KOSyncClient:update_progress(
         username,
         password,
         document,
+        metadata,
         progress,
         percentage,
         device,
@@ -122,14 +123,18 @@ function KOSyncClient:update_progress(
     -- Set *very* tight timeouts to avoid blocking for too long...
     socketutil:set_timeout(PROGRESS_TIMEOUTS[1], PROGRESS_TIMEOUTS[2])
     local co = coroutine.create(function()
+        local params = {
+            document = document,
+            progress = tostring(progress),
+            percentage = percentage,
+            device = device,
+            device_id = device_id,
+        }
+        if metadata then
+            params.metadata = metadata
+        end
         local ok, res = pcall(function()
-            return self.client:update_progress({
-                document = document,
-                progress = tostring(progress),
-                percentage = percentage,
-                device = device,
-                device_id = device_id,
-            })
+            return self.client:update_progress(params)
         end)
         if ok then
             callback(res.status == 200, res.body)

--- a/plugins/kosync.koplugin/KOSyncClient.lua
+++ b/plugins/kosync.koplugin/KOSyncClient.lua
@@ -123,18 +123,15 @@ function KOSyncClient:update_progress(
     -- Set *very* tight timeouts to avoid blocking for too long...
     socketutil:set_timeout(PROGRESS_TIMEOUTS[1], PROGRESS_TIMEOUTS[2])
     local co = coroutine.create(function()
-        local params = {
-            document = document,
-            progress = tostring(progress),
-            percentage = percentage,
-            device = device,
-            device_id = device_id,
-        }
-        if metadata then
-            params.metadata = metadata
-        end
         local ok, res = pcall(function()
-            return self.client:update_progress(params)
+            return self.client:update_progress({
+                document = document,
+                metadata = metadata,
+                progress = tostring(progress),
+                percentage = percentage,
+                device = device,
+                device_id = device_id,
+            })
         end)
         if ok then
             callback(res.status == 200, res.body)

--- a/plugins/kosync.koplugin/api.json
+++ b/plugins/kosync.koplugin/api.json
@@ -30,8 +30,12 @@
                 "device",
                 "device_id",
             ],
+            "optional_params" : [
+                "metadata",
+            ],
             "payload" : [
                 "document",
+                "metadata",
                 "progress",
                 "percentage",
                 "device",

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -59,6 +59,7 @@ KOSync.default_settings = {
     sync_forward = SYNC_STRATEGY.PROMPT,
     sync_backward = SYNC_STRATEGY.DISABLE,
     checksum_method = CHECKSUM_METHOD.BINARY,
+    send_metadata = false,
 }
 
 function KOSync:init()
@@ -412,6 +413,14 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                     },
                 }
             },
+            {
+                text = _("Send document metadata"),
+                checked_func = function() return self.settings.send_metadata end,
+                help_text = _([[When enabled, document metadata (filename, title, and authors) will be sent along with progress sync requests. This data is ignored by the official sync server but may be used by custom sync servers.]]),
+                callback = function()
+                    self.settings.send_metadata = not self.settings.send_metadata
+                end,
+            },
         }
     }
 end
@@ -631,13 +640,30 @@ function KOSync:getFileDigest()
 end
 
 function KOSync:getFileNameDigest()
+    local file_name = self:getFileName()
+    if not file_name then return end
+    return md5(file_name)
+end
+
+function KOSync:getFileName()
     local file = self.ui.document.file
     if not file then return end
 
     local file_path, file_name = util.splitFilePathName(file) -- luacheck: no unused
     if not file_name then return end
 
-    return md5(file_name)
+    return file_name
+end
+
+function KOSync:getMetadata()
+    if not self.settings.send_metadata then return end
+
+    local props = self.ui.doc_props
+    return {
+        filename = self:getFileName(),
+        title = props.display_title,
+        authors = props.authors,
+    }
 end
 
 function KOSync:syncToProgress(progress)
@@ -673,6 +699,7 @@ function KOSync:updateProgress(ensure_networking, interactive, on_suspend)
         service_spec = self.path .. "/api.json"
     }
     local doc_digest = self:getDocumentDigest()
+    local metadata = self:getMetadata()
     local progress = self:getLastProgress()
     local percentage = self:getLastPercent()
     local chosen_device_name = self.settings.kosync_hostname or Device.model
@@ -681,6 +708,7 @@ function KOSync:updateProgress(ensure_networking, interactive, on_suspend)
         self.settings.username,
         self.settings.userkey,
         doc_digest,
+        metadata,
         progress,
         percentage,
         chosen_device_name,

--- a/spec/unit/kosync_spec.lua
+++ b/spec/unit/kosync_spec.lua
@@ -29,12 +29,18 @@ local service = [[
                 "progress",
                 "percentage",
                 "device",
+                "device_id",
+            ],
+            "optional_params" : [
+                "metadata",
             ],
             "payload" : [
                 "document",
+                "metadata",
                 "progress",
                 "percentage",
                 "device",
+                "device_id",
             ],
             "expected_status" : [200, 202, 401]
         },
@@ -52,7 +58,7 @@ local service = [[
 
 describe("KOSync modules #notest", function()
     local logger, md5, client
-    local username, password, doc, percentage, progress, device
+    local username, password, doc, metadata, percentage, progress, device, device_id
 
     setup(function()
         require("commonrequire")
@@ -72,11 +78,13 @@ describe("KOSync modules #notest", function()
         -- password should be hashed before submitting to server
         username, password = "koreader", md5.sum("koreader")
         -- fake progress data
-        doc, percentage, progress, device =
+        doc, metadata, percentage, progress, device, device_id =
             "41cce710f34e5ec21315e19c99821415", -- fast digest of the document
+            { filename = "my_book.epub", title = "My Book", authors = "Test Author" }, -- document metadata
             0.356, -- percentage of the progress
             "69", -- page number or xpointer
-            "my kpw" -- device name
+            "my kpw", -- device name
+            "test-device-id" -- device id
     end)
 
     it("should create new user", function()
@@ -133,9 +141,11 @@ describe("KOSync modules #notest", function()
         local ok, res = pcall(function()
             return client:update_progress({
                 document = doc,
+                metadata = metadata,
                 progress = progress,
                 percentage = percentage,
                 device = device,
+                device_id = device_id,
             })
         end)
         if ok then
@@ -206,7 +216,7 @@ describe("KOSync modules #notest", function()
             return res.result, res.body
         end
 
-        c.update_progress = function(name, passwd, doc, prog, percent, device, device_id, cb) --luacheck: ignore
+        c.update_progress = function(name, passwd, doc, metadata, prog, percent, device, device_id, cb) --luacheck: ignore
             cb(res.result, res.body)
         end
 


### PR DESCRIPTION
## Summary

- Adds an opt-in "Send document metadata" toggle (default off) to the KOSync settings
- When enabled, sends a `metadata` object (filename, title, authors) alongside progress sync requests
- The official sync server silently ignores this extra field; custom sync servers can use it

Closes #13810
Ref: https://github.com/koreader/koreader/discussions/8764

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15306)
<!-- Reviewable:end -->
