### PR TITLE
TouchMenu: allow mousewheel scrolling; fix possible crash when highlighting

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1810,12 +1810,14 @@ function ReaderHighlight:onHold(arg, ges)
         end
         return true
     end
-    -- It has happened it failed because the text range was detected on the
-    -- previous page and highlighted by crengine, but no word was returned
-    -- (because the boxes were not on the current page).
-    -- Be sure we clear any such selection
-    self.ui.document:clearSelection()
-    -- And that we don't get stuck in a hold state
+    if self.ui.rolling then
+        -- It has happened it failed because the text range was detected on the
+        -- previous page and highlighted by crengine, but no word was returned
+        -- (because the boxes were not on the current page).
+        -- Be sure we clear any such selection
+        self.ui.document:clearSelection()
+    end
+    -- Be sure we don't get stuck in a hold state
     self.hold_pos = nil
     return false
 end

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -508,6 +508,12 @@ function TouchMenu:init()
             range = self.dimen,
         }
     }
+    self.ges_events.Pan = { -- (for mousewheel scrolling support)
+        GestureRange:new{
+            ges = "pan",
+            range = self.dimen,
+        }
+    }
 
     self.key_events.Back = { { Input.group.Back } }
     self.key_events.Close = { { "Menu" } }
@@ -834,6 +840,17 @@ function TouchMenu:onSwipe(arg, ges_ev)
         -- swipe, as the event handled for that is pan south).
         self:backToUpperMenu(true)
     end
+end
+
+function TouchMenu:onPan(arg, ges_ev)
+    if ges_ev.mousewheel_direction then
+        if ges_ev.direction == "north" then
+            self:onNextPage()
+        elseif ges_ev.direction == "south" then
+            self:onPrevPage()
+        end
+    end
+    return true
 end
 
 function TouchMenu:onMenuSelect(item, tap_on_checkmark)


### PR DESCRIPTION
#### TouchMenu: allow mousewheel scrolling

Was welcome to have it while testing initial-letter with various fonts.

#### Highlighting: avoid crash on PDF when nothing selected

Oversight in 148449df6 from #15285.
Noticed at https://github.com/koreader/koreader/pull/15285#discussion_r3252912576.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15402)
<!-- Reviewable:end -->
