### PR TITLE
fix `common/koreader.sh` arguments handling on restart

### DIFF
--- a/platform/common/koreader.sh
+++ b/platform/common/koreader.sh
@@ -25,7 +25,7 @@ while [ ${RETURN_VALUE} -eq 85 ]; do
     ./reader.lua "$@"
     RETURN_VALUE=$?
     # Do not restart with saved arguments.
-    set -- "${HOME}"
+    set --
 done
 
 exit ${RETURN_VALUE}


### PR DESCRIPTION
Cf. https://github.com/koreader/koreader/pull/15271#pullrequestreview-4116067869.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15312)
<!-- Reviewable:end -->
