### PR TITLE
Book metadata archive: 'restore from archive' wording

### DIFF
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -642,13 +642,16 @@ function ReaderUI:showReader(file, provider, seamless, is_provider_forced, after
             local arc_settings_file = DocSettings.getSettingsArcFile(self.md5_checksum, true) -- check if exists
             if arc_settings_file then
                 UIManager:show(ConfirmBox:new{
-                    text = _("The book has been read on this device earlier.\nDo you want to use book metadata from the archive?"),
-                    ok_text = _("Use"),
+                    text =
+_[[The book has been read on this device earlier.
+Do you want to restore book metadata from the archive?
+Discarded metadata will be deleted from the archive.]],
+                    ok_text = _("Restore"),
                     ok_callback = function()
                         self.arc_settings_data = DocSettings.openSettingsFile(arc_settings_file).data
                         do_show(arc_settings_file)
                     end,
-                    cancel_text = _("Don't use"),
+                    cancel_text = _("Discard"),
                     cancel_callback = function()
                         do_show(arc_settings_file)
                     end,

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -643,9 +643,9 @@ function ReaderUI:showReader(file, provider, seamless, is_provider_forced, after
             if arc_settings_file then
                 UIManager:show(ConfirmBox:new{
                     text =
-_[[The book has been read on this device earlier.
-Do you want to restore book metadata from the archive?
-Discarded metadata will be deleted from the archive.]],
+_[[This book was previously opened on this device.
+Would you like to restore its metadata from the archive?
+Discarded metadata will be removed from the archive.]],
                     ok_text = _("Restore"),
                     ok_callback = function()
                         self.arc_settings_data = DocSettings.openSettingsFile(arc_settings_file).data


### PR DESCRIPTION
It's an important dialog within the new feature, it must be clear. Suggestions are welcome.

<img width="400" height="496" alt="1" src="https://github.com/user-attachments/assets/d5d4ab75-8909-483b-a7a7-d8d6a0f95558" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15326)
<!-- Reviewable:end -->
