### PR TITLE
NewsDownloader: per-feed max_age option

### DIFF
--- a/plugins/newsdownloader.koplugin/feed_config.lua
+++ b/plugins/newsdownloader.koplugin/feed_config.lua
@@ -31,6 +31,16 @@ return {--do NOT change this line
  -- 'block_element="name_of_css.element.class" - means to remove the chosen CSS element, it can be easily picked using a modern web browser
  -- The default value is empty. The default list of common annoyances is used as fallback if this value is set.
 
+ -- 'max_age = "7d"' - skip items older than this duration.
+ --   Format: <integer><unit>. Units: s (second), m (minute), h (hour),
+ --   d (day), w (week), M (month=30d), y (year=365d).
+ --   M and y are fixed-length approximations (not calendar months/leap years).
+ --   Examples: "30m", "12h", "7d", "1M".
+ --   Feed must provide <pubDate> (RSS) or <updated>/<published> (Atom).
+ --   If the feed lacks a date field, sync will error and ask you to remove
+ --   this option.
+ --   Default: not set (no age filter).
+
 -- Optional 'credentials' element is used to authenticate on subscription based articles.
 -- It is itself comprised of a 'url' strings, that is the url of the connexion form,
 -- and an 'auth' table that contains form data used for user authentication {form_key = value, …}.

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -101,7 +101,7 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
             end
         },
         {
-            _("Max age"),
+            _("Maximum age"),
             feed.max_age or "",
             callback = function()
                 edit_feed_callback(

--- a/plugins/newsdownloader.koplugin/feed_view.lua
+++ b/plugins/newsdownloader.koplugin/feed_view.lua
@@ -4,6 +4,7 @@ local _ = require("gettext")
 local FeedView = {
     URL = "url",
     LIMIT = "limit",
+    MAX_AGE = "max_age",
     DOWNLOAD_FULL_ARTICLE = "download_full_article",
     INCLUDE_IMAGES = "include_images",
     ENABLE_FILTER = "enable_filter",
@@ -96,6 +97,17 @@ function FeedView:getItem(id, feed, edit_feed_callback, delete_feed_callback)
                     id,
                     FeedView.LIMIT,
                     limit
+                )
+            end
+        },
+        {
+            _("Max age"),
+            feed.max_age or "",
+            callback = function()
+                edit_feed_callback(
+                    id,
+                    FeedView.MAX_AGE,
+                    feed.max_age
                 )
             end
         },

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -355,6 +355,7 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
         local block_element = parseCommaSeparatedOption(feed.block_element)
         local credentials = feed.credentials
         local http_auth = feed.http_auth
+        local max_age_str = feed.max_age
         -- Check if the two required attributes are set.
         if url and limit then
             feed_message = T(_("Processing %1/%2:\n%3"), idx, total_feed_entries, BD.url(url))
@@ -371,7 +372,8 @@ function NewsDownloader:loadConfigAndProcessFeeds(touchmenu_instance)
                 feed_message,
                 enable_filter,
                 filter_element,
-                block_element)
+                block_element,
+                max_age_str)
         else
             logger.warn("NewsDownloader: invalid feed config entry.", feed)
         end
@@ -443,7 +445,7 @@ function NewsDownloader:loadConfigAndProcessFeedsWithUI(touchmenu_instance)
     end)
 end
 
-function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, unsupported_feeds_urls, download_full_article, include_images, message, enable_filter, filter_element, block_element)
+function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, unsupported_feeds_urls, download_full_article, include_images, message, enable_filter, filter_element, block_element, max_age_str)
     -- Check if we have a cached response first
     local cache = DownloadBackend:getCache()
     local cached_response = cache:check(url)
@@ -606,7 +608,8 @@ function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, un
                     message,
                     enable_filter,
                     filter_element,
-                    block_element
+                    block_element,
+                    max_age_str
                 )
         end)
     elseif is_rss then
@@ -622,7 +625,8 @@ function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, un
                     message,
                     enable_filter,
                     filter_element,
-                    block_element
+                    block_element,
+                    max_age_str
                 )
         end)
     end
@@ -667,7 +671,7 @@ function NewsDownloader:deserializeXMLString(xml_str)
     return xmlhandler.root
 end
 
-function NewsDownloader:processFeed(feed_type, feeds, cookies, http_auth, limit, download_full_article, include_images, message, enable_filter, filter_element, block_element)
+function NewsDownloader:processFeed(feed_type, feeds, cookies, http_auth, limit, download_full_article, include_images, message, enable_filter, filter_element, block_element, max_age_str)
     local feed_title
     local feed_item
     local total_items

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -60,18 +60,18 @@ local function parseMaxAge(value)
         return nil, nil
     end
     if type(value) ~= "string" then
