### PR TITLE
[ReaderKeySelection] NT: improved text selection with cursor keys

### DIFF
--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -135,9 +135,7 @@ function ReaderConfig:onShowConfigMenu()
         covers_footer = true,
         close_callback = function() self:onCloseCallback() end,
     }
-    if self.ui.textselection and self.ui.textselection:isActive() then
-        self.ui.textselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
-    end
+    self.ui.keyselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     self.ui:handleEvent(Event:new("DisableHinting"))
     -- show last used panel when opening config dialog
     self.config_dialog:onShowConfigPanel(self.last_panel_index)

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -135,7 +135,9 @@ function ReaderConfig:onShowConfigMenu()
         covers_footer = true,
         close_callback = function() self:onCloseCallback() end,
     }
-    self.ui.highlight:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    if self.ui.textselection and self.ui.textselection:isActive() then
+        self.ui.textselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    end
     self.ui:handleEvent(Event:new("DisableHinting"))
     -- show last used panel when opening config dialog
     self.config_dialog:onShowConfigPanel(self.last_panel_index)

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -135,7 +135,7 @@ function ReaderConfig:onShowConfigMenu()
         covers_footer = true,
         close_callback = function() self:onCloseCallback() end,
     }
-    self.ui.highlight:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    self.ui.keyselection:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     self.ui:handleEvent(Event:new("DisableHinting"))
     -- show last used panel when opening config dialog
     self.config_dialog:onShowConfigPanel(self.last_panel_index)

--- a/frontend/apps/reader/modules/readerconfig.lua
+++ b/frontend/apps/reader/modules/readerconfig.lua
@@ -135,7 +135,7 @@ function ReaderConfig:onShowConfigMenu()
         covers_footer = true,
         close_callback = function() self:onCloseCallback() end,
     }
-    self.ui.keyselection:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    self.ui.keyselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     self.ui:handleEvent(Event:new("DisableHinting"))
     -- show last used panel when opening config dialog
     self.config_dialog:onShowConfigPanel(self.last_panel_index)

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -4,7 +4,6 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonSelector = require("ui/widget/buttonselector")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
-local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local GestureDetector = require("device/gesturedetector")
@@ -19,7 +18,6 @@ local ffiUtil = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
 local Size = require("ui/size")
-local time = require("ui/time")
 local _ = require("gettext")
 local C_ = _.pgettext
 local N_ = _.ngettext
@@ -376,6 +374,9 @@ local long_press_action = {
     {_("Dictionary"), "dictionary"},
     {_("Fulltext search"), "search"},
 }
+-- we need to expose this table to readerkeyselection
+-- as here it is hidden under a isTouchDevice cap
+ReaderHighlight.long_press_action = long_press_action
 
 local highlight_dialog_position = {
     {_("Top"), "top"},
@@ -385,16 +386,6 @@ local highlight_dialog_position = {
 }
 
 function ReaderHighlight:addToMainMenu(menu_items)
-    -- insert table to main reader menu
-    if not Device:isTouchDevice() and Device:hasDPad() and not Device:useDPadAsActionKeys() then
-        menu_items.start_content_selection = {
-            text = _("Start content selection"),
-            callback = function()
-                self:onStartHighlightIndicator()
-            end,
-        }
-    end
-
     -- main menu Typeset
     local star = "   ★"
     local hl_sub_item_table = {}
@@ -813,113 +804,6 @@ Except when in two columns mode, where this is limited to showing only the previ
             self.allow_corner_scroll = G_reader_settings:nilOrTrue("highlight_corner_scroll")
         end,
     })
