### PR TITLE
Folder shortcuts: standard folders

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -106,10 +106,8 @@ function FileManager:onSetDimensions(dimen)
 end
 
 function FileManager:updateTitleBarPath(path)
-    local text = BD.directory(filemanagerutil.abbreviate(path))
-    if self.folder_shortcuts:hasFolderShortcut(path) then
-        text = "☆ " .. text
-    end
+    path = path or self.file_chooser.path
+    local text = self.folder_shortcuts:getShortcutFullName(path) or BD.directory(filemanagerutil.abbreviate(path))
     self.title_bar:setSubTitle(text)
 end
 
@@ -864,9 +862,11 @@ function FileManager:setHome(path)
         text = T(_("Set '%1' as HOME folder?"), BD.dirpath(path)),
         ok_text = _("Set as HOME"),
         ok_callback = function()
+            local path_refreshed = self.folder_shortcuts:updateShortcut("home_dir", path)
             G_reader_settings:saveSetting("home_dir", path)
-            if G_reader_settings:isTrue("lock_home_folder") then
-                self:onRefresh()
+            self:updateTitleBarPath()
+            if not path_refreshed and G_reader_settings:isTrue("lock_home_folder") then
+                self.file_chooser:refreshPath()
             end
         end,
     })
@@ -943,6 +943,7 @@ function FileManager:pasteFileFromClipboard(file)
                 else
                     ReadHistory:updateItemsByPath(orig_file, dest_file)
                     ReadCollection:updateItemsByPath(orig_file, dest_file)
+                    self.folder_shortcuts:updateItemsByPath(orig_file, dest_file) -- will update system folders in settings
                 end
             end
             self.clipboard = nil
@@ -981,13 +982,13 @@ function FileManager:pasteFileFromClipboard(file)
     end
 end
 
-function FileManager:showCopyMoveSelectedFilesDialog(close_callback)
+function FileManager:showCopyMoveSelectedFilesDialog(close_callback, folder)
     local text, ok_text
     if self.cutfile then
-        text = _("Move selected files to the current folder?")
+        text = folder and _("Move selected files?") or _("Move selected files to the current folder?")
         ok_text = _("Move")
     else
-        text = _("Copy selected files to the current folder?")
+        text = folder and _("Copy selected files?") or _("Copy selected files to the current folder?")
         ok_text = _("Copy")
     end
     local confirmbox, check_button_overwrite
@@ -996,7 +997,7 @@ function FileManager:showCopyMoveSelectedFilesDialog(close_callback)
         ok_text = ok_text,
         ok_callback = function()
             close_callback()