-        return nil, _("max_age must be a string")
+        return nil, _("Maximum age must be a string")
     end
     local n, u = value:match("^(%d+)([smhdwMy])$")
     if not n then
-        return nil, _("Invalid max_age format. Use e.g. 7d, 12h, 30m, 1M.")
+        return nil, _("Invalid maximum age format. Use e.g. 7d, 12h, 30m, 1M.")
     end
     return tonumber(n) * DURATION_UNITS[u], nil
 end
 
 -- Returns parsed unix timestamp (number) or nil if no parseable date field.
 local function getFeedItemTimestamp(feed)
-    local raw = feed.pubDate or feed.updated or feed.published
+    local raw = feed.updated or feed.pubDate or feed.published
     if not raw then return nil end
     local ts = dateparser.parse(raw)
     return type(ts) == "number" and ts or nil
@@ -638,7 +638,7 @@ function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, un
         if not ok then
             if type(error) == "string"
                     and error:find("__max_age_no_date__", 1, true) then
-                error_message = _("(Reason: max_age is set but feed has no <pubDate>/<updated>/<published>. Remove max_age from this feed in the config.)")
+                error_message = _("(Reason: Maximum age is set but the feed provides no date field (<updated>/<pubDate>/<published>). Remove maximum age from this feed in the config.)")
             elseif type(error) == "string"
                     and error:find("__max_age_invalid__:", 1, true) then
                 local msg = error:match("__max_age_invalid__:(.*)") or ""
@@ -806,27 +806,11 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, http_auth, limit,
     end
 end
 
-local function parseDate(dateTime)
-    -- Uses lua-feedparser https://github.com/slact/lua-feedparser
-    -- feedparser is available under the (new) BSD license.
-    -- see: koreader/plugins/newsdownloader.koplugin/lib/LICENCE_lua-feedparser
-    logger.dbg("NewsDownloader: Parsing date:", dateTime)
-    local date = dateparser.parse(dateTime)
-    if type(date) == "number" then
-        return os.date("%y-%m-%d_%H-%M_", date)
-    end
-    return dateTime
-end
-
 local function getTitleWithDate(feed)
     local title = util.getSafeFilename(NewsDownloader.getFeedTitle(feed.title))
-    -- Field precedence (pubDate > updated > published) matches getFeedItemTimestamp.
-    -- Note: this is a deliberate change from the previous order (updated > pubDate >
-    -- published) so that both helpers agree on which date the item "has". For
-    -- well-formed feeds only one of these is set, so the visible filename is unchanged.
-    local raw = feed.pubDate or feed.updated or feed.published
-    if raw then
-        title = parseDate(raw) .. title
+    local ts = getFeedItemTimestamp(feed)
+    if ts then
+        title = os.date("%y-%m-%d_%H-%M_", ts) .. title
     end
     return title
 end
@@ -1072,8 +1056,8 @@ function NewsDownloader:editFeedAttribute(id, key, value)
             description = _("Set to 0 for no limit to how many items are downloaded")
             input_type = "number"
         elseif key == FeedView.MAX_AGE then
-            title = _("Edit max age")
-            description = _("Skip items older than this. Format: <number><unit>. " ..
+            title = _("Edit maximum age")
+            description = _("Download articles no older than this duration. Format: <number><unit>. " ..
                             "Units: s, m (minute), h, d, w, M (month=30d), y (year=365d). " ..
                             "Examples: 30m, 12h, 7d, 1M. Leave empty to disable.")
             input_type = "string"

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -69,6 +69,14 @@ local function parseMaxAge(value)
     return tonumber(n) * DURATION_UNITS[u], nil
 end
 
+-- Returns parsed unix timestamp (number) or nil if no parseable date field.
+local function getFeedItemTimestamp(feed)
+    local raw = feed.pubDate or feed.updated or feed.published
+    if not raw then return nil end
+    local ts = dateparser.parse(raw)
+    return type(ts) == "number" and ts or nil
+end
+
 -- If a title looks like <title>blabla</title> it'll just be feed.title.
 -- If a title looks like <title attr="alb">blabla</title> then we get a table
 -- where [1] is the title string and the attributes are also available.
@@ -772,12 +780,13 @@ end
 
 local function getTitleWithDate(feed)
     local title = util.getSafeFilename(NewsDownloader.getFeedTitle(feed.title))
-    if feed.updated then
-        title = parseDate(feed.updated) .. title
-    elseif feed.pubDate then
-        title = parseDate(feed.pubDate) .. title
-    elseif feed.published then
-        title = parseDate(feed.published) .. title
+    -- Field precedence (pubDate > updated > published) matches getFeedItemTimestamp.
+    -- Note: this is a deliberate change from the previous order (updated > pubDate >
+    -- published) so that both helpers agree on which date the item "has". For
+    -- well-formed feeds only one of these is set, so the visible filename is unchanged.
+    local raw = feed.pubDate or feed.updated or feed.published
+    if raw then
+        title = parseDate(raw) .. title
     end
     return title
 end
@@ -1384,5 +1393,6 @@ function NewsDownloader:onCloseDocument()
 end
 
 NewsDownloader._parseMaxAge = parseMaxAge
+NewsDownloader._getFeedItemTimestamp = getFeedItemTimestamp
 
 return NewsDownloader

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1197,6 +1197,18 @@ function NewsDownloader:updateFeedConfig(id, key, value)
                         }
                     )
                 end
