### PR TITLE
Bug fix: ensure default_layout is up to date when generating menu

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -518,6 +518,10 @@ function ReaderDictionary:_genCustomizeButtonsMenu()
         if not spec.conditional and spec.menu_text then
             table.insert(available_options, { text = spec.menu_text, id = spec.id })
         end
+        if not spec.conditional and not DictQuickLookup.layoutContainsButtonId(self.default_layout, spec.id) then
+            local i = spec.insert_first and 1 or (#self.default_layout + 1)
+            table.insert(self.default_layout, i, { spec.id })
+        end
     end
 
     -- This function return the config from settings.

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -992,7 +992,7 @@ function DictQuickLookup:populatePluginButtons(pool, default_layout, extra_layou
             if spec.conditional then
                 local row_key = spec.row_group
                 add_conditional_button(row_key or spec.id, spec.id)
-            elseif default_layout and not DictQuickLookup.layoutContainsButtonId(default_layout, spec.id) then
+            elseif default_layout and not self.layoutContainsButtonId(default_layout, spec.id) then
                 local i = spec.insert_first and 1 or (#default_layout + 1)
                 table.insert(default_layout, i, { spec.id })
             end

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -680,6 +680,7 @@ function DictQuickLookup:registerKeyEvents()
             self.key_events.FastRightTextSelectorIndicator = { { modifier, "Right" }, event = "FindInTextOrMoveSelectorIndicator", args = { 1,  0, true } }
             if Device:hasKeyboard() then
                 self.key_events.LookupInputWordClear = { { Input.group.AlphaNumeric }, { "Shift", Input.group.AlphaNumeric }, event = "LookupInputWord" }
+                self.key_events.LookupInputWordEmpty = { { " " }, event = "LookupInputWord" }
                 if G_reader_settings:nilOrFalse("backspace_as_back") then
                     -- We need to concat here so that the 'del' event press, which propagates to inputText (desirable for previous key_event,
                     -- i.e., LookupInputWordClear) does not remove the last char of self.word
@@ -1800,6 +1801,9 @@ function DictQuickLookup:onLookupInputWord(hint, ev)
     end
     -- Key-event path: open dialog now, then inject key during next tick.
     if Device:isSDL() and not hint and ev and ev.key then
+        if ev.key == " " then
+            return self:lookupInputWord()
+        end
         local k = tostring(ev.key)
         local is_shift = ev.modifiers and ev.modifiers.Shift
         local letter = is_shift and k or k:lower()


### PR DESCRIPTION
### bug fix

* Ensured that when generating the customize buttons menu in `ReaderDictionary:_genCustomizeButtonsMenu()`, any button not already present in the default layout is inserted. If `DictQuickLookup:populatePluginButtons` hasn't been called yet (because the dictionary popup was never opened during that session), the core `self.default_layout` string array wouldn't contain the plugin buttons when you step into the Customise settings menu!

* Added a new key event mapping `LookupInputWordEmpty`. Addresses @poire-z's request https://github.com/koreader/koreader/pull/15158#discussion_r2971883814

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15340)
<!-- Reviewable:end -->
