### PR TITLE
android: add WiFi toggle in Settings → Network

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -314,13 +314,18 @@ end
 
 function Device:initNetworkManager(NetworkMgr)
     function NetworkMgr:turnOnWifi(complete_callback)
-        android.openWifiSettings()
+        if not android.setWifiEnabled(true) then
+            -- Android 10+ blocks programmatic WiFi toggling; fall back to system settings
+            android.openWifiSettings()
+        end
         if complete_callback then
             complete_callback()
         end
     end
     function NetworkMgr:turnOffWifi(complete_callback)
-        android.openWifiSettings()
+        if not android.setWifiEnabled(false) then
+            android.openWifiSettings()
+        end
         if complete_callback then
             complete_callback()
         end
@@ -330,13 +335,16 @@ function Device:initNetworkManager(NetworkMgr)
         android.openWifiSettings()
     end
 
+    function NetworkMgr:isWifiOn()
+        return android.isWifiEnabled()
+    end
+
     function NetworkMgr:isConnected()
         local ok = android.getNetworkInfo()
         ok = tonumber(ok)
         if not ok then return false end
         return ok == 1
     end
-    NetworkMgr.isWifiOn = NetworkMgr.isConnected
 end
 
 function Device:performHapticFeedback(type)

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -833,14 +833,7 @@ end
 
 
 function NetworkMgr:getWifiMenuTable()
-    if Device:isAndroid() then
-        return {
-            text = _("Wi-Fi settings"),
-            callback = function() self:openSettings() end,
-        }
-    else
-        return self:getWifiToggleMenuTable()
-    end
+    return self:getWifiToggleMenuTable()
 end
 
 function NetworkMgr:getWifiToggleMenuTable()


### PR DESCRIPTION
## Summary

- Replaces the "Wi-Fi settings" link in Settings → Network with a direct toggle that enables/disables Wi-Fi without leaving KOReader
- `WifiManager.setWifiEnabled()` is tried first; falls back to `su -c "svc wifi enable/disable"` for OEM-locked devices (e.g. Nook) where the API is restricted
- Adds `isWifiEnabled()` / `setWifiEnabled()` JNI bindings in `android.lua` and the corresponding Kotlin implementations

## Test plan

- [ ] Toggle in Settings → Network turns Wi-Fi on and off
- [ ] Works on stock Android (WifiManager path)
- [ ] Works on rooted OEM devices where WifiManager is blocked (svc fallback)
- [ ] No regression on existing "Wi-Fi settings" link behaviour for non-rooted OEM devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15420)
<!-- Reviewable:end -->