+            elseif key == FeedView.MAX_AGE then
+                if feed.max_age ~= nil then
+                    feed.max_age = value
+                else
+                    table.insert(
+                        feed,
+                        {
+                            "max_age",
+                            value
+                        }
+                    )
+                end
             elseif key == FeedView.DOWNLOAD_FULL_ARTICLE then
                 if feed.download_full_article ~= nil then
                     feed.download_full_article = value

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -60,11 +60,11 @@ local function parseMaxAge(value)
         return nil, nil
     end
     if type(value) ~= "string" then
-        return nil, "max_age must be a string"
+        return nil, _("max_age must be a string")
     end
     local n, u = value:match("^(%d+)([smhdwMy])$")
     if not n then
-        return nil, "Invalid max_age format. Use e.g. 7d, 12h, 30m, 1M."
+        return nil, _("Invalid max_age format. Use e.g. 7d, 12h, 30m, 1M.")
     end
     return tonumber(n) * DURATION_UNITS[u], nil
 end

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -42,6 +42,33 @@ local NewsDownloader = WidgetContainer:extend{
 local FEED_TYPE_RSS = "rss"
 local FEED_TYPE_ATOM = "atom"
 
+-- Single-unit duration shorthand parser used for the per-feed `max_age` option.
+-- Returns (seconds, nil) when enabled, (nil, nil) when disabled (nil/empty),
+-- (nil, error_string) when invalid.
+local DURATION_UNITS = {
+    s = 1,
+    m = 60,           -- minute (lowercase)
+    h = 3600,
+    d = 86400,
+    w = 604800,
+    M = 2592000,      -- month: 30 days (uppercase, distinct from minute)
+    y = 31536000,     -- year: 365 days
+}
+
+local function parseMaxAge(value)
+    if value == nil or value == "" then
+        return nil, nil
+    end
+    if type(value) ~= "string" then
+        return nil, "max_age must be a string"
+    end
+    local n, u = value:match("^(%d+)([smhdwMy])$")
+    if not n then
+        return nil, "Invalid max_age format. Use e.g. 7d, 12h, 30m, 1M."
+    end
+    return tonumber(n) * DURATION_UNITS[u], nil
+end
+
 -- If a title looks like <title>blabla</title> it'll just be feed.title.
 -- If a title looks like <title attr="alb">blabla</title> then we get a table
 -- where [1] is the title string and the attributes are also available.
@@ -1355,5 +1382,7 @@ function NewsDownloader:onCloseDocument()
         self.ui:setLastDirForFileBrowser(doc_dir)
     end
 end
+
+NewsDownloader._parseMaxAge = parseMaxAge
 
 return NewsDownloader

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1238,17 +1238,7 @@ function NewsDownloader:updateFeedConfig(id, key, value)
                     )
                 end
             elseif key == FeedView.MAX_AGE then
-                if feed.max_age ~= nil then
-                    feed.max_age = value
-                else
-                    table.insert(
-                        feed,
-                        {
-                            "max_age",
-                            value
-                        }
-                    )
-                end
+                feed.max_age = value
             elseif key == FeedView.DOWNLOAD_FULL_ARTICLE then
                 if feed.download_full_article ~= nil then
                     feed.download_full_article = value

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -697,6 +697,22 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, http_auth, limit,
             feed_item = {feed_item}
         end
     end
