### PR TITLE
[TextBoxWidget] Find in definition (wiki edition)

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1232,10 +1232,10 @@ function DictQuickLookup:_instantiateScrollWidget()
             image_alt_face = self.image_alt_face,
             images = self.images,
             highlight_text_selection = true,
-            -- on_clear_search = function()
-            --     self.in_definition_search = false
-            --     self.stw_widget:setTapScrollEnabled(true)
-            -- end,
+            on_clear_search = function()
+                self.in_definition_search = false
+                self.stw_widget:setTapScrollEnabled(true)
+            end,
             -- We need to override the widget's paintTo method to draw our indicator
             paintTo = self.allow_key_text_selection and function(widget, bb, x, y)
                 -- Call original paintTo from ScrollTextWidget
@@ -1847,9 +1847,6 @@ function DictQuickLookup:lookupInputWord(hint)
         {
             {
                 text = _("Find in definition"),
-                enabled_func = function()
-                    return self.is_html and self.shw_widget
-                end,
                 callback = function()
                     local text = self.input_dialog:getInputText()
                     if text ~= "" and not text:match("^%s*$") then

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -305,7 +305,7 @@ function ScrollTextWidget:onScrollText(arg, ges)
 end
 
 function ScrollTextWidget:onTapScrollText(arg, ges)
-    if not self:isTapScrollEnabled() then return false end
+    if self.ignore_taps then return false end
     if self.editable then
         -- Tap is used to position cursor
         return false
@@ -316,10 +316,6 @@ function ScrollTextWidget:onTapScrollText(arg, ges)
     else
         return self:onScrollDown()
     end
-end
-
-function ScrollTextWidget:isTapScrollEnabled()
-    return not self.ignore_taps
 end
 
 function ScrollTextWidget:setTapScrollEnabled(enabled)

--- a/frontend/ui/widget/scrolltextwidget.lua
+++ b/frontend/ui/widget/scrolltextwidget.lua
@@ -42,6 +42,7 @@ local ScrollTextWidget = InputContainer:extend{
     auto_para_direction = false,
     alignment_strict = false,
     highlight_text_selection = false,
+    on_clear_search = nil,
 
     -- for internal use
     for_measurement_only = nil, -- When the widget is a one-off used to compute text height
@@ -70,6 +71,7 @@ function ScrollTextWidget:init()
         alignment_strict = self.alignment_strict,
         for_measurement_only = self.for_measurement_only,
         highlight_text_selection = self.highlight_text_selection,
+        on_clear_search = self.on_clear_search,
     }
     local visible_line_count = self.text_widget:getVisLineCount()
     local total_line_count = self.text_widget:getAllLineCount()
@@ -303,6 +305,7 @@ function ScrollTextWidget:onScrollText(arg, ges)
 end
 
 function ScrollTextWidget:onTapScrollText(arg, ges)
+    if not self:isTapScrollEnabled() then return false end
     if self.editable then
         -- Tap is used to position cursor
         return false
@@ -313,6 +316,14 @@ function ScrollTextWidget:onTapScrollText(arg, ges)
     else
         return self:onScrollDown()
     end
+end
+
+function ScrollTextWidget:isTapScrollEnabled()
+    return not self.ignore_taps
+end
+
+function ScrollTextWidget:setTapScrollEnabled(enabled)
+    self.ignore_taps = not enabled
 end
 
 function ScrollTextWidget:onScrollUp()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -967,20 +967,20 @@ end
 -- (NOTE: This instantiates the inner bb (self._bb), so be careful about its lifecycle when you call this,
 --        c.f., TextBoxWidget:update).
 function TextBoxWidget:_updateLayout(update_highlight)
-    -- Pre-shape all visible lines so xglyphs exist before highlight
-    -- rect computation. _shapeLine is idempotent so _renderText
-    -- calling it again afterwards is safe.
-    if self.search_term and self.use_xtext and self._xtext then
-        local end_line = math.min(
-            self.virtual_line_num + self.lines_per_page - 1,
-            #self.vertical_string_list
-        )
-        for i = self.virtual_line_num, end_line do
-            local line = self.vertical_string_list[i]
-            if line then self:_shapeLine(line) end
-        end
-    end
     if self.highlight_text_selection and (update_highlight == nil or update_highlight) then
+        if self.search_term and self.use_xtext and self._xtext then
+            -- Pre-shape all visible lines so xglyphs exist before highlight
+            -- rect computation. _shapeLine is idempotent so _renderText
+            -- calling it again afterwards is safe.
+            local end_line = math.min(
+                self.virtual_line_num + self.lines_per_page - 1,
+                #self.vertical_string_list
+            )
+            for i = self.virtual_line_num, end_line do
+                local line = self.vertical_string_list[i]
+                if line then self:_shapeLine(line) end
+            end
+        end
         self:updateHighlight()
     end
     self:_renderText(self.virtual_line_num, self.virtual_line_num + self.lines_per_page - 1)
@@ -1315,6 +1315,7 @@ function TextBoxWidget:free(full)
         -- c.f., :_splitToLines
         self.vertical_string_list = {}
         self.line_num_to_image = nil
+        self:clearSearch()
     end
 end
 
@@ -1337,6 +1338,7 @@ function TextBoxWidget:setText(text)
     self._search_lower = nil      -- search term cache is also stale
     self._search_char_len = nil   -- if text changed, term length against new text may differ
     self._match_page_list = nil
+    self._match_char_list = nil
     self._match_page_index = nil
     self.highlight_rects = nil
     self.highlight_start_idx = nil
@@ -1390,9 +1392,6 @@ end
 function TextBoxWidget:_postScrollHighlight()
     if self.search_term then
         self._match_page_index = nil
-        UIManager:setDirty(self.dialog or "all", function()
-            return "ui", self.dimen
-        end)
     end
 end
 
@@ -1414,7 +1413,6 @@ function TextBoxWidget:scrollDown()
         end
         self:_updateLayout()
     end
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
@@ -1434,7 +1432,6 @@ function TextBoxWidget:scrollUp()
         end
         self:_updateLayout()
     end
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
@@ -1459,7 +1456,6 @@ function TextBoxWidget:scrollLines(nb_lines)
     self.virtual_line_num = new_line_num
     self:free(false)
     self:_updateLayout()
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         local x, y = self:_getXYForCharPos() -- luacheck: no unused
@@ -1958,7 +1954,7 @@ function TextBoxWidget:scrollViewToCharPos()
 end
 
 -- Builds all derived structures once so findText only pays O(n) for the
--- string.find scan itself; all byte↔char conversions become O(1) lookups.
+-- string.find scan itself; all byte<=>char conversions become O(1) lookups.
 -- Uses Utf8Proc.lowercase(str, false) which guarantees strict 1:1 char mapping,
 -- allowing the lowercased and original char indices to be used interchangeably.
 function TextBoxWidget:_buildTextCache()
@@ -2004,24 +2000,29 @@ function TextBoxWidget:findText(text)
         self.highlight_start_idx = nil
         self:_buildMatchPageList()
     end
-    local cache = self._text_cache
-    local search_lower = self._search_lower
+    local match_chars = self._match_char_list
+    if not match_chars or #match_chars == 0 then return false end
+
     -- Advance from end of last match, or from current viewport if this is a fresh search
-    local start_byte
+    local start_char
     if self.highlight_end_idx then
-        start_byte = cache.char_to_byte[self.highlight_end_idx + 1] or 1
+        start_char = self.highlight_end_idx + 1
     else
         local current_line = self.vertical_string_list[self.virtual_line_num]
-        start_byte = current_line and cache.char_to_byte[current_line.offset] or 1
+        start_char = current_line and current_line.offset or 1
     end
-    -- O(n): unavoidable scan, wraps around if nothing found ahead of current position
-    local match_start, _ = cache.lower:find(search_lower, start_byte, true)
-    if not match_start and start_byte > 1 then
-        match_start, _ = cache.lower:find(search_lower, 1, true)
+    -- Reuse precomputed matches: pick first >= start_char, wrap to first when needed.
+    local char_start
+    for i = 1, #match_chars do
+        if match_chars[i] >= start_char then
+            char_start = match_chars[i]
+            break
+        end
     end
-    if not match_start then return false end
-    -- Since lowercase is 1:1, byte_to_char gives us the original char index directly
-    local char_start = cache.byte_to_char[match_start]
+    if not char_start then
+        char_start = match_chars[1]
+    end
+
     local char_end = char_start + self._search_char_len - 1
 
     self.highlight_start_idx = char_start
@@ -2040,6 +2041,7 @@ end
 
 function TextBoxWidget:_buildMatchPageList()
     self._match_page_list = {}
+    self._match_char_list = {}
     if not self._text_cache or not self._search_lower then return end
 
     local cache = self._text_cache
@@ -2047,8 +2049,9 @@ function TextBoxWidget:_buildMatchPageList()
     local match_byte, match_end = cache.lower:find(self._search_lower, 1, true)
 
     while match_byte do
-        -- Convert lower char index → original char index before page lookup
+        -- Convert lower char index -> original char index before page lookup
         local char_start = cache.byte_to_char[match_byte]
+        table.insert(self._match_char_list, char_start)
         local page_line = self:getCharPageTopLineNumber(char_start)
         if not seen_pages[page_line] then
             seen_pages[page_line] = true
@@ -2100,7 +2103,6 @@ function TextBoxWidget:_highlightSearchInView()
         self:_buildTextCache()
     end
     local cache = self._text_cache
-    local search_lower = self._search_lower or Utf8Proc.lowercase(self.search_term, false)
     local search_len = self._search_char_len or #util.splitToChars(self.search_term)
     self.highlight_rects = {}
 
@@ -2113,16 +2115,24 @@ function TextBoxWidget:_highlightSearchInView()
 
     local visible_start_char = self.vertical_string_list[start_line].offset
     local visible_end_char = self.vertical_string_list[end_line].end_offset or #cache.chars
+    local match_chars = self._match_char_list
+    if not match_chars then
+        self:_buildMatchPageList()
+        match_chars = self._match_char_list
+    end
+    if not match_chars or #match_chars == 0 then
+        self.highlight_rects = nil
+        return false
+    end
 
     local found_any = false
 
-    -- Back up by search term byte length to catch matches straddling the top of the viewport
-    local scan_start_byte = math.max(1, (cache.char_to_byte[visible_start_char] or 1) - #search_lower)
-    local match_start_byte, match_end_byte = cache.lower:find(search_lower, scan_start_byte, true)
+    -- Reuse precomputed char-start matches and inspect potentially straddling matches
+    local first_idx = util.bsearch_left(match_chars, visible_start_char - search_len + 1)
+    if first_idx < 1 then first_idx = 1 end
 
-    while match_start_byte do
-        -- O(1) byte → char conversion; since lowercase is 1:1 this is also the original char index
-        local char_start = cache.byte_to_char[match_start_byte]
+    for i = first_idx, #match_chars do
+        local char_start = match_chars[i]
         if char_start > visible_end_char then break end -- remaining matches are beyond the visible area
         local char_end = char_start + search_len - 1
 
@@ -2162,7 +2172,6 @@ function TextBoxWidget:_highlightSearchInView()
                 end
             end
         end
-        match_start_byte, match_end_byte = cache.lower:find(search_lower, match_end_byte + 1, true)
     end
     if not found_any then
         self.highlight_rects = nil
@@ -2176,6 +2185,7 @@ function TextBoxWidget:clearSearch(redraw)
     self._search_lower = nil
     self._search_char_len = nil
     self._match_page_list = nil
+    self._match_char_list = nil
     self._match_page_index = nil
     if self.on_clear_search then
         self.on_clear_search()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1249,9 +1249,9 @@ function TextBoxWidget:getCharPos()
     return self.charpos, self.virtual_line_num, self.current_line_num
 end
 
-function TextBoxWidget:getCharPageTopLineNumber(charpos)
+function TextBoxWidget:getCharPageTopLineNumber(charpos, ln)
     -- returns top line number of the page containing charpos
-    local ln = 1
+    ln = ln or 1
     while true do
         local lend = ln + self.lines_per_page - 1
         if lend >= #self.vertical_string_list -- last page
@@ -2046,13 +2046,14 @@ function TextBoxWidget:_buildMatchPageList()
 
     local cache = self._text_cache
     local seen_pages = {}
+    local page_line = 1
     local match_byte, match_end = cache.lower:find(self._search_lower, 1, true)
 
     while match_byte do
         -- Convert lower char index -> original char index before page lookup
         local char_start = cache.byte_to_char[match_byte]
         table.insert(self._match_char_list, char_start)
-        local page_line = self:getCharPageTopLineNumber(char_start)
+        page_line = self:getCharPageTopLineNumber(char_start, page_line)
         if not seen_pages[page_line] then
             seen_pages[page_line] = true
             table.insert(self._match_page_list, page_line)

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -25,6 +25,7 @@ local RightContainer = require("ui/widget/container/rightcontainer")
 local Size = require("ui/size")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
+local Utf8Proc = require("ffi/utf8proc")
 local Math = require("optmath")
 local logger = require("logger")
 local dbg = require("dbg")
@@ -77,6 +78,9 @@ local TextBoxWidget = InputContainer:extend{
     highlight_clear_and_redraw_action = nil,
     hold_start_pos = nil,
     hold_end_pos = nil,
+
+    search_term = nil,
+    on_clear_search = nil, -- callback, set by parent if needed
 
     -- We can provide a list of images: each image will be displayed on each
     -- scrolled page, in its top right corner (if more images than pages, remaining
@@ -963,6 +967,19 @@ end
 -- (NOTE: This instantiates the inner bb (self._bb), so be careful about its lifecycle when you call this,
 --        c.f., TextBoxWidget:update).
 function TextBoxWidget:_updateLayout(update_highlight)
+    -- Pre-shape all visible lines so xglyphs exist before highlight
+    -- rect computation. _shapeLine is idempotent so _renderText
+    -- calling it again afterwards is safe.
+    if self.search_term and self.use_xtext and self._xtext then
+        local end_line = math.min(
+            self.virtual_line_num + self.lines_per_page - 1,
+            #self.vertical_string_list
+        )
+        for i = self.virtual_line_num, end_line do
+            local line = self.vertical_string_list[i]
+            if line then self:_shapeLine(line) end
+        end
+    end
     if self.highlight_text_selection and (update_highlight == nil or update_highlight) then
         self:updateHighlight()
     end
@@ -1316,6 +1333,14 @@ function TextBoxWidget:setText(text)
     end
 
     self.text = text
+    self._text_cache = nil
+    self._search_lower = nil      -- search term cache is also stale
+    self._search_char_len = nil   -- if text changed, term length against new text may differ
+    self._match_page_list = nil
+    self._match_page_index = nil
+    self.highlight_rects = nil
+    self.highlight_start_idx = nil
+    self.highlight_end_idx = nil
     self:_computeTextDimensions()
     self:update()
 
@@ -1362,6 +1387,15 @@ function TextBoxWidget:onTapImage(arg, ges)
     end
 end
 
+function TextBoxWidget:_postScrollHighlight()
+    if self.search_term then
+        self._match_page_index = nil
+        UIManager:setDirty(self.dialog or "all", function()
+            return "ui", self.dimen
+        end)
+    end
+end
+
 function TextBoxWidget:scrollDown()
     self.image_show_alt_text = nil -- reset image bb/alt state
     if self.virtual_line_num + self.lines_per_page <= #self.vertical_string_list then
@@ -1380,6 +1414,8 @@ function TextBoxWidget:scrollDown()
         end
         self:_updateLayout()
     end
+    -- Re-apply search highlight after scrolling
+    self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1398,6 +1434,8 @@ function TextBoxWidget:scrollUp()
         end
         self:_updateLayout()
     end
+    -- Re-apply search highlight after scrolling
+    self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1421,6 +1459,8 @@ function TextBoxWidget:scrollLines(nb_lines)
     self.virtual_line_num = new_line_num
     self:free(false)
     self:_updateLayout()
+    -- Re-apply search highlight after scrolling
+    self:_postScrollHighlight()
     if self.editable then
         local x, y = self:_getXYForCharPos() -- luacheck: no unused
         if y < 0 or y >= self.text_height then
@@ -1438,6 +1478,7 @@ function TextBoxWidget:scrollToTop()
         self.virtual_line_num = 1
         self:_updateLayout()
     end
+    self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first char
         self:moveCursorToCharPos(1)
@@ -1456,6 +1497,7 @@ function TextBoxWidget:scrollToBottom()
         self.virtual_line_num = ln
         self:_updateLayout()
     end
+    self:_postScrollHighlight()
     if self.editable then
         -- move cursor to last char
         self:moveCursorToCharPos(#self.charlist + 1)
@@ -1487,6 +1529,7 @@ function TextBoxWidget:scrollToRatio(ratio, force_to_page)
         self.virtual_line_num = line_num
         self:_updateLayout()
     end
+    self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1914,6 +1957,241 @@ function TextBoxWidget:scrollViewToCharPos()
     end
 end
 
+-- Builds all derived structures once so findText only pays O(n) for the
+-- string.find scan itself; all byte↔char conversions become O(1) lookups.
+-- Uses Utf8Proc.lowercase(str, false) which guarantees strict 1:1 char mapping,
+-- allowing the lowercased and original char indices to be used interchangeably.
+function TextBoxWidget:_buildTextCache()
+    if not self.text then
+        self._text_cache = nil
+        return
+    end
+
+    local lower_str = Utf8Proc.lowercase(self.text, false)
+    local lower_chars = util.splitToChars(lower_str)
+
+    -- Because lowercase(str, false) is strictly 1:1, char index in lower == char index in orig
+    local char_to_byte = {}
+    local byte_to_char = {}
+    local byte = 1
+    for i, ch in ipairs(lower_chars) do
+        char_to_byte[i] = byte
+        byte_to_char[byte] = i
+        byte = byte + #ch
+    end
+    char_to_byte[#lower_chars + 1] = byte
+
+    self._text_cache = {
+        lower = lower_str,
+        chars = lower_chars,
+        char_to_byte = char_to_byte,
+        byte_to_char = byte_to_char,
+    }
+end
+
+function TextBoxWidget:findText(text)
+    if not self.text or text == "" then return false end
+    if not self._text_cache then
+        self:_buildTextCache()
+    end
+    -- Rebuild search term cache only when the term changes.
+    -- Resets position so the next search starts from the current viewport.
+    if self.search_term ~= text then
+        self.search_term = text
+        self._search_lower = Utf8Proc.lowercase(text, false)
+        self._search_char_len = #util.splitToChars(text)
+        self.highlight_end_idx = nil
+        self.highlight_start_idx = nil
+        self:_buildMatchPageList()
+    end
+    local cache = self._text_cache
+    local search_lower = self._search_lower
+    -- Advance from end of last match, or from current viewport if this is a fresh search
+    local start_byte
+    if self.highlight_end_idx then
+        start_byte = cache.char_to_byte[self.highlight_end_idx + 1] or 1
+    else
+        local current_line = self.vertical_string_list[self.virtual_line_num]
+        start_byte = current_line and cache.char_to_byte[current_line.offset] or 1
+    end
+    -- O(n): unavoidable scan, wraps around if nothing found ahead of current position
+    local match_start, _ = cache.lower:find(search_lower, start_byte, true)
+    if not match_start and start_byte > 1 then
+        match_start, _ = cache.lower:find(search_lower, 1, true)
+    end
+    if not match_start then return false end
+    -- Since lowercase is 1:1, byte_to_char gives us the original char index directly
+    local char_start = cache.byte_to_char[match_start]
+    local char_end = char_start + self._search_char_len - 1
+
+    self.highlight_start_idx = char_start
+    self.highlight_end_idx = char_end
+    self.highlight_text_selection = true
+    self.charpos = char_start
+    self:scrollViewToCharPos()
+
+    self:free(false)
+    self:_updateLayout()
+    UIManager:setDirty(self.dialog or "all", function()
+        return "ui", self.dimen
+    end)
+    return true
+end
+
+function TextBoxWidget:_buildMatchPageList()
+    self._match_page_list = {}
+    if not self._text_cache or not self._search_lower then return end
+
+    local cache = self._text_cache
+    local seen_pages = {}
+    local match_byte, match_end = cache.lower:find(self._search_lower, 1, true)
+
+    while match_byte do
+        -- Convert lower char index → original char index before page lookup
+        local char_start = cache.byte_to_char[match_byte]
+        local page_line = self:getCharPageTopLineNumber(char_start)
+        if not seen_pages[page_line] then
+            seen_pages[page_line] = true
+            table.insert(self._match_page_list, page_line)
+        end
+        match_byte, match_end = cache.lower:find(self._search_lower, match_end + 1, true)
+    end
+end
+
+function TextBoxWidget:findTextNextPage(direction)
+    local list = self._match_page_list
+    local count = list and #list or 0
+    if count == 0 then return false end
+    if count == 1 and list[1] == self.virtual_line_num then return true end -- only one match and we're on it
+    if not self._match_page_index then
+        if direction > 0 then
+            local idx = util.bsearch_right(list, self.virtual_line_num) - 1
+            if idx < 1 then idx = count end
+            self._match_page_index = idx
+        else
+            local idx = util.bsearch_left(list, self.virtual_line_num)
+            if idx > count then idx = 1 end
+            self._match_page_index = idx
+        end
+    end
+    local idx = self._match_page_index
+    if direction > 0 then
+        idx = idx + 1
+        if idx > count then idx = 1 end
+    else
+        idx = idx - 1
+        if idx < 1 then idx = count end
+    end
+
+    self._match_page_index = idx
+    self:free(false)
+    self.virtual_line_num = list[idx]
+    self:_updateLayout()
+    UIManager:setDirty(self.dialog or "all", function()
+        return "ui", self.dimen
+    end)
+    return true
+end
+
+function TextBoxWidget:_highlightSearchInView()
+    if not self.search_term or not self.text then return false end
+
+    if not self._text_cache then
+        self:_buildTextCache()
+    end
+    local cache = self._text_cache
+    local search_lower = self._search_lower or Utf8Proc.lowercase(self.search_term, false)
+    local search_len = self._search_char_len or #util.splitToChars(self.search_term)
+    self.highlight_rects = {}
+
+    if not self.vertical_string_list or not self.vertical_string_list[self.virtual_line_num] then
+        return false
+    end
+
+    local start_line = self.virtual_line_num
+    local end_line = math.min(start_line + self.lines_per_page - 1, #self.vertical_string_list)
+
+    local visible_start_char = self.vertical_string_list[start_line].offset
+    local visible_end_char = self.vertical_string_list[end_line].end_offset or #cache.chars
+
+    local found_any = false
+
+    -- Back up by search term byte length to catch matches straddling the top of the viewport
+    local scan_start_byte = math.max(1, (cache.char_to_byte[visible_start_char] or 1) - #search_lower)
+    local match_start_byte, match_end_byte = cache.lower:find(search_lower, scan_start_byte, true)
+
+    while match_start_byte do
+        -- O(1) byte → char conversion; since lowercase is 1:1 this is also the original char index
+        local char_start = cache.byte_to_char[match_start_byte]
+        if char_start > visible_end_char then break end -- remaining matches are beyond the visible area
+        local char_end = char_start + search_len - 1
+
+        -- Process any match that at least partially intersects the viewport (straddling matches)
+        if char_end >= visible_start_char then
+            found_any = true
+            -- Clamp to visible area to handle matches straddling the viewport boundary
+            local clamped_start = math.max(char_start, visible_start_char)
+            local clamped_end = math.min(char_end, visible_end_char)
+            -- Two separate loops so we break as soon as each boundary line is found
+            local m_start_line, m_end_line
+            for l = start_line, end_line do
+                local line = self.vertical_string_list[l]
+                if line.offset <= clamped_start and clamped_start <= (line.end_offset or math.huge) then
+                    m_start_line = l
+                    break
+                end
+            end
+            for l = (m_start_line or start_line), end_line do
+                local line = self.vertical_string_list[l]
+                if line.offset <= clamped_end and clamped_end <= (line.end_offset or math.huge) then
+                    m_end_line = l
+                    break
+                end
+            end
+            if m_start_line and m_end_line then
+                local new_rects
+                if self.use_xtext then
+                    new_rects = self:getXtextHighlightRects(clamped_start, clamped_end, m_start_line, m_end_line)
+                else
+                    new_rects = self:getNonXtextHighlightRects(clamped_start, clamped_end, m_start_line, m_end_line)
+                end
+                if new_rects then
+                    for _, r in ipairs(new_rects) do
+                        table.insert(self.highlight_rects, r)
+                    end
+                end
+            end
+        end
+        match_start_byte, match_end_byte = cache.lower:find(search_lower, match_end_byte + 1, true)
+    end
+    if not found_any then
+        self.highlight_rects = nil
+        return false
+    end
+    return true
+end
+
+function TextBoxWidget:clearSearch(redraw)
+    self.search_term = nil
+    self._search_lower = nil
+    self._search_char_len = nil
+    self._match_page_list = nil
+    self._match_page_index = nil
+    if self.on_clear_search then
+        self.on_clear_search()
+    end
+    if redraw then
+        self.highlight_rects = nil
+        self.highlight_start_idx = nil
+        self.highlight_end_idx = nil
+        self:free(false)
+        self:_updateLayout(false)  -- re-renders without highlights
+        UIManager:setDirty(self.dialog or "all", function()
+            return "ui", self.dimen
+        end)
+    end
+end
+
 function TextBoxWidget:moveCursorLeft()
     if self.charpos > 1 then
         self:moveCursorToCharPos(self.charpos-1)
@@ -1999,6 +2277,7 @@ local FIND_END = 2
 
 function TextBoxWidget:onHoldStartText(_, ges)
     -- store hold start position and timestamp, will be used on release
+    self:clearSearch() -- clear search when manually selecting
 
     local pos = Geom:new{
         x = ges.pos.x - self.dimen.x,
@@ -2303,6 +2582,12 @@ end
 
 -- Returns true if the highlight has changed.
 function TextBoxWidget:updateHighlight()
+    -- If we have an active search and valid highlights, but no user touch (hold_start_pos),
+    -- -- do NOT clear the highlights. If searching, refresh ALL highlights in view
+    if self.search_term and not self.hold_start_pos then
+        self:_highlightSearchInView()
+        return self.highlight_rects ~= nil
+    end
     if not self.hold_start_pos or not self.hold_end_pos then
         local changed = self.highlight_start_idx ~= nil or self.highlight_end_idx ~= nil
         self.highlight_start_idx = nil

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -967,20 +967,20 @@ end
 -- (NOTE: This instantiates the inner bb (self._bb), so be careful about its lifecycle when you call this,
 --        c.f., TextBoxWidget:update).
 function TextBoxWidget:_updateLayout(update_highlight)
-    -- Pre-shape all visible lines so xglyphs exist before highlight
-    -- rect computation. _shapeLine is idempotent so _renderText
-    -- calling it again afterwards is safe.
-    if self.search_term and self.use_xtext and self._xtext then
-        local end_line = math.min(
-            self.virtual_line_num + self.lines_per_page - 1,
-            #self.vertical_string_list
-        )
-        for i = self.virtual_line_num, end_line do
-            local line = self.vertical_string_list[i]
-            if line then self:_shapeLine(line) end
-        end
-    end
     if self.highlight_text_selection and (update_highlight == nil or update_highlight) then
+        if self.search_term and self.use_xtext and self._xtext then
+            -- Pre-shape all visible lines so xglyphs exist before highlight
+            -- rect computation. _shapeLine is idempotent so _renderText
+            -- calling it again afterwards is safe.
+            local end_line = math.min(
+                self.virtual_line_num + self.lines_per_page - 1,
+                #self.vertical_string_list
+            )
+            for i = self.virtual_line_num, end_line do
+                local line = self.vertical_string_list[i]
+                if line then self:_shapeLine(line) end
+            end
+        end
         self:updateHighlight()
     end
     self:_renderText(self.virtual_line_num, self.virtual_line_num + self.lines_per_page - 1)
@@ -1315,6 +1315,7 @@ function TextBoxWidget:free(full)
         -- c.f., :_splitToLines
         self.vertical_string_list = {}
         self.line_num_to_image = nil
+        self:clearSearch()
     end
 end
 
@@ -1337,6 +1338,7 @@ function TextBoxWidget:setText(text)
     self._search_lower = nil      -- search term cache is also stale
     self._search_char_len = nil   -- if text changed, term length against new text may differ
     self._match_page_list = nil
+    self._match_char_list = nil
     self._match_page_index = nil
     self.highlight_rects = nil
     self.highlight_start_idx = nil
@@ -1390,9 +1392,6 @@ end
 function TextBoxWidget:_postScrollHighlight()
     if self.search_term then
         self._match_page_index = nil
-        UIManager:setDirty(self.dialog or "all", function()
-            return "ui", self.dimen
-        end)
     end
 end
 
@@ -1414,7 +1413,6 @@ function TextBoxWidget:scrollDown()
         end
         self:_updateLayout()
     end
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
@@ -1434,7 +1432,6 @@ function TextBoxWidget:scrollUp()
         end
         self:_updateLayout()
     end
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         -- move cursor to first line of visible area
@@ -1459,7 +1456,6 @@ function TextBoxWidget:scrollLines(nb_lines)
     self.virtual_line_num = new_line_num
     self:free(false)
     self:_updateLayout()
-    -- Re-apply search highlight after scrolling
     self:_postScrollHighlight()
     if self.editable then
         local x, y = self:_getXYForCharPos() -- luacheck: no unused
@@ -1958,7 +1954,7 @@ function TextBoxWidget:scrollViewToCharPos()
 end
 
 -- Builds all derived structures once so findText only pays O(n) for the
--- string.find scan itself; all byte↔char conversions become O(1) lookups.
+-- string.find scan itself; all byte<=>char conversions become O(1) lookups.
 -- Uses Utf8Proc.lowercase(str, false) which guarantees strict 1:1 char mapping,
 -- allowing the lowercased and original char indices to be used interchangeably.
 function TextBoxWidget:_buildTextCache()
@@ -2005,23 +2001,29 @@ function TextBoxWidget:findText(text)
         self:_buildMatchPageList()
     end
     local cache = self._text_cache
-    local search_lower = self._search_lower
+    local match_chars = self._match_char_list
+    if not match_chars or #match_chars == 0 then return false end
+
     -- Advance from end of last match, or from current viewport if this is a fresh search
-    local start_byte
+    local start_char
     if self.highlight_end_idx then
-        start_byte = cache.char_to_byte[self.highlight_end_idx + 1] or 1
+        start_char = self.highlight_end_idx + 1
     else
         local current_line = self.vertical_string_list[self.virtual_line_num]
-        start_byte = current_line and cache.char_to_byte[current_line.offset] or 1
+        start_char = current_line and current_line.offset or 1
     end
-    -- O(n): unavoidable scan, wraps around if nothing found ahead of current position
-    local match_start, _ = cache.lower:find(search_lower, start_byte, true)
-    if not match_start and start_byte > 1 then
-        match_start, _ = cache.lower:find(search_lower, 1, true)
+    -- Reuse precomputed matches: pick first >= start_char, wrap to first when needed.
+    local char_start
+    for i = 1, #match_chars do
+        if match_chars[i] >= start_char then
+            char_start = match_chars[i]
+            break
+        end
     end
-    if not match_start then return false end
-    -- Since lowercase is 1:1, byte_to_char gives us the original char index directly
-    local char_start = cache.byte_to_char[match_start]
+    if not char_start then
+        char_start = match_chars[1]
+    end
+
     local char_end = char_start + self._search_char_len - 1
 
     self.highlight_start_idx = char_start
@@ -2040,6 +2042,7 @@ end
 
 function TextBoxWidget:_buildMatchPageList()
     self._match_page_list = {}
+    self._match_char_list = {}
     if not self._text_cache or not self._search_lower then return end
 
     local cache = self._text_cache
@@ -2047,8 +2050,9 @@ function TextBoxWidget:_buildMatchPageList()
     local match_byte, match_end = cache.lower:find(self._search_lower, 1, true)
 
     while match_byte do
-        -- Convert lower char index → original char index before page lookup
+        -- Convert lower char index -> original char index before page lookup
         local char_start = cache.byte_to_char[match_byte]
+        table.insert(self._match_char_list, char_start)
         local page_line = self:getCharPageTopLineNumber(char_start)
         if not seen_pages[page_line] then
             seen_pages[page_line] = true
@@ -2113,16 +2117,24 @@ function TextBoxWidget:_highlightSearchInView()
 
     local visible_start_char = self.vertical_string_list[start_line].offset
     local visible_end_char = self.vertical_string_list[end_line].end_offset or #cache.chars
+    local match_chars = self._match_char_list
+    if not match_chars then
+        self:_buildMatchPageList()
+        match_chars = self._match_char_list
+    end
+    if not match_chars or #match_chars == 0 then
+        self.highlight_rects = nil
+        return false
+    end
 
     local found_any = false
 
-    -- Back up by search term byte length to catch matches straddling the top of the viewport
-    local scan_start_byte = math.max(1, (cache.char_to_byte[visible_start_char] or 1) - #search_lower)
-    local match_start_byte, match_end_byte = cache.lower:find(search_lower, scan_start_byte, true)
+    -- Reuse precomputed char-start matches and inspect potentially straddling matches
+    local first_idx = util.bsearch_left(match_chars, visible_start_char - search_len + 1)
+    if first_idx < 1 then first_idx = 1 end
 
-    while match_start_byte do
-        -- O(1) byte → char conversion; since lowercase is 1:1 this is also the original char index
-        local char_start = cache.byte_to_char[match_start_byte]
+    for i = first_idx, #match_chars do
+        local char_start = match_chars[i]
         if char_start > visible_end_char then break end -- remaining matches are beyond the visible area
         local char_end = char_start + search_len - 1
 
@@ -2162,7 +2174,6 @@ function TextBoxWidget:_highlightSearchInView()
                 end
             end
         end
-        match_start_byte, match_end_byte = cache.lower:find(search_lower, match_end_byte + 1, true)
     end
     if not found_any then
         self.highlight_rects = nil
@@ -2176,6 +2187,7 @@ function TextBoxWidget:clearSearch(redraw)
     self._search_lower = nil
     self._search_char_len = nil
     self._match_page_list = nil
+    self._match_char_list = nil
     self._match_page_index = nil
     if self.on_clear_search then
         self.on_clear_search()

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -2000,7 +2000,6 @@ function TextBoxWidget:findText(text)
         self.highlight_start_idx = nil
         self:_buildMatchPageList()
     end
-    local cache = self._text_cache
     local match_chars = self._match_char_list
     if not match_chars or #match_chars == 0 then return false end
 
@@ -2104,7 +2103,6 @@ function TextBoxWidget:_highlightSearchInView()
         self:_buildTextCache()
     end
     local cache = self._text_cache
-    local search_lower = self._search_lower or Utf8Proc.lowercase(self.search_term, false)
     local search_len = self._search_char_len or #util.splitToChars(self.search_term)
     self.highlight_rects = {}
 

--- a/frontend/ui/widget/textboxwidget.lua
+++ b/frontend/ui/widget/textboxwidget.lua
@@ -1389,7 +1389,7 @@ function TextBoxWidget:onTapImage(arg, ges)
     end
 end
 
-function TextBoxWidget:_postScrollHighlight()
+function TextBoxWidget:_postScrollFixup()
     if self.search_term then
         self._match_page_index = nil
     end
@@ -1413,7 +1413,7 @@ function TextBoxWidget:scrollDown()
         end
         self:_updateLayout()
     end
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1432,7 +1432,7 @@ function TextBoxWidget:scrollUp()
         end
         self:_updateLayout()
     end
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num
@@ -1456,7 +1456,7 @@ function TextBoxWidget:scrollLines(nb_lines)
     self.virtual_line_num = new_line_num
     self:free(false)
     self:_updateLayout()
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         local x, y = self:_getXYForCharPos() -- luacheck: no unused
         if y < 0 or y >= self.text_height then
@@ -1474,7 +1474,7 @@ function TextBoxWidget:scrollToTop()
         self.virtual_line_num = 1
         self:_updateLayout()
     end
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         -- move cursor to first char
         self:moveCursorToCharPos(1)
@@ -1493,7 +1493,7 @@ function TextBoxWidget:scrollToBottom()
         self.virtual_line_num = ln
         self:_updateLayout()
     end
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         -- move cursor to last char
         self:moveCursorToCharPos(#self.charlist + 1)
@@ -1525,7 +1525,7 @@ function TextBoxWidget:scrollToRatio(ratio, force_to_page)
         self.virtual_line_num = line_num
         self:_updateLayout()
     end
-    self:_postScrollHighlight()
+    self:_postScrollFixup()
     if self.editable then
         -- move cursor to first line of visible area
         local ln = self.height == nil and 1 or self.virtual_line_num

--- a/spec/unit/textboxwidget_spec.lua
+++ b/spec/unit/textboxwidget_spec.lua
@@ -54,4 +54,104 @@ describe("TextBoxWidget module", function()
         end, {pos={x=20,y=80}})
         ]]--
     end)
+
+    it("should build text cache correctly", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0},
+            face = Font:getFace("cfont", 25),
+            text = 'Hello World',
+        }
+
+        tw:_buildTextCache()
+        assert.is_not_nil(tw._text_cache)
+        assert.is_not_nil(tw._text_cache.lower)
+        assert.is_not_nil(tw._text_cache.chars)
+        assert.is_not_nil(tw._text_cache.char_to_byte)
+        assert.is_not_nil(tw._text_cache.byte_to_char)
+    end)
+
+    it("should find text in widget", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0, w = 400, h = 600},
+            face = Font:getFace("cfont", 25),
+            text = 'The quick brown fox jumps over the lazy dog',
+            virtual_line_num = 1,
+            lines_per_page = 10,
+        }
+
+        tw.vertical_string_list = {{offset = 1}}
+        local result = tw:findText('quick')
+        assert.is_true(result)
+        assert.is_not_nil(tw.highlight_start_idx)
+        assert.is_not_nil(tw.highlight_end_idx)
+    end)
+
+    it("should return false when finding nonexistent text", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0, w = 400, h = 600},
+            face = Font:getFace("cfont", 25),
+            text = 'The quick brown fox',
+            virtual_line_num = 1,
+        }
+
+        tw.vertical_string_list = {{offset = 1}}
+        local result = tw:findText('xyz')
+        assert.is_false(result)
+    end)
+
+    it("should clear search results", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0, w = 400, h = 600},
+            face = Font:getFace("cfont", 25),
+            text = 'search test text',
+            virtual_line_num = 1,
+        }
+
+        tw.search_term = 'test'
+        tw._search_lower = 'test'
+        tw._search_char_len = 4
+        tw._match_page_list = {1}
+        tw._match_page_index = 1
+        tw.highlight_start_idx = 1
+        tw.highlight_end_idx = 4
+
+        tw:clearSearch(false)
+        assert.is_nil(tw.search_term)
+        assert.is_nil(tw._search_lower)
+        assert.is_nil(tw._search_char_len)
+        assert.is_nil(tw._match_page_list)
+        assert.is_nil(tw._match_page_index)
+    end)
+
+    it("should build match page list correctly", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0, w = 400, h = 600},
+            face = Font:getFace("cfont", 25),
+            text = 'foo bar foo baz foo',
+            virtual_line_num = 1,
+        }
+
+        tw:_buildTextCache()
+        tw._search_lower = 'foo'
+        tw.getCharPageTopLineNumber = function(self, char) return 1 end
+
+        tw:_buildMatchPageList()
+        assert.is_not_nil(tw._match_page_list)
+    end)
+
+    it("should navigate to next page with matches", function()
+        local tw = TextBoxWidget:new{
+            dimen = {x = 0, y = 0, w = 400, h = 600},
+            face = Font:getFace("cfont", 25),
+            text = 'foo bar foo baz foo',
+            virtual_line_num = 1,
+            lines_per_page = 5,
+        }
+
+        tw._match_page_list = {1, 3, 5}
+        tw.vertical_string_list = {{offset = 1}, {offset = 10}, {offset = 20}}
+
+        local result = tw:findTextNextPage(1)
+        assert.is_true(result)
+    end)
 end)


