### PR TITLE
android: show SSID, IP address, and MAC in Network info

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -353,14 +353,16 @@ function Device:retrieveNetworkInfo()
     ok, type = tonumber(ok), tonumber(type)
     if not ok or not type or type == C.ANETWORK_NONE then
         return _("Not connected")
-    else
-        if type == C.ANETWORK_WIFI then
-            return _("Connected to Wi-Fi")
-        elseif type == C.ANETWORK_MOBILE then
-            return _("Connected to mobile data network")
-        elseif type == C.ANETWORK_ETHERNET then
-            return _("Connected to Ethernet")
+    elseif type == C.ANETWORK_WIFI then
+        local details = android.getWifiNetworkDetails()
+        if details and details ~= "" then
+            return _("Connected to Wi-Fi") .. "\n" .. details
         end
+        return _("Connected to Wi-Fi")
+    elseif type == C.ANETWORK_MOBILE then
+        return _("Connected to mobile data network")
+    elseif type == C.ANETWORK_ETHERNET then
+        return _("Connected to Ethernet")
     end
 end
 


### PR DESCRIPTION
## Summary

- Extends the Network info dialog in Settings → Network to show Wi-Fi SSID, IP address, and MAC address
- IP is read from `WifiManager.connectionInfo.ipAddress`
- MAC is read from `NetworkInterface.getByName("wlan0")` (avoids the randomized MAC returned by WifiManager on API 28+)
- SSID falls back to parsing `dumpsys wifi | grep -m1 'extra:'` via root shell when the WifiManager API returns `<unknown ssid>` (common without `ACCESS_FINE_LOCATION` permission, e.g. on Nook)
- Adds `getWifiNetworkDetails()` JNI binding in `android.lua` and the corresponding Kotlin implementation

## Test plan

- [ ] Network info shows SSID, IP, and MAC when connected to Wi-Fi
- [ ] Fields are omitted gracefully if unavailable (no location permission, not connected, etc.)
- [ ] No regression when Wi-Fi is off (returns empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15421)
<!-- Reviewable:end -->