+    -- Parse max_age (if set) and prepare the cutoff timestamp. Invalid format
+    -- and missing-date conditions raise sentinel errors that the caller's
+    -- pcall converts into user-facing messages.
+    local max_age_seconds, max_age_err = parseMaxAge(max_age_str)
+    if max_age_err then
+        error("__max_age_invalid__:" .. max_age_err)
+    end
+
+    local cutoff
+    if max_age_seconds and feed_item[1] then
+        local first_ts = getFeedItemTimestamp(feed_item[1])
+        if not first_ts then
+            error("__max_age_no_date__")
+        end
+        cutoff = os.time() - max_age_seconds
+    end
     -- Get the path to the output directory.
     local feed_output_dir = ("%s%s/"):format(
         self.download_dir,
@@ -710,6 +726,17 @@ function NewsDownloader:processFeed(feed_type, feeds, cookies, http_auth, limit,
         -- If limit has been met, stop downloading feed.
         if limit ~= 0 and index - 1 == limit then
             break
+        end
+        if cutoff then
+            local ts = getFeedItemTimestamp(feed)
+            if ts and ts < cutoff then
+                -- Feeds are chronological newest-first; remaining items are
+                -- older too, so we can stop iterating.
+                break
+            end
+            -- ts == nil after the first-item probe succeeded means the
+            -- publisher omitted a date for this item. Process it normally
+            -- without an age check.
         end
         -- Create a message to display during processing.
         local article_message = T(

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -636,8 +636,17 @@ function NewsDownloader:processFeedSource(url, credentials, http_auth, limit, un
     if not ok or (not is_rss and not is_atom) then
         local error_message
         if not ok then
-            logger.err("NewsDownloader: Error processing feed", error)
-            error_message = _("(Reason: Failed to download content)")
+            if type(error) == "string"
+                    and error:find("__max_age_no_date__", 1, true) then
+                error_message = _("(Reason: max_age is set but feed has no <pubDate>/<updated>/<published>. Remove max_age from this feed in the config.)")
+            elseif type(error) == "string"
+                    and error:find("__max_age_invalid__:", 1, true) then
+                local msg = error:match("__max_age_invalid__:(.*)") or ""
+                error_message = T(_("(Reason: %1)"), msg)
+            else
+                logger.err("NewsDownloader: Error processing feed", error)
+                error_message = _("(Reason: Failed to download content)")
+            end
         elseif not is_rss then
             error_message = _("(Reason: Couldn't process RSS)")
         elseif not is_atom then

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1014,6 +1014,7 @@ function NewsDownloader:editFeedAttribute(id, key, value)
     -- attribute will need and displays the corresponding dialog.
     if key == FeedView.URL
         or key == FeedView.LIMIT
+        or key == FeedView.MAX_AGE
         or key == FeedView.FILTER_ELEMENT
         or key == FeedView.BLOCK_ELEMENT
         or key == FeedView.HTTP_AUTH_USERNAME
@@ -1030,6 +1031,12 @@ function NewsDownloader:editFeedAttribute(id, key, value)
             title = _("Edit feed limit")
             description = _("Set to 0 for no limit to how many items are downloaded")
             input_type = "number"
+        elseif key == FeedView.MAX_AGE then
+            title = _("Edit max age")
+            description = _("Skip items older than this. Format: <number><unit>. " ..
+                            "Units: s, m (minute), h, d, w, M (month=30d), y (year=365d). " ..
+                            "Examples: 30m, 12h, 7d, 1M. Leave empty to disable.")
+            input_type = "string"
         elseif key == FeedView.FILTER_ELEMENT then
             title = _("Edit filter element.")
             description = _("Filter based on the given CSS selector. E.g.: name_of_css.element.class")
@@ -1068,8 +1075,16 @@ function NewsDownloader:editFeedAttribute(id, key, value)
                         text = _("Save"),
                         is_enter_default = true,
                         callback = function()
+                            local new_value = input_dialog:getInputValue()
+                            if key == FeedView.MAX_AGE and new_value ~= "" then
+                                local _seconds, err = parseMaxAge(new_value)
+                                if err then
+                                    UIManager:show(InfoMessage:new{ text = err })
+                                    return
+                                end
+                            end
                             UIManager:close(input_dialog)
-                            self:updateFeedConfig(id, key, input_dialog:getInputValue())
+                            self:updateFeedConfig(id, key, new_value)
                         end,
                     },
                 }

--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1117,7 +1117,7 @@ function NewsDownloader:editFeedAttribute(id, key, value)
                         callback = function()
                             local new_value = input_dialog:getInputValue()
                             if key == FeedView.MAX_AGE and new_value ~= "" then
-                                local _seconds, err = parseMaxAge(new_value)
+                                local _, err = parseMaxAge(new_value)
                                 if err then
                                     UIManager:show(InfoMessage:new{ text = err })
                                     return

--- a/spec/unit/newsdownloader_spec.lua
+++ b/spec/unit/newsdownloader_spec.lua
@@ -322,4 +322,45 @@ describe("NewsDownloader module", function()
             assert.is_string(err)
         end)
     end)
+
+    describe("getFeedItemTimestamp", function()
+        local getFeedItemTimestamp
+
+        setup(function()
+            getFeedItemTimestamp = NewsDownloader._getFeedItemTimestamp
+            assert.is_function(getFeedItemTimestamp)
+        end)
+
+        it("parses RSS pubDate", function()
+            local ts = getFeedItemTimestamp({ pubDate = "Mon, 01 Jan 2024 00:00:00 GMT" })
+            assert.is_number(ts)
+        end)
+
+        it("parses Atom updated", function()
+            local ts = getFeedItemTimestamp({ updated = "2024-01-01T00:00:00Z" })
+            assert.is_number(ts)
+        end)
+
+        it("parses Atom published", function()
+            local ts = getFeedItemTimestamp({ published = "2024-01-01T00:00:00Z" })
+            assert.is_number(ts)
+        end)
+
+        it("returns nil when no date fields present", function()
+            assert.is_nil(getFeedItemTimestamp({ title = "no date here" }))
+        end)
+
+        it("returns nil for unparseable date string", function()
+            assert.is_nil(getFeedItemTimestamp({ pubDate = "not a date" }))
+        end)
+
+        it("prefers pubDate over updated and published", function()
+            local ts = getFeedItemTimestamp({
+                pubDate = "Mon, 01 Jan 2024 00:00:00 GMT",
+                updated = "garbage",
+                published = "garbage",
+            })
+            assert.is_number(ts)
+        end)
+    end)
 end)

