### PR TITLE
feat: add Lemma Greek-English dictionary

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -1596,6 +1596,14 @@ local dictionaries = {
         url = "https://github.com/Vuizur/Wiktionary-Dictionaries/raw/master/Greek-English%20Wiktionary%20dictionary%20stardict.tar.gz",
     },
     {
+        name = "Lemma Greek-English Dictionary",
+        lang_in = "ell",
+        lang_out = "eng",
+        entries = 31143,
+        license = "CC-BY-SA 4.0 https://github.com/ciscoriordan/lemma",
+        url = "https://github.com/ciscoriordan/lemma/releases/download/v1.3.1/lemma_greek_en_stardict.zip",
+    },
+    {
         name = "Greenlandic-English Wiktionary",
         lang_in = "kal",
         lang_out = "eng",


### PR DESCRIPTION
Adds an entry to `frontend/ui/data/dictionaries.lua` for the [Lemma Greek-English dictionary](https://github.com/ciscoriordan/lemma).

| Field | Value |
| --- | --- |
| Name | Lemma Greek-English Dictionary |
| Languages | ell → eng (Modern Greek to English) |
| Entries | 31,143 articles + 609,175 inflection redirects |
| License | CC-BY-SA 4.0 (inherited from English Wiktionary) |
| Format | StarDict 2.4.2 (`.ifo` / `.idx` / `.dict` / `.syn`), zipped |
| URL | `https://github.com/ciscoriordan/lemma/releases/download/v1.3.1/lemma_greek_en_stardict.zip` (3.8 MB) |

Built from English Wiktionary's Greek lemma data via [lemma](https://github.com/ciscoriordan/lemma) and [kindling](https://github.com/ciscoriordan/kindling). The `.syn` file maps every inflected form (declensions, conjugations) to its lemma, so KOReader users get full inflection lookup with no extra config.

Tested locally in KOReader v2026.03 emulator. Both direct headword lookup and inflection redirects (via `.syn`) resolve correctly:

![Lemma Greek Dictionary in KOReader: looking up λόγου (genitive) resolves to λόγος via .syn redirect](https://github.com/ciscoriordan/lemma/releases/download/v1.3.1/koreader-lemma-lookup.png)

Discussion / context: ciscoriordan/lemma#2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15357)
<!-- Reviewable:end -->
