### PR TITLE
fix: bump Lemma Greek-English Dictionary URL to v1.3.3

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -1601,7 +1601,7 @@ local dictionaries = {
         lang_out = "eng",
         entries = 31143,
         license = "CC-BY-SA 4.0 https://github.com/ciscoriordan/lemma",
-        url = "https://github.com/ciscoriordan/lemma/releases/download/v1.3.1/lemma_greek_en_stardict.zip",
+        url = "https://github.com/ciscoriordan/lemma/releases/download/v1.3.2/lemma_greek_en_stardict.zip",
     },
     {
         name = "Greenlandic-English Wiktionary",

--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -1601,7 +1601,7 @@ local dictionaries = {
         lang_out = "eng",
         entries = 31143,
         license = "CC-BY-SA 4.0 https://github.com/ciscoriordan/lemma",
-        url = "https://github.com/ciscoriordan/lemma/releases/download/v1.3.2/lemma_greek_en_stardict.zip",
+        url = "https://github.com/ciscoriordan/lemma/releases/download/v1.3.3/lemma_greek_en_stardict_v1.3.3.zip",
     },
     {
         name = "Greenlandic-English Wiktionary",


### PR DESCRIPTION
Bumps the Lemma Greek-English Dictionary URL in `frontend/ui/data/dictionaries.lua` from v1.3.1 to v1.3.3.

Closes #15358.

## Why

This PR rolls up two fixes since the v1.3.1 entry was added in #15357:

**v1.3.2** changed the StarDict `bookname` from `Lemma Greek Dictionary` to `Lemma Greek Dictionary (el-en)`, so `LangCoder::findLangIdPairFromName` and the equivalent regex in GoldenDict-ng now return `el → en` instead of `(0, 0)`. Without it, the dictionary info dialog rendered "Translates from / to" blank (see ciscoriordan/lemma#2). The bookname auto-augmentation lives upstream in [kindling 0.15.3](https://github.com/ciscoriordan/kindling/releases/tag/v0.15.3).

**v1.3.3** changes the StarDict bundle directory and inner file basenames to embed the lemma version (`lemma_greek_en_stardict_v1.3.3/lemma_greek_en_stardict_v1.3.3.{ifo,idx,dict,syn}`). On Linux, GoldenDict-ng caches StarDict metadata by .ifo path, so a stable stem leaves users stuck on the metadata of whichever version they installed first (xiaoyifang/goldendict-ng#2829, ciscoriordan/lemma#2). The new versioned stem forces a fresh index on every release. KOReader uses StarDict bundles too and is affected by the same caching code path on Linux; KOReader users will not see the metadata difference until the dictionary info UI gains the relevant fields (see #15343), but a fresh stem is the right output regardless.

## Filename change

The release zip filename also picks up the version suffix:

- old: `lemma_greek_en_stardict.zip`
- new: `lemma_greek_en_stardict_v1.3.3.zip`

This is intentional and stable going forward: future releases will be `lemma_greek_en_stardict_v<X.Y.Z>.zip`.

## Verification

GoldenDict-ng 26.5.3 (macOS, Qt 6.10.3) loading the v1.3.2 zip. v1.3.3 has identical dictionary content (31,143 articles, 609,175 inflection redirects, CC-BY-SA 4.0); only the bundle stem differs.

![Lemma in GoldenDict-ng: Translates from Greek, Translates to English](https://github.com/ciscoriordan/lemma/releases/download/v1.3.2/goldendict-ng-lemma.png)

KOReader users who already downloaded via the in-app dictionary list can either re-download or manually replace the bundle. Removing the old `lemma_greek_en_stardict/` directory before installing the new versioned one is recommended on Linux (sidesteps the GoldenDict-ng cache bug).

Refs: #15357 (original add), #15343 (related dictionary metadata UI request).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15359)
<!-- Reviewable:end -->
