### PR TITLE
Perception expander: minor fixes

### DIFF
--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -460,8 +460,12 @@ function PluginLoader:showPluginDialog(plugin, touchmenu_instance)
             }})
         end
     end
+    local title = plugin.fullname .. "\n\n" .. plugin.description .. "\n"
+    if plugin.enable and not plugin_instance then
+        title = title .. "\n" .. _("This plugin is used in the reader only.\nOpen this dialog while reading a document to view additional options.")
+    end
     plugin_dialog = ButtonDialog:new{
-        title = plugin.fullname .. "\n\n" .. plugin.description .. "\n",
+        title = title,
         title_align = "center",
         buttons = buttons,
     }

--- a/plugins/perceptionexpander.koplugin/main.lua
+++ b/plugins/perceptionexpander.koplugin/main.lua
@@ -14,8 +14,10 @@ local DataStorage = require("datastorage")
 local Blitbuffer = require("ffi/blitbuffer")
 
 local PerceptionExpander = Widget:extend{
-    is_enabled = nil,
     name = "perceptionexpander",
+    is_doc_only = true,
+    settings_file = DataStorage:getSettingsDir() .. "/perception_expander.lua",
+    is_enabled = nil,
     page_counter = 0,
     shift_each_pages = 100,
     margin = 0.1,
@@ -24,21 +26,15 @@ local PerceptionExpander = Widget:extend{
     margin_shift = 0.03,
     settings = nil,
     ALMOST_CENTER_OF_THE_SCREEN = 0.37,
-    last_screen_mode = nil
+    last_screen_mode = nil,
 }
 
 function PerceptionExpander:init()
-    if not self.settings then self:readSettingsFile() end
-
-    self.is_enabled = self.settings:isTrue("is_enabled")
-    if not self.is_enabled then
-        return
+    self.settings = LuaSettings:open(self.settings_file)
+    if self.settings:isTrue("is_enabled") then
+        self.is_enabled = true
+        self:createUI(true)
     end
-    self:createUI(true)
-end
-
-function PerceptionExpander:readSettingsFile()
-    self.settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/perception_expander.lua")
 end
 
 function PerceptionExpander:createUI(readSettings)
@@ -230,7 +226,7 @@ function PerceptionExpander:saveSettings(fields)
     self.settings:saveSetting("line_color_intensity", self.line_color_intensity)
     self.settings:saveSetting("shift_each_pages", self.shift_each_pages)
     self.settings:saveSetting("is_enabled", self.is_enabled)
-    self.settings:flush()
+    self.updated = true
 
     self:createUI()
 end
@@ -238,6 +234,13 @@ end
 function PerceptionExpander:paintTo(bb, x, y)
     if self.is_enabled and self[1] then
         self[1]:paintTo(bb, x, y)
+    end
+end
+
+function PerceptionExpander:onFlushSettings()
+    if self.updated then
+        self.settings:flush()
+        self.updated = nil
     end
 end
 


### PR DESCRIPTION
(1) Enable in reader mode only.
(2) Allow to delete the settings file when disabling the plugin.
(3) Don't flush settings on every change.

A minor inconvenience is that the plugin instance is required to delete the plugin settings.
If a plugin is designed to be used in reader mode only, there is no instance in fm mode.
I propose to extend the Plugin management popup dialog for this case.

FM:
<img width="400" height="484" alt="1" src="https://github.com/user-attachments/assets/8c55f83b-5dee-47cf-9bd9-716d9f053ef4" />

-----

Reader:
<img width="400" height="484" alt="2" src="https://github.com/user-attachments/assets/8701054c-54c5-4a12-9a38-4a6c2ada49d7" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15364)
<!-- Reviewable:end -->
