### PR TITLE
ReaderView: fix highlight in night mode

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -703,7 +703,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         if Blitbuffer.isColor8(color) then
             bb:paintRect(x, y + h - 1, w, Size.line.thick, color)
         else
-            bb:paintRectRGB32(x, y + h - 1, w, Size.line.thick, color)
+            bb:paintRectRGB32(x, y + h - 1, w, Size.line.thick, Screen.night_mode and color:invert() or color)
         end
     elseif drawer == "strikeout" then
         if not color then
@@ -716,7 +716,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         if Blitbuffer.isColor8(color) then
             bb:paintRect(x, line_y, w, Size.line.medium, color)
         else
-            bb:paintRectRGB32(x, line_y, w, Size.line.medium, color)
+            bb:paintRectRGB32(x, line_y, w, Size.line.medium, Screen.night_mode and color:invert() or color)
         end
     elseif drawer == "invert" then
         bb:invertRect(x, y, w, h)
@@ -740,7 +740,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
                 if Blitbuffer.isColor8(color) then
                     bb:paintRect(note_mark_pos_x, y, self.note_mark_line_w, rect.h, color)
                 else
-                    bb:paintRectRGB32(note_mark_pos_x, y, self.note_mark_line_w, rect.h, color)
+                    bb:paintRectRGB32(note_mark_pos_x, y, self.note_mark_line_w, rect.h, Screen.night_mode and color:invert() or color)
                 end
             elseif self.highlight.note_mark == "sidemark" then
                 if draw_note_mark then


### PR DESCRIPTION
Fixes color for `paintRectRGB32()` in night mode.
Used in highlight styles "Underline", "Strikethrough" and in note marker "Side line".

-----
Before
<img width="400" height="500" alt="1" src="https://github.com/user-attachments/assets/0eb5f0e1-5b37-483a-b4aa-208f641e6b2a" />

-----
After
<img width="400" height="495" alt="2" src="https://github.com/user-attachments/assets/f4837c9c-4f6a-4f30-a4e2-fd675ef2bf9c" />

-----
Day mode unchanged
<img width="400" height="497" alt="3" src="https://github.com/user-attachments/assets/08e8e7fd-73db-4603-9114-55145bffa95c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15336)
<!-- Reviewable:end -->