--- a/spec/unit/newsdownloader_spec.lua
+++ b/spec/unit/newsdownloader_spec.lua
@@ -237,4 +237,89 @@ describe("NewsDownloader module", function()
             NewsDownloader.createFromDescription = old_createFromDescription
         end)
     end)
+
+    describe("parseMaxAge", function()
+        local parseMaxAge
+
+        setup(function()
+            parseMaxAge = NewsDownloader._parseMaxAge
+            assert.is_function(parseMaxAge)
+        end)
+
+        it("returns (nil, nil) for nil (disabled)", function()
+            local s, err = parseMaxAge(nil)
+            assert.is_nil(s)
+            assert.is_nil(err)
+        end)
+
+        it("returns (nil, nil) for empty string (disabled)", function()
+            local s, err = parseMaxAge("")
+            assert.is_nil(s)
+            assert.is_nil(err)
+        end)
+
+        it("parses seconds", function()
+            assert.equals(1, parseMaxAge("1s"))
+        end)
+
+        it("parses minutes (lowercase m)", function()
+            assert.equals(1800, parseMaxAge("30m"))
+        end)
+
+        it("parses hours", function()
+            assert.equals(43200, parseMaxAge("12h"))
+        end)
+
+        it("parses days", function()
+            assert.equals(604800, parseMaxAge("7d"))
+        end)
+
+        it("parses weeks", function()
+            assert.equals(1209600, parseMaxAge("2w"))
+        end)
+
+        it("parses months (uppercase M, 30d)", function()
+            assert.equals(2592000, parseMaxAge("1M"))
+        end)
+
+        it("parses years (365d)", function()
+            assert.equals(31536000, parseMaxAge("1y"))
+        end)
+
+        it("rejects bare number", function()
+            local s, err = parseMaxAge("7")
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+
+        it("rejects 7days", function()
+            local s, err = parseMaxAge("7days")
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+
+        it("rejects uppercase D (case-sensitive)", function()
+            local s, err = parseMaxAge("7D")
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+
+        it("rejects negative duration", function()
+            local s, err = parseMaxAge("-1d")
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+
+        it("rejects pure garbage", function()
+            local s, err = parseMaxAge("abc")
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+
+        it("rejects non-string types", function()
+            local s, err = parseMaxAge(7)
+            assert.is_nil(s)
+            assert.is_string(err)
+        end)
+    end)
 end)

--- a/spec/unit/newsdownloader_spec.lua
+++ b/spec/unit/newsdownloader_spec.lua
@@ -354,10 +354,10 @@ describe("NewsDownloader module", function()
             assert.is_nil(getFeedItemTimestamp({ pubDate = "not a date" }))
         end)
 
-        it("prefers pubDate over updated and published", function()
+        it("prefers updated over pubDate and published", function()
             local ts = getFeedItemTimestamp({
-                pubDate = "Mon, 01 Jan 2024 00:00:00 GMT",
-                updated = "garbage",
+                updated = "2024-01-01T00:00:00Z",
+                pubDate = "garbage",
                 published = "garbage",
             })
             assert.is_number(ts)

--- a/spec/unit/newsdownloader_spec.lua
+++ b/spec/unit/newsdownloader_spec.lua
@@ -363,4 +363,19 @@ describe("NewsDownloader module", function()
             assert.is_number(ts)
         end)
     end)
+
+    describe("getFeedItemTimestamp publisher quirk", function()
+        local getFeedItemTimestamp
+
+        setup(function()
+            getFeedItemTimestamp = NewsDownloader._getFeedItemTimestamp
+        end)
+
+        it("returns nil for an item missing all date fields, so the for-loop processes it without filtering", function()
+            -- The for-loop in processFeed treats `ts == nil` as "no age check"
+            -- once the first-item probe has succeeded. This test locks in the
+            -- nil contract that the loop relies on.
+            assert.is_nil(getFeedItemTimestamp({ title = "x", link = "y" }))
+        end)
+    end)
 end)


### PR DESCRIPTION
## Summary

Add per-feed `max_age` option to the News Downloader plugin so users can skip RSS/Atom items older than a configurable duration. Configurable from the in-app feed-edit UI and from `feed_config.lua`. Surfaces a clear error when a feed lacks date fields instead of silently failing.

- `max_age = "7d"` per-feed setting. Format: `<integer><unit>` where unit is `s` / `m` (minute) / `h` / `d` / `w` / `M` (month=30d) / `y` (year=365d).
- New "Max age" row in *Edit feed* with on-save validation.
- At sync, items older than `now - max_age` are skipped; loop breaks early since feeds are chronological newest-first.
- Missing-date or malformed `max_age` surface in the existing end-of-sync error dialog with actionable text.

## Files

- `plugins/newsdownloader.koplugin/main.lua` — `parseMaxAge`, `getFeedItemTimestamp`, plumbing through `processFeedSource` → `processFeed`, filter loop, error sentinels caught and translated in `processFeedSource`, UI dialog branch + validation, persistence branch
- `plugins/newsdownloader.koplugin/feed_view.lua` — `MAX_AGE` key + KeyValuePage row
- `plugins/newsdownloader.koplugin/feed_config.lua` — header docs
- `spec/unit/newsdownloader_spec.lua` — 22 new test cases (parser, timestamp helper, publisher quirk)

## Behavior

| Scenario | Result |
|----------|--------|
| `max_age` unset | No filter, no date check (existing behavior) |
| `max_age = "7d"`, all items fresh | All items within `limit` downloaded |
| `max_age = "7d"`, first item stale | Loop breaks on item 1 → 0 items, no error |
| Invalid `max_age` saved via UI | Rejected before save with `InfoMessage` |
| Invalid `max_age` from hand-edited config | End-of-sync dialog: `(Reason: Invalid max_age format. Use e.g. 7d, 12h, 30m, 1M.)` |
| `max_age` set but feed has no date field | End-of-sync dialog: `(Reason: max_age is set but feed has no <pubDate>/<updated>/<published>. Remove max_age from this feed in the config.)` |
| Per-item missing date after first item had one | Treated as publisher quirk — processed without age check |

## Test plan

- [x] `./kodev test front newsdownloader` — passes (22 new cases)
- [x] `./kodev test front` — full front suite green (except `koreader-testrunner:version`)
- [x] Manual smoke on Kobo:
  - [x] *Max age* row appears between *Limit* and *Download full article*
  - [x] Empty value persists, raw shorthand persists (`7d`, `12h`)
  - [x] Invalid input (e.g. `7days`) rejected on save with InfoMessage; dialog stays open
  - [x] Sync with valid `max_age` skips items older than the cutoff
  - [x] Sync with hand-edited invalid `max_age` shows the parser error in end-of-sync dialog
  - [x] Clearing the field disables the filter (sync runs, no error)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15322)
<!-- Reviewable:end -->
