### PR TITLE
Increase viewport for PB743K3

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -834,7 +834,7 @@ end
 local PocketBook743K3 = PocketBook:extend{
     model = "PBInkPadColor3",
     display_dpi = 300,
-    viewport = Geom:new{x=3, y=2, w=1395, h=1864},
+    viewport = Geom:new{x=3, y=2, w=1398, h=1864},
     hasColorScreen = yes,
     canHWDither = yes, -- Adjust color saturation with inkview
     canUseCBB = no, -- 24bpp


### PR DESCRIPTION
The viewport introduced in #11302 is a bit conservative and as a result, after opening KOReader menus, some artifacts remain on the right screen margin as black bars, which are disturbing.

Solution: Increase the viewport until no artifacts can be seen and also make sure book is not rendered behind the screen bezel.

Tested on real hardware, PB743K3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15410)
<!-- Reviewable:end -->
