### PR TITLE
kobo: Fix detection of 'Kobo mode' of Tolino devices

### DIFF
--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1780,9 +1780,9 @@ elseif codename == "condor" then
     return KoboCondor
 elseif codename == "monza" or codename == "monzaKobo" or codename == "monzaTolino" then
     return KoboMonza
-elseif codename == "spaBW" or codename == "spaTolinoBW" or codename == "spaBWTPV" then
+elseif codename == "spaBW" or codename == "spaKoboBW" or codename == "spaTolinoBW" or codename == "spaBWTPV" then
     return KoboSpaBW
-elseif codename == "spaColour" or codename == "spaTolinoColour" then
+elseif codename == "spaColour" or codename == "spaKoboColour" or codename == "spaTolinoColour" then
     return KoboSpaColour
 else
     error("unrecognized Kobo model ".. codename .. " with device id " .. product_id)


### PR DESCRIPTION
If you have a Tolino device and have switched it into "Kobo mode" using the developer options, the codename of the device is updated as well. This adds the codenames for these devices to the device detection for Kobo devices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15389)
<!-- Reviewable:end -->
