### PR TITLE
plugins: avoid legacy use of double quoted sqlite strings

### DIFF
--- a/plugins/exporter.koplugin/target/xmnote.lua
+++ b/plugins/exporter.koplugin/target/xmnote.lua
@@ -80,7 +80,7 @@ end
 function XMNoteExporter:getBookReadingDurationsByDay(title, md5)
     if util.fileExists(db_location) then
         local conn = SQ3.open(db_location)
-        local sql_query_book_id = [[SELECT id FROM book WHERE title = "%s" and md5 = "%s" LIMIT 1]]
+        local sql_query_book_id = [[SELECT id FROM book WHERE title = '%s' and md5 = '%s' LIMIT 1]]
         local sql_query_durations = [[
             SELECT date(start_time, 'unixepoch', 'localtime') AS date,
                    max(page)                                  AS last_page,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -2994,7 +2994,7 @@ function ReaderStatistics:getCurrentBookReadPages()
         SELECT
           page,
           min(sum(duration), ?) AS durations,
-          strftime("%s", "now") - max(start_time) AS delay
+          strftime('%s', 'now') - max(start_time) AS delay
         FROM page_stat
         WHERE id_book = ?
         GROUP BY page

--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -9,24 +9,24 @@ local db_location = DataStorage:getSettingsDir() .. "/vocabulary_builder.sqlite3
 local DB_SCHEMA_VERSION = 20240905
 local VOCABULARY_DB_SCHEMA = [[
     -- To store looked up words
-    CREATE TABLE IF NOT EXISTS "vocabulary" (
-        "word"          TEXT NOT NULL UNIQUE,
-        "title_id"      INTEGER,
-        "create_time"   INTEGER NOT NULL,
-        "review_time"   INTEGER,
-        "due_time"      INTEGER NOT NULL,
-        "review_count"  INTEGER NOT NULL DEFAULT 0,
-        "prev_context"  TEXT,
-        "next_context"  TEXT,
-        "streak_count"  INTEGER NOT NULL DEFAULT 0,
-        "highlight"     TEXT,
-        PRIMARY KEY("word")
+    CREATE TABLE IF NOT EXISTS vocabulary (
+        word          TEXT NOT NULL UNIQUE,
+        title_id      INTEGER,
+        create_time   INTEGER NOT NULL,
+        review_time   INTEGER,
+        due_time      INTEGER NOT NULL,
+        review_count  INTEGER NOT NULL DEFAULT 0,
+        prev_context  TEXT,
+        next_context  TEXT,
+        streak_count  INTEGER NOT NULL DEFAULT 0,
+        highlight     TEXT,
+        PRIMARY KEY(word)
     );
-    CREATE TABLE IF NOT EXISTS "title" (
-        "id"            INTEGER NOT NULL UNIQUE,
-        "name"          TEXT UNIQUE,
-        "filter"        INTEGER NOT NULL DEFAULT 1,
-        PRIMARY KEY("id")
+    CREATE TABLE IF NOT EXISTS title (
+        id            INTEGER NOT NULL UNIQUE,
+        name          TEXT UNIQUE,
+        filter        INTEGER NOT NULL DEFAULT 1,
+        PRIMARY KEY(id)
     );
     CREATE INDEX IF NOT EXISTS due_time_index ON vocabulary(due_time);
     CREATE INDEX IF NOT EXISTS title_name_index ON title(name);


### PR DESCRIPTION
Cf. koreader/koreader-base#2338.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15318)
<!-- Reviewable:end -->
