### PR TITLE
Collections: fix renaming folder

### DIFF
--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -281,9 +281,9 @@ end
 
 function ReadCollection:updateItemsByPath(path, new_path) -- FM: rename folder, move folder
     local len = #path
-    local seen = {}
     local do_write
     for coll_name, coll in pairs(self.coll) do
+        local seen = {}
         for file_name in pairs(coll) do
             if not seen[file_name] and file_name:sub(1, len) == path then
                 local new_file_name = self:_updateItem(coll_name, file_name, new_path .. file_name:sub(len + 1))

--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -246,6 +246,7 @@ function ReadCollection:_updateItem(coll_name, file_name, new_filepath, new_path
     local item = buildEntry(new_filepath, item_old.order, item_old.attr) -- no lfs call
     coll[item.file] = item
     coll[file_name] = nil
+    return item.file
 end
 
 function ReadCollection:updateItem(file, new_filepath) -- FM: rename file, move file
@@ -280,11 +281,13 @@ end
 
 function ReadCollection:updateItemsByPath(path, new_path) -- FM: rename folder, move folder
     local len = #path
+    local seen = {}
     local do_write
     for coll_name, coll in pairs(self.coll) do
         for file_name in pairs(coll) do
-            if file_name:sub(1, len) == path then
-                self:_updateItem(coll_name, file_name, new_path .. file_name:sub(len + 1))
+            if not seen[file_name] and file_name:sub(1, len) == path then
+                local new_file_name = self:_updateItem(coll_name, file_name, new_path .. file_name:sub(len + 1))
+                seen[new_file_name] = true
                 do_write = true
             end
         end


### PR DESCRIPTION
Unreported bug.
When a folder is renamed, all collections are updated to set new file paths for their entries.
Collections are hash tables, the old entry is deleted, the new entry is added.
If a folder is renamed by just **adding** chars to the old name, the 'pairs' loop over the collection met the new entry and tried to handle it once more, caused a crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15320)
<!-- Reviewable:end -->
