### PR TITLE
android: add Nook Glowlight 4 Plus (bnrv1300) brightness and warmth support

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -180,6 +180,7 @@ function Device:init()
                 end
                 if this.device:hasNaturalLight() then
                     local powerd = this.device.powerd
+                    logger.warn("APP_CMD_RESUME: fl_warmth=", powerd.fl_warmth, "->native=", powerd:toNativeWarmth(powerd.fl_warmth or 0))
                     if powerd.fl_warmth and powerd.fl_warmth > 0 then
                         android.setScreenWarmth(powerd:toNativeWarmth(powerd.fl_warmth))
                     end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -180,7 +180,6 @@ function Device:init()
                 end
                 if this.device:hasNaturalLight() then
                     local powerd = this.device.powerd
-                    logger.warn("APP_CMD_RESUME: fl_warmth=", powerd.fl_warmth, "->native=", powerd:toNativeWarmth(powerd.fl_warmth or 0))
                     if powerd.fl_warmth and powerd.fl_warmth > 0 then
                         android.setScreenWarmth(powerd:toNativeWarmth(powerd.fl_warmth))
                     end

--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -178,6 +178,12 @@ function Device:init()
                 if not android.prop.brokenLifecycle then
                     UIManager:broadcastEvent(Event:new("Resume"))
                 end
+                if this.device:hasNaturalLight() then
+                    local powerd = this.device.powerd
+                    if powerd.fl_warmth and powerd.fl_warmth > 0 then
+                        android.setScreenWarmth(powerd:toNativeWarmth(powerd.fl_warmth))
+                    end
+                end
                 if external.when_back_callback then
                     external.when_back_callback()
                     external.when_back_callback = nil

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -34,11 +34,24 @@ function AndroidPowerD:init()
         self.fl_warmth_min = android.getScreenMinWarmth()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
+        -- The sysfs warmth node resets on every app start/resume, so push the
+        -- saved value back to hardware now so frontlightWarmthHW() reads it correctly.
+        local saved = G_reader_settings:readSetting("frontlight_warmth") or 0
+        if saved > 0 then
+            android.setScreenWarmth(math.floor(saved * self.warm_diff / 100))
+        end
     end
 end
 
 function AndroidPowerD:setWarmthHW(warmth)
     android.setScreenWarmth(warmth)
+end
+
+function AndroidPowerD:afterResume()
+    if self.device:hasNaturalLight() and self.fl_warmth and self.fl_warmth > 0 then
+        android.setScreenWarmth(self:toNativeWarmth(self.fl_warmth))
+    end
+    BasePowerD.afterResume(self)
 end
 
 function AndroidPowerD:frontlightWarmthHW()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -47,6 +47,7 @@ function AndroidPowerD:setWarmthHW(warmth)
     android.setScreenWarmth(warmth)
     if self.fl_warmth then
         G_reader_settings:saveSetting("frontlight_warmth", self.fl_warmth)
+        G_reader_settings:flush()
     end
 end
 

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -47,13 +47,6 @@ function AndroidPowerD:setWarmthHW(warmth)
     android.setScreenWarmth(warmth)
 end
 
-function AndroidPowerD:afterResume()
-    if self.device:hasNaturalLight() and self.fl_warmth and self.fl_warmth > 0 then
-        android.setScreenWarmth(self:toNativeWarmth(self.fl_warmth))
-    end
-    BasePowerD.afterResume(self)
-end
-
 function AndroidPowerD:frontlightWarmthHW()
     return android.getScreenWarmth() * self.warm_diff
 end

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,5 +1,4 @@
 local BasePowerD = require("device/generic/powerd")
-local logger = require("logger")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
@@ -38,22 +37,17 @@ function AndroidPowerD:init()
         -- The sysfs warmth node resets on every app start/resume, so push the
         -- saved value back to hardware now so frontlightWarmthHW() reads it correctly.
         local saved = G_reader_settings:readSetting("frontlight_warmth") or 0
-        logger.warn("AndroidPowerD:init: saved frontlight_warmth=", saved, "warm_diff=", self.warm_diff)
         if saved > 0 then
-            local native = math.floor(saved * self.warm_diff / 100)
-            logger.warn("AndroidPowerD:init: setting native warmth=", native)
-            android.setScreenWarmth(native)
+            android.setScreenWarmth(math.floor(saved * self.warm_diff / 100))
         end
     end
 end
 
 function AndroidPowerD:setWarmthHW(warmth)
-    logger.warn("AndroidPowerD:setWarmthHW: warmth=", warmth, "fl_warmth=", self.fl_warmth)
     android.setScreenWarmth(warmth)
     if self.fl_warmth then
         G_reader_settings:saveSetting("frontlight_warmth", self.fl_warmth)
         G_reader_settings:flush()
-        logger.warn("AndroidPowerD:setWarmthHW: saved frontlight_warmth=", self.fl_warmth)
     end
 end
 
@@ -81,7 +75,6 @@ function AndroidPowerD:turnOffFrontlightHW()
 end
 
 function AndroidPowerD:turnOnFrontlightHW(done_callback)
-    logger.warn("AndroidPowerD:turnOnFrontlightHW: fl_warmth=", self.fl_warmth, "hasStandaloneWarmth=", android.hasStandaloneWarmth())
     if self:isFrontlightOn() and self:isFrontlightOnHW() then
         return
     end

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -45,6 +45,9 @@ end
 
 function AndroidPowerD:setWarmthHW(warmth)
     android.setScreenWarmth(warmth)
