### PR TITLE
plugins/calibre: preserve author_sort in slim metadata

### DIFF
--- a/plugins/calibre.koplugin/metadata.lua
+++ b/plugins/calibre.koplugin/metadata.lua
@@ -21,6 +21,7 @@ local used_metadata = {
     "size",
     "title",
     "authors",
+    "author_sort",
     "tags",
     "series",
     "series_index"


### PR DESCRIPTION
## What

Add `author_sort` to the `used_metadata` whitelist in `slim()` so it's preserved when the Calibre Companion plugin writes the device-side `.metadata.calibre` after a wireless transfer.

## Why

Calibre's `author_sort` is the user-curated "Surname, Forename" form for each author, distinct from the display string in `authors`. It handles compound names ("Nikki St. Crowe" → "St. Crowe, Nikki"), particles ("van der Berg"), and inverted-naming cultures (family-first in CJK names) that simple parsing can't infer reliably.

`slim()` currently strips this field even when the desktop Calibre instance includes it in its transfer payload, which means downstream plugins that want correct surname ordering can't read it on wirelessly-synced libraries.

Reported downstream in [bookshelf.koplugin#43](https://github.com/AndyHazz/bookshelf.koplugin/issues/43) — a user with ~2250 books synced via Calibre Companion has empty `author_sort` for every book despite their desktop Calibre having the field populated.

## Risk

Minimal. Adding one string field to the whitelist; books without `author_sort` continue to load cleanly (the `slim()` loop's `or rapidjson.null` handles missing fields). The on-disk file grows by a small constant per book.

`search_used_metadata` is intentionally left unchanged — search displays the author string, not the sort form.

## Test

Local round-trip: a book sent via Calibre with `author_sort = "St. Crowe, Nikki"` retains that string after KOReader writes `.metadata.calibre`, where it was previously dropped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15398)
<!-- Reviewable:end -->