-            self:pasteSelectedFiles(check_button_overwrite.checked)
+            self:pasteSelectedFiles(check_button_overwrite.checked, folder)
         end,
     }
     check_button_overwrite = CheckButton:new{
@@ -1008,8 +1009,8 @@ function FileManager:showCopyMoveSelectedFilesDialog(close_callback)
     UIManager:show(confirmbox)
 end
 
-function FileManager:pasteSelectedFiles(overwrite)
-    local dest_path = ffiUtil.realpath(self.file_chooser.path)
+function FileManager:pasteSelectedFiles(overwrite, folder)
+    local dest_path = ffiUtil.realpath(folder or self.file_chooser.path)
     local ok_files = {}
     for orig_file in pairs(self.selected_files) do
         local orig_name = ffiUtil.basename(orig_file)
@@ -1146,6 +1147,7 @@ function FileManager:deleteFile(file, is_file)
         if ok then
             ReadHistory:folderDeleted(file) -- will delete sdr
             ReadCollection:removeItemsByPath(file)
+            self.folder_shortcuts:updateItemsByPath(nil, file) -- will delete system folders in settings
             return true
         end
     end
@@ -1227,6 +1229,7 @@ function FileManager:renameFile(file, basename, is_file)
             else
                 ReadHistory:updateItemsByPath(file, dest)
                 ReadCollection:updateItemsByPath(file, dest)
+                self.folder_shortcuts:updateItemsByPath(file, dest) -- will update system folders in settings
             end
             self:onRefresh()
         else

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -340,6 +340,7 @@ function FileManagerMenu:setUpdateItemTable()
                             local current_path = G_reader_settings:readSetting("home_dir")
                             local default_path = filemanagerutil.getDefaultDir()
                             local caller_callback = function(path)
+                                self.ui.folder_shortcuts:updateShortcut("home_dir", path)
                                 G_reader_settings:saveSetting("home_dir", path)
                                 self.ui:updateTitleBarPath()
                             end

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -262,7 +262,7 @@ function FileManagerShortcuts:updateItemTable()
     end
     if #item_table > 1 then
         table.sort(item_table, function(a, b)
-            if not a.provider ~= not b.provider then
+            if (not a.provider) ~= (not b.provider) then
                 return a.provider -- system shortcuts first
             end
             return ffiUtil.strcoll(a.text, b.text)

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -85,9 +85,8 @@ function FileManagerShortcuts:refreshFileManager()
     return path_refreshed
 end
 
-function FileManagerShortcuts.registerShortcuts(shortcuts) -- for plugins
-    for _, shortcut in ipairs(shortcuts) do
-        if FileManagerShortcuts.provider_props[shortcut.provider] then return end
+function FileManagerShortcuts.registerShortcut(shortcut) -- for plugins
+    if not FileManagerShortcuts.provider_props[shortcut.provider] then
         shortcut.is_plugin = true
         table.insert(FileManagerShortcuts.providers, shortcut.provider)
         FileManagerShortcuts.provider_props[shortcut.provider] = shortcut

--- a/frontend/apps/filemanager/filemanagershortcuts.lua
+++ b/frontend/apps/filemanager/filemanagershortcuts.lua
@@ -1,35 +1,274 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
+local Device = require("device")
+local DictQuickLookup = require("ui/widget/dictquicklookup")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("ui/widget/menu")
+local PathChooser = require("ui/widget/pathchooser")
+local Screenshoter = require("ui/widget/screenshoter")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local ffiUtil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
+local util = require("util")
 local _ = require("gettext")
 
 local FileManagerShortcuts = WidgetContainer:extend{
     title = _("Folder shortcuts"),
     folder_shortcuts = G_reader_settings:readSetting("folder_shortcuts", {}),
+    settings = G_reader_settings:readSetting("folder_shortcuts_settings", {}),
+
+    -- system shortcuts
+    providers_nb = 4, -- without plugins
+    providers = {
+        "home_dir",
+        "download_dir",
+        "screenshot_dir",
+        "wikipedia_save_dir",
+        -- plugin shortcuts
+    },
+    provider_props = {
+        home_dir = {
+            name = _("Home"),
+            get = function()
+                return G_reader_settings:readSetting("home_dir") or Device.home_dir
+            end,
+            set = function(path)
+                G_reader_settings:saveSetting("home_dir", path)
+            end,
+        },
+        download_dir = {
+            name = _("Download folder"),
+            get = function()
+                return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
+            end,
+            set = function(path)
+                G_reader_settings:saveSetting("download_dir", path)
+            end,
+        },
+        screenshot_dir = {
+            name = _("Screenshot folder"),
+            get = function()
+                return G_reader_settings:readSetting("screenshot_dir") or Screenshoter.default_dir
+            end,
+            set = function(path)
+                G_reader_settings:saveSetting("screenshot_dir", path)
+            end,
+        },
+        wikipedia_save_dir = {
+            name = _("Wikipedia 'Save as EPUB' folder"),
+            get = function()
+                return G_reader_settings:readSetting("wikipedia_save_dir") or DictQuickLookup.getWikiSaveEpubDefaultDir()
+            end,
+            set = function(path)
+                G_reader_settings:saveSetting("wikipedia_save_dir", path)
+                if not util.pathExists(path) then
+                    lfs.mkdir(path)
+                end
+            end,
+        },
+    },
 }
+
+function FileManagerShortcuts:refreshFileManager()
+    local path_refreshed
+    if self.ui.file_chooser then
+        if self.settings.show_marker ~= false then
+            self.ui.file_chooser:refreshPath()
+            path_refreshed = true
+        end
+        if self.settings.show_name ~= false then
+            self.ui:updateTitleBarPath()
+        end
+    end
+    return path_refreshed
+end
+
+function FileManagerShortcuts.registerShortcuts(shortcuts) -- for plugins
+    for _, shortcut in ipairs(shortcuts) do
+        if FileManagerShortcuts.provider_props[shortcut.provider] then return end
+        shortcut.is_plugin = true
+        table.insert(FileManagerShortcuts.providers, shortcut.provider)
+        FileManagerShortcuts.provider_props[shortcut.provider] = shortcut
+    end
+end
+
+function FileManagerShortcuts:updateShortcut(provider, new_folder) -- for all providers
+    local old_folder = FileManagerShortcuts.provider_props[provider].get()
+    if old_folder then
+        self:_delShortcut(old_folder, provider)
+        if new_folder then
+            self:_addShortcut(new_folder, provider)
+            return self:refreshFileManager()
+        end
+    end
+end
+
+function FileManagerShortcuts:_addShortcut(folder, provider, name)
+    folder = folder:gsub("/$", "")
+    local shortcut = self.folder_shortcuts[folder]
+    if shortcut then
+        if name then -- user shortcut
+            shortcut.text = name
+        else -- system shortcuts have no 'text' field
+            shortcut.providers = shortcut.providers or {}
+            shortcut.providers[provider] = true
+        end
+    else -- new
+        self.folder_shortcuts[folder] = { time = os.time() }
+        if name then
+            self.folder_shortcuts[folder].text = name
+        else
+            self.folder_shortcuts[folder].providers = { [provider] = true }
+        end
+    end
+end
+
+function FileManagerShortcuts:_delShortcut(folder, provider)
+    folder = folder:gsub("/$", "")
+    local shortcut = self.folder_shortcuts[folder]
+    if shortcut then
+        if provider then
+            if shortcut.providers then
+                shortcut.providers[provider] = nil
+                if not next(shortcut.providers) then
+                    shortcut.providers = nil
+                end
+            end
+        else -- user shortcut
+            shortcut.text = nil
+        end
+        if shortcut.text == nil and shortcut.providers == nil then
+            self.folder_shortcuts[folder] = nil
+        end
+    end
+end
+
+function FileManagerShortcuts:getShortcutFullName(folder)
+    if self.settings.show_name == false then return end
+    -- a folder may be linked to one user shortcut and several system shortcuts
+    local shortcut = self.folder_shortcuts[folder]
+    if shortcut then
+        local text = shortcut.text
+        if shortcut.providers then
+            local t = { text }
+            for _, provider in ipairs(FileManagerShortcuts.providers) do -- keep order
+                if shortcut.providers[provider] then
+                    table.insert(t, FileManagerShortcuts.provider_props[provider].name)
+                end
+            end
+            text = table.concat(t, " | ")
+        end
+        return text and "☆ " .. text
+    end
+end
+
+function FileManagerShortcuts:hasFolderShortcut(folder, for_marker)
+    if for_marker and self.settings.show_marker == false then
+        return false
+    end
+    local shortcut = self.folder_shortcuts[folder]
+    return shortcut and shortcut.text and true or false -- user shortcuts only
+end
+
+function FileManagerShortcuts:updateItemsByPath(old_path, new_path)
+    -- used on renaming/moving/deleting folders in the file browser
+    -- if old_path == nil then remove the shortcut and system folder in settings
+    -- update shortcuts
+    local seen = {}
+    for old_folder, shortcut in pairs(self.folder_shortcuts) do
+        if not seen[old_folder] then
+            local new_folder, count = old_folder:gsub(old_path or new_path, new_path)
+            if count > 0 then
+                self.folder_shortcuts[old_folder] = nil
+                if old_path then
+                    self.folder_shortcuts[new_folder] = shortcut
+                    seen[new_folder] = true
+                end
+            end
+        end
+    end
+    -- also update system folders in settings
+    for _, prop in pairs(FileManagerShortcuts.provider_props) do
+        if prop.set then
+            local old_folder = prop.get()
+            if old_folder then
+                local new_folder, count = old_folder:gsub(old_path or new_path, new_path)
+                if count > 0 then
+                    prop.set(old_path and new_folder)
+                end
+            end
+        end
+    end
+end
+
+-- shortcut list
+
+function FileManagerShortcuts:onShowFolderShortcutsDialog(select_callback)
+    self.shortcuts_menu = Menu:new{
+        title = self.title,
+        covers_fullscreen = true,
+        is_borderless = true,
+        is_popout = false,
+        select_callback = select_callback, -- called from PathChooser titlebar left button
+        title_bar_fm_style = true,
+        title_bar_left_icon = not select_callback and "plus" or nil,
+        onLeftButtonTap = function() self:addShortcut() end,
+        onLeftButtonHold = function() self:showMenu() end,
+        onMenuChoice = self.onMenuChoice,
+        onMenuHold = not select_callback and self.onMenuHold or nil,
+        _manager = self,
+        _recreate_func = function() self:onShowFolderShortcutsDialog(select_callback) end,
+    }
+    self.shortcuts_menu.close_callback = function()
+        UIManager:close(self.shortcuts_menu)
+        if self.fm_updated then
+            self:refreshFileManager()
+            self.fm_updated = nil
+        end
+        self.shortcuts_menu = nil
+    end
+    self:updateItemTable()
+    UIManager:show(self.shortcuts_menu)
+end
 
 function FileManagerShortcuts:updateItemTable()
     local item_table = {}
-    for folder, item in pairs(self.folder_shortcuts) do
-        table.insert(item_table, {
-            text = string.format("%s (%s)", item.text, folder),
-            folder = folder,
-            name = item.text,
-        })
+    for folder, shortcut in pairs(self.folder_shortcuts) do
+        if shortcut.text then -- user shortcut
+            local name = shortcut.text
+            table.insert(item_table, {
+                text = self.settings.show_path == false and name or string.format("%s (%s)", name, BD.dirpath(folder)),
+                folder = folder,
+                name = name,
+            })
+        end
+        if shortcut.providers then
+            for provider in pairs(shortcut.providers) do
+                local provider_props = FileManagerShortcuts.provider_props[provider]
+                if provider_props then
+                    table.insert(item_table, {
+                        text = provider_props.name,
+                        folder = folder,
+                        name = provider_props.name,
+                        provider = provider,
+                        mandatory = self.settings.show_type ~= false and (provider == "home_dir" and "\u{f015}" -- 'home'
+                            or (provider_props.is_plugin and "\u{E20F}" or "\u{F013}")), -- 'tools' or 'cog'
+                    })
+                end
+            end
+        end
     end
-    table.sort(item_table, function(l, r)
-        return l.text < r.text
-    end)
+    if #item_table > 1 then
+        table.sort(item_table, function(a, b)
+            if not a.provider ~= not b.provider then
+                return a.provider -- system shortcuts first
+            end
+            return ffiUtil.strcoll(a.text, b.text)
+        end)
+    end
     self.shortcuts_menu:switchItemTable(nil, item_table, -1)
-end
-
-function FileManagerShortcuts:hasFolderShortcut(folder)
-    return self.folder_shortcuts[folder] and true or false
 end
 
 function FileManagerShortcuts:onMenuChoice(item)
@@ -38,16 +277,19 @@ function FileManagerShortcuts:onMenuChoice(item)
     if self.select_callback then
         self.select_callback(folder)
     else
+        self._manager.fm_updated = nil
         if self._manager.ui.file_chooser then
             self._manager.ui.file_chooser:changeToPath(folder)
         else -- called from Reader
             self._manager.ui:onClose()
-            self._manager.ui:showFileManager(folder .. "/")
+            folder = folder:sub(-1) == "/" and folder or folder .. "/"
+            self._manager.ui:showFileManager(folder)
         end
     end
 end
 
 function FileManagerShortcuts:onMenuHold(item)
+    local folder, provider = item.folder, item.provider
     local dialog
     local buttons = {
         {
@@ -55,29 +297,60 @@ function FileManagerShortcuts:onMenuHold(item)
                 text = _("Remove shortcut"),
                 callback = function()
                     UIManager:close(dialog)
-                    self._manager:removeShortcut(item.folder)
-                end
+                    self._manager:removeShortcut(folder, item)
+                end,
             },
             {
-                text = _("Rename shortcut"),
+                text = provider and _("Set folder") or _("Rename shortcut"),
+                enabled = not provider or FileManagerShortcuts.provider_props[provider].set ~= nil,
                 callback = function()
                     UIManager:close(dialog)
-                    self._manager:editShortcut(item.folder)
-                end
-            },
-        },
-        self._manager.ui.file_chooser and self._manager.ui.clipboard and {
-            {
-                text = _("Paste to folder"),
-                callback = function()
-                    UIManager:close(dialog)
-                    self._manager.ui:pasteFileFromClipboard(item.folder)
-                end
+                    if provider then
+                        self._manager:setProviderFolder(item)
+                    else
+                        self._manager:editShortcut(folder)
+                    end
+                end,
             },
         },
     }
+    local ui = self._manager.ui
+    if ui.file_chooser then
+        if ui.clipboard then
+            table.insert(buttons, {}) -- separator
+            table.insert(buttons, {
+                {
+                    text = _("Paste to folder"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        ui:pasteFileFromClipboard(folder)
+                    end,
+                },
+            })
+        end
+        if ui.selected_files then
+            table.insert(buttons, {}) -- separator
+            table.insert(buttons, {
+                {
+                    text = _("Copy selected files to folder"),
+                    callback = function()
+                        ui:showCopyMoveSelectedFilesDialog(function() UIManager:close(dialog) end, folder)
+                    end,
+                },
+            })
+            table.insert(buttons, {
+                {
+                    text = _("Move selected files to folder"),
+                    callback = function()
+                        ui.cutfile = true
+                        ui:showCopyMoveSelectedFilesDialog(function() UIManager:close(dialog) end, folder)
+                    end,
+                },
+            })
+        end
+    end
     dialog = ButtonDialog:new{
-        title = item.name .. "\n" .. BD.dirpath(item.folder),
+        title = item.name .. "\n" .. BD.dirpath(folder),
         title_align = "center",
         buttons = buttons,
     }
@@ -85,11 +358,12 @@ function FileManagerShortcuts:onMenuHold(item)
     return true
 end
 
-function FileManagerShortcuts:removeShortcut(folder)
-    self.folder_shortcuts[folder] = nil
-    if self.shortcuts_menu then
+function FileManagerShortcuts:removeShortcut(folder, item)
+    self:_delShortcut(folder, item and item.provider)
+    if item then -- called from the shortcut list
         self.fm_updated = true
-        self:updateItemTable()
+        table.remove(self.shortcuts_menu.item_table, item.idx)
+        self.shortcuts_menu:updateItems(1, true)
     end
 end
 
@@ -116,10 +390,10 @@ function FileManagerShortcuts:editShortcut(folder, post_callback)
                     local new_name = input_dialog:getInputText()
                     if new_name == "" or new_name == name then return end
                     UIManager:close(input_dialog)
-                    if item then
+                    if name then
                         item.text = new_name
-                    else
-                        self.folder_shortcuts[folder] = { text = new_name, time = os.time() }
+                    else -- new
+                        self:_addShortcut(folder, nil, new_name)
                         if post_callback then
                             post_callback()
                         end
@@ -137,22 +411,137 @@ function FileManagerShortcuts:editShortcut(folder, post_callback)
 end
 
 function FileManagerShortcuts:addShortcut()
-    local PathChooser = require("ui/widget/pathchooser")
-    local path_chooser = PathChooser:new{
+    local add_dialog
+    local buttons = {
+        {
+            {
+                text = _("Folder"),
+                callback = function()
+                    UIManager:close(add_dialog)
+                    UIManager:show(PathChooser:new{
+                        select_directory = true,
+                        select_file = false,
+                        path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
+                        onConfirm = function(path)
+                            if self:hasFolderShortcut(path) then
+                                UIManager:show(InfoMessage:new{
+                                    text = _("Shortcut already exists."),
+                                })
+                            else
+                                self:editShortcut(path)
+                            end
+                        end,
+                    })
+                end,
+            },
+        },
+        {}, -- separator
+    }
+    for _, provider in ipairs(FileManagerShortcuts.providers) do
+        if #buttons == FileManagerShortcuts.providers_nb + 2 then
+            table.insert(buttons, {}) -- separator before plugin shortcuts
+        end
+        local folder = FileManagerShortcuts.provider_props[provider].get()
+        table.insert(buttons, {
+            {
+                text = FileManagerShortcuts.provider_props[provider].name,
+                enabled = folder ~= nil,
+                callback = function()
+                    UIManager:close(add_dialog)
+                    local shortcut = self.folder_shortcuts[folder]
+                    if not (shortcut and shortcut.providers and shortcut.providers[provider]) then
+                        self:_addShortcut(folder, provider)
+                        self.fm_updated = true
+                        self:updateItemTable()
+                    end
+                end,
+            },
+        })
+    end
+    add_dialog = ButtonDialog:new{
+        buttons = buttons,
+    }
+    UIManager:show(add_dialog)
+end
+
+function FileManagerShortcuts:setProviderFolder(item)
+    local old_folder, provider = item.folder, item.provider
+    UIManager:show(PathChooser:new{
         select_directory = true,
         select_file = false,
-        path = self.ui.file_chooser and self.ui.file_chooser.path or self.ui:getLastDirFile(),
-        onConfirm = function(path)
-            if self:hasFolderShortcut(path) then
-                UIManager:show(InfoMessage:new{
-                    text = _("Shortcut already exists."),
-                })
-            else
-                self:editShortcut(path)
+        path = old_folder,
+        onConfirm = function(new_folder)
+            if new_folder ~= old_folder then
+                FileManagerShortcuts.provider_props[provider].set(new_folder)
+                self:_delShortcut(old_folder, provider)
+                self:_addShortcut(new_folder, provider)
+                item.folder = new_folder
+                self.fm_updated = true
             end
         end,
+    })
+end
+
+function FileManagerShortcuts:showMenu()
+    local function flip(a)
+        if a ~= false then return false end
+    end
+    local menu_dialog
+    local buttons = {
+        {{
+            text = _("Show marker in file list"),
+            align = "left",
+            checked_func = function()
+                return self.settings.show_marker ~= false
+            end,
+            callback = function()
+                self.settings.show_marker = flip(self.settings.show_marker)
+                self.fm_updated = true
+            end,
+        }},
+        {{
+            text = _("Show shortcut name in subtitle"),
+            align = "left",
+            checked_func = function()
+                return self.settings.show_name ~= false
+            end,
+            callback = function()
+                self.settings.show_name = flip(self.settings.show_name)
+                self.fm_updated = true
+            end,
+        }},
+        {}, -- separator
+        {{
+            text = _("Show path in shortcut list"),
+            align = "left",
+            checked_func = function()
+                return self.settings.show_path ~= false
+            end,
+            callback = function()
+                self.settings.show_path = flip(self.settings.show_path)
+                self:updateItemTable()
+            end,
+        }},
+        {{
+            text = _("Show type in shortcut list"),
+            align = "left",
+            checked_func = function()
+                return self.settings.show_type ~= false
+            end,
+            callback = function()
+                self.settings.show_type = flip(self.settings.show_type)
+                self:updateItemTable()
+            end,
+        }},
     }
-    UIManager:show(path_chooser)
+    menu_dialog = ButtonDialog:new{
+        shrink_unneeded_width = true,
+        buttons = buttons,
+        anchor = function()
+            return self.shortcuts_menu.title_bar.left_button.image.dimen
+        end,
+    }
+    UIManager:show(menu_dialog)
 end
 
 function FileManagerShortcuts:genShowFolderShortcutsButton(pre_callback)
@@ -188,35 +577,6 @@ end
 
 function FileManagerShortcuts:onSetDimensions(dimen)
     self.dimen = dimen
-end
-
-function FileManagerShortcuts:onShowFolderShortcutsDialog(select_callback)
-    self.shortcuts_menu = Menu:new{
-        title = self.title,
-        covers_fullscreen = true,
-        is_borderless = true,
-        is_popout = false,
-        select_callback = select_callback, -- called from PathChooser titlebar left button
-        title_bar_left_icon = not select_callback and "plus" or nil,
-        onLeftButtonTap = function() self:addShortcut() end,
-        onMenuChoice = self.onMenuChoice,
-        onMenuHold = not select_callback and self.onMenuHold or nil,
-        _manager = self,
-        _recreate_func = function() self:onShowFolderShortcutsDialog(select_callback) end,
-    }
-    self.shortcuts_menu.close_callback = function()
-        UIManager:close(self.shortcuts_menu)
-        if self.fm_updated then
-            if self.ui.file_chooser then
-                self.ui.file_chooser:refreshPath()
-                self.ui:updateTitleBarPath()
-            end
-            self.fm_updated = nil
-        end
-        self.shortcuts_menu = nil
-    end
-    self:updateItemTable()
-    UIManager:show(self.shortcuts_menu)
 end
 
 return FileManagerShortcuts

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -205,6 +205,7 @@ You can choose an existing folder, or use a default folder named "Wikipedia" in 
                     local current_path = G_reader_settings:readSetting("wikipedia_save_dir")
                     local default_path = DictQuickLookup.getWikiSaveEpubDefaultDir()
                     local caller_callback = function(path)
+                        self.ui.folder_shortcuts:updateShortcut("wikipedia_save_dir", path)
                         G_reader_settings:saveSetting("wikipedia_save_dir", path)
                         if not util.pathExists(path) then
                             lfs.mkdir(path)

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -320,7 +320,8 @@ function FileChooser:refreshPath()
         itemmatch = {path = self.focused_path}
         self.focused_path = nil
     end
-    local subtitle = self.name ~= "filemanager" and BD.directory(filemanagerutil.abbreviate(self.path)) -- PathChooser
+    local subtitle = self.name ~= "filemanager" -- filemanager does it by itself
+        and (self.ui.folder_shortcuts:getShortcutFullName(self.path) or BD.directory(filemanagerutil.abbreviate(self.path)))
     self:switchItemTable(nil, self:genItemTableFromPath(self.path), self.path_items[self.path], itemmatch, subtitle)
 end
 

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -3,7 +3,6 @@ local BookList = require("ui/widget/booklist")
 local Device = require("device")
 local DocumentRegistry = require("document/documentregistry")
 local Event = require("ui/event")
-local FileManagerShortcuts = require("apps/filemanager/filemanagershortcuts")
 local ReadCollection = require("readcollection")
 local UIManager = require("ui/uimanager")
 local ffi = require("ffi")
@@ -300,7 +299,7 @@ function FileChooser:getMenuItemMandatory(item, collate)
         if #sub_dirs > 0 then
             text = T("%1 \u{F114} ", #sub_dirs) .. text
         end
-        if FileManagerShortcuts:hasFolderShortcut(item.path) then
+        if self.ui.folder_shortcuts:hasFolderShortcut(item.path, true) then
             text = "☆ " .. text
         end
     end

--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -137,6 +137,8 @@ function Screenshoter:chooseFolder()
     local current_path = G_reader_settings:readSetting("screenshot_dir")
     local default_path = self.default_dir
     local caller_callback = function(path)
+        local ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
+        ui.folder_shortcuts:updateShortcut("screenshot", path)
         G_reader_settings:saveSetting("screenshot_dir", path)
     end
     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path, default_path)

--- a/plugins/cloudstorage.koplugin/cloudstorage.lua
+++ b/plugins/cloudstorage.koplugin/cloudstorage.lua
@@ -574,6 +574,7 @@ function CloudStorage:showFileDownloadDialog(item)
                         select_file = false,
                         path = download_dir,
                         onConfirm = function(path)
+                            self._manager.ui.folder_shortcuts:updateShortcut("cloudstorage", path)
                             self.settings:saveSetting("download_dir", path)
                             self._manager.updated = true
                             download_dir = path

--- a/plugins/cloudstorage.koplugin/main.lua
+++ b/plugins/cloudstorage.koplugin/main.lua
@@ -24,6 +24,20 @@ function Cloud:init()
     self:getProviders()
     self:onDispatcherRegisterActions() -- will call loadSettings()
     self.ui.menu:registerToMainMenu(self)
+    self.ui.folder_shortcuts.registerShortcuts({
+        {
+            provider = Cloud.name,
+            name = _("Cloud storage download folder"),
+            get = function()
+                self:loadSettings()
+                return self.settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
+            end,
+            set = function(path)
+                self.settings:saveSetting("download_dir", path)
+                self.updated = true
+            end,
+        },
+    })
 end
 
 function Cloud:getProviders()

--- a/plugins/cloudstorage.koplugin/main.lua
+++ b/plugins/cloudstorage.koplugin/main.lua
@@ -24,19 +24,17 @@ function Cloud:init()
     self:getProviders()
     self:onDispatcherRegisterActions() -- will call loadSettings()
     self.ui.menu:registerToMainMenu(self)
-    self.ui.folder_shortcuts.registerShortcuts({
-        {
-            provider = Cloud.name,
-            name = _("Cloud storage download folder"),
-            get = function()
-                self:loadSettings()
-                return self.settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
-            end,
-            set = function(path)
-                self.settings:saveSetting("download_dir", path)
-                self.updated = true
-            end,
-        },
+    self.ui.folder_shortcuts.registerShortcut({
+        provider = Cloud.name,
+        name = _("Cloud storage download folder"),
+        get = function()
+            self:loadSettings()
+            return self.settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
+        end,
+        set = function(path)
+            self.settings:saveSetting("download_dir", path)
+            self.updated = true
+        end,
     })
 end
 

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -121,6 +121,18 @@ function Exporter:init()
     self.targets = genExportersTable(self.path)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
+    self.ui.folder_shortcuts.registerShortcuts({
+        {
+            provider = Exporter.name,
+            name = _("Export highlights folder"),
+            get = function()
+                return self.settings.clipping_dir or self.default_clipping_dir
+            end,
+            set = function(path)
+                self.settings.clipping_dir = path
+            end,
+        },
+    })
 end
 
 function Exporter:onDispatcherRegisterActions()
@@ -484,7 +496,10 @@ function Exporter:chooseFolder()
     local current_path = self.settings.clipping_dir
     local default_path = self.default_clipping_dir
     local caller_callback = function(path)
-        self.settings.clipping_dir = path
+        if current_path ~= path then
+            self.ui.folder_shortcuts:updateShortcut(Exporter.name, path)
+            self.settings.clipping_dir = path
+        end
     end
     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path, default_path)
 end

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -121,17 +121,15 @@ function Exporter:init()
     self.targets = genExportersTable(self.path)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
-    self.ui.folder_shortcuts.registerShortcuts({
-        {
-            provider = Exporter.name,
-            name = _("Export highlights folder"),
-            get = function()
-                return self.settings.clipping_dir or self.default_clipping_dir
-            end,
-            set = function(path)
-                self.settings.clipping_dir = path
-            end,
-        },
+    self.ui.folder_shortcuts.registerShortcut({
+        provider = Exporter.name,
+        name = _("Export highlights folder"),
+        get = function()
+            return self.settings.clipping_dir or self.default_clipping_dir
+        end,
+        set = function(path)
+            self.settings.clipping_dir = path
+        end,
     })
 end
 

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -24,19 +24,17 @@ local MoveToArchive = WidgetContainer:extend{
 function MoveToArchive:init()
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
-    self.ui.folder_shortcuts.registerShortcuts({
-        {
-            provider = MoveToArchive.name,
-            name = _("Move to archive folder"),
-            get = function()
-                self:loadSettings()
-                return self.data.archive_dir_path
-            end,
-            set = function(path)
-                self.data.archive_dir_path = path
-                self.updated = true
-            end,
-        },
+    self.ui.folder_shortcuts.registerShortcut({
+        provider = MoveToArchive.name,
+        name = _("Move to archive folder"),
+        get = function()
+            self:loadSettings()
+            return self.data.archive_dir_path
+        end,
+        set = function(path)
+            self.data.archive_dir_path = path
+            self.updated = true
+        end,
     })
 end
 

--- a/plugins/movetoarchive.koplugin/main.lua
+++ b/plugins/movetoarchive.koplugin/main.lua
@@ -24,6 +24,20 @@ local MoveToArchive = WidgetContainer:extend{
 function MoveToArchive:init()
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
+    self.ui.folder_shortcuts.registerShortcuts({
+        {
+            provider = MoveToArchive.name,
+            name = _("Move to archive folder"),
+            get = function()
+                self:loadSettings()
+                return self.data.archive_dir_path
+            end,
+            set = function(path)
+                self.data.archive_dir_path = path
+                self.updated = true
+            end,
+        },
+    })
 end
 
 function MoveToArchive:loadSettings()
@@ -92,12 +106,17 @@ function MoveToArchive:getSubMenuItems()
             end,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
+                local curr_path = self.data.archive_dir_path
                 local caller_callback = function(path)
-                    self.data.archive_dir_path = path .. "/"
-                    self.updated = true
-                    touchmenu_instance:updateItems()
+                    path = path .. "/" -- trailing slash on purpose
+                    if curr_path ~= path then
+                        self.ui.folder_shortcuts:updateShortcut(MoveToArchive.name, path)
+                        self.data.archive_dir_path = path
+                        self.updated = true
+                        touchmenu_instance:updateItems()
+                    end
                 end
-                filemanagerutil.showChooseDialog(_("Archive folder:"), caller_callback, self.data.archive_dir_path)
+                filemanagerutil.showChooseDialog(_("Archive folder:"), caller_callback, curr_path)
             end,
         },
     }
@@ -114,7 +133,7 @@ function MoveToArchive:onMoveToArchive(do_copy)
     local document_full_path = self.document.file
     local last_copied_from_dir, filename = util.splitFilePathName(document_full_path)
     if self.data.last_copied_from_dir ~= last_copied_from_dir then
-        self.data.last_copied_from_dir = last_copied_from_dir
+        self.data.last_copied_from_dir = last_copied_from_dir -- trailing slash on purpose
         self.updated = true
     end
     local dest_file = string.format("%s%s", archive_dir_path, filename)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -900,6 +900,7 @@ function OPDSBrowser:showDownloads(item)
                 require("ui/downloadmgr"):new{
                     onConfirm = function(path)
                         logger.dbg("Download folder set to", path)
+                        self._manager.ui.folder_shortcuts:updateShortcut("download_dir", path)
                         G_reader_settings:saveSetting("download_dir", path)
                         self.download_dialog:setTitle(createTitle(path, filename))
                     end,


### PR DESCRIPTION
(1) Add standard folders. Plugins can register shortcuts to their folders.
(2) Copy/Move selected files to a folder via its shortcut.
(3) Update shortcuts and system folders in settings on renaming/moving/deleting a folder.
(4) An option to show shotcut name in the file browser subtitle instead of the path.

-----

<img width="400" height="496" alt="1" src="https://github.com/user-attachments/assets/f47735f1-a158-449e-b062-06685869d8f6" />

-----

'Add shortcut' dialog
<img width="400" height="496" alt="2" src="https://github.com/user-attachments/assets/a3c7002a-ee33-4532-8d41-2d5f40ecc341" />

-----

Long-pressing on a shortcut
<img width="400" height="496" alt="3" src="https://github.com/user-attachments/assets/9edd33a2-6aa3-4e2b-93a4-182b5a4cfd56" />

-----

Long-pressing on 'Plus'
<img width="400" height="496" alt="4" src="https://github.com/user-attachments/assets/c426db75-000a-4c21-96a6-bb61608cb265" />

-----

<img width="400" height="202" alt="5" src="https://github.com/user-attachments/assets/058d0d3c-7f53-4b01-acd5-388d8b1e4502" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15323)
<!-- Reviewable:end -->
