### PR TITLE
Profiles: external auto-exec triggers

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -388,9 +388,14 @@ function FileManager:registerModule(name, ui_module, always_active)
     end
 end
 
+function FileManager:registerPostInitCallback(callback)
+    table.insert(self.postInitCallback, callback)
+end
+
 -- NOTE: The only thing that will *ever* instantiate a new FileManager object is our very own showFiles below!
 function FileManager:init()
     self.active_widgets = {}
+    self.postInitCallback = {}
 
     self:registerModule("screenshot", Screenshoter:new{
         prefix = "FileManager",
@@ -427,6 +432,11 @@ function FileManager:init()
     self:initGesListener()
     self:handleEvent(Event:new("SetDimensions", self.dimen))
     self:handleEvent(Event:new("PathChanged", self.file_chooser.path))
+
+    for _, v in ipairs(self.postInitCallback) do
+        v()
+    end
+    self.postInitCallback = nil
 
     if FileManager.instance == nil then
         logger.dbg("Spinning up new FileManager instance", tostring(self))

--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -49,6 +49,8 @@ local AutoWarmth = WidgetContainer:extend{
     name = "autowarmth",
     sched_times_s = nil, -- array
     sched_warmths = nil, -- array
+    event_auto_night_mode_activated = "AutoNightModeActivated",
+    event_auto_warmth_activated = "AutoWarmthActivated",
 
     -- Static member that shall survive reloading of the plugin but not a restart
     fl_user_toggle = false, -- true/false if someone (AutoWarmth, gesture ...) has toggled the frontlight
@@ -56,6 +58,20 @@ local AutoWarmth = WidgetContainer:extend{
 }
 
 function AutoWarmth:init()
+    self.ui:registerPostInitCallback(function()
+        if self.ui.profiles then
+            self.ui.profiles:registerAutoExecTrigger({
+                text = _("on auto night mode activation"),
+                event = self.event_auto_night_mode_activated,
+            })
+            if Device:hasNaturalLight() then
+                self.ui.profiles:registerAutoExecTrigger({
+                    text = _("on auto warmth activation"),
+                    event = self.event_auto_warmth_activated,
+                })
+            end
+        end
+    end)
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
 
@@ -536,11 +552,13 @@ function AutoWarmth:setWarmth(val, force_warmth)
     if val then
         if self.control_nightmode then
             DeviceListener:onSetNightMode(val > 100)
+            UIManager:broadcastEvent(Event:new(self.event_auto_night_mode_activated))
         end
 
         if self.control_warmth and Device:hasNaturalLight() then
             val = math.min(val, 100) -- "mask" night mode
             Powerd:setWarmth(val, force_warmth)
+            UIManager:broadcastEvent(Event:new(self.event_auto_warmth_activated))
         end
     end
 end

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -30,6 +30,7 @@ local Profiles = WidgetContainer:extend{
 function Profiles:init()
     Dispatcher:init()
     self.autoexec = G_reader_settings:readSetting("profiles_autoexec", {})
+    self.external_autoexec_triggers = {}
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions() -- will call loadSettings()
     self:onStart()
@@ -75,6 +76,13 @@ function Profiles:onDispatcherRegisterActions()
         if v.settings.registered then
             dispatcherRegisterProfile(k)
         end
+    end
+end
+
+function Profiles:registerAutoExecTrigger(trigger)
+    table.insert(self.external_autoexec_triggers, trigger) -- for menu
+    self["on" .. trigger.event] = function()
+        self:executeAutoExecEvent(trigger.event)
     end
 end
 
@@ -147,167 +155,7 @@ function Profiles:getSubMenuItems()
                     end
                 end,
                 sub_item_table_func = function()
-                    return {
-                        {
-                            text = _("Ask to execute"),
-                            checked_func = function()
-                                return v.settings.auto_exec_ask
-                            end,
-                            callback = function()
-                                v.settings.auto_exec_ask = not v.settings.auto_exec_ask or nil
-                                self.updated = true
-                            end,
-                        },
-                        {
-                            text_func = function()
-                                local txt
-                                if v.settings.auto_exec_promptly then
-                                    txt = _("promptly")
-                                elseif v.settings.auto_exec_delay then
-                                    txt = string.format("%0.1f", v.settings.auto_exec_delay) .. " " .. C_("Time", "s")
-                                else
-                                    txt = _("default")
-                                end
-                                return T(_("Executing delay: %1"), txt)
-                            end,
-                            checked_func = function()
-                                return v.settings.auto_exec_promptly or v.settings.auto_exec_delay ~= nil
-                            end,
-                            sub_item_table_func = function()
-                                return {
-                                    {
-                                        text = _("promptly"),
-                                        help_text =
-_([[Enable this option to execute the profile before some other operations triggered by the event.
-For example, with a trigger "on document closing" the profile will be executed before the document is closed.]]),
-                                        checked_func = function()
-                                            return v.settings.auto_exec_promptly
-                                        end,
-                                        radio = true,
-                                        callback = function()
-                                            if not v.settings.auto_exec_promptly then
-                                                v.settings.auto_exec_promptly = true
-                                                v.settings.auto_exec_delay = nil
-                                                self.updated = true
-                                            end
-                                        end,
-                                    },
-                                    {
-                                        text = _("default"),
-                                        checked_func = function()
-                                            return not (v.settings.auto_exec_promptly or v.settings.auto_exec_delay)
-                                        end,
-                                        radio = true,
-                                        callback = function()
-                                            if v.settings.auto_exec_promptly or v.settings.auto_exec_delay then
-                                                v.settings.auto_exec_promptly = nil
-                                                v.settings.auto_exec_delay = nil
-                                                self.updated = true
-                                            end
-                                        end,
-                                    },
-                                    {
-                                        text_func = function()
-                                            return v.settings.auto_exec_delay
-                                                and string.format("%0.1f", v.settings.auto_exec_delay) .. " " .. C_("Time", "s")
-                                                 or _("custom")
-                                        end,
-                                        checked_func = function()
-                                            return v.settings.auto_exec_delay ~= nil
-                                        end,
-                                        radio = true,
-                                        callback = function(touchmenu_instance)
-                                            local SpinWidget = require("ui/widget/spinwidget")
-                                            UIManager:show(SpinWidget:new{
-                                                title_text = _("Executing delay"),
-                                                value = v.settings.auto_exec_delay or 3,
-                                                value_min = 1,
-                                                value_max = 10,
-                                                value_hold_step = 0.1,
-                                                precision = "%0.1f",
-                                                unit = C_("Time", "s"),
-                                                ok_always_enabled = true,
-                                                callback = function(spin)
-                                                    v.settings.auto_exec_promptly = nil
-                                                    v.settings.auto_exec_delay = spin.value
-                                                    self.updated = true
-                                                    touchmenu_instance:updateItems()
-                                                end,
-                                            })
-                                        end,
-                                    },
-                                }
-                            end,
-                            hold_callback = function(touchmenu_instance)
-                                v.settings.auto_exec_promptly = nil
-                                v.settings.auto_exec_delay = nil
-                                self.updated = true
-                                touchmenu_instance:updateItems()
-                            end,
-                        },
-                        {
-                            text_func = function()
-                                local interval = v.settings.auto_exec_time_interval
-                                return _("Only within time interval") ..
-                                    (interval and ": " .. interval[1] .. " - " .. interval[2] or "")
-                            end,
-                            checked_func = function()
-                                return v.settings.auto_exec_time_interval and true
-                            end,
-                            sub_item_table_func = function()
-                                local sub_sub_item_table = {}
-                                local points = { _("start: "), _("end: ") }
-                                local titles = { _("Set start time"), _("Set end time") }
-                                for i, point in ipairs(points) do
-                                    sub_sub_item_table[i] = {
-                                        text_func = function()
-                                            local interval = v.settings.auto_exec_time_interval
-                                            return point .. (interval and interval[i] or "--:--")
-                                        end,
-                                        keep_menu_open = true,
-                                        callback = function(touchmenu_instance)
-                                            local interval = v.settings.auto_exec_time_interval
-                                            local time_str = interval and interval[i] or os.date("%H:%M")
-                                            local h, m = time_str:match("(%d+):(%d+)")
-                                            UIManager:show(DateTimeWidget:new{
-                                                title_text = titles[i],
-                                                info_text = _("Enter time in hours and minutes."),
-                                                hour = tonumber(h),
-                                                min = tonumber(m),
-                                                ok_text = _("Set time"),
-                                                callback = function(new_time)
-                                                    local str = string.format("%02d:%02d", new_time.hour, new_time.min)
-                                                    if interval then
-                                                        v.settings.auto_exec_time_interval[i] = str
-                                                    else
-                                                        v.settings.auto_exec_time_interval = { str, str }
-                                                    end
-                                                    self.updated = true
-                                                    touchmenu_instance:updateItems()
-                                                end,
-                                            })
-                                        end,
-                                    }
-                                end
-                                return sub_sub_item_table
-                            end,
-                            hold_callback = function(touchmenu_instance)
-                                v.settings.auto_exec_time_interval = nil
-                                self.updated = true
-                                touchmenu_instance:updateItems()
-                            end,
-                            separator = true,
-                        },
-                        self:genAutoExecMenuItem(_("on KOReader start"), "Start", k),
-                        self:genAutoExecMenuItem(_("on wake-up"), "Resume", k),
-                        self:genAutoExecMenuItem(_("on exiting sleep screen"), "OutOfScreenSaver", k),
-                        self:genAutoExecMenuItem(_("on read timer expiry"), "ReadTimerExpired", k),
-                        self:genAutoExecMenuItem(_("on rotation"), "SetRotationMode", k),
-                        self:genAutoExecMenuItem(_("on showing folder"), "PathChanged", k),
-                        self:genAutoExecMenuItem(_("on book opening"), "ReaderReadyAll", k),
-                        self:genAutoExecMenuItem(_("on book closing"), "CloseDocumentAll", k),
-                        max_per_page = 11,
-                    }
+                    return self:genAutoExecMenu(k, v)
                 end,
                 hold_callback = function(touchmenu_instance)
                     for event, profiles in pairs(self.autoexec) do
@@ -628,6 +476,174 @@ function Profiles:updateAutoExec(old_name, new_name)
             end
         end
     end
+end
+
+function Profiles:genAutoExecMenu(k, v)
+    -- k - profile name, v - profile table
+    local sub_item_table = {
+        {
+            text = _("Ask to execute"),
+            checked_func = function()
+                return v.settings.auto_exec_ask
+            end,
+            callback = function()
+                v.settings.auto_exec_ask = not v.settings.auto_exec_ask or nil
+                self.updated = true
+            end,
+        },
+        {
+            text_func = function()
+                local txt
+                if v.settings.auto_exec_promptly then
+                    txt = _("promptly")
+                elseif v.settings.auto_exec_delay then
+                    txt = string.format("%0.1f", v.settings.auto_exec_delay) .. " " .. C_("Time", "s")
+                else
+                    txt = _("default")
+                end
+                return T(_("Executing delay: %1"), txt)
+            end,
+            checked_func = function()
+                return v.settings.auto_exec_promptly or v.settings.auto_exec_delay ~= nil
+            end,
+            sub_item_table_func = function()
+                return {
+                    {
+                        text = _("promptly"),
+                        help_text =
+_([[Enable this option to execute the profile before some other operations triggered by the event.
+For example, with a trigger "on document closing" the profile will be executed before the document is closed.]]),
+                        checked_func = function()
+                            return v.settings.auto_exec_promptly
+                        end,
+                        radio = true,
+                        callback = function()
+                            if not v.settings.auto_exec_promptly then
+                                v.settings.auto_exec_promptly = true
+                                v.settings.auto_exec_delay = nil
+                                self.updated = true
+                            end
+                        end,
+                    },
+                    {
+                        text = _("default"),
+                        checked_func = function()
+                            return not (v.settings.auto_exec_promptly or v.settings.auto_exec_delay)
+                        end,
+                        radio = true,
+                        callback = function()
+                            if v.settings.auto_exec_promptly or v.settings.auto_exec_delay then
+                                v.settings.auto_exec_promptly = nil
+                                v.settings.auto_exec_delay = nil
+                                self.updated = true
+                            end
+                        end,
+                    },
+                    {
+                        text_func = function()
+                            return v.settings.auto_exec_delay
+                                and string.format("%0.1f", v.settings.auto_exec_delay) .. " " .. C_("Time", "s")
+                                 or _("custom")
+                        end,
+                        checked_func = function()
+                            return v.settings.auto_exec_delay ~= nil
+                        end,
+                        radio = true,
+                        callback = function(touchmenu_instance)
+                            local SpinWidget = require("ui/widget/spinwidget")
+                            UIManager:show(SpinWidget:new{
+                                title_text = _("Executing delay"),
+                                value = v.settings.auto_exec_delay or 3,
+                                value_min = 1,
+                                value_max = 10,
+                                value_hold_step = 0.1,
+                                precision = "%0.1f",
+                                unit = C_("Time", "s"),
+                                ok_always_enabled = true,
+                                callback = function(spin)
+                                    v.settings.auto_exec_promptly = nil
+                                    v.settings.auto_exec_delay = spin.value
+                                    self.updated = true
+                                    touchmenu_instance:updateItems()
+                                end,
+                            })
+                        end,
+                    },
+                }
+            end,
+            hold_callback = function(touchmenu_instance)
+                v.settings.auto_exec_promptly = nil
+                v.settings.auto_exec_delay = nil
+                self.updated = true
+                touchmenu_instance:updateItems()
+            end,
+        },
+        {
+            text_func = function()
+                local interval = v.settings.auto_exec_time_interval
+                return _("Only within time interval") ..
+                    (interval and ": " .. interval[1] .. " - " .. interval[2] or "")
+            end,
+            checked_func = function()
+                return v.settings.auto_exec_time_interval and true
+            end,
+            sub_item_table_func = function()
+                local sub_sub_item_table = {}
+                local points = { _("start: "), _("end: ") }
+                local titles = { _("Set start time"), _("Set end time") }
+                for i, point in ipairs(points) do
+                    sub_sub_item_table[i] = {
+                        text_func = function()
+                            local interval = v.settings.auto_exec_time_interval
+                            return point .. (interval and interval[i] or "--:--")
+                        end,
+                        keep_menu_open = true,
+                        callback = function(touchmenu_instance)
+                            local interval = v.settings.auto_exec_time_interval
+                            local time_str = interval and interval[i] or os.date("%H:%M")
+                            local h, m = time_str:match("(%d+):(%d+)")
+                            UIManager:show(DateTimeWidget:new{
+                                title_text = titles[i],
+                                info_text = _("Enter time in hours and minutes."),
+                                hour = tonumber(h),
+                                min = tonumber(m),
+                                ok_text = _("Set time"),
+                                callback = function(new_time)
+                                    local str = string.format("%02d:%02d", new_time.hour, new_time.min)
+                                    if interval then
+                                        v.settings.auto_exec_time_interval[i] = str
+                                    else
+                                        v.settings.auto_exec_time_interval = { str, str }
+                                    end
+                                    self.updated = true
+                                    touchmenu_instance:updateItems()
+                                end,
+                            })
+                        end,
+                    }
+                end
+                return sub_sub_item_table
+            end,
+            hold_callback = function(touchmenu_instance)
+                v.settings.auto_exec_time_interval = nil
+                self.updated = true
+                touchmenu_instance:updateItems()
+            end,
+            separator = true,
+        },
+        self:genAutoExecMenuItem(_("on KOReader start"), "Start", k),
+        self:genAutoExecMenuItem(_("on wake-up"), "Resume", k),
+        self:genAutoExecMenuItem(_("on exiting sleep screen"), "OutOfScreenSaver", k),
+        self:genAutoExecMenuItem(_("on rotation"), "SetRotationMode", k),
+        self:genAutoExecMenuItem(_("on showing folder"), "PathChanged", k),
+        self:genAutoExecMenuItem(_("on book opening"), "ReaderReadyAll", k),
+        self:genAutoExecMenuItem(_("on book closing"), "CloseDocumentAll", k),
+    }
+
+    for _, trigger in ipairs(self.external_autoexec_triggers) do
+        table.insert(sub_item_table, self:genAutoExecMenuItem(trigger.text .. "  \u{E20F}", trigger.event, k)) -- 'tools'
+    end
+    return sub_item_table
 end
 
 function Profiles:genAutoExecMenuItem(text, event, profile_name, separator)

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -21,6 +21,7 @@ local ReadTimer = WidgetContainer:extend{
     timer_symbol = "\u{23F2}", -- ⏲ timer symbol
     timer_letter = "T",
     default_expiry_message_text = _("Time is up"),
+    event_timer_expired = "ReadTimerExpired",
 
     -- static for all plugin instances, to keep scheduled timer across views
     restore_scheduled_time = nil,
@@ -55,7 +56,7 @@ function ReadTimer:init()
         end
 
         self.time = 0
-        UIManager:broadcastEvent(Event:new("ReadTimerExpired"))
+        UIManager:broadcastEvent(Event:new(self.event_timer_expired))
         if self.settings.show_on_expiry == "nothing" then
             maybeRescheduleInterval()
             return
@@ -144,6 +145,14 @@ function ReadTimer:init()
         self:addAdditionalFooterContent()
     end
 
+    self.ui:registerPostInitCallback(function()
+        if self.ui.profiles then
+            self.ui.profiles:registerAutoExecTrigger({
+                text = _("on read timer expiry"),
+                event = self.event_timer_expired,
+            })
+        end
+    end)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end


### PR DESCRIPTION
Allows plugins to register their auto-exec triggers.
Currently for AutoWarmth and ReadTimer plugins.
- Closes #15321 

-----

Built-in triggers (unchanged):
<img width="400" height="405" alt="1" src="https://github.com/user-attachments/assets/6fafa996-42a2-45b2-9978-3ed3f2cec317" />

-----

Plugins' triggers:
<img width="400" height="168" alt="2" src="https://github.com/user-attachments/assets/6e33869f-1ef2-48be-b67c-f1e98758bcae" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15329)
<!-- Reviewable:end -->
