### PR TITLE
kindle: add SSH server support to KUAL extension

### DIFF
--- a/platform/kindle/extensions/koreader/bin/koreader-ext.sh
+++ b/platform/kindle/extensions/koreader/bin/koreader-ext.sh
@@ -97,12 +97,41 @@ install_koreader() {
     update_koreader "clean"
 }
 
+start_ssh() {
+    iptables -A INPUT -p tcp --dport 2222 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+    iptables -A OUTPUT -p tcp --sport 2222 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+    (cd /mnt/us/koreader && ./dropbear -E -R -p 2222 -P /tmp/dropbear_koreader.pid)
+}
+
+stop_ssh() {
+    pid="$(cat /tmp/dropbear_koreader.pid)"
+    for spec in TERM:20 KILL:10; do
+        signal=${spec%:*}
+        tries=${spec#*:}
+        for n in $(seq "${tries}"); do
+            if [ -z "${pid}" ] || ! [ -d "/proc/${pid}" ]; then
+                break
+            fi
+            if [ "${n}" = 1 ]; then
+                kill -"${signal}" "${pid}"
+            fi
+            sleep 0.1
+        done
+    done
+    rm /tmp/dropbear_koreader.pid
+    iptables -D INPUT -p tcp --dport 2222 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+    iptables -D OUTPUT -p tcp --sport 2222 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+}
+
 ## Main
 case "${1}" in
     "update_koreader")
         ${1}
         ;;
     "install_koreader")
+        ${1}
+        ;;
+    start_ssh | stop_ssh)
         ${1}
         ;;
     *)

--- a/platform/kindle/extensions/koreader/menu.json
+++ b/platform/kindle/extensions/koreader/menu.json
@@ -60,9 +60,7 @@
 				"action": "./bin/koreader-ext.sh",
 				"params": "update_koreader",
 				"exitmenu": false,
-				"checked": true,
 				"refresh": false,
-				"status": false,
 				"internal": "status Try to update KOReader . . ."
 			},
 			{
@@ -71,10 +69,26 @@
 				"action": "./bin/koreader-ext.sh",
 				"params": "install_koreader",
 				"exitmenu": false,
-				"checked": true,
 				"refresh": false,
-				"status": false,
 				"internal": "status Try to install KOReader from scratch . . ."
+			},
+			{
+				"name": "Start SSH server",
+				"priority": 3,
+				"action": "./bin/koreader-ext.sh",
+				"params": "start_ssh",
+				"exitmenu": false,
+				"refresh": false,
+				"internal": "status Trying to start SSH server . . ."
+			},
+			{
+				"name": "Stop SSH server",
+				"priority": 4,
+				"action": "./bin/koreader-ext.sh",
+				"params": "stop_ssh",
+				"exitmenu": false,
+				"refresh": false,
+				"internal": "status Trying to stop SSH server . . ."
 			}
 			]
 		}


### PR DESCRIPTION
So the server can be started/stopped from there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15352)
<!-- Reviewable:end -->
