### PR TITLE
[DictQuickLookUp] bug_fix: don't mutate default_layout

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1038,7 +1038,7 @@ function DictQuickLookup:buildButtonLayout()
         -- We must do util.tableDeepCopy here so we don't accidentally save
         -- transient buttons into user settings!
         local config = G_reader_settings:readSetting("dict_button_config")
-        button_layout = config and util.tableDeepCopy(config.layout) or default_layout
+        button_layout = util.tableDeepCopy(config and config.layout or default_layout)
     end
 
     local frame_bordersize = Size.border.window


### PR DESCRIPTION
### bug fix

* ensure we don't accidentally mutate `self.ui.dictionary.default_layout` during dictquicklookup's `buildButtonLayout`

reported https://github.com/koreader/koreader/pull/15184#issuecomment-4485312065

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15422)
<!-- Reviewable:end -->
