### PR TITLE
OPDS: 'crawlable' relation

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -44,6 +44,13 @@ local OPDSBrowser = Menu:extend{
     borrow_rel           = "http://opds-spec.org/acquisition/borrow",
     stream_rel           = "http://vaemendis.net/opds-pse/stream",
     facet_rel            = "http://opds-spec.org/facet",
+    catalog_rel          = {
+        ["subsection"] = true,
+        ["http://opds-spec.org/subsection"] = true,
+        ["http://opds-spec.org/crawlable"] = true,
+        ["http://opds-spec.org/sort/popular"] = true,
+        ["http://opds-spec.org/sort/new"] = true,
+    },
     image_rel            = {
         ["http://opds-spec.org/image"] = true,
         ["http://opds-spec.org/cover"] = true, -- ManyBooks.net, not in spec
@@ -587,12 +594,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
             for ___, link in ipairs(entry.link) do
                 local link_href = build_href(link.href)
                 if link.type and link.type:find(self.catalog_type)
-                        and (not link.rel
-                             or link.rel == "subsection"
-                             or link.rel == "http://opds-spec.org/subsection"
-                             or link.rel == "http://opds-spec.org/crawlable"
-                             or link.rel == "http://opds-spec.org/sort/popular"
-                             or link.rel == "http://opds-spec.org/sort/new") then
+                        and (not link.rel or self.catalog_rel[link.rel]) then
                     item.url = link_href
                 end
                 -- Some catalogs do not use the rel attribute to denote

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -590,6 +590,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                         and (not link.rel
                              or link.rel == "subsection"
                              or link.rel == "http://opds-spec.org/subsection"
+                             or link.rel == "http://opds-spec.org/crawlable"
                              or link.rel == "http://opds-spec.org/sort/popular"
                              or link.rel == "http://opds-spec.org/sort/new") then
                     item.url = link_href


### PR DESCRIPTION
Add support of 'crawlable' relation.
See https://specs.opds.io/opds-1.2.html#25-complete-acquisition-feeds

This relation is available in Standard Ebooks "All Standard Ebooks" OPDS feed (https://github.com/koreader/koreader/issues/10871#issuecomment-4445416852).

Actually it returns a huge number of entries and I'm not sure if it is useful for browsing.
But, due to the spec:
_This representation is called a Complete Acquisition Feed and each OPDS Catalog Entry **must** be ordered by atom:updated, with the most recently updated Atom Entries coming first in the document order._

So this may be useful for our OPDS Sync feature, in the case when the server doesn't provide the "Newest books" feed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15384)
<!-- Reviewable:end -->
