### PR TITLE
ReadTimer: use elapsed real time for intervals

### DIFF
--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -144,6 +144,7 @@ function ReadTimer:init()
         self:addAdditionalFooterContent()
     end
 
+    UIManager.event_hook:registerWidget("InputEvent", self)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end
@@ -169,10 +170,13 @@ function ReadTimer:scheduled()
     return self.time ~= 0
 end
 
+function ReadTimer:now()
+    return time.boottime_or_realtime_coarse()
+end
+
 function ReadTimer:remaining()
     if self:scheduled() then
-        -- Resolution: time.now() subsecond, os.time() two seconds
-        local remaining_s = time.to_s(self.time - time.now())
+        local remaining_s = time.to_s(self.time - self:now())
         if remaining_s > 0 then
             return remaining_s
         else
@@ -243,11 +247,27 @@ function ReadTimer:unschedule()
 end
 
 function ReadTimer:rescheduleIn(seconds)
-    -- Resolution: time.now() subsecond, os.time() two seconds
-    self.time = time.now() + time.s(seconds)
+    self.time = self:now() + time.s(seconds)
     UIManager:scheduleIn(seconds, self.alarm_callback)
     if self.settings.show_value_in_header or self.settings.show_value_in_footer then
         self:update_status_bars(seconds)
+    end
+end
+
+function ReadTimer:expireIfDue()
+    if self:scheduled() and self:remaining() == 0 then
+        UIManager:unschedule(self.alarm_callback)
+        UIManager:unschedule(self.update_status_bars, self)
+        self:alarm_callback()
+        return true
+    end
+    return false
+end
+
+function ReadTimer:onInputEvent()
+    if self:scheduled() and not self:expireIfDue() then
+        UIManager:unschedule(self.alarm_callback)
+        UIManager:scheduleIn(self:remaining(), self.alarm_callback)
     end
 end
 
@@ -391,7 +411,7 @@ function ReadTimer:addToMainMenu(menu_items)
     }
 end
 
--- The UI ticks on a MONOTONIC time domain, while this plugin deals with REAL wall clock time.
+-- The UI ticks on a MONOTONIC time domain, while this plugin deals with elapsed real time.
 function ReadTimer:onResume()
     if self:scheduled() then
         logger.dbg("ReadTimer: onResume with an active timer")
@@ -399,10 +419,9 @@ function ReadTimer:onResume()
 
         if remainder == 0 then
             -- Make sure we fire the alarm right away if it expired during suspend...
-            self:alarm_callback()
-            self:unschedule()
+            self:expireIfDue()
         else
