### PR TITLE
bump crengine: MOBI and CSS fixes ; add getNearestWordFromPosition()

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -716,6 +716,10 @@ function CreDocument:getScreenBoxesFromPositions(pos0, pos1, get_segments)
     return line_boxes
 end
 
+function CreDocument:getNearestWordFromPosition(pos, direction)
+    return self._document:getNearestWordFromPosition(pos.x, pos.y, direction)
+end
+
 function CreDocument:compareXPointers(xp1, xp2)
     -- Returns 1 if XPointers are ordered (if xp2 is after xp1), -1 if not, 0 if same
     -- Returns nil if any of XPointers are invalid
@@ -1894,6 +1898,7 @@ function CreDocument:setupCallCache()
             elseif name == "getPageLinks" then cache_by_tag = true
             elseif name == "getScreenBoxesFromPositions" then cache_by_tag = true
             elseif name == "getScreenPositionFromXPointer" then cache_by_tag = true
+            elseif name == "getNearestWordFromPosition" then cache_by_tag = true
             elseif name == "getXPointer" then cache_by_tag = true
             elseif name == "isXPointerInCurrentPage" then cache_by_tag = true
             elseif name == "getPageMapCurrentPageLabel" then cache_by_tag = true


### PR DESCRIPTION
#### bump crengine: MOBI and CSS fixes

Includes:
- https://github.com/koreader/crengine/pull/661
  - pdbfmt: don't overwrite extracted metadata
  - pdbfmt: extract more metadata from MOBI EXTH
  - pdbfmt: extract MOBI non-EXTH title if necessary
- https://github.com/koreader/crengine/pull/662
  - CSS first-line: fix possible crash
  - CSS width: fit-content: account for the element padding
  - getNodeByPoint(): improve fallback check

#### cre.cpp: add getNearestWordFromPosition()

Useful for improve text selection using DPAD/arrow keys.
Requested along https://github.com/koreader/crengine/issues/659.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15310)
<!-- Reviewable:end -->
