### PR TITLE
Add support for Pocketbook Era Lite

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -977,10 +977,10 @@ elseif codename == "650" then
     return PocketBook650
 elseif codename == "700" then
     return PocketBook700
-elseif codename == "710" then
-    return PocketBook710
 elseif codename == "700K3" then
     return PocketBook700K3
+elseif codename == "710" then
+    return PocketBook710
 elseif codename == "740" then
     return PocketBook740
 elseif codename == "740-2" or codename == "740-3" then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -752,6 +752,17 @@ local PocketBook700 = PocketBook:extend{
     needs_orientation_sync_after_resume = true,
 }
 
+-- PocketBook Era Lite (710)
+local PocketBook710 = PocketBook:extend{
+    model = "PB710",
+    display_dpi = 300,
+    isAlwaysPortrait = yes,
+    hasNaturalLight = yes,
+    -- c.f., https://github.com/koreader/koreader/issues/9556
+    inkview_translates_buttons = true,
+    needs_orientation_sync_after_resume = true,
+}
+
 -- PocketBook Era Color (PB700K3)
 local PocketBook700K3 = PocketBook:extend{
     model = "PBEraColor",
@@ -966,6 +977,8 @@ elseif codename == "650" then
     return PocketBook650
 elseif codename == "700" then
     return PocketBook700
+elseif codename == "710" then
+    return PocketBook710
 elseif codename == "700K3" then
     return PocketBook700K3
 elseif codename == "740" then

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -752,17 +752,6 @@ local PocketBook700 = PocketBook:extend{
     needs_orientation_sync_after_resume = true,
 }
 
--- PocketBook Era Lite (710)
-local PocketBook710 = PocketBook:extend{
-    model = "PB710",
-    display_dpi = 300,
-    isAlwaysPortrait = yes,
-    hasNaturalLight = yes,
-    -- c.f., https://github.com/koreader/koreader/issues/9556
-    inkview_translates_buttons = true,
-    needs_orientation_sync_after_resume = true,
-}
-
 -- PocketBook Era Color (PB700K3)
 local PocketBook700K3 = PocketBook:extend{
     model = "PBEraColor",
@@ -770,6 +759,17 @@ local PocketBook700K3 = PocketBook:extend{
     hasColorScreen = yes,
     canHWDither = yes, -- Adjust color saturation with inkview
     canUseCBB = no, -- 24bpp
+    isAlwaysPortrait = yes,
+    hasNaturalLight = yes,
+    -- c.f., https://github.com/koreader/koreader/issues/9556
+    inkview_translates_buttons = true,
+    needs_orientation_sync_after_resume = true,
+}
+
+-- PocketBook Era Lite (710)
+local PocketBook710 = PocketBook:extend{
+    model = "PB710",
+    display_dpi = 300,
     isAlwaysPortrait = yes,
     hasNaturalLight = yes,
     -- c.f., https://github.com/koreader/koreader/issues/9556

--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -766,6 +766,11 @@ local PocketBook700K3 = PocketBook:extend{
     needs_orientation_sync_after_resume = true,
 }
 
+function PocketBook700K3._fb_init(fb, finfo, vinfo)
+    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
+    vinfo.bits_per_pixel = 24
+end
+
 -- PocketBook Era Lite (710)
 local PocketBook710 = PocketBook:extend{
     model = "PB710",
@@ -776,11 +781,6 @@ local PocketBook710 = PocketBook:extend{
     inkview_translates_buttons = true,
     needs_orientation_sync_after_resume = true,
 }
-
-function PocketBook700K3._fb_init(fb, finfo, vinfo)
-    -- Pocketbook Color Lux reports bits_per_pixel = 8, but actually uses an RGB24 framebuffer
-    vinfo.bits_per_pixel = 24
-end
 
 -- PocketBook InkPad 3 (740)
 local PocketBook740 = PocketBook:extend{


### PR DESCRIPTION
added device info for the new Pocketbook Era Lite (PB710) wich prevented the start of Koreader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15415)
<!-- Reviewable:end -->