-
-    -- we allow user to select the rate at which the content selection tool moves through screen
-    if not Device:isTouchDevice() and Device:hasDPad() then
-        table.insert(menu_items.long_press.sub_item_table, {
-            text_func = function()
-                local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
-                local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
-                return T(_("Crosshairs speed (reader/dict): %1 / %2"), reader_speed, dict_speed)
-            end,
-            callback = function(touchmenu_instance)
-                local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
-                local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
-                local double_spin_widget = DoubleSpinWidget:new{
-                    left_text = _("Reader"),
-                    left_value = reader_speed,
-                    left_min = 0.25,
-                    left_max = 5,
-                    left_default = 4,
-                    left_precision = "%.2f",
-                    left_step = 0.25,
-                    left_hold_step = 0.05,
-                    right_text = _("Dictionary"),
-                    right_value = dict_speed,
-                    right_min = 0.25,
-                    right_max = 5,
-                    right_default = 3,
-                    right_precision = "%.2f",
-                    right_step = 0.25,
-                    right_hold_step = 0.05,
-                    title_text = _("Crosshairs speed"),
-                    info_text = _("Select a decimal value from 0.25 to 5. A smaller value increases the travel distance of the crosshairs per keystroke. Font size and this value are inversely correlated, meaning a smaller font size requires a larger value and vice versa."),
-                    callback = function(left_value, right_value)
-                        G_reader_settings:saveSetting("highlight_non_touch_factor", left_value)
-                        G_reader_settings:saveSetting("highlight_non_touch_factor_dict", right_value)
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end
-                }
-                UIManager:show(double_spin_widget)
-            end,
-        })
-        table.insert(menu_items.long_press.sub_item_table, {
-            text = _("Increase crosshairs speed on consecutive keystrokes"),
-            checked_func = function()
-                return G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
-            end,
-            enabled_func = function()
-                return not self.view.highlight.disabled
-            end,
-            callback = function()
-                G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
-            end,
-        })
-        table.insert(menu_items.long_press.sub_item_table, {
-            text_func = function()
-                local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                return T(N_("Interval for crosshairs speed increase: 1 second", "Interval for crosshairs speed increase: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
-            end,
-            separator = true, -- needed as this is not the last item, readerlink adds another one
-            enabled_func = function()
-                return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
-            end,
-            callback = function(touchmenu_instance)
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                local spin_widget = SpinWidget:new{
-                    value = curr_val,
-                    value_min = 0.1,
-                    value_max = 1,
-                    precision = "%.1f",
-                    value_step = 0.1,
-                    default_value = 1,
-                    title_text = _("Time interval"),
-                    info_text = _("Select a decimal value up to 1 second. This defines the time period within which multiple keystrokes will trigger an increase in the crosshairs speed."),
-                    callback = function(spin)
-                        G_reader_settings:saveSetting("highlight_non_touch_interval", spin.value)
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end
-                }
-                UIManager:show(spin_widget)
-            end,
-        })
-
-        -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
-        -- Clone long_press settings, and change its label, making it much more meaningful for non-touch device users.
-        menu_items.selection_text = {
-            text = _("Text selection tools"),
-            sub_item_table = {
-                menu_items.long_press.sub_item_table[1], -- Dictionary on single word selection
-                {
-                    text_func = function()
-                        local multi_word = G_reader_settings:readSetting("default_highlight_action")
-                        for __, v in ipairs(long_press_action) do
-                            if v[2] == multi_word then
-                                return T(_("Multi-word selection: %1"), v[1]:lower())
-                            end
-                        end
-                    end,
-                    sub_item_table = { table.unpack(menu_items.long_press.sub_item_table, 2, #long_press_action + 1) }
-                }
-            }
-        }
-        local post_long_press_action_index = #menu_items.selection_text.sub_item_table + #long_press_action -- index after long_press_action
-        -- Copy remaining items (anything after long_press_action) directly to selection_text's sub_item_table
-        for i = post_long_press_action_index, #menu_items.long_press.sub_item_table do
-            table.insert(menu_items.selection_text.sub_item_table, menu_items.long_press.sub_item_table[i])
-        end
-        menu_items.long_press = nil
-    end
 
     -- main menu Search
     menu_items.translation_settings = Translator:genSettingsMenu()
@@ -2711,7 +2595,5 @@ function ReaderHighlight:onClose(keep_highlight)
         self:clear()
     end
 end
-
-
 
 return ReaderHighlight

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -86,14 +86,8 @@ function ReaderHighlight:init()
     self.screen_w = Screen:getWidth()
     self.screen_h = Screen:getHeight()
     self.select_mode = false -- extended highlighting
-    self._start_indicator_highlight = false
-    self._current_indicator_pos = nil
-    self._previous_indicator_pos = nil
-    self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
     self._fallback_drawer = self.view.highlight.saved_drawer -- "lighten"
     self._fallback_color = self.view.highlight.saved_color -- "yellow" or "gray"
-
-    self:registerKeyEvents()
 
     self._highlight_buttons = {
         -- highlight and add_note are for the document itself,
@@ -270,31 +264,6 @@ function ReaderHighlight:onSetDimensions(dimen)
 end
 
 function ReaderHighlight:onGesture() end
-
-function ReaderHighlight:registerKeyEvents()
-    if Device:hasDPad() then
-        self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
-        self.key_events.UpHighlightIndicator    = { { "Up" },    event = "MoveHighlightIndicator", args = {0, -1} }
-        self.key_events.DownHighlightIndicator  = { { "Down" },  event = "MoveHighlightIndicator", args = {0, 1} }
-        -- let hasFewKeys device move the indicator left
-        self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
-        self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
-        self.key_events.HighlightPress          = { { "Press" } }
-    end
-    if Device:hasScreenKB() or Device:hasKeyboard() then
-        local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
-        -- Used for text selection with dpad/keys
-        local QUICK_INDICATOR_MOVE = true
-        self.key_events.QuickUpHighlightIndicator    = { { modifier, "Up" },    event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickDownHighlightIndicator  = { { modifier, "Down" },  event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickLeftHighlightIndicator  = { { modifier, "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickRightHighlightIndicator = { { modifier, "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICATOR_MOVE} }
-        self.key_events.HighlightModifierPress       = { { modifier, "Press" } }
-        -- onStartHighlightIndicator (H) is handled by hotkeys.koplugin
-    end
-end
-
-ReaderHighlight.onPhysicalKeyboardConnected = ReaderHighlight.registerKeyEvents
 
 function ReaderHighlight:setupTouchZones()
     if not Device:isTouchDevice() then return end
@@ -1738,7 +1707,7 @@ function ReaderHighlight:onHold(arg, ges)
             with_title_bar = false, -- more room for image
             fullscreen = true,
         })
-        self:onStopHighlightIndicator()
+        self.ui.keyselection:onStopHighlightIndicator()
         return true
     end
 
@@ -2743,240 +2712,6 @@ function ReaderHighlight:onClose(keep_highlight)
     end
 end
 
--- dpad/keys support
 
-function ReaderHighlight:onHighlightPress(skip_tap_check)
-    if not self._current_indicator_pos then return false end
-    if self._start_indicator_highlight then
-        self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
-        return true
-    end
-    -- Check if we're in select mode (or extending an existing highlight)
-    if self.select_mode and self.highlight_idx then
-        self:onHold(nil, self:_createHighlightGesture("hold"))
-        self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
-        return true
-    end
-    -- Attempt to open an existing highlight
-    if not skip_tap_check and self:onTap(nil, self:_createHighlightGesture("tap")) then
-        self:onStopHighlightIndicator(true) -- need_clear_selection=true
-        return true
-    end
-    -- no existing highlight at current indicator position: start hold
-    self._start_indicator_highlight = true
-    self:onHold(nil, self:_createHighlightGesture("hold"))
-
-    if not (self.ui.rolling and self.selected_text and self.selected_text.sboxes and #self.selected_text.sboxes > 0) then
-        return true
-    end
-    -- With crengine, selected_text.sboxes have good coordinates, so we'll borrow them.
-    local pos = self.selected_text.sboxes[1]
-    local margins = self.ui.document.configurable.h_page_margins[1] + self.ui.document.configurable.h_page_margins[2]
-    local two_column_mode = self.ui.document.configurable.visible_pages == 2
-    local effective_width = two_column_mode and (self.screen_w - margins) / 2 or self.screen_w - margins
-    -- When words are split (and hyphenated) due to line breaks, they create selection boxes that are almost as wide as the
-    -- effective_width, so we need to check if that is the case, in order to handle those cases properly. We cannot precisely
-    -- and easily recognise hyphenated words in the front end, so a heuristic approach is used, it goes in two steps.
-    -- Step one: check if our box is a 'big boy'. We must allow some room for unknown variables like publisher-embedded padding, etc.
-    local is_word_split = pos.w > 0.7 * effective_width
-    -- Step two: weed out false positives (i.e long words) by comparing words found at different box coordinates.
-    if is_word_split then
-        -- In the case of a split (and hyphenated) word, we should get distinct words at different coordinates inside the box,
-        -- false positives on the other hand, should return the same word at different coordinates.
-        local word_at_pos1 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-            y = pos.y + pos.h * 1/4 -- puts us at a potential line 1 of 2
-        })
-        local word_at_pos2 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x or pos.x + pos.w,
-            y = pos.y + pos.h * 3/4 -- puts us at a potential line 2 of 2
-        })
-        local does_word_at_pos1_match = word_at_pos1 and word_at_pos1.word == self.selected_text.text
-        local does_word_at_pos2_match = word_at_pos2 and word_at_pos2.word == self.selected_text.text
-        -- If all 3 words are a match, then we're likely not a split word, just a very long one, something worthy of floccinaucinihilipilification.
-        if does_word_at_pos1_match and does_word_at_pos2_match then
-            is_word_split = false -- check mate
-        else -- We're reasonably sure the word was split (and hyphenated). Re-select the original word to ensure the correct word is highlighted.
-            self.ui.document:getWordFromPosition({
-                x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-                y = pos.y + pos.h * 3/4
-            })
-        end
-    end
-
-    -- helper function to update crosshairs positioning and self.hold_pos
-    local function updatePositions(hold_x, hold_y, indicator_x, indicator_y)
-        self.hold_pos = self.view:screenToPageTransform({ x = hold_x, y = hold_y })
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos.x = indicator_x
-        self._current_indicator_pos.y = indicator_y
-    end
-    -- Determine positions based on word type and layout.
-    if is_word_split then
-        if BD.mirroredUILayout() then -- RTL
-            updatePositions(
-                pos.x + pos.w,          -- rightmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x + pos.w,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        else
-            updatePositions(
-                pos.x,                  -- leftmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        end
-    else
-        updatePositions(
-            -- set hold_pos to center of selected_text to make center selection more stable, not JITted at edge
-            pos.x + pos.w / 2,          -- center of word horizontally
-            pos.y + pos.h / 2,          -- center of word vertically
-            pos.x + pos.w / 2 - self._current_indicator_pos.w / 2,
-            pos.y + pos.h / 2 - self._current_indicator_pos.h / 2
-        )
-    end
-    return true
-end
-
-function ReaderHighlight:onHighlightModifierPress()
-    if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
-    if not self._start_indicator_highlight then
-        self:onHighlightPress(true)
-        return true -- don't trigger hotkeys during text selection
-    end
-    -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
-    self.long_hold_reached = true
-    self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-    self:onStopHighlightIndicator()
-    return true
-end
-
-function ReaderHighlight:onStartHighlightIndicator()
-    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
-    self.long_hold_reached_action = function() end
-    if self.view.visible_area and not self._current_indicator_pos then
-        -- set start position to centor of page
-        local rect = self._previous_indicator_pos
-        if not rect then
-            rect = Geom:new()
-            rect.x = self.view.visible_area.w / 2
-            rect.y = self.view.visible_area.h / 2
-            rect.w = Size.item.height_default
-            rect.h = rect.w
-        end
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
-        return true
-    end
-    return false
-end
-
-function ReaderHighlight:onStopHighlightIndicator(need_clear_selection)
-    if not self._current_indicator_pos then return false end
-    -- If we're in select mode and user presses back, end the selection
-    if self.select_mode and self.highlight_idx then
-        self.select_mode = false
-        if self.ui.annotation.annotations[self.highlight_idx].is_tmp then
-            self:deleteHighlight(self.highlight_idx) -- temporary highlight, delete it
-        else
-            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
-        end
-        self.highlight_idx = nil
-    end
-
-    local rect = self._current_indicator_pos
-    self._previous_indicator_pos = rect
-    self._start_indicator_highlight = false
-    self._current_indicator_pos = nil
-    self.view.highlight.indicator = nil
-    UIManager:setDirty(self.dialog, "ui", rect)
-    if need_clear_selection then
-        self:clear()
-    end
-    return true
-end
-
-function ReaderHighlight:onMoveHighlightIndicator(args)
-    if self.view.visible_area and self._current_indicator_pos then
-        local dx, dy, quick_move = unpack(args)
-        local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
-        local quick_move_distance_dy = self.view.visible_area.h * (1/5)
-        -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
-        local rect = self._current_indicator_pos:copy()
-        if quick_move then
-            rect.x = rect.x + quick_move_distance_dx * dx
-            rect.y = rect.y + quick_move_distance_dy * dy
-        else
-            local now = time:now()
-            if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
-                local diff = now - self._last_indicator_move_args.time
-                -- if user presses same arrow key within 1 second (default, user adjustable), speed up
-                -- double press: 4 single move distances, usually move to next word or line
-                -- triple press: 16 single distances, usually skip several words or lines
-                -- quadruple press: 64 single distances, almost move to screen edge
-                if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
-                    -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                    if diff < time.s( t_inter ) then
-                        move_distance = self._last_indicator_move_args.distance * 4
-                    end
-                end
-            end
-            rect.x = rect.x + move_distance * dx
-            rect.y = rect.y + move_distance * dy
-            self._last_indicator_move_args.distance = move_distance
-            self._last_indicator_move_args.dx = dx
-            self._last_indicator_move_args.dy = dy
-            self._last_indicator_move_args.time = now
-        end
-        if rect.x < 0 then
-            rect.x = 0
-        end
-        if rect.x + rect.w > self.view.visible_area.w then
-            rect.x = self.view.visible_area.w - rect.w
-        end
-        -- make sure we account for both the status bar and alt status bar so we don't overlap them with the indicator
-        local alt_status_bar_height = 0
-        if self.ui.rolling and self.ui.document.configurable.status_line == 0 then
-            alt_status_bar_height = self.ui.document:getHeaderHeight()
-        end
-        if rect.y < alt_status_bar_height then
-            rect.y = alt_status_bar_height
-        end
-        local footer_height = self.view.footer_visible and self.view.footer:getHeight() or 0
-        local status_bar_height = self.ui.rolling and footer_height or 0 -- for PDFs, status bar is already accounted for
-        if rect.y + rect.h > self.view.visible_area.h - status_bar_height then
-            rect.y = self.view.visible_area.h - status_bar_height - rect.h
-        end
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
-        if self._start_indicator_highlight then
-            self:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
-        end
-        return true
-    end
-    return false
-end
-
-function ReaderHighlight:_createHighlightGesture(gesture)
-    local point = self._current_indicator_pos:copy()
-    point.x = point.x + point.w / 2
-    point.y = point.y + point.h / 2
-    point.w = 0
-    point.h = 0
-    return {
-        ges = gesture,
-        pos = point,
-        time = time.realtime(),
-    }
-end
 
 return ReaderHighlight

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -4,7 +4,6 @@ local ButtonDialog = require("ui/widget/buttondialog")
 local ButtonSelector = require("ui/widget/buttonselector")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
-local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
 local GestureDetector = require("device/gesturedetector")
@@ -375,6 +374,9 @@ local long_press_action = {
     {_("Dictionary"), "dictionary"},
     {_("Fulltext search"), "search"},
 }
+-- we need to expose this table to readertextselection
+-- as here it is hidden under a isTouchDevice cap
+ReaderHighlight.long_press_action = long_press_action
 
 local highlight_dialog_position = {
     {_("Top"), "top"},
@@ -802,113 +804,6 @@ Except when in two columns mode, where this is limited to showing only the previ
             self.allow_corner_scroll = G_reader_settings:nilOrTrue("highlight_corner_scroll")
         end,
     })
-
-    -- we allow user to select the rate at which the content selection tool moves through screen
-    if not Device:isTouchDevice() and Device:hasDPad() then
-        table.insert(menu_items.long_press.sub_item_table, {
-            text_func = function()
-                local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
-                local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
-                return T(_("Crosshairs speed (reader/dict): %1 / %2"), reader_speed, dict_speed)
-            end,
-            callback = function(touchmenu_instance)
-                local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
-                local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
-                local double_spin_widget = DoubleSpinWidget:new{
-                    left_text = _("Reader"),
-                    left_value = reader_speed,
-                    left_min = 0.25,
-                    left_max = 5,
-                    left_default = 4,
-                    left_precision = "%.2f",
-                    left_step = 0.25,
-                    left_hold_step = 0.05,
-                    right_text = _("Dictionary"),
-                    right_value = dict_speed,
-                    right_min = 0.25,
-                    right_max = 5,
-                    right_default = 3,
-                    right_precision = "%.2f",
-                    right_step = 0.25,
-                    right_hold_step = 0.05,
-                    title_text = _("Crosshairs speed"),
-                    info_text = _("Select a decimal value from 0.25 to 5. A smaller value increases the travel distance of the crosshairs per keystroke. Font size and this value are inversely correlated, meaning a smaller font size requires a larger value and vice versa."),
-                    callback = function(left_value, right_value)
-                        G_reader_settings:saveSetting("highlight_non_touch_factor", left_value)
-                        G_reader_settings:saveSetting("highlight_non_touch_factor_dict", right_value)
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end
-                }
-                UIManager:show(double_spin_widget)
-            end,
-        })
-        table.insert(menu_items.long_press.sub_item_table, {
-            text = _("Increase crosshairs speed on consecutive keystrokes"),
-            checked_func = function()
-                return G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
-            end,
-            enabled_func = function()
-                return not self.view.highlight.disabled
-            end,
-            callback = function()
-                G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
-            end,
-        })
-        table.insert(menu_items.long_press.sub_item_table, {
-            text_func = function()
-                local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                return T(N_("Interval for crosshairs speed increase: 1 second", "Interval for crosshairs speed increase: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
-            end,
-            separator = true, -- needed as this is not the last item, readerlink adds another one
-            enabled_func = function()
-                return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
-            end,
-            callback = function(touchmenu_instance)
-                local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                local spin_widget = SpinWidget:new{
-                    value = curr_val,
-                    value_min = 0.1,
-                    value_max = 1,
-                    precision = "%.1f",
-                    value_step = 0.1,
-                    default_value = 1,
-                    title_text = _("Time interval"),
-                    info_text = _("Select a decimal value up to 1 second. This defines the time period within which multiple keystrokes will trigger an increase in the crosshairs speed."),
-                    callback = function(spin)
-                        G_reader_settings:saveSetting("highlight_non_touch_interval", spin.value)
-                        if touchmenu_instance then touchmenu_instance:updateItems() end
-                    end
-                }
-                UIManager:show(spin_widget)
-            end,
-        })
-
-        -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
-        -- Clone long_press settings, and change its label, making it much more meaningful for non-touch device users.
-        menu_items.selection_text = {
-            text = _("Text selection tools"),
-            sub_item_table = {
-                menu_items.long_press.sub_item_table[1], -- Dictionary on single word selection
-                {
-                    text_func = function()
-                        local multi_word = G_reader_settings:readSetting("default_highlight_action")
-                        for __, v in ipairs(long_press_action) do
-                            if v[2] == multi_word then
-                                return T(_("Multi-word selection: %1"), v[1]:lower())
-                            end
-                        end
-                    end,
-                    sub_item_table = { table.unpack(menu_items.long_press.sub_item_table, 2, #long_press_action + 1) }
-                }
-            }
-        }
-        local post_long_press_action_index = #menu_items.selection_text.sub_item_table + #long_press_action -- index after long_press_action
-        -- Copy remaining items (anything after long_press_action) directly to selection_text's sub_item_table
-        for i = post_long_press_action_index, #menu_items.long_press.sub_item_table do
-            table.insert(menu_items.selection_text.sub_item_table, menu_items.long_press.sub_item_table[i])
-        end
-        menu_items.long_press = nil
-    end
 
     -- main menu Search
     menu_items.translation_settings = Translator:genSettingsMenu()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -98,7 +98,7 @@ function ReaderHighlight:init()
                     this:startSelection(index)
                     this:onClose()
                     if not Device:isTouchDevice() then
-                        self.ui.textselection:onStartHighlightIndicator()
+                        self.ui.keyselection:startHighlightIndicator()
                     end
                 end,
             }
@@ -374,7 +374,7 @@ local long_press_action = {
     {_("Dictionary"), "dictionary"},
     {_("Fulltext search"), "search"},
 }
--- we need to expose this table to readertextselection
+-- we need to expose this table to readerkeyselection
 -- as here it is hidden under a isTouchDevice cap
 ReaderHighlight.long_press_action = long_press_action
 

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -19,7 +19,6 @@ local ffiUtil = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
 local Size = require("ui/size")
-local time = require("ui/time")
 local _ = require("gettext")
 local C_ = _.pgettext
 local N_ = _.ngettext
@@ -86,14 +85,8 @@ function ReaderHighlight:init()
     self.screen_w = Screen:getWidth()
     self.screen_h = Screen:getHeight()
     self.select_mode = false -- extended highlighting
-    self._start_indicator_highlight = false
-    self._current_indicator_pos = nil
-    self._previous_indicator_pos = nil
-    self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
     self._fallback_drawer = self.view.highlight.saved_drawer -- "lighten"
     self._fallback_color = self.view.highlight.saved_color -- "yellow" or "gray"
-
-    self:registerKeyEvents()
 
     self._highlight_buttons = {
         -- highlight and add_note are for the document itself,
@@ -106,7 +99,7 @@ function ReaderHighlight:init()
                     this:startSelection(index)
                     this:onClose()
                     if not Device:isTouchDevice() then
-                        self:onStartHighlightIndicator()
+                        self.ui.textselection:onStartHighlightIndicator()
                     end
                 end,
             }
@@ -271,31 +264,6 @@ end
 
 function ReaderHighlight:onGesture() end
 
-function ReaderHighlight:registerKeyEvents()
-    if Device:hasDPad() then
-        self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
-        self.key_events.UpHighlightIndicator    = { { "Up" },    event = "MoveHighlightIndicator", args = {0, -1} }
-        self.key_events.DownHighlightIndicator  = { { "Down" },  event = "MoveHighlightIndicator", args = {0, 1} }
-        -- let hasFewKeys device move the indicator left
-        self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
-        self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
-        self.key_events.HighlightPress          = { { "Press" } }
-    end
-    if Device:hasScreenKB() or Device:hasKeyboard() then
-        local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
-        -- Used for text selection with dpad/keys
-        local QUICK_INDICATOR_MOVE = true
-        self.key_events.QuickUpHighlightIndicator    = { { modifier, "Up" },    event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickDownHighlightIndicator  = { { modifier, "Down" },  event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickLeftHighlightIndicator  = { { modifier, "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICATOR_MOVE} }
-        self.key_events.QuickRightHighlightIndicator = { { modifier, "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICATOR_MOVE} }
-        self.key_events.HighlightModifierPress       = { { modifier, "Press" } }
-        -- onStartHighlightIndicator (H) is handled by hotkeys.koplugin
-    end
-end
-
-ReaderHighlight.onPhysicalKeyboardConnected = ReaderHighlight.registerKeyEvents
-
 function ReaderHighlight:setupTouchZones()
     if not Device:isTouchDevice() then return end
     local hold_pan_rate = G_reader_settings:readSetting("hold_pan_rate")
@@ -416,16 +384,6 @@ local highlight_dialog_position = {
 }
 
 function ReaderHighlight:addToMainMenu(menu_items)
-    -- insert table to main reader menu
-    if not Device:isTouchDevice() and Device:hasDPad() and not Device:useDPadAsActionKeys() then
-        menu_items.start_content_selection = {
-            text = _("Start content selection"),
-            callback = function()
-                self:onStartHighlightIndicator()
-            end,
-        }
-    end
-
     -- main menu Typeset
     local star = "   ★"
     local hl_sub_item_table = {}
@@ -1738,7 +1696,6 @@ function ReaderHighlight:onHold(arg, ges)
             with_title_bar = false, -- more room for image
             fullscreen = true,
         })
-        self:onStopHighlightIndicator()
         return true
     end
 
@@ -2733,242 +2690,6 @@ function ReaderHighlight:onClose(keep_highlight)
     if not keep_highlight then
         self:clear()
     end
-end
-
--- dpad/keys support
-
-function ReaderHighlight:onHighlightPress(skip_tap_check)
-    if not self._current_indicator_pos then return false end
-    if self._start_indicator_highlight then
-        self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
-        return true
-    end
-    -- Check if we're in select mode (or extending an existing highlight)
-    if self.select_mode and self.highlight_idx then
-        self:onHold(nil, self:_createHighlightGesture("hold"))
-        self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
-        return true
-    end
-    -- Attempt to open an existing highlight
-    if not skip_tap_check and self:onTap(nil, self:_createHighlightGesture("tap")) then
-        self:onStopHighlightIndicator(true) -- need_clear_selection=true
-        return true
-    end
-    -- no existing highlight at current indicator position: start hold
-    self._start_indicator_highlight = true
-    self:onHold(nil, self:_createHighlightGesture("hold"))
-
-    if not (self.ui.rolling and self.selected_text and self.selected_text.sboxes and #self.selected_text.sboxes > 0) then
-        return true
-    end
-    -- With crengine, selected_text.sboxes have good coordinates, so we'll borrow them.
-    local pos = self.selected_text.sboxes[1]
-    local margins = self.ui.document.configurable.h_page_margins[1] + self.ui.document.configurable.h_page_margins[2]
-    local two_column_mode = self.ui.document.configurable.visible_pages == 2
-    local effective_width = two_column_mode and (self.screen_w - margins) / 2 or self.screen_w - margins
-    -- When words are split (and hyphenated) due to line breaks, they create selection boxes that are almost as wide as the
-    -- effective_width, so we need to check if that is the case, in order to handle those cases properly. We cannot precisely
-    -- and easily recognise hyphenated words in the front end, so a heuristic approach is used, it goes in two steps.
-    -- Step one: check if our box is a 'big boy'. We must allow some room for unknown variables like publisher-embedded padding, etc.
-    local is_word_split = pos.w > 0.7 * effective_width
-    -- Step two: weed out false positives (i.e long words) by comparing words found at different box coordinates.
-    if is_word_split then
-        -- In the case of a split (and hyphenated) word, we should get distinct words at different coordinates inside the box,
-        -- false positives on the other hand, should return the same word at different coordinates.
-        local word_at_pos1 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-            y = pos.y + pos.h * 1/4 -- puts us at a potential line 1 of 2
-        })
-        local word_at_pos2 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x or pos.x + pos.w,
-            y = pos.y + pos.h * 3/4 -- puts us at a potential line 2 of 2
-        })
-        local does_word_at_pos1_match = word_at_pos1 and word_at_pos1.word == self.selected_text.text
-        local does_word_at_pos2_match = word_at_pos2 and word_at_pos2.word == self.selected_text.text
-        -- If all 3 words are a match, then we're likely not a split word, just a very long one, something worthy of floccinaucinihilipilification.
-        if does_word_at_pos1_match and does_word_at_pos2_match then
-            is_word_split = false -- check mate
-        else -- We're reasonably sure the word was split (and hyphenated). Re-select the original word to ensure the correct word is highlighted.
-            self.ui.document:getWordFromPosition({
-                x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-                y = pos.y + pos.h * 3/4
-            })
-        end
-    end
-
-    -- helper function to update crosshairs positioning and self.hold_pos
-    local function updatePositions(hold_x, hold_y, indicator_x, indicator_y)
-        self.hold_pos = self.view:screenToPageTransform({ x = hold_x, y = hold_y })
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos.x = indicator_x
-        self._current_indicator_pos.y = indicator_y
-    end
-    -- Determine positions based on word type and layout.
-    if is_word_split then
-        if BD.mirroredUILayout() then -- RTL
-            updatePositions(
-                pos.x + pos.w,          -- rightmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x + pos.w,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        else
-            updatePositions(
-                pos.x,                  -- leftmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        end
-    else
-        updatePositions(
-            -- set hold_pos to center of selected_text to make center selection more stable, not JITted at edge
-            pos.x + pos.w / 2,          -- center of word horizontally
-            pos.y + pos.h / 2,          -- center of word vertically
-            pos.x + pos.w / 2 - self._current_indicator_pos.w / 2,
-            pos.y + pos.h / 2 - self._current_indicator_pos.h / 2
-        )
-    end
-    return true
-end
-
-function ReaderHighlight:onHighlightModifierPress()
-    if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
-    if not self._start_indicator_highlight then
-        self:onHighlightPress(true)
-        return true -- don't trigger hotkeys during text selection
-    end
-    -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
-    self.long_hold_reached = true
-    self:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-    self:onStopHighlightIndicator()
-    return true
-end
-
-function ReaderHighlight:onStartHighlightIndicator()
-    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
-    self.long_hold_reached_action = function() end
-    if self.view.visible_area and not self._current_indicator_pos then
-        -- set start position to centor of page
-        local rect = self._previous_indicator_pos
-        if not rect then
-            rect = Geom:new()
-            rect.x = self.view.visible_area.w / 2
-            rect.y = self.view.visible_area.h / 2
-            rect.w = Size.item.height_default
-            rect.h = rect.w
-        end
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
-        return true
-    end
-    return false
-end
-
-function ReaderHighlight:onStopHighlightIndicator(need_clear_selection)
-    if not self._current_indicator_pos then return false end
-    -- If we're in select mode and user presses back, end the selection
-    if self.select_mode and self.highlight_idx then
-        self.select_mode = false
-        if self.ui.annotation.annotations[self.highlight_idx].is_tmp then
-            self:deleteHighlight(self.highlight_idx) -- temporary highlight, delete it
-        else
-            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
-        end
-        self.highlight_idx = nil
-    end
-
-    local rect = self._current_indicator_pos
-    self._previous_indicator_pos = rect
-    self._start_indicator_highlight = false
-    self._current_indicator_pos = nil
-    self.view.highlight.indicator = nil
-    UIManager:setDirty(self.dialog, "ui", rect)
-    if need_clear_selection then
-        self:clear()
-    end
-    return true
-end
-
-function ReaderHighlight:onMoveHighlightIndicator(args)
-    if self.view.visible_area and self._current_indicator_pos then
-        local dx, dy, quick_move = unpack(args)
-        local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
-        local quick_move_distance_dy = self.view.visible_area.h * (1/5)
-        -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
-        local rect = self._current_indicator_pos:copy()
-        if quick_move then
-            rect.x = rect.x + quick_move_distance_dx * dx
-            rect.y = rect.y + quick_move_distance_dy * dy
-        else
-            local now = time:now()
-            if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
-                local diff = now - self._last_indicator_move_args.time
-                -- if user presses same arrow key within 1 second (default, user adjustable), speed up
-                -- double press: 4 single move distances, usually move to next word or line
-                -- triple press: 16 single distances, usually skip several words or lines
-                -- quadruple press: 64 single distances, almost move to screen edge
-                if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
-                    -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                    if diff < time.s( t_inter ) then
-                        move_distance = self._last_indicator_move_args.distance * 4
-                    end
-                end
-            end
-            rect.x = rect.x + move_distance * dx
-            rect.y = rect.y + move_distance * dy
-            self._last_indicator_move_args.distance = move_distance
-            self._last_indicator_move_args.dx = dx
-            self._last_indicator_move_args.dy = dy
-            self._last_indicator_move_args.time = now
-        end
-        if rect.x < 0 then
-            rect.x = 0
-        end
-        if rect.x + rect.w > self.view.visible_area.w then
-            rect.x = self.view.visible_area.w - rect.w
-        end
-        -- make sure we account for both the status bar and alt status bar so we don't overlap them with the indicator
-        local alt_status_bar_height = 0
-        if self.ui.rolling and self.ui.document.configurable.status_line == 0 then
-            alt_status_bar_height = self.ui.document:getHeaderHeight()
-        end
-        if rect.y < alt_status_bar_height then
-            rect.y = alt_status_bar_height
-        end
-        local footer_height = self.view.footer_visible and self.view.footer:getHeight() or 0
-        local status_bar_height = self.ui.rolling and footer_height or 0 -- for PDFs, status bar is already accounted for
-        if rect.y + rect.h > self.view.visible_area.h - status_bar_height then
-            rect.y = self.view.visible_area.h - status_bar_height - rect.h
-        end
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
-        if self._start_indicator_highlight then
-            self:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
-        end
-        return true
-    end
-    return false
-end
-
-function ReaderHighlight:_createHighlightGesture(gesture)
-    local point = self._current_indicator_pos:copy()
-    point.x = point.x + point.w / 2
-    point.y = point.y + point.h / 2
-    point.w = 0
-    point.h = 0
-    return {
-        ges = gesture,
-        pos = point,
-        time = time.realtime(),
-    }
 end
 
 return ReaderHighlight

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -98,7 +98,7 @@ function ReaderHighlight:init()
                     this:startSelection(index)
                     this:onClose()
                     if not Device:isTouchDevice() then
-                        self:onStartHighlightIndicator()
+                        self.ui.keyselection:startHighlightIndicator()
                     end
                 end,
             }
@@ -1591,7 +1591,7 @@ function ReaderHighlight:onHold(arg, ges)
             with_title_bar = false, -- more room for image
             fullscreen = true,
         })
-        self.ui.keyselection:onStopHighlightIndicator()
+        self.ui.keyselection:stopHighlightIndicator()
         return true
     end
 

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -225,6 +225,10 @@ function ReaderKeySelection:onStartOrMoveHighlightIndicator(args)
     return true
 end
 
+function ReaderKeySelection:isActive()
+    return self._current_indicator_pos ~= nil
+end
+
 function ReaderKeySelection:startHighlightIndicator()
     -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
     self.ui.highlight.long_hold_reached_action = function() end
@@ -404,6 +408,27 @@ function ReaderKeySelection:moveHighlightIndicator(args)
         self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
     end
     return true
+end
+
+function ReaderKeySelection:pageTurnDuringSelection()
+    self._edge_dx, self._edge_dy = nil, nil
+    self._previous_indicator_word = nil
+    local last_pos = self._current_indicator_pos
+    local target_x = last_pos.x + last_pos.w * 0.5
+    local target_y = last_pos.y + last_pos.h * 0.5
+
+    local new_word = self:_getNearestWordFromScreenPoint(target_x, target_y)
+    if new_word then
+        self:_setIndicatorToWord(new_word)
+        if not self.ui.highlight.select_mode and self._start_indicator_highlight then
+            self.ui.highlight:startSelection()
+            -- we don't want to HoldPan during moveHighlightIndicator, a following Press
+            -- key should close the startSelection loop though.
+            self._start_indicator_highlight = nil -- breaks the `if moved and self._ then`
+        end
+    else
+        self:stopHighlightIndicator(true)
+    end
 end
 
 function ReaderKeySelection:_isSingleWord(word)

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -40,8 +40,9 @@ end
 function ReaderKeySelection:registerKeyEvents()
     if Device:hasDPad() then
         self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
-        self.key_events.UpHighlightIndicator    = { { "Up" },    event = "MoveHighlightIndicator", args = {0, -1} }
-        self.key_events.DownHighlightIndicator  = { { "Down" },  event = "MoveHighlightIndicator", args = {0, 1} }
+        local event = Device:useDPadAsActionKeys() and "StartOrMoveHighlightIndicator" or "MoveHighlightIndicator"
+        self.key_events.UpHighlightIndicator    = { { "Up" },    event = event, args = {0, -1} }
+        self.key_events.DownHighlightIndicator  = { { "Down" },  event = event, args = {0, 1} }
         -- let hasFewKeys device move the indicator left
         self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
         self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
@@ -56,7 +57,7 @@ function ReaderKeySelection:registerKeyEvents()
         self.key_events.QuickLeftHighlightIndicator  = { { modifier, "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICATOR_MOVE} }
         self.key_events.QuickRightHighlightIndicator = { { modifier, "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICATOR_MOVE} }
         self.key_events.HighlightModifierPress       = { { modifier, "Press" } }
-        -- onStartHighlightIndicator (H) is handled by hotkeys.koplugin
+        -- startHighlightIndicator (H) is handled by hotkeys.koplugin
     end
 end
 ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.registerKeyEvents
@@ -181,23 +182,53 @@ function ReaderKeySelection:addToMainMenu(menu_items)
     end
 end
 
+-- for dispatcher and hotkeys
+function ReaderKeySelection:onStartHighlightIndicator()
+    return self:startHighlightIndicator()
+end
+
+function ReaderKeySelection:onStopHighlightIndicator(need_clear_selection)
+    return self:stopHighlightIndicator(need_clear_selection)
+end
+
 function ReaderKeySelection:onHighlightPress(skip_tap_check)
+    return self:highlightPress(skip_tap_check)
+end
+
+function ReaderKeySelection:onHighlightModifierPress()
+    return self:highlightModifierPress()
+end
+
+function ReaderKeySelection:onMoveHighlightIndicator(args)
+    return self:moveHighlightIndicator(args)
+end
+
+function ReaderKeySelection:onStartOrMoveHighlightIndicator(args)
+    if not self._current_indicator_pos then
+        self:startHighlightIndicator()
+    else
+        self:moveHighlightIndicator(args)
+    end
+    return true
+end
+
+function ReaderKeySelection:highlightPress(skip_tap_check)
     if not self._current_indicator_pos then return false end
     if self._start_indicator_highlight then
         self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
+        self:stopHighlightIndicator()
         return true
     end
     -- Check if we're in select mode (or extending an existing highlight)
     if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
         self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
         self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-        self:onStopHighlightIndicator()
+        self:stopHighlightIndicator()
         return true
     end
     -- Attempt to open an existing highlight
     if not skip_tap_check and self.ui.highlight:onTap(nil, self:_createHighlightGesture("tap")) then
-        self:onStopHighlightIndicator(true) -- need_clear_selection=true
+        self:stopHighlightIndicator(true) -- need_clear_selection=true
         return true
     end
     -- no existing highlight at current indicator position: start hold
@@ -278,20 +309,20 @@ function ReaderKeySelection:onHighlightPress(skip_tap_check)
     return true
 end
 
-function ReaderKeySelection:onHighlightModifierPress()
+function ReaderKeySelection:highlightModifierPress()
     if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
     if not self._start_indicator_highlight then
-        self:onHighlightPress(true)
+        self:highlightPress(true)
         return true -- don't trigger hotkeys during text selection
     end
     -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
     self.ui.highlight.long_hold_reached = true
     self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
-    self:onStopHighlightIndicator()
+    self:stopHighlightIndicator()
     return true
 end
 
-function ReaderKeySelection:onStartHighlightIndicator()
+function ReaderKeySelection:startHighlightIndicator()
     -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
     self.ui.highlight.long_hold_reached_action = function() end
     if self.view.visible_area and not self._current_indicator_pos then
@@ -312,7 +343,7 @@ function ReaderKeySelection:onStartHighlightIndicator()
     return false
 end
 
-function ReaderKeySelection:onStopHighlightIndicator(need_clear_selection)
+function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
     if not self._current_indicator_pos then return false end
     -- If we're in select mode and user presses back, end the selection
     if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
@@ -337,7 +368,7 @@ function ReaderKeySelection:onStopHighlightIndicator(need_clear_selection)
     return true
 end
 
-function ReaderKeySelection:onMoveHighlightIndicator(args)
+function ReaderKeySelection:moveHighlightIndicator(args)
     if self.view.visible_area and self._current_indicator_pos then
         local dx, dy, quick_move = unpack(args)
         local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -4,16 +4,23 @@ local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
+local Size = require("ui/size")
 local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
-local logger = require("logger")
-local Size = require("ui/size")
-local time = require("ui/time")
-local Screen = Device.screen
 local ffiUtil = require("ffi/util")
+local logger = require("logger")
+local time = require("ui/time")
 local _ = require("gettext")
+local Screen = Device.screen
 local N_ = _.ngettext
 local T = ffiUtil.template
+
+-- see https://www.lua.org/gems/sample.pdf for Lua Performance Tips
+-- GC Optimisations
+local math_abs = math.abs
+local math_max = math.max
+local math_min = math.min
+local math_floor = math.floor
 
 local ReaderKeySelection = InputContainer:extend{}
 
@@ -24,10 +31,16 @@ function ReaderKeySelection:init()
     self:registerKeyEvents()
     self.screen_w = Screen:getWidth()
     self.screen_h = Screen:getHeight()
+    self._previous_indicator_word = nil
     self._start_indicator_highlight = false
     self._current_indicator_pos = nil
     self._previous_indicator_pos = nil
-    self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+    self._vertical_move_anchor_x = nil
+    self._last_move_was_vertical = false
+    self._edge_dx = nil
+    self._edge_dy = nil
+    self._last_move_was_quick_move = nil
+    self.mirroredUI = BD.mirroredUILayout()
     self.ui:registerPostInitCallback(function()
         self.ui.menu:registerToMainMenu(self)
     end)
@@ -60,7 +73,7 @@ function ReaderKeySelection:registerKeyEvents()
         -- startHighlightIndicator (H) is handled by hotkeys.koplugin
     end
 end
-ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.registerKeyEvents
+ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.init
 
 function ReaderKeySelection:addToMainMenu(menu_items)
     if Device:isTouchDevice() or not Device:hasDPad() then return end
@@ -117,7 +130,7 @@ function ReaderKeySelection:addToMainMenu(menu_items)
             return G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
         end,
         enabled_func = function()
-            return not self.view.highlight.disabled
+            return not self.view.highlight.disabled and not self.ui.rolling
         end,
         callback = function()
             G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
@@ -130,7 +143,7 @@ function ReaderKeySelection:addToMainMenu(menu_items)
         end,
         separator = true, -- needed as this is not the last item, readerlink adds another one
         enabled_func = function()
-            return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
+            return not self.ui.rolling and not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
         end,
         callback = function(touchmenu_instance)
             local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
@@ -212,6 +225,69 @@ function ReaderKeySelection:onStartOrMoveHighlightIndicator(args)
     return true
 end
 
+function ReaderKeySelection:startHighlightIndicator()
+    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
+    self.ui.highlight.long_hold_reached_action = function() end
+    if self.view.visible_area and not self._current_indicator_pos then
+        local rect = self._previous_indicator_pos
+        -- set start position to centre of page
+        if not rect then
+            rect = Geom:new()
+            rect.x = self.view.visible_area.w * 0.5
+            rect.y = self.view.visible_area.h * 0.5
+            rect.w = Size.item.height_default
+            rect.h = rect.w
+        end
+        self._current_indicator_pos = rect
+        if self.ui.paging then
+            self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+            self.view.highlight.indicator = rect
+            UIManager:setDirty(self.dialog, "ui", rect)
+            return true
+        end
+        local center_x = rect.x + rect.w * 0.5
+        local center_y = rect.y + rect.h * 0.5
+        local nearest_word = self:_getNearestWordFromScreenPoint(center_x, center_y)
+        if nearest_word then
+            self:_setIndicatorToWord(nearest_word)
+        else
+            self:stopHighlightIndicator()
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
+    if not self._current_indicator_pos then return false end
+    -- If we're in select mode and user presses back, end the selection
+    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+        self.ui.highlight.select_mode = false
+        if self.ui.annotation.annotations[self.ui.highlight.highlight_idx].is_tmp then
+            self.ui.highlight:deleteHighlight(self.ui.highlight.highlight_idx) -- temporary highlight, delete it
+        else
+            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+        end
+        self.ui.highlight.highlight_idx = nil
+    end
+    local rect = self._current_indicator_pos
+    self._previous_indicator_pos = rect
+    self._vertical_move_anchor_x = nil
+    self._last_move_was_vertical = false
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self.view.highlight.indicator = nil
+    self._edge_dx, self._edge_dy = nil, nil
+    self._last_move_was_quick_move = nil
+    self._previous_indicator_word = nil
+    self._last_indicator_move_args = nil
+    UIManager:setDirty(self.dialog, "ui", rect)
+    if need_clear_selection then
+        self.ui.highlight:clear()
+    end
+    return true
+end
+
 function ReaderKeySelection:highlightPress(skip_tap_check)
     if not self._current_indicator_pos then return false end
     if self._start_indicator_highlight then
@@ -234,78 +310,6 @@ function ReaderKeySelection:highlightPress(skip_tap_check)
     -- no existing highlight at current indicator position: start hold
     self._start_indicator_highlight = true
     self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
-
-    if not (self.ui.rolling and self.ui.highlight.selected_text and self.ui.highlight.selected_text.sboxes and #self.ui.highlight.selected_text.sboxes > 0) then
-        return true
-    end
-    -- With crengine, selected_text.sboxes have good coordinates, so we'll borrow them.
-    local pos = self.ui.highlight.selected_text.sboxes[1]
-    local margins = self.ui.document.configurable.h_page_margins[1] + self.ui.document.configurable.h_page_margins[2]
-    local two_column_mode = self.ui.document.configurable.visible_pages == 2
-    local effective_width = two_column_mode and (self.screen_w - margins) / 2 or self.screen_w - margins
-    -- When words are split (and hyphenated) due to line breaks, they create selection boxes that are almost as wide as the
-    -- effective_width, so we need to check if that is the case, in order to handle those cases properly. We cannot precisely
-    -- and easily recognise hyphenated words in the front end, so a heuristic approach is used, it goes in two steps.
-    -- Step one: check if our box is a 'big boy'. We must allow some room for unknown variables like publisher-embedded padding, etc.
-    local is_word_split = pos.w > 0.7 * effective_width
-    -- Step two: weed out false positives (i.e long words) by comparing words found at different box coordinates.
-    if is_word_split then
-        -- In the case of a split (and hyphenated) word, we should get distinct words at different coordinates inside the box,
-        -- false positives on the other hand, should return the same word at different coordinates.
-        local word_at_pos1 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-            y = pos.y + pos.h * 1/4 -- puts us at a potential line 1 of 2
-        })
-        local word_at_pos2 = self.ui.document:getWordFromPosition({
-            x = BD.mirroredUILayout() and pos.x or pos.x + pos.w,
-            y = pos.y + pos.h * 3/4 -- puts us at a potential line 2 of 2
-        })
-        local does_word_at_pos1_match = word_at_pos1 and word_at_pos1.word == self.ui.highlight.selected_text.text
-        local does_word_at_pos2_match = word_at_pos2 and word_at_pos2.word == self.ui.highlight.selected_text.text
-        -- If all 3 words are a match, then we're likely not a split word, just a very long one, something worthy of floccinaucinihilipilification.
-        if does_word_at_pos1_match and does_word_at_pos2_match then
-            is_word_split = false -- check mate
-        else -- We're reasonably sure the word was split (and hyphenated). Re-select the original word to ensure the correct word is highlighted.
-            self.ui.document:getWordFromPosition({
-                x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
-                y = pos.y + pos.h * 3/4
-            })
-        end
-    end
-
-    -- helper function to update crosshairs positioning and self.hold_pos
-    local function updatePositions(hold_x, hold_y, indicator_x, indicator_y)
-        self.hold_pos = self.view:screenToPageTransform({ x = hold_x, y = hold_y })
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos.x = indicator_x
-        self._current_indicator_pos.y = indicator_y
-    end
-    -- Determine positions based on word type and layout.
-    if is_word_split then
-        if BD.mirroredUILayout() then -- RTL
-            updatePositions(
-                pos.x + pos.w,          -- rightmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x + pos.w,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        else
-            updatePositions(
-                pos.x,                  -- leftmost point
-                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
-                pos.x,
-                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
-            )
-        end
-    else
-        updatePositions(
-            -- set hold_pos to center of selected_text to make center selection more stable, not JITted at edge
-            pos.x + pos.w / 2,          -- center of word horizontally
-            pos.y + pos.h / 2,          -- center of word vertically
-            pos.x + pos.w / 2 - self._current_indicator_pos.w / 2,
-            pos.y + pos.h / 2 - self._current_indicator_pos.h / 2
-        )
-    end
     return true
 end
 
@@ -322,121 +326,600 @@ function ReaderKeySelection:highlightModifierPress()
     return true
 end
 
-function ReaderKeySelection:startHighlightIndicator()
-    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
-    self.ui.highlight.long_hold_reached_action = function() end
-    if self.view.visible_area and not self._current_indicator_pos then
-        -- set start position to centor of page
-        local rect = self._previous_indicator_pos
-        if not rect then
-            rect = Geom:new()
-            rect.x = self.view.visible_area.w / 2
-            rect.y = self.view.visible_area.h / 2
-            rect.w = Size.item.height_default
-            rect.h = rect.w
-        end
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
+function ReaderKeySelection:moveHighlightIndicator(args)
+    if not (self.view.visible_area and self._current_indicator_pos) then return false end
+    local dx, dy, quick_move = unpack(args)
+    if dx == self._edge_dx and dy == self._edge_dy and self._last_move_was_quick_move == quick_move then
+        -- don't waste resources trying to move in a direction that we know is blocked
+        -- Note: the self._last_move_was_quick_move == quick_move is important because we don't
+        --       want a quick_move (which does not wrap around) to block a legitimate wrap around.
+        logger.dbg("ReaderKeySelection: Previous boundary hit in this direction, skipping move attempt.")
         return true
     end
-    return false
-end
+    local moved = false
 
-function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
-    if not self._current_indicator_pos then return false end
-    -- If we're in select mode and user presses back, end the selection
-    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
-        self.ui.highlight.select_mode = false
-        if self.ui.annotation.annotations[self.ui.highlight.highlight_idx].is_tmp then
-            self.ui.highlight:deleteHighlight(self.ui.highlight.highlight_idx) -- temporary highlight, delete it
-        else
-            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
-        end
-        self.ui.highlight.highlight_idx = nil
-    end
-
-    local rect = self._current_indicator_pos
-    self._previous_indicator_pos = rect
-    self._start_indicator_highlight = false
-    self._current_indicator_pos = nil
-    self.view.highlight.indicator = nil
-    UIManager:setDirty(self.dialog, "ui", rect)
-    if need_clear_selection then
-        self.ui.highlight:clear()
-    end
-    return true
-end
-
-function ReaderKeySelection:moveHighlightIndicator(args)
-    if self.view.visible_area and self._current_indicator_pos then
-        local dx, dy, quick_move = unpack(args)
-        local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
-        local quick_move_distance_dy = self.view.visible_area.h * (1/5)
-        -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
-        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
-        local rect = self._current_indicator_pos:copy()
-        if quick_move then
-            rect.x = rect.x + quick_move_distance_dx * dx
-            rect.y = rect.y + quick_move_distance_dy * dy
-        else
-            local now = time:now()
-            if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
-                local diff = now - self._last_indicator_move_args.time
-                -- if user presses same arrow key within 1 second (default, user adjustable), speed up
-                -- double press: 4 single move distances, usually move to next word or line
-                -- triple press: 16 single distances, usually skip several words or lines
-                -- quadruple press: 64 single distances, almost move to screen edge
-                if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
-                    -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
-                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
-                    if diff < time.s( t_inter ) then
-                        move_distance = self._last_indicator_move_args.distance * 4
-                    end
-                end
-            end
-            rect.x = rect.x + move_distance * dx
-            rect.y = rect.y + move_distance * dy
-            self._last_indicator_move_args.distance = move_distance
-            self._last_indicator_move_args.dx = dx
-            self._last_indicator_move_args.dy = dy
-            self._last_indicator_move_args.time = now
-        end
-        if rect.x < 0 then
-            rect.x = 0
-        end
-        if rect.x + rect.w > self.view.visible_area.w then
-            rect.x = self.view.visible_area.w - rect.w
-        end
-        -- make sure we account for both the status bar and alt status bar so we don't overlap them with the indicator
-        local alt_status_bar_height = 0
-        if self.ui.rolling and self.ui.document.configurable.status_line == 0 then
-            alt_status_bar_height = self.ui.document:getHeaderHeight()
-        end
-        if rect.y < alt_status_bar_height then
-            rect.y = alt_status_bar_height
-        end
-        local footer_height = self.view.footer_visible and self.view.footer:getHeight() or 0
-        local status_bar_height = self.ui.rolling and footer_height or 0 -- for PDFs, status bar is already accounted for
-        if rect.y + rect.h > self.view.visible_area.h - status_bar_height then
-            rect.y = self.view.visible_area.h - status_bar_height - rect.h
-        end
-        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
-        self._current_indicator_pos = rect
-        self.view.highlight.indicator = rect
-        UIManager:setDirty(self.dialog, "ui", rect)
-        if self._start_indicator_highlight then
+    -- PDF/DjVu uses the old free form text selector mode.
+    if self.ui.paging then
+        moved = self:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
+        if moved and self._start_indicator_highlight then
             self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
         end
         return true
     end
-    return false
+
+    local is_vertical_move = dx == 0 and dy ~= 0
+    self._last_move_was_quick_move = quick_move
+    local current_word = self._previous_indicator_word
+    logger.dbg("ReaderKeySelection: Current cached word:", current_word and current_word.word or "nil", "| dx:", dx, "| dy:", dy, "| quick_move:", quick_move)
+    if not current_word then
+        current_word = self:_getCurrentIndicatorWord(dx, dy)
+    end
+
+    if is_vertical_move then
+        if not self._last_move_was_vertical or not self._vertical_move_anchor_x then
+            -- remember x coordinate so subsequent vertical moves can try to stay in the same horizontal "band"
+            self._vertical_move_anchor_x = self._current_indicator_pos.x + self._current_indicator_pos.w * 0.5
+        end
+        if current_word and current_word.pos0 then
+            if quick_move then
+                local _, current_anchor_y = self:_getWordAnchorCoordinates(current_word)
+                local target_y = current_anchor_y + (self.view.visible_area.h * (1/5) * dy)
+                if target_y < 0 then
+                    target_y = 0
+                elseif target_y > self.view.visible_area.h then
+                    target_y = self.view.visible_area.h
+                end
+                local nearest_vertical_word = self:_getQuickVerticalWordRolling(
+                    self._vertical_move_anchor_x,
+                    target_y,
+                    dy,
+                    current_word,
+                    current_anchor_y
+                )
+                if nearest_vertical_word then
+                    moved = self:_setIndicatorToWord(nearest_vertical_word)
+                else -- Keep moving in the requested direction if no target-band word was found.
+                    moved = self:_moveIndicatorCreDoc(current_word, 0, dy, 1, false, self._vertical_move_anchor_x)
+                end
+                if moved and self._edge_dx and self._edge_dy then
+                    self._edge_dx, self._edge_dy = nil, nil
+                end
+            else -- Always move line-by-line vertically in rolling mode.
+                moved = self:_moveIndicatorCreDoc(current_word, 0, dy, 1, false, self._vertical_move_anchor_x)
+            end
+        end -- if current_word
+        self._last_move_was_vertical = true
+    else
+        self._vertical_move_anchor_x = nil
+        self._last_move_was_vertical = false
+        if current_word and current_word.pos0 then
+            local steps = quick_move and 4 or 1
+            local no_wrap_horizontal = quick_move and dx ~= 0
+            moved = self:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal)
+        end
+    end
+
+    if moved and self._start_indicator_highlight then
+        self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
+    end
+    return true
+end
+
+function ReaderKeySelection:_isSingleWord(word)
+    if not word or not word.word then return false end
+    local trimmed_word = word.word:match("^%s*(.-)%s*$") or word.word
+    if trimmed_word:match("%s") then
+        return false
+    end
+    return true
+end
+
+function ReaderKeySelection:_isSplitHyphenatedWord(word)
+    if not word or not word.pos0 or not word.pos1 then return false end
+    -- A single hyphenated word does not contain spaces in the middle.
+    if not self:_isSingleWord(word) then
+        return false
+    end
+    -- Avoid pulling crengine layout data twice if we've already cached it for this word
+    if word.segments then
+        return #word.segments > 1 and word.segments[1].y ~= word.segments[#word.segments].y
+    end
+    local segments = self.ui.document:getScreenBoxesFromPositions(word.pos0, word.pos1, true)
+    if not segments or #segments == 0 then return false end
+    -- Cache the segments directly onto the word object for downstream geometry targeting
+    word.segments = segments
+    -- A word is deterministically split across a line break if it returns multiple
+    -- fragment boxes that exist on completely different vertical coordinates.
+    local is_split = #segments > 1 and segments[1].y ~= segments[#segments].y
+    if is_split then
+        logger.dbg("ReaderKeySelection: Deterministic split word detected:", word.word)
+    end
+    return is_split
+end
+
+-- X-based head/tail logic that manages RTL layout translation
+function ReaderKeySelection:_resolveSplitWordFromX(word, x_pos)
+    if not self:_isSplitHyphenatedWord(word) then
+        return word, word.sbox.y
+    end
+    local head_box = word.segments[1]
+    local tail_box = word.segments[#word.segments]
+
+    local right_half = x_pos > (word.sbox.x + word.sbox.w * 0.5)
+    -- LTR: Right side is the end of line 1 (head). RTL: Right side is the start of line 2 (tail).
+    local is_head
+    if self.mirroredUI then
+        is_head = not right_half
+    else
+        is_head = right_half
+    end
+    if is_head then
+        word.is_split_fragment = "head"
+        return word, head_box.y
+    else
+        word.is_split_fragment = "tail"
+        return word, tail_box.y
+    end
+end
+
+function ReaderKeySelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal, preferred_center_x)
+    local target_word = current_word
+    local did_move = false
+    local lock_line_center_y
+    local lock_line_tolerance
+
+    if no_wrap_horizontal and dx ~= 0 then
+        local _, cy = self:_getWordAnchorCoordinates(current_word)
+        lock_line_center_y = self._current_indicator_pos and (self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5) or cy
+
+        local line_h = Size.item.height_default
+        if current_word.sbox and not self:_isSplitHyphenatedWord(current_word) then
+            line_h = current_word.sbox.h
+        end
+        lock_line_tolerance = math_max(1, line_h * 0.5)
+    end
+
+    for _ = 1, steps do
+        local step_word
+        if dx ~= 0 then
+            local drop_off_head = dx > 0
+            local drop_off_tail = dx < 0
+            if self.mirroredUI then
+                drop_off_head, drop_off_tail = drop_off_tail, drop_off_head
+            end
+            -- Pre-emptive wrap guard: If we are on a split fragment edge and no_wrap is true,
+            -- stepping "off" the edge is a guaranteed line wrap.
+            if no_wrap_horizontal and target_word.is_split_fragment then
+                if (drop_off_head and target_word.is_split_fragment == "head") or
+                   (drop_off_tail and target_word.is_split_fragment == "tail") then
+                    logger.dbg("ReaderKeySelection: Semantic wrap prevented on split word edge.")
+                    break -- Terminate wrap before mutating state
+                end
+            end
+
+            step_word = self:_getAdjacentWordRolling(target_word, dx, lock_line_center_y, lock_line_tolerance)
+            -- The engine's logical traversal will happily wrap to the next physical line at the margins.
+            -- Because _getAdjacentWordRolling relies on these logical XPointer jumps, we must enforce
+            -- a strict physical boundary check after the word is found.
+            -- If the Y-coordinate of the new word drifts vertically outside our locked horizontal band,
+            -- it means a line wrap occurred. If horizontal wrapping is forbidden, we abort the move.
+            if step_word and no_wrap_horizontal and step_word ~= target_word then
+                local _, next_cy = self:_getWordAnchorCoordinates(step_word)
+                if math_abs(next_cy - lock_line_center_y) > lock_line_tolerance then
+                    break
+                end
+            end
+        else
+            step_word = self:_getAdjacentLineWordRolling(target_word, dy, preferred_center_x)
+        end
+
+        if not step_word then
+            -- Set the edge cache: We've hit a physical or logical wall.
+            self._edge_dx, self._edge_dy = dx, dy
+            break
+        end
+        self._edge_dx, self._edge_dy = nil, nil
+        target_word = step_word
+        did_move = true
+    end
+
+    if did_move then
+        self:_setIndicatorToWord(target_word)
+    end
+    return did_move
+end
+
+function ReaderKeySelection:_setIndicatorToWord(word)
+    if not word or not word.sbox then return false end
+    local rect = self._current_indicator_pos:copy()
+    local anchor_x, anchor_y, is_split = self:_getWordAnchorCoordinates(word)
+    rect.x = is_split and anchor_x or (anchor_x - rect.w * 0.5)
+    rect.y = anchor_y - rect.h * 0.5
+    self:_setIndicatorRect(rect)
+    self._previous_indicator_word = word
+    return true
+end
+
+function ReaderKeySelection:_setIndicatorRect(rect)
+    UIManager:setDirty(self.dialog, "fast", self._current_indicator_pos)
+    self._current_indicator_pos = rect
+    self.view.highlight.indicator = self._current_indicator_pos
+    UIManager:setDirty(self.dialog, "fast", self._current_indicator_pos)
+end
+
+function ReaderKeySelection:_getWordAnchorCoordinates(word)
+    if not word or not word.sbox then
+        return nil, nil, false
+    end
+    local sbox = word.sbox
+    -- Fallback for when the word hasn't been flagged yet
+    if not word.is_split_fragment and self:_isSplitHyphenatedWord(word) then
+        -- Infer fragment from the indicator position.
+        if self._current_indicator_pos and word.segments and #word.segments > 1 then
+            local indicator_cy = self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5
+            local head_box = word.segments[1]
+            local tail_box = word.segments[#word.segments]
+            local midpoint_y = (head_box.y + tail_box.y + tail_box.h) * 0.5
+            if indicator_cy <= midpoint_y then
+                word.is_split_fragment = "head"
+            else
+                word.is_split_fragment = "tail"
+            end
+        end
+    end
+    if word.is_split_fragment then
+        -- Grab the width of the crosshairs so we can tuck it inside the bounding box
+        local ind_w = self._current_indicator_pos and self._current_indicator_pos.w or 0
+        if word.is_split_fragment == "head" and word.segments then
+            -- Target the physical box of the head fragment
+            local head_box = word.segments[1]
+            local x = self.mirroredUI and head_box.x or (head_box.x + head_box.w - ind_w)
+            local y = head_box.y + head_box.h * 0.5
+            return x, y, true
+        elseif word.is_split_fragment == "tail" and word.segments then
+            -- Target the physical box of the tail fragment
+            local tail_box = word.segments[#word.segments]
+            local x = self.mirroredUI and (tail_box.x + tail_box.w - ind_w) or tail_box.x
+            local y = tail_box.y + tail_box.h * 0.5
+            return x, y, true
+        end
+    end
+    return sbox.x + sbox.w * 0.5, sbox.y + sbox.h * 0.5, false
+end
+
+function ReaderKeySelection:_getWordFromScreenPoint(screen_x, screen_y, dx, dy)
+    local probe = {}
+    if screen_x >= 0 and screen_x <= self.view.visible_area.w and screen_y >= 0 and screen_y <= self.view.visible_area.h then
+        probe.x = screen_x
+        probe.y = screen_y
+        local pos = self.view:screenToPageTransform(probe)
+        local word = self.ui.document:getWordFromPosition(pos, true)
+        if word and word.sbox then
+            return word
+        end
+    end
+    if (dx == nil or dx == 0) and (dy == nil or dy == 0) then return nil end
+
+    local step = math_max(4, math_floor(Size.item.height_default * 0.5))
+    local max_distance = math_max(self.view.visible_area.w, self.view.visible_area.h)
+
+    for dist = step, max_distance, step do
+        local px = screen_x + dx * dist
+        local py = screen_y + dy * dist
+        if px >= 0 and px <= self.view.visible_area.w and py >= 0 and py <= self.view.visible_area.h then
+            probe.x = px
+            probe.y = py
+            local pos = self.view:screenToPageTransform(probe)
+            local word = self.ui.document:getWordFromPosition(pos, true)
+            if word and word.sbox then return word end
+        end
+    end
+end
+
+function ReaderKeySelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
+    local probe = { x = screen_x, y = screen_y }
+    local pos = self.view:screenToPageTransform(probe)
+    local doc = self.ui.document
+
+    local origin_word = doc:getWordFromPosition(pos, true)
+    if origin_word and origin_word.sbox then
+        logger.dbg("ReaderKeySelection: Exact word found at position:", origin_word.word)
+        if self:_isSingleWord(origin_word) then
+            return origin_word
+        end
+    end
+    -- No exact word found, perform a ripple search for the nearest word
+    local nearest_word = doc:getNearestWordAndBoxFromPosition(pos, 0) -- 0 means DIR_ANY, search the entire page
+    if nearest_word and nearest_word.sbox then
+        logger.dbg("ReaderKeySelection: No word at exact position. Nearest word is:", nearest_word.word)
+        return nearest_word
+    end
+    logger.dbg("ReaderKeySelection: No word found in current page.")
+    return nil
+end
+
+function ReaderKeySelection:_getCurrentIndicatorWord(dx, dy)
+    local center_x = self._current_indicator_pos.x + self._current_indicator_pos.w * 0.5
+    local center_y = self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5
+    local word = self:_getWordFromScreenPoint(center_x, center_y, dx, dy)
+
+    -- State Recovery: Re-stamp the mega-box based on the indicator's physical position
+    if word and word.sbox and not word.is_split_fragment then
+        if self:_isSplitHyphenatedWord(word) then
+            local midpoint_y = word.sbox.y + (word.sbox.h * 0.5)
+            -- Y-coordinates are absolute, universally bypassing RTL rules
+            if center_y < midpoint_y then
+                word.is_split_fragment = "head"
+                logger.dbg("ReaderKeySelection: State recovered -> Head")
+            else
+                word.is_split_fragment = "tail"
+                logger.dbg("ReaderKeySelection: State recovered -> Tail")
+            end
+        end
+    end
+    self._previous_indicator_word = word
+    return word
+end
+
+function ReaderKeySelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy, exclude_word, current_anchor_y)
+    local doc = self.ui.document
+    -- Prevent wrapping off the current page.
+    local safe_y = math_max(self.view.visible_area.y, math_min(target_y, self.view.visible_area.y + self.view.visible_area.h))
+
+    local probe = { x = anchor_x, y = safe_y }
+    -- let Crengine's native fuzzy search do the work
+    local candidate = doc:getWordFromPosition(probe, true)
+
+    if not candidate or not candidate.sbox then
+        logger.dbg("ReaderKeySelection: Quick move failed - no word found at target.")
+        return nil
+    end
+
+    if exclude_word and exclude_word.pos0 and candidate.pos0 == exclude_word.pos0 then
+        logger.dbg("ReaderKeySelection: Quick move rejected - hit origin word.")
+        return nil
+    end
+
+    local candidate_sy
+    candidate, candidate_sy = self:_resolveSplitWordFromX(candidate, anchor_x)
+
+    local line_tol = (exclude_word and exclude_word.sbox) and math_max(1, exclude_word.sbox.h * 0.5) or math_max(1, Size.item.height_default * 0.5)
+    if current_anchor_y then
+        if math_abs(candidate_sy - current_anchor_y) <= line_tol then
+            logger.dbg("ReaderKeySelection: Quick move rejected - did not clear current line.")
+            return nil
+        end
+        if dy < 0 and candidate_sy >= current_anchor_y - line_tol then return nil end
+        if dy > 0 and candidate_sy <= current_anchor_y + line_tol then return nil end
+    end
+
+    logger.dbg("ReaderKeySelection: Quick vertical jump success to:", candidate.word)
+    return candidate
+end
+
+function ReaderKeySelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
+    if not word or not word.pos0 then return nil end
+    local is_forward_physical = (not self.mirroredUI and direction > 0) or (self.mirroredUI and direction < 0)
+    -- If we're on one half of a split word, the next 'line' is just the other half.
+    if self:_isSplitHyphenatedWord(word) then
+        if is_forward_physical and word.is_split_fragment == "head" then
+            logger.dbg("ReaderKeySelection: Internal jump Forward -> Tail")
+            word.is_split_fragment = "tail"
+            return word
+        elseif not is_forward_physical and word.is_split_fragment == "tail" then
+            logger.dbg("ReaderKeySelection: Internal jump Backward -> Head")
+            word.is_split_fragment = "head"
+            return word
+        end
+    end
+    local doc = self.ui.document
+    -- Map physical direction to logical XPointer direction
+    local logical_dir = self.mirroredUI and -direction or direction
+
+    -- Advance strictly via logical XPointer to perfectly step over BiDi traps
+    local next_xp = logical_dir > 0 and doc:getNextVisibleWordStart(word.pos0) or doc:getPrevVisibleWordStart(word.pos0)
+    if not next_xp or next_xp == word.pos0 then
+        logger.dbg("ReaderKeySelection: Reached logical end of stream.")
+        return nil
+    end
+    -- For hyphenated words straddled across different pages, tails are not detected so we need to physically
+    -- probe for them, otherwise indicator will hit a boundary before the fragment.
+    if not doc:isXPointerInCurrentPage(next_xp) then
+        logger.dbg("ReaderKeySelection: Logical boundary hit. Attempting physical horizontal probe.")
+        local probe = {}
+        if self.mirroredUI then
+            probe.x = is_forward_physical and (word.sbox.x - 10) or (word.sbox.x + word.sbox.w + 10)
+        else
+            probe.x = is_forward_physical and (word.sbox.x + word.sbox.w + 10) or (word.sbox.x - 10)
+        end
+        probe.y = lock_line_center_y or (word.sbox.y + word.sbox.h * 0.5)
+        local probe_word = self:_getWordFromScreenPoint(probe.x, probe.y, direction, 0)
+
+        if probe_word and probe_word.sbox and probe_word.pos0 ~= word.pos0 then
+            -- Directional Entry state stamping
+            if not probe_word.is_split_fragment and self:_isSplitHyphenatedWord(probe_word) then
+                probe_word.is_split_fragment = is_forward_physical and "head" or "tail"
+            end
+            logger.dbg("ReaderKeySelection: Physical probe rescued word:", probe_word.word)
+            return probe_word
+        end
+        return nil
+    end
+
+    -- Recover the word's end pointer logically
+    local end_xp = doc:getNextVisibleWordEnd(next_xp)
+    if not end_xp then return nil end
+    -- Reconstruct the full word indicator object natively
+    local word_boxes = doc:getScreenBoxesFromPositions(next_xp, end_xp, true)
+    if not word_boxes or #word_boxes == 0 then return nil end
+    local candidate = {
+        word = doc:getTextFromXPointers(next_xp, end_xp),
+        pos0 = next_xp,
+        pos1 = end_xp,
+        sbox = Geom.boundingBox(word_boxes),
+        segments = word_boxes,
+    }
+    -- Directional Entry: Stamp the initial state on newly discovered split words
+    if not candidate.is_split_fragment and self:_isSplitHyphenatedWord(candidate) then
+        if is_forward_physical then
+            logger.dbg("ReaderKeySelection: External entry Forward -> Head")
+            candidate.is_split_fragment = "head"
+        else
+            logger.dbg("ReaderKeySelection: External entry Backward -> Tail")
+            candidate.is_split_fragment = "tail"
+        end
+    end
+    -- Enforce the physical bounds logic for rolling within a locked line if provided
+    if lock_line_center_y and lock_line_tolerance then
+        local candidate_center_y = candidate.sbox.y + candidate.sbox.h * 0.5
+        if math_abs(candidate_center_y - lock_line_center_y) > lock_line_tolerance then
+            return nil
+        end
+    end
+
+    return candidate
+end
+
+function ReaderKeySelection:_getAdjacentLineWordRolling(word, direction, preferred_center_x)
+    if not (word and word.pos0 and word.sbox) then return end
+
+    local doc = self.ui.document
+    local target_x = preferred_center_x or (word.sbox.x + word.sbox.w * 0.5)
+
+    -- Align to the physical top of the line to prevent offset drift
+    local start_sy
+    if word.is_split_fragment == "head" and word.segments then
+        start_sy = word.segments[1].y
+    elseif word.is_split_fragment == "tail" and word.segments then
+        start_sy = word.segments[#word.segments].y
+    else
+        -- Page Boundary Fallback
+        local valid_xp = doc:isXPointerInCurrentPage(word.pos0) and word.pos0 or word.pos1
+        start_sy = doc:getScreenPositionFromXPointer(valid_xp) or word.sbox.y
+    end
+
+    local logical_h = Size.item.height_default
+    local line_tol = logical_h * 0.3
+
+    logger.dbg("ReaderKeySelection: Start ultra-lean search. AnchorY:", start_sy, "| TargetX:", target_x, "| Dir:", direction)
+
+    local current_xp = word.pos0
+    local target_line_y, fallback_sx, fallback_sy = nil, nil, nil
+
+    -- Phase 1: Fast logical skip (Burn through the current line and break immediately)
+    for _ = 1, 80 do
+        local next_xp = direction > 0 and doc:getNextVisibleWordStart(current_xp) or doc:getPrevVisibleWordStart(current_xp)
+        if not next_xp or next_xp == current_xp then
+            logger.dbg("ReaderKeySelection: Break - end of stream.")
+            break
+        end
+        current_xp = next_xp
+
+        if not doc:isXPointerInCurrentPage(next_xp) then
+            logger.dbg("ReaderKeySelection: Break - hit page boundary.")
+            break
+        end
+
+        local sy, sx = doc:getScreenPositionFromXPointer(next_xp)
+        if not sy or not sx then break end
+
+        local is_new_line = (direction > 0 and sy > start_sy + line_tol) or (direction < 0 and sy < start_sy - line_tol)
+        if is_new_line then
+            target_line_y, fallback_sx, fallback_sy = sy, sx, sy
+            logger.dbg("ReaderKeySelection: Target line hit at Y:", sy, "- Breaking loop.")
+            break -- The magic bullet: Stop scanning. We have our Y-coordinate.
+        end
+    end
+
+    -- Phase 2: Physical Probe (The single heavy lift)
+    local probe = {}
+    probe.x = target_x
+    probe.y = target_line_y or (start_sy + (direction * logical_h))
+    local probe_word = doc:getWordFromPosition(probe, true)
+
+    local best_word = nil
+    if probe_word and probe_word.sbox and probe_word.pos0 ~= word.pos0 then
+        local evaluate_y
+        -- Determine fragment state and adjust physical Y before clamping
+        probe_word, evaluate_y = self:_resolveSplitWordFromX(probe_word, target_x)
+        -- Strict Y-Clamp to prevent <br/> boxes or fuzzy search drift
+        if not (evaluate_y and target_line_y and math_abs(evaluate_y - target_line_y) > line_tol) then
+            best_word = probe_word
+        else
+            logger.dbg("ReaderKeySelection: Physical probe rejected - out of bounds:", evaluate_y)
+        end
+    end
+
+    -- Phase 3: Fallback (If the line is short and the physical probe grabbed empty space)
+    if not best_word and fallback_sx and fallback_sy then
+        logger.dbg("ReaderKeySelection: Probe failed. Falling back to logical edge word.")
+        probe.x = fallback_sx
+        probe.y = fallback_sy
+        best_word = doc:getWordFromPosition(probe, true)
+    end
+
+    if best_word then
+        logger.dbg("ReaderKeySelection: Success. Best word:", best_word.word)
+    else
+        logger.dbg("ReaderKeySelection: Failed to find valid adjacent word.")
+    end
+
+    return best_word
+end
+
+function ReaderKeySelection:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
+    local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
+    local quick_move_distance_dy = self.view.visible_area.h * (1/5)
+    -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
+    local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
+    local rect = self._current_indicator_pos:copy()
+    if quick_move then
+        rect.x = rect.x + quick_move_distance_dx * dx
+        rect.y = rect.y + quick_move_distance_dy * dy
+    else
+        local now = time:now()
+        if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
+            local diff = now - self._last_indicator_move_args.time
+            -- if user presses same arrow key within 1 second (default, user adjustable), speed up
+            -- double press: 4 single move distances, usually move to next word or line
+            -- triple press: 16 single distances, usually skip several words or lines
+            -- quadruple press: 64 single distances, almost move to screen edge
+            if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
+                -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
+                local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                if diff < time.s( t_inter ) then
+                    move_distance = self._last_indicator_move_args.distance * 4
+                end
+            end
+        end
+        rect.x = rect.x + move_distance * dx
+        rect.y = rect.y + move_distance * dy
+        self._last_indicator_move_args.distance = move_distance
+        self._last_indicator_move_args.dx = dx
+        self._last_indicator_move_args.dy = dy
+        self._last_indicator_move_args.time = now
+    end
+    if rect.x < 0 then
+        rect.x = 0
+    end
+    if rect.x + rect.w > self.view.visible_area.w then
+        rect.x = self.view.visible_area.w - rect.w
+    end
+    if rect.y < 0 then
+        rect.y = 0
+    end
+    if rect.y + rect.h > self.view.visible_area.h then
+        rect.y = self.view.visible_area.h - rect.h
+    end
+    local moved = rect.x ~= self._current_indicator_pos.x or rect.y ~= self._current_indicator_pos.y
+    self:_setIndicatorRect(rect)
+    return moved
 end
 
 function ReaderKeySelection:_createHighlightGesture(gesture)
     local point = self._current_indicator_pos:copy()
-    point.x = point.x + point.w / 2
-    point.y = point.y + point.h / 2
+    point.x = point.x + point.w * 0.5
+    point.y = point.y + point.h * 0.5
     point.w = 0
     point.h = 0
     return {

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -24,9 +24,9 @@ local math_floor = math.floor
 -- Reusable table for FFI probes to avoid repeated allocations.
 local SHARED_PROBE = { x = 0, y = 0 }
 
-local ReaderTextSelection = InputContainer:extend{}
+local ReaderKeySelection = InputContainer:extend{}
 
-function ReaderTextSelection:init()
+function ReaderKeySelection:init()
     if Device:isTouchDevice() and not Device:hasDPad() then
         return
     end
@@ -48,11 +48,11 @@ function ReaderTextSelection:init()
     end)
 end
 
-function ReaderTextSelection:onSetDimensions(dimen)
+function ReaderKeySelection:onSetDimensions(dimen)
     self.screen_w, self.screen_h = dimen.w, dimen.h
 end
 
-function ReaderTextSelection:registerKeyEvents()
+function ReaderKeySelection:registerKeyEvents()
     if Device:hasDPad() then
         self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
         local event = Device:useDPadAsActionKeys() and "StartOrMoveHighlightIndicator" or "MoveHighlightIndicator"
@@ -75,9 +75,9 @@ function ReaderTextSelection:registerKeyEvents()
         -- startHighlightIndicator (H) is handled by hotkeys.koplugin
     end
 end
-ReaderTextSelection.onPhysicalKeyboardConnected = ReaderTextSelection.init
+ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.init
 
-function ReaderTextSelection:addToMainMenu(menu_items)
+function ReaderKeySelection:addToMainMenu(menu_items)
     if Device:isTouchDevice() or not Device:hasDPad() then return end
     -- insert table to main reader menu
     if not Device:useDPadAsActionKeys() then
@@ -198,27 +198,27 @@ function ReaderTextSelection:addToMainMenu(menu_items)
 end
 
 -- for dispatcher and hotkeys
-function ReaderTextSelection:onStartHighlightIndicator()
+function ReaderKeySelection:onStartHighlightIndicator()
     return self:startHighlightIndicator()
 end
 
-function ReaderTextSelection:onStopHighlightIndicator(need_clear_selection)
+function ReaderKeySelection:onStopHighlightIndicator(need_clear_selection)
     return self:stopHighlightIndicator(need_clear_selection)
 end
 
-function ReaderTextSelection:onHighlightPress(skip_tap_check)
+function ReaderKeySelection:onHighlightPress(skip_tap_check)
     return self:highlightPress(skip_tap_check)
 end
 
-function ReaderTextSelection:onHighlightModifierPress()
+function ReaderKeySelection:onHighlightModifierPress()
     return self:highlightModifierPress()
 end
 
-function ReaderTextSelection:onMoveHighlightIndicator(args)
+function ReaderKeySelection:onMoveHighlightIndicator(args)
     return self:moveHighlightIndicator(args)
 end
 
-function ReaderTextSelection:onStartOrMoveHighlightIndicator(args)
+function ReaderKeySelection:onStartOrMoveHighlightIndicator(args)
     if not self._current_indicator_pos then
         self:startHighlightIndicator()
     else
@@ -227,11 +227,11 @@ function ReaderTextSelection:onStartOrMoveHighlightIndicator(args)
     return true
 end
 
-function ReaderTextSelection:isActive()
+function ReaderKeySelection:isActive()
     return self._current_indicator_pos ~= nil
 end
 
-function ReaderTextSelection:startHighlightIndicator()
+function ReaderKeySelection:startHighlightIndicator()
     -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
     self.ui.highlight.long_hold_reached_action = function() end
     if self.view.visible_area and not self._current_indicator_pos then
@@ -265,7 +265,7 @@ function ReaderTextSelection:startHighlightIndicator()
     return false
 end
 
-function ReaderTextSelection:stopHighlightIndicator(need_clear_selection)
+function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
     if not self._current_indicator_pos then return false end
     -- If we're in select mode and user presses back, end the selection
     if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
@@ -294,7 +294,7 @@ function ReaderTextSelection:stopHighlightIndicator(need_clear_selection)
     return true
 end
 
-function ReaderTextSelection:highlightPress(skip_tap_check)
+function ReaderKeySelection:highlightPress(skip_tap_check)
     if not self._current_indicator_pos then return false end
     if self._start_indicator_highlight then
         self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
@@ -326,7 +326,7 @@ function ReaderTextSelection:highlightPress(skip_tap_check)
     return true
 end
 
-function ReaderTextSelection:highlightModifierPress()
+function ReaderKeySelection:highlightModifierPress()
     if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
     if not self._start_indicator_highlight then
         self:highlightPress(true)
@@ -339,14 +339,14 @@ function ReaderTextSelection:highlightModifierPress()
     return true
 end
 
-function ReaderTextSelection:moveHighlightIndicator(args)
+function ReaderKeySelection:moveHighlightIndicator(args)
     if not (self.view.visible_area and self._current_indicator_pos) then return false end
     local dx, dy, quick_move = unpack(args)
     if dx == self._edge_dx and dy == self._edge_dy and self._last_move_was_quick_move == quick_move then
         -- don't waste resources trying to move in a direction that we know is blocked
         -- Note: the self._last_move_was_quick_move == quick_move is important because we don't
         --       want a quick_move (which does not wrap around) to block a legitimate wrap around.
-        logger.dbg("ReaderTextSelection: Previous boundary hit in this direction, skipping move attempt.")
+        logger.dbg("ReaderKeySelection: Previous boundary hit in this direction, skipping move attempt.")
         return true
     end
     local moved = false
@@ -363,7 +363,7 @@ function ReaderTextSelection:moveHighlightIndicator(args)
     local is_vertical_move = dx == 0 and dy ~= 0
     self._last_move_was_quick_move = quick_move
     local current_word = self._previous_indicator_word
-    logger.dbg("ReaderTextSelection: Current cached word:", current_word and current_word.word or "nil", "| dx:", dx, "| dy:", dy, "| quick_move:", quick_move)
+    logger.dbg("ReaderKeySelection: Current cached word:", current_word and current_word.word or "nil", "| dx:", dx, "| dy:", dy, "| quick_move:", quick_move)
     if not current_word then
         current_word = self:_getCurrentIndicatorWord(dx, dy)
     end
@@ -418,7 +418,7 @@ function ReaderTextSelection:moveHighlightIndicator(args)
     return true
 end
 
-function ReaderTextSelection:pageTurnDuringSelection()
+function ReaderKeySelection:pageTurnDuringSelection()
     self._edge_dx, self._edge_dy = nil, nil
     self._previous_indicator_word = nil
     local last_pos = self._current_indicator_pos
@@ -440,7 +440,7 @@ function ReaderTextSelection:pageTurnDuringSelection()
     end
 end
 
-function ReaderTextSelection:_isSingleWord(word)
+function ReaderKeySelection:_isSingleWord(word)
     local trimmed_word = word.word:match("^%s*(.-)%s*$") or word.word
     if trimmed_word:match("%s") then
         return false
@@ -448,7 +448,7 @@ function ReaderTextSelection:_isSingleWord(word)
     return true
 end
 
-function ReaderTextSelection:_isSplitHyphenatedWord(word)
+function ReaderKeySelection:_isSplitHyphenatedWord(word)
     if not word or not word.pos0 or not word.pos1 then return false end
     -- A single hyphenated word does not contain spaces in the middle.
     if not self:_isSingleWord(word) then
@@ -466,13 +466,13 @@ function ReaderTextSelection:_isSplitHyphenatedWord(word)
     -- fragment boxes that exist on completely different vertical coordinates.
     local is_split = #segments > 1 and segments[1].y ~= segments[#segments].y
     if is_split then
-        logger.dbg("ReaderTextSelection: Deterministic split word detected:", word.word)
+        logger.dbg("ReaderKeySelection: Deterministic split word detected:", word.word)
     end
     return is_split
 end
 
 -- X-based head/tail logic that manages RTL layout translation
-function ReaderTextSelection:_resolveSplitWordFromX(word, x_pos)
+function ReaderKeySelection:_resolveSplitWordFromX(word, x_pos)
     if not self:_isSplitHyphenatedWord(word) then
         return word, word.sbox.y
     end
@@ -499,7 +499,7 @@ function ReaderTextSelection:_resolveSplitWordFromX(word, x_pos)
     end
 end
 
-function ReaderTextSelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal, preferred_center_x)
+function ReaderKeySelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal, preferred_center_x)
     local target_word = current_word
     local did_move = false
     local lock_line_center_y
@@ -529,7 +529,7 @@ function ReaderTextSelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, n
             if no_wrap_horizontal and target_word.is_split_fragment then
                 if (drop_off_head and target_word.is_split_fragment == "head") or
                    (drop_off_tail and target_word.is_split_fragment == "tail") then
-                    logger.dbg("ReaderTextSelection: Semantic wrap prevented on split word edge.")
+                    logger.dbg("ReaderKeySelection: Semantic wrap prevented on split word edge.")
                     break -- Terminate wrap before mutating state
                 end
             end
@@ -566,7 +566,7 @@ function ReaderTextSelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, n
     return did_move
 end
 
-function ReaderTextSelection:_setIndicatorToWord(word)
+function ReaderKeySelection:_setIndicatorToWord(word)
     if not word or not word.sbox then return false end
     local rect = self._current_indicator_pos:copy()
     local anchor_x, anchor_y, is_split = self:_getWordAnchorCoordinates(word)
@@ -577,14 +577,14 @@ function ReaderTextSelection:_setIndicatorToWord(word)
     return true
 end
 
-function ReaderTextSelection:_setIndicatorRect(rect)
+function ReaderKeySelection:_setIndicatorRect(rect)
     UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
     self._current_indicator_pos = rect
     self.view.highlight.indicator = self._current_indicator_pos
     UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
 end
 
-function ReaderTextSelection:_getWordAnchorCoordinates(word)
+function ReaderKeySelection:_getWordAnchorCoordinates(word)
     if not word or not word.sbox then
         return nil, nil, false
     end
@@ -628,7 +628,7 @@ function ReaderTextSelection:_getWordAnchorCoordinates(word)
     return sbox.x + sbox.w * 0.5, sbox.y + sbox.h * 0.5, false
 end
 
-function ReaderTextSelection:_getWordFromScreenPoint(screen_x, screen_y, dx, dy)
+function ReaderKeySelection:_getWordFromScreenPoint(screen_x, screen_y, dx, dy)
     if screen_x >= 0 and screen_x <= self.view.visible_area.w and screen_y >= 0 and screen_y <= self.view.visible_area.h then
         SHARED_PROBE.x = screen_x
         SHARED_PROBE.y = screen_y
@@ -656,7 +656,7 @@ function ReaderTextSelection:_getWordFromScreenPoint(screen_x, screen_y, dx, dy)
     end
 end
 
-function ReaderTextSelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
+function ReaderKeySelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
     SHARED_PROBE.x = screen_x
     SHARED_PROBE.y = screen_y
     local pos = self.view:screenToPageTransform(SHARED_PROBE)
@@ -664,7 +664,7 @@ function ReaderTextSelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
 
     local origin_word = doc:getWordFromPosition(pos, true)
     if origin_word and origin_word.sbox then
-        logger.dbg("ReaderTextSelection: Exact word found at position:", origin_word.word)
+        logger.dbg("ReaderKeySelection: Exact word found at position:", origin_word.word)
         if self:_isSingleWord(origin_word) then
             return origin_word
         end
@@ -672,14 +672,14 @@ function ReaderTextSelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
     -- No exact word found, perform a ripple search for the nearest word
     local nearest_word = doc:getNearestWordAndBoxFromPosition(pos, 0) -- 0 means DIR_ANY, search the entire page
     if nearest_word and nearest_word.sbox then
-        logger.dbg("ReaderTextSelection: No word at exact position. Nearest word is:", nearest_word.word)
+        logger.dbg("ReaderKeySelection: No word at exact position. Nearest word is:", nearest_word.word)
         return nearest_word
     end
-    logger.dbg("ReaderTextSelection: No word found in current page.")
+    logger.dbg("ReaderKeySelection: No word found in current page.")
     return nil
 end
 
-function ReaderTextSelection:_getCurrentIndicatorWord(dx, dy)
+function ReaderKeySelection:_getCurrentIndicatorWord(dx, dy)
     local center_x = self._current_indicator_pos.x + self._current_indicator_pos.w * 0.5
     local center_y = self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5
     local word = self:_getWordFromScreenPoint(center_x, center_y, dx, dy)
@@ -691,10 +691,10 @@ function ReaderTextSelection:_getCurrentIndicatorWord(dx, dy)
             -- Y-coordinates are absolute, universally bypassing RTL rules
             if center_y < midpoint_y then
                 word.is_split_fragment = "head"
-                logger.dbg("ReaderTextSelection: State recovered -> Head")
+                logger.dbg("ReaderKeySelection: State recovered -> Head")
             else
                 word.is_split_fragment = "tail"
-                logger.dbg("ReaderTextSelection: State recovered -> Tail")
+                logger.dbg("ReaderKeySelection: State recovered -> Tail")
             end
         end
     end
@@ -702,7 +702,7 @@ function ReaderTextSelection:_getCurrentIndicatorWord(dx, dy)
     return word
 end
 
-function ReaderTextSelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy, exclude_word, current_anchor_y)
+function ReaderKeySelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy, exclude_word, current_anchor_y)
     local doc = self.ui.document
     -- Prevent wrapping off the current page.
     local safe_y = math_max(self.view.visible_area.y, math_min(target_y, self.view.visible_area.y + self.view.visible_area.h))
@@ -713,12 +713,12 @@ function ReaderTextSelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy
     local candidate = doc:getWordFromPosition(SHARED_PROBE, true)
 
     if not candidate or not candidate.sbox then
-        logger.dbg("ReaderTextSelection: Quick move failed - no word found at target.")
+        logger.dbg("ReaderKeySelection: Quick move failed - no word found at target.")
         return nil
     end
 
     if exclude_word and exclude_word.pos0 and candidate.pos0 == exclude_word.pos0 then
-        logger.dbg("ReaderTextSelection: Quick move rejected - hit origin word.")
+        logger.dbg("ReaderKeySelection: Quick move rejected - hit origin word.")
         return nil
     end
 
@@ -728,18 +728,18 @@ function ReaderTextSelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy
     local line_tol = (exclude_word and exclude_word.sbox) and math_max(1, exclude_word.sbox.h * 0.5) or math_max(1, Size.item.height_default * 0.5)
     if current_anchor_y then
         if math_abs(candidate_sy - current_anchor_y) <= line_tol then
-            logger.dbg("ReaderTextSelection: Quick move rejected - did not clear current line.")
+            logger.dbg("ReaderKeySelection: Quick move rejected - did not clear current line.")
             return nil
         end
         if dy < 0 and candidate_sy >= current_anchor_y - line_tol then return nil end
         if dy > 0 and candidate_sy <= current_anchor_y + line_tol then return nil end
     end
 
-    logger.dbg("ReaderTextSelection: Quick vertical jump success to:", candidate.word)
+    logger.dbg("ReaderKeySelection: Quick vertical jump success to:", candidate.word)
     return candidate
 end
 
-function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
+function ReaderKeySelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
     if not word or not word.pos0 then return nil end
     local is_forward_physical = (not self.mirroredUI and direction > 0) or (self.mirroredUI and direction < 0)
     if self.invert_ui_layout then
@@ -749,11 +749,11 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
     -- If we're on one half of a split word, the next 'line' is just the other half.
     if self:_isSplitHyphenatedWord(word) then
         if is_forward_physical and word.is_split_fragment == "head" then
-            logger.dbg("ReaderTextSelection: Internal jump Forward -> Tail")
+            logger.dbg("ReaderKeySelection: Internal jump Forward -> Tail")
             word.is_split_fragment = "tail"
             return word
         elseif not is_forward_physical and word.is_split_fragment == "tail" then
-            logger.dbg("ReaderTextSelection: Internal jump Backward -> Head")
+            logger.dbg("ReaderKeySelection: Internal jump Backward -> Head")
             word.is_split_fragment = "head"
             return word
         end
@@ -765,13 +765,13 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
     -- Advance strictly via logical XPointer to perfectly step over BiDi traps
     local next_xp = logical_dir > 0 and doc:getNextVisibleWordStart(word.pos0) or doc:getPrevVisibleWordStart(word.pos0)
     if not next_xp or next_xp == word.pos0 then
-        logger.dbg("ReaderTextSelection: Reached logical end of stream.")
+        logger.dbg("ReaderKeySelection: Reached logical end of stream.")
         return nil
     end
     -- For hyphenated words straddled across different pages, tails are not detected so we need to phycally
     -- probe for them, otherwise indicator will hit a boundary before the fragment.
     if not doc:isXPointerInCurrentPage(next_xp) then
-        logger.dbg("ReaderTextSelection: Logical boundary hit. Attempting physical horizontal probe.")
+        logger.dbg("ReaderKeySelection: Logical boundary hit. Attempting physical horizontal probe.")
         local head_is_left = self.mirroredUI
         if self.invert_ui_layout then
             head_is_left = not head_is_left
@@ -789,7 +789,7 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
             if not probe_word.is_split_fragment and self:_isSplitHyphenatedWord(probe_word) then
                 probe_word.is_split_fragment = is_forward_physical and "head" or "tail"
             end
-            logger.dbg("ReaderTextSelection: Physical probe rescued word:", probe_word.word)
+            logger.dbg("ReaderKeySelection: Physical probe rescued word:", probe_word.word)
             return probe_word
         end
         return nil
@@ -810,10 +810,10 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
     -- Directional Entry: Stamp the initial state on newly discovered split words
     if not candidate.is_split_fragment and self:_isSplitHyphenatedWord(candidate) then
         if is_forward_physical then
-            logger.dbg("ReaderTextSelection: External entry Forward -> Head")
+            logger.dbg("ReaderKeySelection: External entry Forward -> Head")
             candidate.is_split_fragment = "head"
         else
-            logger.dbg("ReaderTextSelection: External entry Backward -> Tail")
+            logger.dbg("ReaderKeySelection: External entry Backward -> Tail")
             candidate.is_split_fragment = "tail"
         end
     end
@@ -828,7 +828,7 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
     return candidate
 end
 
-function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, preferred_center_x)
+function ReaderKeySelection:_getAdjacentLineWordRolling(word, direction, preferred_center_x)
     if not (word and word.pos0 and word.sbox) then return end
 
     local doc = self.ui.document
@@ -849,7 +849,7 @@ function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, prefer
     local logical_h = Size.item.height_default
     local line_tol = logical_h * 0.3
 
-    logger.dbg("ReaderTextSelection: Start ultra-lean search. AnchorY:", start_sy, "| TargetX:", target_x, "| Dir:", direction)
+    logger.dbg("ReaderKeySelection: Start ultra-lean search. AnchorY:", start_sy, "| TargetX:", target_x, "| Dir:", direction)
 
     local current_xp = word.pos0
     local target_line_y, fallback_sx, fallback_sy = nil, nil, nil
@@ -858,13 +858,13 @@ function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, prefer
     for _ = 1, 80 do
         local next_xp = direction > 0 and doc:getNextVisibleWordStart(current_xp) or doc:getPrevVisibleWordStart(current_xp)
         if not next_xp or next_xp == current_xp then
-            logger.dbg("ReaderTextSelection: Break - end of stream.")
+            logger.dbg("ReaderKeySelection: Break - end of stream.")
             break
         end
         current_xp = next_xp
 
         if not doc:isXPointerInCurrentPage(next_xp) then
-            logger.dbg("ReaderTextSelection: Break - hit page boundary.")
+            logger.dbg("ReaderKeySelection: Break - hit page boundary.")
             break
         end
 
@@ -874,7 +874,7 @@ function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, prefer
         local is_new_line = (direction > 0 and sy > start_sy + line_tol) or (direction < 0 and sy < start_sy - line_tol)
         if is_new_line then
             target_line_y, fallback_sx, fallback_sy = sy, sx, sy
-            logger.dbg("ReaderTextSelection: Target line hit at Y:", sy, "- Breaking loop.")
+            logger.dbg("ReaderKeySelection: Target line hit at Y:", sy, "- Breaking loop.")
             break -- The magic bullet: Stop scanning. We have our Y-coordinate.
         end
     end
@@ -893,28 +893,28 @@ function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, prefer
         if not (evaluate_y and target_line_y and math_abs(evaluate_y - target_line_y) > line_tol) then
             best_word = probe_word
         else
-            logger.dbg("ReaderTextSelection: Physical probe rejected - out of bounds:", evaluate_y)
+            logger.dbg("ReaderKeySelection: Physical probe rejected - out of bounds:", evaluate_y)
         end
     end
 
     -- Phase 3: Fallback (If the line is short and the physical probe grabbed empty space)
     if not best_word and fallback_sx and fallback_sy then
-        logger.dbg("ReaderTextSelection: Probe failed. Falling back to logical edge word.")
+        logger.dbg("ReaderKeySelection: Probe failed. Falling back to logical edge word.")
         SHARED_PROBE.x = fallback_sx
         SHARED_PROBE.y = fallback_sy
         best_word = doc:getWordFromPosition(SHARED_PROBE, true)
     end
 
     if best_word then
-        logger.dbg("ReaderTextSelection: Success. Best word:", best_word.word)
+        logger.dbg("ReaderKeySelection: Success. Best word:", best_word.word)
     else
-        logger.dbg("ReaderTextSelection: Failed to find valid adjacent word.")
+        logger.dbg("ReaderKeySelection: Failed to find valid adjacent word.")
     end
 
     return best_word
 end
 
-function ReaderTextSelection:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
+function ReaderKeySelection:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
     local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
     local quick_move_distance_dy = self.view.visible_area.h * (1/5)
     -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
@@ -963,7 +963,7 @@ function ReaderTextSelection:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
     return moved
 end
 
-function ReaderTextSelection:_createHighlightGesture(gesture)
+function ReaderKeySelection:_createHighlightGesture(gesture)
     local point = self._current_indicator_pos:copy()
     point.x = point.x + point.w * 0.5
     point.y = point.y + point.h * 0.5
@@ -976,4 +976,4 @@ function ReaderTextSelection:_createHighlightGesture(gesture)
     }
 end
 
-return ReaderTextSelection
+return ReaderKeySelection

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -247,6 +247,7 @@ function ReaderKeySelection:startHighlightIndicator()
         end
         local center_x = rect.x + rect.w * 0.5
         local center_y = rect.y + rect.h * 0.5
+        self.invert_ui_layout = self.view:shouldInvertBiDiLayoutMirroring()
         local nearest_word = self:_getNearestWordFromScreenPoint(center_x, center_y)
         if nearest_word then
             self:_setIndicatorToWord(nearest_word)
@@ -453,6 +454,9 @@ function ReaderKeySelection:_resolveSplitWordFromX(word, x_pos)
     else
         is_head = right_half
     end
+    if self.invert_ui_layout then
+        is_head = not is_head
+    end
     if is_head then
         word.is_split_fragment = "head"
         return word, head_box.y
@@ -568,18 +572,22 @@ function ReaderKeySelection:_getWordAnchorCoordinates(word)
         end
     end
     if word.is_split_fragment then
+        local head_is_left = self.mirroredUI
+        if self.invert_ui_layout then
+            head_is_left = not head_is_left
+        end
         -- Grab the width of the crosshairs so we can tuck it inside the bounding box
         local ind_w = self._current_indicator_pos and self._current_indicator_pos.w or 0
         if word.is_split_fragment == "head" and word.segments then
             -- Target the physical box of the head fragment
             local head_box = word.segments[1]
-            local x = self.mirroredUI and head_box.x or (head_box.x + head_box.w - ind_w)
+            local x = head_is_left and head_box.x or (head_box.x + head_box.w - ind_w)
             local y = head_box.y + head_box.h * 0.5
             return x, y, true
         elseif word.is_split_fragment == "tail" and word.segments then
             -- Target the physical box of the tail fragment
             local tail_box = word.segments[#word.segments]
-            local x = self.mirroredUI and (tail_box.x + tail_box.w - ind_w) or tail_box.x
+            local x = head_is_left and (tail_box.x + tail_box.w - ind_w) or tail_box.x
             local y = tail_box.y + tail_box.h * 0.5
             return x, y, true
         end
@@ -700,6 +708,10 @@ end
 function ReaderKeySelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
     if not word or not word.pos0 then return nil end
     local is_forward_physical = (not self.mirroredUI and direction > 0) or (self.mirroredUI and direction < 0)
+    if self.invert_ui_layout then
+        is_forward_physical = not is_forward_physical
+        direction = -direction
+    end
     -- If we're on one half of a split word, the next 'line' is just the other half.
     if self:_isSplitHyphenatedWord(word) then
         if is_forward_physical and word.is_split_fragment == "head" then
@@ -726,8 +738,12 @@ function ReaderKeySelection:_getAdjacentWordRolling(word, direction, lock_line_c
     -- probe for them, otherwise indicator will hit a boundary before the fragment.
     if not doc:isXPointerInCurrentPage(next_xp) then
         logger.dbg("ReaderKeySelection: Logical boundary hit. Attempting physical horizontal probe.")
+        local head_is_left = self.mirroredUI
+        if self.invert_ui_layout then
+            head_is_left = not head_is_left
+        end
         local probe = {}
-        if self.mirroredUI then
+        if head_is_left then
             probe.x = is_forward_physical and (word.sbox.x - 10) or (word.sbox.x + word.sbox.w + 10)
         else
             probe.x = is_forward_physical and (word.sbox.x + word.sbox.w + 10) or (word.sbox.x - 10)

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -1,12 +1,19 @@
 local BD = require("ui/bidi")
 local Device = require("device")
+local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local ReaderHighlight = require("apps/reader/modules/readerhighlight")
+local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local Size = require("ui/size")
 local time = require("ui/time")
 local Screen = Device.screen
+local ffiUtil = require("ffi/util")
+local _ = require("gettext")
+local N_ = _.ngettext
+local T = ffiUtil.template
 
 local ReaderKeySelection = InputContainer:extend{}
 
@@ -21,6 +28,9 @@ function ReaderKeySelection:init()
     self._current_indicator_pos = nil
     self._previous_indicator_pos = nil
     self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+    self.ui:registerPostInitCallback(function()
+        self.ui.menu:registerToMainMenu(self)
+    end)
 end
 
 function ReaderKeySelection:onSetDimensions(dimen)
@@ -50,6 +60,126 @@ function ReaderKeySelection:registerKeyEvents()
     end
 end
 ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.registerKeyEvents
+
+function ReaderKeySelection:addToMainMenu(menu_items)
+    if Device:isTouchDevice() or not Device:hasDPad() then return end
+    -- insert table to main reader menu
+    if not Device:useDPadAsActionKeys() then
+        menu_items.start_content_selection = {
+            text = _("Start text selection"),
+            callback = function()
+                self:onStartHighlightIndicator()
+            end,
+        }
+    end
+    -- we allow user to select the rate at which the content selection tool moves through screen
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
+            local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
+            return T(_("Crosshairs speed (reader/dict): %1 / %2"), reader_speed, dict_speed)
+        end,
+        callback = function(touchmenu_instance)
+            local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
+            local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
+            local double_spin_widget = DoubleSpinWidget:new{
+                left_text = _("Reader") .. " PDF/DjVu",
+                left_value = reader_speed,
+                left_min = 0.25,
+                left_max = 5,
+                left_default = 4,
+                left_precision = "%.2f",
+                left_step = 0.25,
+                left_hold_step = 0.05,
+                right_text = _("Dictionary"),
+                right_value = dict_speed,
+                right_min = 0.25,
+                right_max = 5,
+                right_default = 3,
+                right_precision = "%.2f",
+                right_step = 0.25,
+                right_hold_step = 0.05,
+                title_text = _("Crosshairs speed"),
+                info_text = _("Select a decimal value from 0.25 to 5. A smaller value increases the travel distance of the crosshairs per keystroke. Font size and this value are inversely correlated, meaning a smaller font size requires a larger value and vice versa."),
+                callback = function(left_value, right_value)
+                    G_reader_settings:saveSetting("highlight_non_touch_factor", left_value)
+                    G_reader_settings:saveSetting("highlight_non_touch_factor_dict", right_value)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end
+            }
+            UIManager:show(double_spin_widget)
+        end,
+    })
+    table.insert(menu_items.long_press.sub_item_table, {
+        text = _("Increase crosshairs speed on consecutive keystrokes"),
+        checked_func = function()
+            return G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
+        end,
+        enabled_func = function()
+            return not self.view.highlight.disabled
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
+        end,
+    })
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+            return T(N_("Interval for crosshairs speed increase: 1 second", "Interval for crosshairs speed increase: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
+        end,
+        separator = true, -- needed as this is not the last item, readerlink adds another one
+        enabled_func = function()
+            return not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
+        end,
+        callback = function(touchmenu_instance)
+            local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+            local spin_widget = SpinWidget:new{
+                value = curr_val,
+                value_min = 0.1,
+                value_max = 1,
+                precision = "%.1f",
+                value_step = 0.1,
+                default_value = 1,
+                title_text = _("Time interval"),
+                info_text = _("Select a decimal value up to 1 second. This defines the time period within which multiple keystrokes will trigger an increase in the crosshairs speed."),
+                callback = function(spin)
+                    G_reader_settings:saveSetting("highlight_non_touch_interval", spin.value)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end
+            }
+            UIManager:show(spin_widget)
+        end,
+    })
+
+    if menu_items.long_press then
+        local long_press_action = ReaderHighlight.long_press_action
+        -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
+        -- Clone long_press settings, and change its label, making it much more meaningful for non-touch device users.
+        menu_items.selection_text = {
+            text = _("Text selection tools"),
+            sub_item_table = {
+                menu_items.long_press.sub_item_table[1], -- Dictionary on single word selection
+                {
+                    text_func = function()
+                        local multi_word = G_reader_settings:readSetting("default_highlight_action")
+                        for __, v in ipairs(long_press_action) do
+                            if v[2] == multi_word then
+                                return T(_("Multi-word selection: %1"), v[1]:lower())
+                            end
+                        end
+                    end,
+                    sub_item_table = { table.unpack(menu_items.long_press.sub_item_table, 2, #long_press_action + 1) }
+                }
+            }
+        }
+        local post_long_press_action_index = #menu_items.selection_text.sub_item_table + #long_press_action -- index after long_press_action
+        -- Copy remaining items (anything after long_press_action) directly to selection_text's sub_item_table
+        for i = post_long_press_action_index, #menu_items.long_press.sub_item_table do
+            table.insert(menu_items.selection_text.sub_item_table, menu_items.long_press.sub_item_table[i])
+        end
+        menu_items.long_press = nil
+    end
+end
 
 function ReaderKeySelection:onHighlightPress(skip_tap_check)
     if not self._current_indicator_pos then return false end

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -307,10 +307,17 @@ function ReaderKeySelection:highlightPress(skip_tap_check)
         self:stopHighlightIndicator()
         return true
     end
-    -- Attempt to open an existing highlight
-    if not skip_tap_check and self.ui.highlight:onTap(nil, self:_createHighlightGesture("tap")) then
-        self:stopHighlightIndicator(true) -- need_clear_selection=true
-        return true
+    if not skip_tap_check then
+        -- Follow link if there's one at the current indicator position
+        if self.ui.link and self.ui.link:onTap(nil, self:_createHighlightGesture("tap")) then
+            self:stopHighlightIndicator()
+            return true
+        end
+        -- Attempt to open an existing highlight
+        if self.ui.highlight:onTap(nil, self:_createHighlightGesture("tap")) then
+            self:stopHighlightIndicator(true) -- need_clear_selection=true
+            return true
+        end
     end
     -- no existing highlight at current indicator position: start hold
     self._start_indicator_highlight = true

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -1,0 +1,288 @@
+local BD = require("ui/bidi")
+local Device = require("device")
+local Geom = require("ui/geometry")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local Size = require("ui/size")
+local time = require("ui/time")
+local Screen = Device.screen
+
+local ReaderKeySelection = InputContainer:extend{}
+
+function ReaderKeySelection:init()
+    if Device:isTouchDevice() and not Device:hasDPad() then
+        return
+    end
+    self:registerKeyEvents()
+    self.screen_w = Screen:getWidth()
+    self.screen_h = Screen:getHeight()
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self._previous_indicator_pos = nil
+    self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+end
+
+function ReaderKeySelection:onSetDimensions(dimen)
+    self.screen_w, self.screen_h = dimen.w, dimen.h
+end
+
+function ReaderKeySelection:registerKeyEvents()
+    if Device:hasDPad() then
+        self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
+        self.key_events.UpHighlightIndicator    = { { "Up" },    event = "MoveHighlightIndicator", args = {0, -1} }
+        self.key_events.DownHighlightIndicator  = { { "Down" },  event = "MoveHighlightIndicator", args = {0, 1} }
+        -- let hasFewKeys device move the indicator left
+        self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
+        self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
+        self.key_events.HighlightPress          = { { "Press" } }
+    end
+    if Device:hasScreenKB() or Device:hasKeyboard() then
+        local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+        -- Used for text selection with dpad/keys
+        local QUICK_INDICATOR_MOVE = true
+        self.key_events.QuickUpHighlightIndicator    = { { modifier, "Up" },    event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickDownHighlightIndicator  = { { modifier, "Down" },  event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickLeftHighlightIndicator  = { { modifier, "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickRightHighlightIndicator = { { modifier, "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICATOR_MOVE} }
+        self.key_events.HighlightModifierPress       = { { modifier, "Press" } }
+        -- onStartHighlightIndicator (H) is handled by hotkeys.koplugin
+    end
+end
+ReaderKeySelection.onPhysicalKeyboardConnected = ReaderKeySelection.registerKeyEvents
+
+function ReaderKeySelection:onHighlightPress(skip_tap_check)
+    if not self._current_indicator_pos then return false end
+    if self._start_indicator_highlight then
+        self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+        self:onStopHighlightIndicator()
+        return true
+    end
+    -- Check if we're in select mode (or extending an existing highlight)
+    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+        self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
+        self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+        self:onStopHighlightIndicator()
+        return true
+    end
+    -- Attempt to open an existing highlight
+    if not skip_tap_check and self.ui.highlight:onTap(nil, self:_createHighlightGesture("tap")) then
+        self:onStopHighlightIndicator(true) -- need_clear_selection=true
+        return true
+    end
+    -- no existing highlight at current indicator position: start hold
+    self._start_indicator_highlight = true
+    self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
+
+    if not (self.ui.rolling and self.ui.highlight.selected_text and self.ui.highlight.selected_text.sboxes and #self.ui.highlight.selected_text.sboxes > 0) then
+        return true
+    end
+    -- With crengine, selected_text.sboxes have good coordinates, so we'll borrow them.
+    local pos = self.ui.highlight.selected_text.sboxes[1]
+    local margins = self.ui.document.configurable.h_page_margins[1] + self.ui.document.configurable.h_page_margins[2]
+    local two_column_mode = self.ui.document.configurable.visible_pages == 2
+    local effective_width = two_column_mode and (self.screen_w - margins) / 2 or self.screen_w - margins
+    -- When words are split (and hyphenated) due to line breaks, they create selection boxes that are almost as wide as the
+    -- effective_width, so we need to check if that is the case, in order to handle those cases properly. We cannot precisely
+    -- and easily recognise hyphenated words in the front end, so a heuristic approach is used, it goes in two steps.
+    -- Step one: check if our box is a 'big boy'. We must allow some room for unknown variables like publisher-embedded padding, etc.
+    local is_word_split = pos.w > 0.7 * effective_width
+    -- Step two: weed out false positives (i.e long words) by comparing words found at different box coordinates.
+    if is_word_split then
+        -- In the case of a split (and hyphenated) word, we should get distinct words at different coordinates inside the box,
+        -- false positives on the other hand, should return the same word at different coordinates.
+        local word_at_pos1 = self.ui.document:getWordFromPosition({
+            x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
+            y = pos.y + pos.h * 1/4 -- puts us at a potential line 1 of 2
+        })
+        local word_at_pos2 = self.ui.document:getWordFromPosition({
+            x = BD.mirroredUILayout() and pos.x or pos.x + pos.w,
+            y = pos.y + pos.h * 3/4 -- puts us at a potential line 2 of 2
+        })
+        local does_word_at_pos1_match = word_at_pos1 and word_at_pos1.word == self.ui.highlight.selected_text.text
+        local does_word_at_pos2_match = word_at_pos2 and word_at_pos2.word == self.ui.highlight.selected_text.text
+        -- If all 3 words are a match, then we're likely not a split word, just a very long one, something worthy of floccinaucinihilipilification.
+        if does_word_at_pos1_match and does_word_at_pos2_match then
+            is_word_split = false -- check mate
+        else -- We're reasonably sure the word was split (and hyphenated). Re-select the original word to ensure the correct word is highlighted.
+            self.ui.document:getWordFromPosition({
+                x = BD.mirroredUILayout() and pos.x + pos.w or pos.x,
+                y = pos.y + pos.h * 3/4
+            })
+        end
+    end
+
+    -- helper function to update crosshairs positioning and self.hold_pos
+    local function updatePositions(hold_x, hold_y, indicator_x, indicator_y)
+        self.hold_pos = self.view:screenToPageTransform({ x = hold_x, y = hold_y })
+        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+        self._current_indicator_pos.x = indicator_x
+        self._current_indicator_pos.y = indicator_y
+    end
+    -- Determine positions based on word type and layout.
+    if is_word_split then
+        if BD.mirroredUILayout() then -- RTL
+            updatePositions(
+                pos.x + pos.w,          -- rightmost point
+                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
+                pos.x + pos.w,
+                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
+            )
+        else
+            updatePositions(
+                pos.x,                  -- leftmost point
+                pos.y + pos.h * 3 / 4,  -- adjusted vertical position
+                pos.x,
+                pos.y + pos.h * 3 / 4 - self._current_indicator_pos.h / 2
+            )
+        end
+    else
+        updatePositions(
+            -- set hold_pos to center of selected_text to make center selection more stable, not JITted at edge
+            pos.x + pos.w / 2,          -- center of word horizontally
+            pos.y + pos.h / 2,          -- center of word vertically
+            pos.x + pos.w / 2 - self._current_indicator_pos.w / 2,
+            pos.y + pos.h / 2 - self._current_indicator_pos.h / 2
+        )
+    end
+    return true
+end
+
+function ReaderKeySelection:onHighlightModifierPress()
+    if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
+    if not self._start_indicator_highlight then
+        self:onHighlightPress(true)
+        return true -- don't trigger hotkeys during text selection
+    end
+    -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
+    self.ui.highlight.long_hold_reached = true
+    self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+    self:onStopHighlightIndicator()
+    return true
+end
+
+function ReaderKeySelection:onStartHighlightIndicator()
+    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
+    self.ui.highlight.long_hold_reached_action = function() end
+    if self.view.visible_area and not self._current_indicator_pos then
+        -- set start position to centor of page
+        local rect = self._previous_indicator_pos
+        if not rect then
+            rect = Geom:new()
+            rect.x = self.view.visible_area.w / 2
+            rect.y = self.view.visible_area.h / 2
+            rect.w = Size.item.height_default
+            rect.h = rect.w
+        end
+        self._current_indicator_pos = rect
+        self.view.highlight.indicator = rect
+        UIManager:setDirty(self.dialog, "ui", rect)
+        return true
+    end
+    return false
+end
+
+function ReaderKeySelection:onStopHighlightIndicator(need_clear_selection)
+    if not self._current_indicator_pos then return false end
+    -- If we're in select mode and user presses back, end the selection
+    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+        self.ui.highlight.select_mode = false
+        if self.ui.annotation.annotations[self.ui.highlight.highlight_idx].is_tmp then
+            self.ui.highlight:deleteHighlight(self.ui.highlight.highlight_idx) -- temporary highlight, delete it
+        else
+            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+        end
+        self.ui.highlight.highlight_idx = nil
+    end
+
+    local rect = self._current_indicator_pos
+    self._previous_indicator_pos = rect
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self.view.highlight.indicator = nil
+    UIManager:setDirty(self.dialog, "ui", rect)
+    if need_clear_selection then
+        self.ui.highlight:clear()
+    end
+    return true
+end
+
+function ReaderKeySelection:onMoveHighlightIndicator(args)
+    if self.view.visible_area and self._current_indicator_pos then
+        local dx, dy, quick_move = unpack(args)
+        local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
+        local quick_move_distance_dy = self.view.visible_area.h * (1/5)
+        -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
+        local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
+        local rect = self._current_indicator_pos:copy()
+        if quick_move then
+            rect.x = rect.x + quick_move_distance_dx * dx
+            rect.y = rect.y + quick_move_distance_dy * dy
+        else
+            local now = time:now()
+            if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
+                local diff = now - self._last_indicator_move_args.time
+                -- if user presses same arrow key within 1 second (default, user adjustable), speed up
+                -- double press: 4 single move distances, usually move to next word or line
+                -- triple press: 16 single distances, usually skip several words or lines
+                -- quadruple press: 64 single distances, almost move to screen edge
+                if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
+                    -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
+                    local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                    if diff < time.s( t_inter ) then
+                        move_distance = self._last_indicator_move_args.distance * 4
+                    end
+                end
+            end
+            rect.x = rect.x + move_distance * dx
+            rect.y = rect.y + move_distance * dy
+            self._last_indicator_move_args.distance = move_distance
+            self._last_indicator_move_args.dx = dx
+            self._last_indicator_move_args.dy = dy
+            self._last_indicator_move_args.time = now
+        end
+        if rect.x < 0 then
+            rect.x = 0
+        end
+        if rect.x + rect.w > self.view.visible_area.w then
+            rect.x = self.view.visible_area.w - rect.w
+        end
+        -- make sure we account for both the status bar and alt status bar so we don't overlap them with the indicator
+        local alt_status_bar_height = 0
+        if self.ui.rolling and self.ui.document.configurable.status_line == 0 then
+            alt_status_bar_height = self.ui.document:getHeaderHeight()
+        end
+        if rect.y < alt_status_bar_height then
+            rect.y = alt_status_bar_height
+        end
+        local footer_height = self.view.footer_visible and self.view.footer:getHeight() or 0
+        local status_bar_height = self.ui.rolling and footer_height or 0 -- for PDFs, status bar is already accounted for
+        if rect.y + rect.h > self.view.visible_area.h - status_bar_height then
+            rect.y = self.view.visible_area.h - status_bar_height - rect.h
+        end
+        UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+        self._current_indicator_pos = rect
+        self.view.highlight.indicator = rect
+        UIManager:setDirty(self.dialog, "ui", rect)
+        if self._start_indicator_highlight then
+            self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderKeySelection:_createHighlightGesture(gesture)
+    local point = self._current_indicator_pos:copy()
+    point.x = point.x + point.w / 2
+    point.y = point.y + point.h / 2
+    point.w = 0
+    point.h = 0
+    return {
+        ges = gesture,
+        pos = point,
+        time = time.realtime(),
+    }
+end
+
+return ReaderKeySelection

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -408,7 +408,7 @@ function ReaderMenu:exitOrRestart(callback, force)
 end
 
 function ReaderMenu:onShowMenu(tab_index, do_not_show)
-    self.ui.highlight:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    self.ui.keyselection:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -408,7 +408,7 @@ function ReaderMenu:exitOrRestart(callback, force)
 end
 
 function ReaderMenu:onShowMenu(tab_index, do_not_show)
-    self.ui.keyselection:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    self.ui.keyselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -408,7 +408,9 @@ function ReaderMenu:exitOrRestart(callback, force)
 end
 
 function ReaderMenu:onShowMenu(tab_index, do_not_show)
-    self.ui.highlight:onStopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    if self.ui.textselection and self.ui.textselection:isActive() then
+        self.ui.textselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
+    end
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
     end

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -408,9 +408,7 @@ function ReaderMenu:exitOrRestart(callback, force)
 end
 
 function ReaderMenu:onShowMenu(tab_index, do_not_show)
-    if self.ui.textselection and self.ui.textselection:isActive() then
-        self.ui.textselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
-    end
+    self.ui.keyselection:stopHighlightIndicator(true) -- stop any text selection in progress, if applicable
     if self.tab_item_table == nil then
         self:setUpdateItemTable()
     end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -944,6 +944,9 @@ function ReaderRolling:onGotoViewRel(diff)
     if self.ui.document ~= nil then
         self.xpointer = self.ui.document:getXPointer()
     end
+    if self.ui.textselection and self.ui.textselection:isActive() then
+        self.ui.textselection:pageTurnDuringSelection()
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -944,6 +944,9 @@ function ReaderRolling:onGotoViewRel(diff)
     if self.ui.document ~= nil then
         self.xpointer = self.ui.document:getXPointer()
     end
+    if self.ui.keyselection:isActive() then
+        self.ui.keyselection:pageTurnDuringSelection()
+    end
     return true
 end
 

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -944,8 +944,8 @@ function ReaderRolling:onGotoViewRel(diff)
     if self.ui.document ~= nil then
         self.xpointer = self.ui.document:getXPointer()
     end
-    if self.ui.textselection and self.ui.textselection:isActive() then
-        self.ui.textselection:pageTurnDuringSelection()
+    if self.ui.keyselection:isActive() then
+        self.ui.keyselection:pageTurnDuringSelection()
     end
     return true
 end

--- a/frontend/apps/reader/modules/readertextselection.lua
+++ b/frontend/apps/reader/modules/readertextselection.lua
@@ -1,13 +1,19 @@
 local BD = require("ui/bidi")
 local Device = require("device")
+local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Geom = require("ui/geometry")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local ReaderHighlight = require("apps/reader/modules/readerhighlight")
+local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local Size = require("ui/size")
 local time = require("ui/time")
 local Screen = Device.screen
+local ffiUtil = require("ffi/util")
 local _ = require("gettext")
+local N_ = _.ngettext
+local T = ffiUtil.template
 
 -- see https://www.lua.org/gems/sample.pdf for Lua Performance Tips
 -- GC Optimisations
@@ -72,14 +78,122 @@ end
 ReaderTextSelection.onPhysicalKeyboardConnected = ReaderTextSelection.init
 
 function ReaderTextSelection:addToMainMenu(menu_items)
+    if Device:isTouchDevice() or not Device:hasDPad() then return end
     -- insert table to main reader menu
-    if not Device:isTouchDevice() and Device:hasDPad() and not Device:useDPadAsActionKeys() then
+    if not Device:useDPadAsActionKeys() then
         menu_items.start_content_selection = {
             text = _("Start text selection"),
             callback = function()
                 self:startHighlightIndicator()
             end,
         }
+    end
+    -- we allow user to select the rate at which the content selection tool moves through screen
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
+            local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
+            return T(_("Crosshairs speed (reader/dict): %1 / %2"), reader_speed, dict_speed)
+        end,
+        callback = function(touchmenu_instance)
+            local reader_speed = G_reader_settings:readSetting("highlight_non_touch_factor") or 4
+            local dict_speed = G_reader_settings:readSetting("highlight_non_touch_factor_dict") or 3
+            local double_spin_widget = DoubleSpinWidget:new{
+                left_text = _("Reader PDF/DjVU"),
+                left_value = reader_speed,
+                left_min = 0.25,
+                left_max = 5,
+                left_default = 4,
+                left_precision = "%.2f",
+                left_step = 0.25,
+                left_hold_step = 0.05,
+                right_text = _("Dictionary"),
+                right_value = dict_speed,
+                right_min = 0.25,
+                right_max = 5,
+                right_default = 3,
+                right_precision = "%.2f",
+                right_step = 0.25,
+                right_hold_step = 0.05,
+                title_text = _("Crosshairs speed"),
+                info_text = _("Select a decimal value from 0.25 to 5. A smaller value increases the travel distance of the crosshairs per keystroke. Font size and this value are inversely correlated, meaning a smaller font size requires a larger value and vice versa."),
+                callback = function(left_value, right_value)
+                    G_reader_settings:saveSetting("highlight_non_touch_factor", left_value)
+                    G_reader_settings:saveSetting("highlight_non_touch_factor_dict", right_value)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end
+            }
+            UIManager:show(double_spin_widget)
+        end,
+    })
+    table.insert(menu_items.long_press.sub_item_table, {
+        text = _("Increase crosshairs speed on consecutive keystrokes"),
+        checked_func = function()
+            return G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
+        end,
+        enabled_func = function()
+            return not self.view.highlight.disabled and not self.ui.rolling
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
+        end,
+    })
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+            return T(N_("Interval for crosshairs speed increase: 1 second", "Interval for crosshairs speed increase: %1 seconds", highlight_non_touch_interval), highlight_non_touch_interval)
+        end,
+        separator = true, -- needed as this is not the last item, readerlink adds another one
+        enabled_func = function()
+            return not self.ui.rolling and not self.view.highlight.disabled and G_reader_settings:nilOrTrue("highlight_non_touch_spedup")
+        end,
+        callback = function(touchmenu_instance)
+            local curr_val = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+            local spin_widget = SpinWidget:new{
+                value = curr_val,
+                value_min = 0.1,
+                value_max = 1,
+                precision = "%.1f",
+                value_step = 0.1,
+                default_value = 1,
+                title_text = _("Time interval"),
+                info_text = _("Select a decimal value up to 1 second. This defines the time period within which multiple keystrokes will trigger an increase in the crosshairs speed."),
+                callback = function(spin)
+                    G_reader_settings:saveSetting("highlight_non_touch_interval", spin.value)
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                end
+            }
+            UIManager:show(spin_widget)
+        end,
+    })
+
+    if menu_items.long_press then
+        local long_press_action = ReaderHighlight.long_press_action
+        -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
+        -- Clone long_press settings, and change its label, making it much more meaningful for non-touch device users.
+        menu_items.selection_text = {
+            text = _("Text selection tools"),
+            sub_item_table = {
+                menu_items.long_press.sub_item_table[1], -- Dictionary on single word selection
+                {
+                    text_func = function()
+                        local multi_word = G_reader_settings:readSetting("default_highlight_action")
+                        for __, v in ipairs(long_press_action) do
+                            if v[2] == multi_word then
+                                return T(_("Multi-word selection: %1"), v[1]:lower())
+                            end
+                        end
+                    end,
+                    sub_item_table = { table.unpack(menu_items.long_press.sub_item_table, 2, #long_press_action + 1) }
+                }
+            }
+        }
+        local post_long_press_action_index = #menu_items.selection_text.sub_item_table + #long_press_action -- index after long_press_action
+        -- Copy remaining items (anything after long_press_action) directly to selection_text's sub_item_table
+        for i = post_long_press_action_index, #menu_items.long_press.sub_item_table do
+            table.insert(menu_items.selection_text.sub_item_table, menu_items.long_press.sub_item_table[i])
+        end
+        menu_items.long_press = nil
     end
 end
 

--- a/frontend/apps/reader/modules/readertextselection.lua
+++ b/frontend/apps/reader/modules/readertextselection.lua
@@ -1,0 +1,827 @@
+local BD = require("ui/bidi")
+local Device = require("device")
+local Geom = require("ui/geometry")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local Size = require("ui/size")
+local time = require("ui/time")
+local Screen = Device.screen
+local _ = require("gettext")
+
+-- see https://www.lua.org/gems/sample.pdf for Lua Performance Tips
+-- GC Optimisations
+local math_abs = math.abs
+local math_max = math.max
+local math_min = math.min
+local math_floor = math.floor
+-- Reusable table for FFI probes to avoid repeated allocations.
+local SHARED_PROBE = { x = 0, y = 0 }
+
+local ReaderTextSelection = InputContainer:extend{}
+
+function ReaderTextSelection:init()
+    if Device:isTouchDevice() and not Device:hasDPad() then
+        return
+    end
+    self:registerKeyEvents()
+    self.screen_w = Screen:getWidth()
+    self.screen_h = Screen:getHeight()
+    self._previous_indicator_word = nil
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self._previous_indicator_pos = nil
+    self._vertical_move_anchor_x = nil
+    self._last_move_was_vertical = false
+    self._edge_dx = nil
+    self._edge_dy = nil
+    self._last_move_was_quick_move = nil
+    self.mirroredUI = BD.mirroredUILayout()
+    self.ui:registerPostInitCallback(function()
+        self.ui.menu:registerToMainMenu(self)
+    end)
+end
+
+function ReaderTextSelection:onSetDimensions(dimen)
+    self.screen_w, self.screen_h = dimen.w, dimen.h
+end
+
+function ReaderTextSelection:registerKeyEvents()
+    if Device:hasDPad() then
+        self.key_events.StopHighlightIndicator  = { { Device.input.group.Back }, args = true } -- true: clear highlight selection
+        local event = Device:useDPadAsActionKeys() and "StartOrMoveHighlightIndicator" or "MoveHighlightIndicator"
+        self.key_events.UpHighlightIndicator    = { { "Up" },    event = event, args = {0, -1} }
+        self.key_events.DownHighlightIndicator  = { { "Down" },  event = event, args = {0, 1} }
+        -- let hasFewKeys device move the indicator left
+        self.key_events.LeftHighlightIndicator  = { { "Left" },  event = "MoveHighlightIndicator", args = {-1, 0} }
+        self.key_events.RightHighlightIndicator = { { "Right" }, event = "MoveHighlightIndicator", args = {1, 0} }
+        self.key_events.HighlightPress          = { { "Press" } }
+    end
+    if Device:hasScreenKB() or Device:hasKeyboard() then
+        local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+        -- Used for text selection with dpad/keys
+        local QUICK_INDICATOR_MOVE = true
+        self.key_events.QuickUpHighlightIndicator    = { { modifier, "Up" },    event = "MoveHighlightIndicator", args = {0, -1, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickDownHighlightIndicator  = { { modifier, "Down" },  event = "MoveHighlightIndicator", args = {0, 1, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickLeftHighlightIndicator  = { { modifier, "Left" },  event = "MoveHighlightIndicator", args = {-1, 0, QUICK_INDICATOR_MOVE} }
+        self.key_events.QuickRightHighlightIndicator = { { modifier, "Right" }, event = "MoveHighlightIndicator", args = {1, 0, QUICK_INDICATOR_MOVE} }
+        self.key_events.HighlightModifierPress       = { { modifier, "Press" } }
+        -- startHighlightIndicator (H) is handled by hotkeys.koplugin
+    end
+end
+ReaderTextSelection.onPhysicalKeyboardConnected = ReaderTextSelection.init
+
+function ReaderTextSelection:addToMainMenu(menu_items)
+    -- insert table to main reader menu
+    if not Device:isTouchDevice() and Device:hasDPad() and not Device:useDPadAsActionKeys() then
+        menu_items.start_content_selection = {
+            text = _("Start text selection"),
+            callback = function()
+                self:startHighlightIndicator()
+            end,
+        }
+    end
+end
+
+-- for dispatcher and hotkeys
+function ReaderTextSelection:onStartHighlightIndicator()
+    return self:startHighlightIndicator()
+end
+
+function ReaderTextSelection:onStopHighlightIndicator(need_clear_selection)
+    return self:stopHighlightIndicator(need_clear_selection)
+end
+
+function ReaderTextSelection:onHighlightPress(skip_tap_check)
+    return self:highlightPress(skip_tap_check)
+end
+
+function ReaderTextSelection:onHighlightModifierPress()
+    return self:highlightModifierPress()
+end
+
+function ReaderTextSelection:onMoveHighlightIndicator(args)
+    return self:moveHighlightIndicator(args)
+end
+
+function ReaderTextSelection:onStartOrMoveHighlightIndicator(args)
+    if not self._current_indicator_pos then
+        self:startHighlightIndicator()
+    else
+        self:moveHighlightIndicator(args)
+    end
+    return true
+end
+
+function ReaderTextSelection:isActive()
+    return self._current_indicator_pos ~= nil
+end
+
+function ReaderTextSelection:startHighlightIndicator()
+    -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
+    self.ui.highlight.long_hold_reached_action = function() end
+    if self.view.visible_area and not self._current_indicator_pos then
+        -- set start position to centre of page
+        local rect = self._previous_indicator_pos
+        if not rect then
+            rect = Geom:new()
+            rect.x = self.view.visible_area.w * 0.5
+            rect.y = self.view.visible_area.h * 0.5
+            rect.w = Size.item.height_default
+            rect.h = rect.w
+        end
+        self._current_indicator_pos = rect
+        if self.ui.paging then
+            self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
+            self.view.highlight.indicator = rect
+            UIManager:setDirty(self.dialog, "ui", rect)
+            return true
+        end
+        local center_x = rect.x + rect.w * 0.5
+        local center_y = rect.y + rect.h * 0.5
+        local nearest_word = self:_getNearestWordFromScreenPoint(center_x, center_y)
+        if nearest_word then
+            self:_setIndicatorToWord(nearest_word)
+        else
+            self:stopHighlightIndicator()
+        end
+        return true
+    end
+    return false
+end
+
+function ReaderTextSelection:stopHighlightIndicator(need_clear_selection)
+    if not self._current_indicator_pos then return false end
+    -- If we're in select mode and user presses back, end the selection
+    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+        self.ui.highlight.select_mode = false
+        if self.ui.annotation.annotations[self.ui.highlight.highlight_idx].is_tmp then
+            self.ui.highlight:deleteHighlight(self.ui.highlight.highlight_idx) -- temporary highlight, delete it
+        else
+            UIManager:setDirty(self.dialog, "ui", self.view.flipping:getRefreshRegion())
+        end
+        self.ui.highlight.highlight_idx = nil
+    end
+    local rect = self._current_indicator_pos
+    self._previous_indicator_pos = rect
+    self._vertical_move_anchor_x = nil
+    self._last_move_was_vertical = false
+    self._start_indicator_highlight = false
+    self._current_indicator_pos = nil
+    self.view.highlight.indicator = nil
+    self._edge_dx, self._edge_dy = nil, nil
+    self._last_move_was_quick_move = nil
+    self._previous_indicator_word = nil
+    UIManager:setDirty(self.dialog, "ui", rect)
+    if need_clear_selection then
+        self.ui.highlight:clear()
+    end
+    return true
+end
+
+function ReaderTextSelection:highlightPress(skip_tap_check)
+    if not self._current_indicator_pos then return false end
+    if self._start_indicator_highlight then
+        self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+        self:stopHighlightIndicator()
+        return true
+    end
+    -- Check if we're in select mode (or extending an existing highlight)
+    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+        self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
+        self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+        self:stopHighlightIndicator()
+        return true
+    end
+    if not skip_tap_check then
+        -- Follow link if there's one at the current indicator position
+        if self.ui.link and self.ui.link:onTap(nil, self:_createHighlightGesture("tap")) then
+            self:stopHighlightIndicator()
+            return true
+        end
+        -- Attempt to open an existing highlight
+        if self.ui.highlight:onTap(nil, self:_createHighlightGesture("tap")) then
+            self:stopHighlightIndicator(true) -- need_clear_selection=true
+            return true
+        end
+    end
+    -- no existing highlight at current indicator position: start hold
+    self._start_indicator_highlight = true
+    self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
+    return true
+end
+
+function ReaderTextSelection:highlightModifierPress()
+    if not self._current_indicator_pos then return false end -- let event propagate to hotkeys
+    if not self._start_indicator_highlight then
+        self:highlightPress(true)
+        return true -- don't trigger hotkeys during text selection
+    end
+    -- Simulate very long-long press by setting the long hold flag. This will trigger the long-press dialog.
+    self.ui.highlight.long_hold_reached = true
+    self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
+    self:stopHighlightIndicator()
+    return true
+end
+
+function ReaderTextSelection:moveHighlightIndicator(args)
+    if not (self.view.visible_area and self._current_indicator_pos) then return false end
+    local dx, dy, quick_move = unpack(args)
+    if dx == self._edge_dx and dy == self._edge_dy and self._last_move_was_quick_move == quick_move then
+        -- don't waste resources trying to move in a direction that we know is blocked
+        -- Note: the self._last_move_was_quick_move == quick_move is important because we don't
+        --       want a quick_move (which does not wrap around) to block a legitimate wrap around.
+        logger.dbg("ReaderTextSelection: Previous boundary hit in this direction, skipping move attempt.")
+        return true
+    end
+    local moved = false
+
+    -- PDF/DjVU uses the old free form text selector mode.
+    if self.ui.paging then
+        moved = self:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
+        if moved and self._start_indicator_highlight then
+            self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
+        end
+        return true
+    end
+
+    local is_vertical_move = dx == 0 and dy ~= 0
+    self._last_move_was_quick_move = quick_move
+    local current_word = self._previous_indicator_word
+    logger.dbg("ReaderTextSelection: Current cached word:", current_word and current_word.word or "nil", "| dx:", dx, "| dy:", dy, "| quick_move:", quick_move)
+    if not current_word then
+        current_word = self:_getCurrentIndicatorWord(dx, dy)
+    end
+
+    if is_vertical_move then
+        if not self._last_move_was_vertical or not self._vertical_move_anchor_x then
+            -- remember x coordinate so subsequent vertical moves can try to stay in the same horizontal "band"
+            self._vertical_move_anchor_x = self._current_indicator_pos.x + self._current_indicator_pos.w * 0.5
+        end
+        if current_word and current_word.pos0 then
+            if quick_move then
+                local _, current_anchor_y = self:_getWordAnchorCoordinates(current_word)
+                local target_y = current_anchor_y + (self.view.visible_area.h * (1/5) * dy)
+                if target_y < 0 then
+                    target_y = 0
+                elseif target_y > self.view.visible_area.h then
+                    target_y = self.view.visible_area.h
+                end
+                local nearest_vertical_word = self:_getQuickVerticalWordRolling(
+                    self._vertical_move_anchor_x,
+                    target_y,
+                    dy,
+                    current_word,
+                    current_anchor_y
+                )
+                if nearest_vertical_word then
+                    moved = self:_setIndicatorToWord(nearest_vertical_word)
+                else -- Keep moving in the requested direction if no target-band word was found.
+                    moved = self:_moveIndicatorCreDoc(current_word, 0, dy, 1, false, self._vertical_move_anchor_x)
+                end
+                if moved and self._edge_dx and self._edge_dy then
+                    self._edge_dx, self._edge_dy = nil, nil
+                end
+            else -- Always move line-by-line vertically in rolling mode.
+                moved = self:_moveIndicatorCreDoc(current_word, 0, dy, 1, false, self._vertical_move_anchor_x)
+            end
+        end -- if current_word
+        self._last_move_was_vertical = true
+    else
+        self._vertical_move_anchor_x = nil
+        self._last_move_was_vertical = false
+        if current_word and current_word.pos0 then
+            local steps = quick_move and 4 or 1
+            local no_wrap_horizontal = quick_move and dx ~= 0
+            moved = self:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal)
+        end
+    end
+
+    if moved and self._start_indicator_highlight then
+        self.ui.highlight:onHoldPan(nil, self:_createHighlightGesture("hold_pan"))
+    end
+    return true
+end
+
+function ReaderTextSelection:_isSingleWord(word)
+    local trimmed_word = word.word:match("^%s*(.-)%s*$") or word.word
+    if trimmed_word:match("%s") then
+        return false
+    end
+    return true
+end
+
+function ReaderTextSelection:_isSplitHyphenatedWord(word)
+    if not word or not word.pos0 or not word.pos1 then return false end
+    -- A single hyphenated word does not contain spaces in the middle.
+    if not self:_isSingleWord(word) then
+        return false
+    end
+    -- Avoid pulling FFI layout data twice if we've already cached it for this word
+    if word.segments then
+        return #word.segments > 1 and word.segments[1].y ~= word.segments[#word.segments].y
+    end
+    local segments = self.ui.document:getScreenBoxesFromPositions(word.pos0, word.pos1, true)
+    if not segments or #segments == 0 then return false end
+    -- Cache the segments directly onto the word object for downstream geometry targeting
+    word.segments = segments
+    -- A word is deterministically split across a line break if it returns multiple
+    -- fragment boxes that exist on completely different vertical coordinates.
+    local is_split = #segments > 1 and segments[1].y ~= segments[#segments].y
+    if is_split then
+        logger.dbg("ReaderTextSelection: Deterministic split word detected:", word.word)
+    end
+    return is_split
+end
+
+-- X-based head/tail logic that manages RTL layout translation
+function ReaderTextSelection:_resolveSplitWordFromX(word, x_pos)
+    if not self:_isSplitHyphenatedWord(word) then
+        return word, word.sbox.y
+    end
+    local head_box = word.segments[1]
+    local tail_box = word.segments[#word.segments]
+
+    local right_half = x_pos > (word.sbox.x + word.sbox.w * 0.5)
+    -- LTR: Right side is the end of line 1 (head). RTL: Right side is the start of line 2 (tail).
+    local is_head
+    if self.mirroredUI then
+        is_head = not right_half
+    else
+        is_head = right_half
+    end
+    if is_head then
+        word.is_split_fragment = "head"
+        return word, head_box.y
+    else
+        word.is_split_fragment = "tail"
+        return word, tail_box.y
+    end
+end
+
+function ReaderTextSelection:_moveIndicatorCreDoc(current_word, dx, dy, steps, no_wrap_horizontal, preferred_center_x)
+    local target_word = current_word
+    local did_move = false
+    local lock_line_center_y
+    local lock_line_tolerance
+
+    if no_wrap_horizontal and dx ~= 0 then
+        local _, cy = self:_getWordAnchorCoordinates(current_word)
+        lock_line_center_y = self._current_indicator_pos and (self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5) or cy
+
+        local line_h = Size.item.height_default
+        if current_word.sbox and not self:_isSplitHyphenatedWord(current_word) then
+            line_h = current_word.sbox.h
+        end
+        lock_line_tolerance = math_max(1, line_h * 0.5)
+    end
+
+    for _ = 1, steps do
+        local step_word
+        if dx ~= 0 then
+            local drop_off_head = dx > 0
+            local drop_off_tail = dx < 0
+            if self.mirroredUI then
+                drop_off_head, drop_off_tail = drop_off_tail, drop_off_head
+            end
+            -- Pre-emptive wrap guard: If we are on a split fragment edge and no_wrap is true,
+            -- stepping "off" the edge is a guaranteed line wrap.
+            if no_wrap_horizontal and target_word.is_split_fragment then
+                if (drop_off_head and target_word.is_split_fragment == "head") or
+                   (drop_off_tail and target_word.is_split_fragment == "tail") then
+                    logger.dbg("ReaderTextSelection: Semantic wrap prevented on split word edge.")
+                    break -- Terminate wrap before mutating state
+                end
+            end
+
+            step_word = self:_getAdjacentWordRolling(target_word, dx, lock_line_center_y, lock_line_tolerance)
+            -- The engine's logical traversal will happily wrap to the next physical line at the margins.
+            -- Because _getAdjacentWordRolling relies on these logical XPointer jumps, we must enforce
+            -- a strict physical boundary check after the word is found.
+            -- If the Y-coordinate of the new word drifts vertically outside our locked horizontal band,
+            -- it means a line wrap occurred. If horizontal wrapping is forbidden, we abort the move.
+            if step_word and no_wrap_horizontal and step_word ~= target_word then
+                local _, next_cy = self:_getWordAnchorCoordinates(step_word)
+                if math_abs(next_cy - lock_line_center_y) > lock_line_tolerance then
+                    break
+                end
+            end
+        else
+            step_word = self:_getAdjacentLineWordRolling(target_word, dy, preferred_center_x)
+        end
+
+        if not step_word then
+            -- Set the edge cache: We've hit a physical or logical wall.
+            self._edge_dx, self._edge_dy = dx, dy
+            break
+        end
+        self._edge_dx, self._edge_dy = nil, nil
+        target_word = step_word
+        did_move = true
+    end
+
+    if did_move then
+        self:_setIndicatorToWord(target_word)
+    end
+    return did_move
+end
+
+function ReaderTextSelection:_setIndicatorToWord(word)
+    if not word or not word.sbox then return false end
+    local rect = self._current_indicator_pos:copy()
+    local anchor_x, anchor_y, is_split = self:_getWordAnchorCoordinates(word)
+    rect.x = is_split and anchor_x or (anchor_x - rect.w * 0.5)
+    rect.y = anchor_y - rect.h * 0.5
+    self:_setIndicatorRect(rect)
+    self._previous_indicator_word = word
+    return true
+end
+
+function ReaderTextSelection:_setIndicatorRect(rect)
+    UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+    self._current_indicator_pos = rect
+    self.view.highlight.indicator = self._current_indicator_pos
+    UIManager:setDirty(self.dialog, "ui", self._current_indicator_pos)
+end
+
+function ReaderTextSelection:_getWordAnchorCoordinates(word)
+    if not word or not word.sbox then
+        return nil, nil, false
+    end
+    local sbox = word.sbox
+    -- Fallback for when the word hasn't been flagged yet
+    if not word.is_split_fragment and self:_isSplitHyphenatedWord(word) then
+        -- Infer fragment from the indicator position.
+        if self._current_indicator_pos and word.segments and #word.segments > 1 then
+            local indicator_cy = self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5
+            local head_box = word.segments[1]
+            local tail_box = word.segments[#word.segments]
+            local midpoint_y = (head_box.y + tail_box.y + tail_box.h) * 0.5
+            if indicator_cy <= midpoint_y then
+                word.is_split_fragment = "head"
+            else
+                word.is_split_fragment = "tail"
+            end
+        end
+    end
+    if word.is_split_fragment then
+        -- Grab the width of the crosshairs so we can tuck it inside the bounding box
+        local ind_w = self._current_indicator_pos and self._current_indicator_pos.w or 0
+        if word.is_split_fragment == "head" and word.segments then
+            -- Target the physical box of the head fragment
+            local head_box = word.segments[1]
+            local x = self.mirroredUI and head_box.x or (head_box.x + head_box.w - ind_w)
+            local y = head_box.y + head_box.h * 0.5
+            return x, y, true
+        elseif word.is_split_fragment == "tail" and word.segments then
+            -- Target the physical box of the tail fragment
+            local tail_box = word.segments[#word.segments]
+            local x = self.mirroredUI and (tail_box.x + tail_box.w - ind_w) or tail_box.x
+            local y = tail_box.y + tail_box.h * 0.5
+            return x, y, true
+        end
+    end
+    return sbox.x + sbox.w * 0.5, sbox.y + sbox.h * 0.5, false
+end
+
+function ReaderTextSelection:_getWordFromScreenPoint(screen_x, screen_y, dx, dy)
+    if screen_x >= 0 and screen_x <= self.view.visible_area.w and screen_y >= 0 and screen_y <= self.view.visible_area.h then
+        SHARED_PROBE.x = screen_x
+        SHARED_PROBE.y = screen_y
+        local pos = self.view:screenToPageTransform(SHARED_PROBE)
+        local word = self.ui.document:getWordFromPosition(pos, true)
+        if word and word.sbox then
+            return word
+        end
+    end
+    if (dx == nil or dx == 0) and (dy == nil or dy == 0) then return nil end
+
+    local step = math_max(4, math_floor(Size.item.height_default * 0.5))
+    local max_distance = math_max(self.view.visible_area.w, self.view.visible_area.h)
+
+    for dist = step, max_distance, step do
+        local px = screen_x + dx * dist
+        local py = screen_y + dy * dist
+        if px >= 0 and px <= self.view.visible_area.w and py >= 0 and py <= self.view.visible_area.h then
+            SHARED_PROBE.x = px
+            SHARED_PROBE.y = py
+            local pos = self.view:screenToPageTransform(SHARED_PROBE)
+            local word = self.ui.document:getWordFromPosition(pos, true)
+            if word and word.sbox then return word end
+        end
+    end
+end
+
+function ReaderTextSelection:_getNearestWordFromScreenPoint(screen_x, screen_y)
+    SHARED_PROBE.x = screen_x
+    SHARED_PROBE.y = screen_y
+    local pos = self.view:screenToPageTransform(SHARED_PROBE)
+    local doc = self.ui.document
+
+    local origin_word = doc:getWordFromPosition(pos, true)
+    if origin_word and origin_word.sbox then
+        logger.dbg("ReaderTextSelection: Exact word found at position:", origin_word.word)
+        if self:_isSingleWord(origin_word) then
+            return origin_word
+        end
+    end
+    -- No exact word found, perform a ripple search for the nearest word
+    local nearest_word = doc:getNearestWordAndBoxFromPosition(pos, 0) -- 0 means DIR_ANY, search the entire page
+    if nearest_word and nearest_word.sbox then
+        logger.dbg("ReaderTextSelection: No word at exact position. Nearest word is:", nearest_word.word)
+        return nearest_word
+    end
+    logger.dbg("ReaderTextSelection: No word found in current page.")
+    return nil
+end
+
+function ReaderTextSelection:_getCurrentIndicatorWord(dx, dy)
+    local center_x = self._current_indicator_pos.x + self._current_indicator_pos.w * 0.5
+    local center_y = self._current_indicator_pos.y + self._current_indicator_pos.h * 0.5
+    local word = self:_getWordFromScreenPoint(center_x, center_y, dx, dy)
+
+    -- State Recovery: Re-stamp the mega-box based on the indicator's physical position
+    if word and word.sbox and not word.is_split_fragment then
+        if self:_isSplitHyphenatedWord(word) then
+            local midpoint_y = word.sbox.y + (word.sbox.h * 0.5)
+            -- Y-coordinates are absolute, universally bypassing RTL rules
+            if center_y < midpoint_y then
+                word.is_split_fragment = "head"
+                logger.dbg("ReaderTextSelection: State recovered -> Head")
+            else
+                word.is_split_fragment = "tail"
+                logger.dbg("ReaderTextSelection: State recovered -> Tail")
+            end
+        end
+    end
+    self._previous_indicator_word = word
+    return word
+end
+
+function ReaderTextSelection:_getQuickVerticalWordRolling(anchor_x, target_y, dy, exclude_word, current_anchor_y)
+    local doc = self.ui.document
+    -- Prevent wrapping off the current page.
+    local safe_y = math_max(self.view.visible_area.y, math_min(target_y, self.view.visible_area.y + self.view.visible_area.h))
+
+    SHARED_PROBE.x = anchor_x
+    SHARED_PROBE.y = safe_y
+    -- let Crengine's native fuzzy search do the work
+    local candidate = doc:getWordFromPosition(SHARED_PROBE, true)
+
+    if not candidate or not candidate.sbox then
+        logger.dbg("ReaderTextSelection: Quick move failed - no word found at target.")
+        return nil
+    end
+
+    if exclude_word and exclude_word.pos0 and candidate.pos0 == exclude_word.pos0 then
+        logger.dbg("ReaderTextSelection: Quick move rejected - hit origin word.")
+        return nil
+    end
+
+    local candidate_sy
+    candidate, candidate_sy = self:_resolveSplitWordFromX(candidate, anchor_x)
+
+    local line_tol = (exclude_word and exclude_word.sbox) and math_max(1, exclude_word.sbox.h * 0.5) or math_max(1, Size.item.height_default * 0.5)
+    if current_anchor_y then
+        if math_abs(candidate_sy - current_anchor_y) <= line_tol then
+            logger.dbg("ReaderTextSelection: Quick move rejected - did not clear current line.")
+            return nil
+        end
+        if dy < 0 and candidate_sy >= current_anchor_y - line_tol then return nil end
+        if dy > 0 and candidate_sy <= current_anchor_y + line_tol then return nil end
+    end
+
+    logger.dbg("ReaderTextSelection: Quick vertical jump success to:", candidate.word)
+    return candidate
+end
+
+function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
+    if not word or not word.pos0 then return nil end
+    local is_forward_physical = (not self.mirroredUI and direction > 0) or (self.mirroredUI and direction < 0)
+    -- If we're on one half of a split word, the next 'line' is just the other half.
+    if self:_isSplitHyphenatedWord(word) then
+        if is_forward_physical and word.is_split_fragment == "head" then
+            logger.dbg("ReaderTextSelection: Internal jump Forward -> Tail")
+            word.is_split_fragment = "tail"
+            return word
+        elseif not is_forward_physical and word.is_split_fragment == "tail" then
+            logger.dbg("ReaderTextSelection: Internal jump Backward -> Head")
+            word.is_split_fragment = "head"
+            return word
+        end
+    end
+    local doc = self.ui.document
+    -- Map physical direction to logical XPointer direction
+    local logical_dir = self.mirroredUI and -direction or direction
+
+    -- Advance strictly via logical XPointer to perfectly step over BiDi traps
+    local next_xp = logical_dir > 0 and doc:getNextVisibleWordStart(word.pos0) or doc:getPrevVisibleWordStart(word.pos0)
+    if not next_xp or next_xp == word.pos0 then
+        logger.dbg("ReaderTextSelection: Reached logical end of stream.")
+        return nil
+    end
+    -- For hyphenated words straddled across different pages, tails are not detected so we need to phycally
+    -- probe for them, otherwise indicator will hit a boundary before the fragment.
+    if not doc:isXPointerInCurrentPage(next_xp) then
+        logger.dbg("ReaderTextSelection: Logical boundary hit. Attempting physical horizontal probe.")
+        if self.mirroredUI then
+            SHARED_PROBE.x = is_forward_physical and (word.sbox.x - 10) or (word.sbox.x + word.sbox.w + 10)
+        else
+            SHARED_PROBE.x = is_forward_physical and (word.sbox.x + word.sbox.w + 10) or (word.sbox.x - 10)
+        end
+        SHARED_PROBE.y = lock_line_center_y or (word.sbox.y + word.sbox.h * 0.5)
+        local probe_word = self:_getWordFromScreenPoint(SHARED_PROBE.x, SHARED_PROBE.y, direction, 0)
+
+        if probe_word and probe_word.sbox and probe_word.pos0 ~= word.pos0 then
+            -- Directional Entry state stamping
+            if not probe_word.is_split_fragment and self:_isSplitHyphenatedWord(probe_word) then
+                probe_word.is_split_fragment = is_forward_physical and "head" or "tail"
+            end
+            logger.dbg("ReaderTextSelection: Physical probe rescued word:", probe_word.word)
+            return probe_word
+        end
+        return nil
+    end
+
+    -- Recover the word's end pointer logically
+    local end_xp = doc:getNextVisibleWordEnd(next_xp)
+    if not end_xp then return nil end
+    -- Reconstruct the full word indicator object natively
+    local word_boxes = doc:getScreenBoxesFromPositions(next_xp, end_xp, true)
+    if not word_boxes or #word_boxes == 0 then return nil end
+    local candidate = {
+        word = doc:getTextFromXPointers(next_xp, end_xp),
+        pos0 = next_xp,
+        pos1 = end_xp,
+        sbox = Geom.boundingBox(word_boxes),
+    }
+    -- Directional Entry: Stamp the initial state on newly discovered split words
+    if not candidate.is_split_fragment and self:_isSplitHyphenatedWord(candidate) then
+        if is_forward_physical then
+            logger.dbg("ReaderTextSelection: External entry Forward -> Head")
+            candidate.is_split_fragment = "head"
+        else
+            logger.dbg("ReaderTextSelection: External entry Backward -> Tail")
+            candidate.is_split_fragment = "tail"
+        end
+    end
+    -- Enforce the physical bounds logic for rolling within a locked line if provided
+    if lock_line_center_y and lock_line_tolerance then
+        local candidate_center_y = candidate.sbox.y + candidate.sbox.h * 0.5
+        if math_abs(candidate_center_y - lock_line_center_y) > lock_line_tolerance then
+            return nil
+        end
+    end
+
+    return candidate
+end
+
+function ReaderTextSelection:_getAdjacentLineWordRolling(word, direction, preferred_center_x)
+    if not (word and word.pos0 and word.sbox) then return end
+
+    local doc = self.ui.document
+    local target_x = preferred_center_x or (word.sbox.x + word.sbox.w * 0.5)
+
+    -- Align to the physical top of the line to prevent offset drift
+    local start_sy
+    if word.is_split_fragment == "head" and word.segments then
+        start_sy = word.segments[1].y
+    elseif word.is_split_fragment == "tail" and word.segments then
+        start_sy = word.segments[#word.segments].y
+    else
+        -- Page Boundary Fallback
+        local valid_xp = doc:isXPointerInCurrentPage(word.pos0) and word.pos0 or word.pos1
+        start_sy = doc:getScreenPositionFromXPointer(valid_xp) or word.sbox.y
+    end
+
+    local logical_h = Size.item.height_default
+    local line_tol = logical_h * 0.3
+
+    logger.dbg("ReaderTextSelection: Start ultra-lean search. AnchorY:", start_sy, "| TargetX:", target_x, "| Dir:", direction)
+
+    local current_xp = word.pos0
+    local target_line_y, fallback_sx, fallback_sy = nil, nil, nil
+
+    -- Phase 1: Fast logical skip (Burn through the current line and break immediately)
+    for _ = 1, 80 do
+        local next_xp = direction > 0 and doc:getNextVisibleWordStart(current_xp) or doc:getPrevVisibleWordStart(current_xp)
+        if not next_xp or next_xp == current_xp then
+            logger.dbg("ReaderTextSelection: Break - end of stream.")
+            break
+        end
+        current_xp = next_xp
+
+        if not doc:isXPointerInCurrentPage(next_xp) then
+            logger.dbg("ReaderTextSelection: Break - hit page boundary.")
+            break
+        end
+
+        local sy, sx = doc:getScreenPositionFromXPointer(next_xp)
+        if not sy or not sx then break end
+
+        local is_new_line = (direction > 0 and sy > start_sy + line_tol) or (direction < 0 and sy < start_sy - line_tol)
+        if is_new_line then
+            target_line_y, fallback_sx, fallback_sy = sy, sx, sy
+            logger.dbg("ReaderTextSelection: Target line hit at Y:", sy, "- Breaking loop.")
+            break -- The magic bullet: Stop scanning. We have our Y-coordinate.
+        end
+    end
+
+    -- Phase 2: Physical Probe (The single heavy lift)
+    SHARED_PROBE.x = target_x
+    SHARED_PROBE.y = target_line_y or (start_sy + (direction * logical_h))
+    local probe_word = doc:getWordFromPosition(SHARED_PROBE, true)
+
+    local best_word = nil
+    if probe_word and probe_word.sbox and probe_word.pos0 ~= word.pos0 then
+        local evaluate_y
+        -- Determine fragment state and adjust physical Y before clamping
+        probe_word, evaluate_y = self:_resolveSplitWordFromX(probe_word, target_x)
+        -- Strict Y-Clamp to prevent <br/> boxes or fuzzy search drift
+        if not (evaluate_y and target_line_y and math_abs(evaluate_y - target_line_y) > line_tol) then
+            best_word = probe_word
+        else
+            logger.dbg("ReaderTextSelection: Physical probe rejected - out of bounds:", evaluate_y)
+        end
+    end
+
+    -- Phase 3: Fallback (If the line is short and the physical probe grabbed empty space)
+    if not best_word and fallback_sx and fallback_sy then
+        logger.dbg("ReaderTextSelection: Probe failed. Falling back to logical edge word.")
+        SHARED_PROBE.x = fallback_sx
+        SHARED_PROBE.y = fallback_sy
+        best_word = doc:getWordFromPosition(SHARED_PROBE, true)
+    end
+
+    if best_word then
+        logger.dbg("ReaderTextSelection: Success. Best word:", best_word.word)
+    else
+        logger.dbg("ReaderTextSelection: Failed to find valid adjacent word.")
+    end
+
+    return best_word
+end
+
+function ReaderTextSelection:_moveIndicatorFreeFormPaging(dx, dy, quick_move)
+    local quick_move_distance_dx = self.view.visible_area.w * (1/5) -- quick move distance: fifth of visible_area
+    local quick_move_distance_dy = self.view.visible_area.h * (1/5)
+    -- single move distance, user adjustable, default value (4) capable to move on word with small font size and narrow line height
+    local move_distance = Size.item.height_default / (G_reader_settings:readSetting("highlight_non_touch_factor") or 4)
+    local rect = self._current_indicator_pos:copy()
+    if quick_move then
+        rect.x = rect.x + quick_move_distance_dx * dx
+        rect.y = rect.y + quick_move_distance_dy * dy
+    else
+        local now = time:now()
+        if dx == self._last_indicator_move_args.dx and dy == self._last_indicator_move_args.dy then
+            local diff = now - self._last_indicator_move_args.time
+            -- if user presses same arrow key within 1 second (default, user adjustable), speed up
+            -- double press: 4 single move distances, usually move to next word or line
+            -- triple press: 16 single distances, usually skip several words or lines
+            -- quadruple press: 64 single distances, almost move to screen edge
+            if G_reader_settings:nilOrTrue("highlight_non_touch_spedup") then
+                -- user selects whether to use 'constant' or [this] 'sped up' rate (speed-up on by default)
+                local t_inter = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
+                if diff < time.s( t_inter ) then
+                    move_distance = self._last_indicator_move_args.distance * 4
+                end
+            end
+        end
+        rect.x = rect.x + move_distance * dx
+        rect.y = rect.y + move_distance * dy
+        self._last_indicator_move_args.distance = move_distance
+        self._last_indicator_move_args.dx = dx
+        self._last_indicator_move_args.dy = dy
+        self._last_indicator_move_args.time = now
+    end
+    if rect.x < 0 then
+        rect.x = 0
+    end
+    if rect.x + rect.w > self.view.visible_area.w then
+        rect.x = self.view.visible_area.w - rect.w
+    end
+    if rect.y < 0 then
+        rect.y = 0
+    end
+    if rect.y + rect.h > self.view.visible_area.h then
+        rect.y = self.view.visible_area.h - rect.h
+    end
+    local moved = rect.x ~= self._current_indicator_pos.x or rect.y ~= self._current_indicator_pos.y
+    self:_setIndicatorRect(rect)
+    return moved
+end
+
+function ReaderTextSelection:_createHighlightGesture(gesture)
+    local point = self._current_indicator_pos:copy()
+    point.x = point.x + point.w * 0.5
+    point.y = point.y + point.h * 0.5
+    point.w = 0
+    point.h = 0
+    return {
+        ges = gesture,
+        pos = point,
+        time = time.realtime(),
+    }
+end
+
+return ReaderTextSelection

--- a/frontend/apps/reader/modules/readertextselection.lua
+++ b/frontend/apps/reader/modules/readertextselection.lua
@@ -139,6 +139,7 @@ function ReaderTextSelection:startHighlightIndicator()
         end
         local center_x = rect.x + rect.w * 0.5
         local center_y = rect.y + rect.h * 0.5
+        self.invert_ui_layout = self.view:shouldInvertBiDiLayoutMirroring()
         local nearest_word = self:_getNearestWordFromScreenPoint(center_x, center_y)
         if nearest_word then
             self:_setIndicatorToWord(nearest_word)
@@ -372,6 +373,9 @@ function ReaderTextSelection:_resolveSplitWordFromX(word, x_pos)
     else
         is_head = right_half
     end
+    if self.invert_ui_layout then
+        is_head = not is_head
+    end
     if is_head then
         word.is_split_fragment = "head"
         return word, head_box.y
@@ -487,18 +491,22 @@ function ReaderTextSelection:_getWordAnchorCoordinates(word)
         end
     end
     if word.is_split_fragment then
+        local head_is_left = self.mirroredUI
+        if self.invert_ui_layout then
+            head_is_left = not head_is_left
+        end
         -- Grab the width of the crosshairs so we can tuck it inside the bounding box
         local ind_w = self._current_indicator_pos and self._current_indicator_pos.w or 0
         if word.is_split_fragment == "head" and word.segments then
             -- Target the physical box of the head fragment
             local head_box = word.segments[1]
-            local x = self.mirroredUI and head_box.x or (head_box.x + head_box.w - ind_w)
+            local x = head_is_left and head_box.x or (head_box.x + head_box.w - ind_w)
             local y = head_box.y + head_box.h * 0.5
             return x, y, true
         elseif word.is_split_fragment == "tail" and word.segments then
             -- Target the physical box of the tail fragment
             local tail_box = word.segments[#word.segments]
-            local x = self.mirroredUI and (tail_box.x + tail_box.w - ind_w) or tail_box.x
+            local x = head_is_left and (tail_box.x + tail_box.w - ind_w) or tail_box.x
             local y = tail_box.y + tail_box.h * 0.5
             return x, y, true
         end
@@ -620,6 +628,10 @@ end
 function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_center_y, lock_line_tolerance)
     if not word or not word.pos0 then return nil end
     local is_forward_physical = (not self.mirroredUI and direction > 0) or (self.mirroredUI and direction < 0)
+    if self.invert_ui_layout then
+        is_forward_physical = not is_forward_physical
+        direction = -direction
+    end
     -- If we're on one half of a split word, the next 'line' is just the other half.
     if self:_isSplitHyphenatedWord(word) then
         if is_forward_physical and word.is_split_fragment == "head" then
@@ -646,7 +658,11 @@ function ReaderTextSelection:_getAdjacentWordRolling(word, direction, lock_line_
     -- probe for them, otherwise indicator will hit a boundary before the fragment.
     if not doc:isXPointerInCurrentPage(next_xp) then
         logger.dbg("ReaderTextSelection: Logical boundary hit. Attempting physical horizontal probe.")
-        if self.mirroredUI then
+        local head_is_left = self.mirroredUI
+        if self.invert_ui_layout then
+            head_is_left = not head_is_left
+        end
+        if head_is_left then
             SHARED_PROBE.x = is_forward_physical and (word.sbox.x - 10) or (word.sbox.x + word.sbox.w + 10)
         else
             SHARED_PROBE.x = is_forward_physical and (word.sbox.x + word.sbox.w + 10) or (word.sbox.x - 10)

--- a/frontend/apps/reader/modules/readertextselection.lua
+++ b/frontend/apps/reader/modules/readertextselection.lua
@@ -303,6 +303,28 @@ function ReaderTextSelection:moveHighlightIndicator(args)
     return true
 end
 
+function ReaderTextSelection:pageTurnDuringSelection()
+    self._edge_dx, self._edge_dy = nil, nil
+    self._previous_indicator_word = nil
+    local last_pos = self._current_indicator_pos
+    local target_x = last_pos.x + last_pos.w * 0.5
+    local target_y = last_pos.y + last_pos.h * 0.5
+
+    local new_word = self:_getNearestWordFromScreenPoint(target_x, target_y)
+    if new_word then
+        self:_setIndicatorToWord(new_word)
+        if not self.ui.highlight.select_mode and self._start_indicator_highlight then
+            self.ui.highlight:startSelection()
+            -- we don't want to HoldPan during moveHighlightIndicator, a following Press
+            -- key should close the startSelection loop though.
+            self._start_indicator_highlight = nil -- breaks the `if moved and self._ then`
+        end
+        return true
+    else
+        self:stopHighlightIndicator(true)
+    end
+end
+
 function ReaderTextSelection:_isSingleWord(word)
     local trimmed_word = word.word:match("^%s*(.-)%s*$") or word.word
     if trimmed_word:match("%s") then

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -41,6 +41,7 @@ local ReaderHandMade = require("apps/reader/modules/readerhandmade")
 local ReaderHinting = require("apps/reader/modules/readerhinting")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderScrolling = require("apps/reader/modules/readerscrolling")
+local ReaderKeySelection = require("apps/reader/modules/readerkeyselection")
 local ReaderKoptListener = require("apps/reader/modules/readerkoptlistener")
 local ReaderLink = require("apps/reader/modules/readerlink")
 local ReaderMenu = require("apps/reader/modules/readermenu")
@@ -51,7 +52,6 @@ local ReaderRolling = require("apps/reader/modules/readerrolling")
 local ReaderSearch = require("apps/reader/modules/readersearch")
 local ReaderStatus = require("apps/reader/modules/readerstatus")
 local ReaderStyleTweak = require("apps/reader/modules/readerstyletweak")
-local ReaderTextSelection = require("apps/reader/modules/readertextselection")
 local ReaderThumbnail = require("apps/reader/modules/readerthumbnail")
 local ReaderToc = require("apps/reader/modules/readertoc")
 local ReaderTypeset = require("apps/reader/modules/readertypeset")
@@ -229,15 +229,13 @@ function ReaderUI:init()
         ui = self,
         document = self.document,
     })
-    if not Device:isTouchDevice() or Device:hasDPad() then
-        -- text selection
-        self:registerModule("textselection", ReaderTextSelection:new{
-            dialog = self.dialog,
-            view = self.view,
-            ui = self,
-            document = self.document,
-        })
-    end
+    -- text selection with cursor keys
+    self:registerModule("keyselection", ReaderKeySelection:new{
+        dialog = self.dialog,
+        view = self.view,
+        ui = self,
+        document = self.document,
+    })
     -- screenshot controller
     self:registerModule("screenshot", Screenshoter:new{
         prefix = 'Reader',

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -51,6 +51,7 @@ local ReaderRolling = require("apps/reader/modules/readerrolling")
 local ReaderSearch = require("apps/reader/modules/readersearch")
 local ReaderStatus = require("apps/reader/modules/readerstatus")
 local ReaderStyleTweak = require("apps/reader/modules/readerstyletweak")
+local ReaderTextSelection = require("apps/reader/modules/readertextselection")
 local ReaderThumbnail = require("apps/reader/modules/readerthumbnail")
 local ReaderToc = require("apps/reader/modules/readertoc")
 local ReaderTypeset = require("apps/reader/modules/readertypeset")
@@ -228,6 +229,15 @@ function ReaderUI:init()
         ui = self,
         document = self.document,
     })
+    if not Device:isTouchDevice() or Device:hasDPad() then
+        -- text selection
+        self:registerModule("textselection", ReaderTextSelection:new{
+            dialog = self.dialog,
+            view = self.view,
+            ui = self,
+            document = self.document,
+        })
+    end
     -- screenshot controller
     self:registerModule("screenshot", Screenshoter:new{
         prefix = 'Reader',
@@ -542,9 +552,6 @@ function ReaderUI:registerKeyEvents()
     if Device:hasKeys() then
         self.key_events.Home = { { "Home" } }
         self.key_events.Reload = { { "F5" } }
-        if Device:hasDPad() and Device:useDPadAsActionKeys() then
-            self.key_events.StartHighlightIndicator = { { { "Up", "Down" } } }
-        end
     end
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -41,6 +41,7 @@ local ReaderHandMade = require("apps/reader/modules/readerhandmade")
 local ReaderHinting = require("apps/reader/modules/readerhinting")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderScrolling = require("apps/reader/modules/readerscrolling")
+local ReaderKeySelection = require("apps/reader/modules/readerkeyselection")
 local ReaderKoptListener = require("apps/reader/modules/readerkoptlistener")
 local ReaderLink = require("apps/reader/modules/readerlink")
 local ReaderMenu = require("apps/reader/modules/readermenu")
@@ -223,6 +224,13 @@ function ReaderUI:init()
     })
     -- wikipedia
     self:registerModule("wikipedia", ReaderWikipedia:new{
+        dialog = self.dialog,
+        view = self.view,
+        ui = self,
+        document = self.document,
+    })
+    -- text selection with cursor keys
+    self:registerModule("keyselection", ReaderKeySelection:new{
         dialog = self.dialog,
         view = self.view,
         ui = self,

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -550,9 +550,6 @@ function ReaderUI:registerKeyEvents()
     if Device:hasKeys() then
         self.key_events.Home = { { "Home" } }
         self.key_events.Reload = { { "F5" } }
-        if Device:hasDPad() and Device:useDPadAsActionKeys() then
-            self.key_events.StartHighlightIndicator = { { { "Up", "Down" } } }
-        end
     end
 end
 

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -716,6 +716,33 @@ function CreDocument:getScreenBoxesFromPositions(pos0, pos1, get_segments)
     return line_boxes
 end
 
+function CreDocument:getNearestWordAndBoxFromPosition(pos, cpp_direction)
+    local nearest = self._document:getNearestWordFromPosition(pos.x, pos.y, cpp_direction)
+    if not nearest or not nearest.text then return nil end
+    logger.dbg("CreDocument: get nearest word", nearest)
+    local wordbox = {
+        page = self._document:getCurrentPage(),
+        word = nearest.text,
+        pos0 = nearest.pos0,
+        pos1 = nearest.pos1,
+    }
+    if nearest.pos0 and nearest.pos1 then
+        local word_boxes = self._document:getWordBoxesFromPositions(nearest.pos0, nearest.pos1, true)
+        if word_boxes then
+            for i = 1, #word_boxes do
+                local v = word_boxes[i]
+                word_boxes[i] = { x = v.x0,        y = v.y0,
+                                  w = v.x1 - v.x0, h = v.y1 - v.y0 }
+            end
+            wordbox.sbox = Geom.boundingBox(word_boxes)
+            if wordbox.sbox then
+                return wordbox
+            end
+        end
+    end
+    return nil
+end
+
 function CreDocument:getNearestWordFromPosition(pos, direction)
     return self._document:getNearestWordFromPosition(pos.x, pos.y, direction)
 end

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -94,7 +94,7 @@ end
 function HotKeys:onHotkeyAction(hotkey)
     -- Note: we could have started text selection and then trigger a reflow through hotkeys (e.g., increase
     --       font-size) which will cause pandemonium to ensue (invalid coordinates).
-    if self.ui.keyselection then self.ui.keyselection:onStopHighlightIndicator(true) end
+    if self.ui.keyselection then self.ui.keyselection:stopHighlightIndicator(true) end
     local hotkey_action_list = self.hotkeys[hotkey]
     local context = self.is_docless and "FileManager" or "Reader"
     if hotkey_action_list == nil then

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -94,8 +94,8 @@ end
 function HotKeys:onHotkeyAction(hotkey)
     -- Note: we could have started text selection and then trigger a reflow through hotkeys (e.g., increase
     --       font-size) which will cause pandemonium to ensue (invalid coordinates).
-    if self.ui.textselection and self.ui.textselection:isActive() then
-        self.ui.textselection:stopHighlightIndicator(true)
+    if self.ui.keyselection and self.ui.keyselection:isActive() then
+        self.ui.keyselection:stopHighlightIndicator(true)
     end
     local hotkey_action_list = self.hotkeys[hotkey]
     local context = self.is_docless and "FileManager" or "Reader"

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -94,7 +94,7 @@ end
 function HotKeys:onHotkeyAction(hotkey)
     -- Note: we could have started text selection and then trigger a reflow through hotkeys (e.g., increase
     --       font-size) which will cause pandemonium to ensue (invalid coordinates).
-    if self.ui.highlight then self.ui.highlight:onStopHighlightIndicator(true) end
+    if self.ui.keyselection then self.ui.keyselection:onStopHighlightIndicator(true) end
     local hotkey_action_list = self.hotkeys[hotkey]
     local context = self.is_docless and "FileManager" or "Reader"
     if hotkey_action_list == nil then

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -94,7 +94,9 @@ end
 function HotKeys:onHotkeyAction(hotkey)
     -- Note: we could have started text selection and then trigger a reflow through hotkeys (e.g., increase
     --       font-size) which will cause pandemonium to ensue (invalid coordinates).
-    if self.ui.highlight then self.ui.highlight:onStopHighlightIndicator(true) end
+    if self.ui.textselection and self.ui.textselection:isActive() then
+        self.ui.textselection:stopHighlightIndicator(true)
+    end
     local hotkey_action_list = self.hotkeys[hotkey]
     local context = self.is_docless and "FileManager" or "Reader"
     if hotkey_action_list == nil then


### PR DESCRIPTION
### what's new 

This pull request refactors and simplifies the text selection indicator and key event handling logic in the reader module, particularly for non-touch devices. The main focus is to move highlight indicator management from `ReaderHighlight` to a dedicated `keyselection` component, streamline key event registration, and clean up related menu options and settings.

### footage 

<details>
  <summary>expand to see</summary>
  <div align="center">
  <img src="https://github.com/user-attachments/assets/8c09ccb6-722a-4da1-ba12-8adaa1cdab50" alt="name" width="400" />
</div> 

</details>

### structural diagrams

```
[Hardware Event / Keypress] 
       │
       ▼
 [InputContainer:key_events] ──► Dispatches to matching handler (e.g., onMoveHighlightIndicator)
       │
       ▼
 [moveHighlightIndicator(args)]
       │
       ├──► [ui.paging == true]  ──► [_moveIndicatorFreeFormPaging] ──► Updates continuous XY rect
       │
       └──► [ui.paging == false] ──► [_moveIndicatorCreDoc]
                                           │
                                           ├──► [_getAdjacentWordRolling] (Horizontal stream)
                                           └──► [_getAdjacentLineWordRolling] (Vertical stream)
                                                   │
                                                   ▼
                                        [ui.document:getWordFromPosition]
                                                   │
                                                   ▼
                                        [_setIndicatorToWord] ──► [_setIndicatorRect] (UIManager:setDirty)
```

<details>
  <summary>helpers</summary>
  

  
  ```
startHighlightIndicator()
 ├──► _getNearestWordFromScreenPoint() ────────────────────────────────────────► _isSingleWord()
 └──► _setIndicatorToWord() ──────────┬────────────────────────────────────────► _getWordAnchorCoordinates()
                                      ├────────────────────────────────────────► _isSplitHyphenatedWord()
                                      └────────────────────────────────────────► _setIndicatorRect()

moveHighlightIndicator()
 ├─► (PDF/DjVu Fixed Layout)
 │    └──► _moveIndicatorFreeFormPaging() ─────────────────────────────────────► _setIndicatorRect()
 │
 └─► (EPUB/FB2 Reflowable Layout)
      ├──► _getCurrentIndicatorWord() ────────┬────────────────────────────────► _getWordFromScreenPoint()
      │                                       └────────────────────────────────► _isSplitHyphenatedWord()
      │
      ├──► _getQuickVerticalWordRolling() ────┬────────────────────────────────► _resolveSplitWordFromX()
      │    (Modifier + Up/Down)               └────────────────────────────────► _isSplitHyphenatedWord()
      │
      └──► _moveIndicatorCreDoc() ────────────┬─► (Horizontal Traversal) ──────► _getAdjacentWordRolling()
                                              │                                    ├──► _isSplitHyphenatedWord()
                                              │                                    └──► _getWordFromScreenPoint()
                                              │
                                              ├─► (Vertical Traversal) ────────► _getAdjacentLineWordRolling()
                                              │                                    ├──► _resolveSplitWordFromX()
                                              │                                    └──► _getWordFromScreenPoint()
                                              │
                                              ├─► (Geometry Locking) ──────────► _getWordAnchorCoordinates()
                                              └─► (Commit Layout Change) ──────► _setIndicatorToWord()

highlightPress() / highlightModifierPress()
 └──► _createHighlightGesture()
  ```
  
</details> 

### related issues

* fixes #4329
* https://github.com/koreader/crengine/issues/659
* https://github.com/koreader/koreader-base/pull/2345
* https://github.com/koreader/koreader/issues/13132

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15377)
<!-- Reviewable:end -->
