### PR TITLE
fix: locale C or en_US has its own plural manipulation, the default one.

### DIFF
--- a/frontend/gettext.lua
+++ b/frontend/gettext.lua
@@ -166,7 +166,10 @@ function GetText_mt.__index.changeLang(new_lang)
     -- the "C" locale disables localization altogether
     -- can be various things such as `en_US` or `en_US:en`
     if new_lang == "C" or new_lang == nil or new_lang == ""
-       or new_lang:match("^en_US") == "en_US" then return end
+       or new_lang:match("^en_US") == "en_US" then
+        GetText.getPlural = getDefaultPlural
+        return
+    end
 
     -- strip encoding suffix in locale like "zh_CN.utf8"
     new_lang = new_lang:sub(1, new_lang:find(".%."))


### PR DESCRIPTION
Bug: If your system language is Chinese and you set KOReader's language to Chinese, KOReader will always display the singular form, e.g.  "Current page: 1 line, 1 word", even though the current page has many words.

Reproduction:

  1. Set system language to Chinese (e.g., LANG=zh_CN).
  2. Start KOReader, Change its language to English, restart.
  3. Book Information -> The user sees "Current page: 1 line, 1 word" even on a page with many lines and words.

Root cause: 
When the system language is Chinese and the user switches KOReader to English, then restarts, plural forms break because changeLang is called twice on startup:

  1. First call (from environment variables) — gettext.lua initialization detects LANG=zh_CN and calls changeLang("zh_CN"). This loads the Chinese MO file, and parse_headers sets getPlural to the Chinese plural function, which always returns 0.
  2. Second call (from saved user preference) — KOReader reads the user's saved English language setting and calls changeLang("en_US"), This hits the early return condition (new_lang:match("^en_US")) and returns immediately — without resetting getPlural, which still always returns 0 from the Chinese step.
  3. Result — ngettext("1 item", "%1 items", 5) calls getPlural(5), which returns 0. Since plural == 0, the singular form "1 item" is returned instead of "5 items".

This is exactly what our fix addresses — resetting getPlural to getDefaultPlural before the early return.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15375)
<!-- Reviewable:end -->