-            -- ...and that we re-schedule the timer against the REAL time if it's still ticking.
+            -- ...and that we re-schedule the timer against the elapsed real time if it's still ticking.
             logger.dbg("ReadTimer: Rescheduling in", remainder, "seconds")
             self:unschedule()
             self:rescheduleIn(remainder)

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -21,7 +21,6 @@ local ReadTimer = WidgetContainer:extend{
     timer_symbol = "\u{23F2}", -- ⏲ timer symbol
     timer_letter = "T",
     default_expiry_message_text = _("Time is up"),
-    event_timer_expired = "ReadTimerExpired",
 
     -- static for all plugin instances, to keep scheduled timer across views
     restore_scheduled_time = nil,
@@ -56,7 +55,7 @@ function ReadTimer:init()
         end
 
         self.time = 0
-        UIManager:broadcastEvent(Event:new(self.event_timer_expired))
+        UIManager:broadcastEvent(Event:new("ReadTimerExpired"))
         if self.settings.show_on_expiry == "nothing" then
             maybeRescheduleInterval()
             return
@@ -145,14 +144,7 @@ function ReadTimer:init()
         self:addAdditionalFooterContent()
     end
 
-    self.ui:registerPostInitCallback(function()
-        if self.ui.profiles then
-            self.ui.profiles:registerAutoExecTrigger({
-                text = _("on read timer expiry"),
-                event = self.event_timer_expired,
-            })
-        end
-    end)
+    UIManager.event_hook:registerWidget("InputEvent", self)
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
 end
@@ -178,10 +170,13 @@ function ReadTimer:scheduled()
     return self.time ~= 0
 end
 
+function ReadTimer:now()
+    return time.boottime_or_realtime_coarse()
+end
+
 function ReadTimer:remaining()
     if self:scheduled() then
-        -- Resolution: time.now() subsecond, os.time() two seconds
-        local remaining_s = time.to_s(self.time - time.now())
+        local remaining_s = time.to_s(self.time - self:now())
         if remaining_s > 0 then
             return remaining_s
         else
@@ -252,12 +247,21 @@ function ReadTimer:unschedule()
 end
 
 function ReadTimer:rescheduleIn(seconds)
-    -- Resolution: time.now() subsecond, os.time() two seconds
-    self.time = time.now() + time.s(seconds)
+    self.time = self:now() + time.s(seconds)
     UIManager:scheduleIn(seconds, self.alarm_callback)
     if self.settings.show_value_in_header or self.settings.show_value_in_footer then
         self:update_status_bars(seconds)
     end
+end
+
+function ReadTimer:expireIfDue()
+    if self:scheduled() and self:remaining() == 0 then
+        UIManager:unschedule(self.alarm_callback)
+        UIManager:unschedule(self.update_status_bars, self)
+        self:alarm_callback()
+        return true
+    end
+    return false
 end
 
 function ReadTimer:addCheckboxes(widget, is_interval)
@@ -408,8 +412,7 @@ function ReadTimer:onResume()
 
         if remainder == 0 then
             -- Make sure we fire the alarm right away if it expired during suspend...
-            self:alarm_callback()
-            self:unschedule()
+            self:expireIfDue()
         else
             -- ...and that we re-schedule the timer against the REAL time if it's still ticking.
             logger.dbg("ReadTimer: Rescheduling in", remainder, "seconds")
@@ -417,6 +420,18 @@ function ReadTimer:onResume()
             self:rescheduleIn(remainder)
         end
 
+    end
+end
+
+-- UI tasks (alarm + status-bar refresh) run on the MONOTONIC clock, which is frozen
+-- while the device is suspended/dozing; remaining() tracks boottime instead. On wake we
+-- must re-sync the scheduled tasks against elapsed real time. onResume() does this when a
+-- Resume event is emitted, but Android only broadcasts Resume when not brokenLifecycle, so
+-- broken-lifecycle devices (e.g. the Boox in #14661) never get it. Re-sync on input too.
+function ReadTimer:onInputEvent()
+    if self:scheduled() and not self:expireIfDue() then
+        UIManager:unschedule(self.alarm_callback)
+        UIManager:scheduleIn(self:remaining(), self.alarm_callback)
     end
 end
 

--- a/spec/unit/readtimer_spec.lua
+++ b/spec/unit/readtimer_spec.lua
@@ -1,0 +1,77 @@
+describe("ReadTimer plugin tests", function()
+    local MockTime, ReadTimer, UIManager, time
+
+    local function new_readtimer()
+        return ReadTimer:new{
+            ui = {
+                bookinfo = {
+                    expandString = function(_, text)
+                        return text
+                    end,
+                },
+                menu = {
+                    registerToMainMenu = function() end,
+                },
+            },
+        }
+    end
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        MockTime = require("mock_time")
+        time = require("ui/time")
+        UIManager = require("ui/uimanager")
+        MockTime:install()
+    end)
+
+    teardown(function()
+        MockTime:uninstall()
+    end)
+
+    before_each(function()
+        UIManager:quit()
+        G_reader_settings:delSetting("readtimer")
+        ReadTimer = dofile("plugins/readtimer.koplugin/main.lua")
+        MockTime.monotonic_time = 0
+        MockTime.boottime_or_realtime_coarse_time = 0
+    end)
+
+    it("should track remaining interval time with elapsed real time", function()
+        local widget = new_readtimer()
+        widget:rescheduleIn(15 * 60)
+
+        MockTime.boottime_or_realtime_coarse_time = MockTime.boottime_or_realtime_coarse_time + time.s(8 * 60)
+
+        assert.are.equal(7 * 60, widget:remaining())
+        widget:onCloseWidget()
+    end)
+
+    it("should expire when elapsed real time passes even if monotonic time does not", function()
+        local widget = new_readtimer()
+        widget.settings.show_on_expiry = "nothing"
+        widget:rescheduleIn(15 * 60)
+
+        MockTime.boottime_or_realtime_coarse_time = MockTime.boottime_or_realtime_coarse_time + time.s(15 * 60)
+
+        assert.is_true(widget:expireIfDue())
+        assert.is_false(widget:scheduled())
+        widget:onCloseWidget()
+    end)
+
+    it("should keep an auto-rescheduled interval after resume expiry", function()
+        local widget = new_readtimer()
+        widget.settings.show_on_expiry = "nothing"
+        widget.settings.auto_reschedule_interval = true
+        widget.last_interval_time = 15 * 60
+        widget:rescheduleIn(widget.last_interval_time)
+
+        MockTime.boottime_or_realtime_coarse_time = MockTime.boottime_or_realtime_coarse_time + time.s(15 * 60)
+
+        widget:onResume()
+
+        assert.is_true(widget:scheduled())
+        assert.are.equal(15 * 60, widget:remaining())
+        widget:onCloseWidget()
+    end)
+end)


### PR DESCRIPTION
Fixes #14661.

### Summary
- Track read timer remaining time against elapsed real time.
- Expire overdue timers from input/resume handling.
- Add readtimer unit coverage for elapsed real time and auto-reschedule behavior.

### Testing
- ./kodev test front readtimer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15335)
<!-- Reviewable:end -->