### PR DESCRIPTION
### what's new

This pull request introduces support for in-text search within the `TextBoxWidget`, along with related improvements to scrolling and tap handling in text widgets. 

* Added efficient, case-insensitive search functionality with highlighting of searched terms, including functions to find next/previous matches, highlight all visible matches, and clear search state. This includes internal caching for fast lookups and correct handling of UTF-8 text. (`frontend/ui/widget/textboxwidget.lua`) 
* Clearing a search or starting a manual text selection resets all search-related highlights and state. (`frontend/ui/widget/textboxwidget.lua`)

* Introduced `on_clear_search` callback property to both `ScrollTextWidget` and `TextBoxWidget`, allowing parent widgets to react when a search is cleared. (`frontend/ui/widget/scrolltextwidget.lua`, `frontend/ui/widget/textboxwidget.lua`) 
* In `DictQuickLookup`, enabled the `on_clear_search` callback to reset search state and tap scroll behaviour, improving integration with the dictionary lookup UI. (`frontend/ui/widget/dictquicklookup.lua`)

* Added methods to enable/disable tap scrolling (`setTapScrollEnabled`, `isTapScrollEnabled`) and updated tap handlers in `ScrollTextWidget` to respect this setting. (`frontend/ui/widget/scrolltextwidget.lua`) 

* Added dependency on `Utf8Proc` for robust and efficient UTF-8 lowercasing and character handling. (`frontend/ui/widget/textboxwidget.lua`)

### screenshots

<p align="center">
<img src="https://github.com/user-attachments/assets/78900f5e-5272-4301-ad33-ee55fab86482" width=40%> 
</p> 

### related issues

* continuation of #15001
* fix #3022

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15356)
<!-- Reviewable:end -->