+    if self.fl_warmth then
+        G_reader_settings:saveSetting("frontlight_warmth", self.fl_warmth)
+    end
 end
 
 function AndroidPowerD:frontlightWarmthHW()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -1,4 +1,5 @@
 local BasePowerD = require("device/generic/powerd")
+local logger = require("logger")
 local _, android = pcall(require, "android")
 
 local AndroidPowerD = BasePowerD:new{
@@ -37,17 +38,22 @@ function AndroidPowerD:init()
         -- The sysfs warmth node resets on every app start/resume, so push the
         -- saved value back to hardware now so frontlightWarmthHW() reads it correctly.
         local saved = G_reader_settings:readSetting("frontlight_warmth") or 0
+        logger.warn("AndroidPowerD:init: saved frontlight_warmth=", saved, "warm_diff=", self.warm_diff)
         if saved > 0 then
-            android.setScreenWarmth(math.floor(saved * self.warm_diff / 100))
+            local native = math.floor(saved * self.warm_diff / 100)
+            logger.warn("AndroidPowerD:init: setting native warmth=", native)
+            android.setScreenWarmth(native)
         end
     end
 end
 
 function AndroidPowerD:setWarmthHW(warmth)
+    logger.warn("AndroidPowerD:setWarmthHW: warmth=", warmth, "fl_warmth=", self.fl_warmth)
     android.setScreenWarmth(warmth)
     if self.fl_warmth then
         G_reader_settings:saveSetting("frontlight_warmth", self.fl_warmth)
         G_reader_settings:flush()
+        logger.warn("AndroidPowerD:setWarmthHW: saved frontlight_warmth=", self.fl_warmth)
     end
 end
 
@@ -75,6 +81,7 @@ function AndroidPowerD:turnOffFrontlightHW()
 end
 
 function AndroidPowerD:turnOnFrontlightHW(done_callback)
+    logger.warn("AndroidPowerD:turnOnFrontlightHW: fl_warmth=", self.fl_warmth, "hasStandaloneWarmth=", android.hasStandaloneWarmth())
     if self:isFrontlightOn() and self:isFrontlightOnHW() then
         return
     end

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -243,7 +243,7 @@ function BasePowerD:setWarmth(warmth, force_setting)
     -- Which means that fl_warmth is *also* in the KOReader scale (unlike fl_intensity)
     self.fl_warmth = self:normalizeWarmth(warmth)
     local nat_warmth = self:toNativeWarmth(self.fl_warmth)
-    logger.warn("BasePowerD:setWarmth: fl_warmth=", self.fl_warmth, "->nat=", nat_warmth)
+    logger.warn("BasePowerD:setWarmth: fl_warmth=", self.fl_warmth, "->nat=", nat_warmth, "\n", debug.traceback())
     self:setWarmthHW(nat_warmth)
     self:stateChanged()
     return true

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -243,7 +243,7 @@ function BasePowerD:setWarmth(warmth, force_setting)
     -- Which means that fl_warmth is *also* in the KOReader scale (unlike fl_intensity)
     self.fl_warmth = self:normalizeWarmth(warmth)
     local nat_warmth = self:toNativeWarmth(self.fl_warmth)
-    logger.warn("BasePowerD:setWarmth: fl_warmth=", self.fl_warmth, "->nat=", nat_warmth, "\n", debug.traceback())
+    logger.dbg("set light warmth", self.fl_warmth, "->", nat_warmth)
     self:setWarmthHW(nat_warmth)
     self:stateChanged()
     return true

--- a/frontend/device/generic/powerd.lua
+++ b/frontend/device/generic/powerd.lua
@@ -243,7 +243,7 @@ function BasePowerD:setWarmth(warmth, force_setting)
     -- Which means that fl_warmth is *also* in the KOReader scale (unlike fl_intensity)
     self.fl_warmth = self:normalizeWarmth(warmth)
     local nat_warmth = self:toNativeWarmth(self.fl_warmth)
-    logger.dbg("set light warmth", self.fl_warmth, "->", nat_warmth)
+    logger.warn("BasePowerD:setWarmth: fl_warmth=", self.fl_warmth, "->nat=", nat_warmth)
     self:setWarmthHW(nat_warmth)
     self:stateChanged()
     return true


### PR DESCRIPTION
## Summary

- Adds `NookGL4plusController` light controller for the Nook Glowlight 4 Plus (bnrv1300, Android 8.1)
- Brightness is controlled via `Settings.System.SCREEN_BRIGHTNESS` (direct sysfs writes are blocked by SELinux for the app process)
- Warmth is controlled by writing to `/sys/class/backlight/lm3630a_led/color` via a persistent root shell (SELinux blocks direct ioctl and sysfs writes from `untrusted_app` domain; `su` transitions to a permitted domain)
- A persistent root shell is kept open to avoid spawning a new `su` process per slider movement, addressing potential latency on rapid calls
- Bumps the `android-luajit-launcher` submodule to pick up the new controller

Closes #14574

## Test plan

- [ ] Brightness slider changes screen brightness on Nook Glowlight 4 Plus
- [ ] Warmth slider changes color temperature smoothly without lag
- [ ] Rapid slider movement does not cause freezes (persistent shell reused)
- [ ] Shell is automatically restarted if it dies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15419)
<!-- Reviewable:end -->
