### PR TITLE
Implement Stages 3 and 4 features and enhance DrawingCanvas functionality

### DIFF
--- a/plugins/fastnote.koplugin/AGENTS.md
+++ b/plugins/fastnote.koplugin/AGENTS.md
@@ -1,0 +1,101 @@
+# fastnote.koplugin — Maintenance Guide
+
+Full-screen pen drawing canvas for KOReader. Built in four phases: gesture-based drawing (A), SVG save (B), raw evdev input with pressure (C), color/shade picker (D).
+
+## Current Status
+
+| Phase | Goal | Status |
+|-------|------|--------|
+| A | Minimal drawing canvas (gesture-based pan strokes) | 🔲 In progress — `drawingcanvas.lua` is empty |
+| B | Save drawing as SVG | 🔲 Not started |
+| C | Raw evdev input, pressure-sensitive line width | 🔲 Not started |
+| D | Ink color / shade picker overlay | 🔲 Not started |
+
+## Architecture
+
+```
+fastnote.koplugin/
+├── _meta.lua              ← Plugin metadata (name, fullname, description)
+├── main.lua               ← WidgetContainer; registers Dispatcher action + menu entry
+├── drawingcanvas.lua      ← InputContainer canvas widget (Phase A–D)
+├── strokebuffer.lua       ← In-memory stroke list + SVG serializer (Phase B+)
+└── PLAN.md                ← Detailed per-phase implementation plan with code examples
+```
+
+`main.lua` is the plugin entry point. It delegates all drawing work to `DrawingCanvas` via `UIManager:show(DrawingCanvas:new{})`. The canvas is a self-contained widget — closing it returns to whatever screen was active before.
+
+## Key KOReader APIs
+
+**Drawing**
+- `Blitbuffer.new(w, h, Blitbuffer.TYPE_BB8)` — allocate an 8-bit grayscale pixel buffer
+- `bb:paintLine(x0, y0, x1, y1, width, color)` — draw a line segment
+- `bb:blitFrom(src, dx, dy, sx, sy, w, h)` — blit canvas onto the display buffer (called by `paintTo`)
+
+**Display refresh**
+- `UIManager:setDirty(widget, mode, geom)` — schedule a partial screen refresh
+  - `"fast"` — low-latency, allows ghosting (use per stroke segment)
+  - `"ui"` — light partial refresh (use on pen-up)
+  - `"full"` — full refresh, no ghosting (use on canvas open/close)
+
+**Input**
+- `InputContainer:registerTouchZones({...})` — register gesture handlers in `init()`
+- `ges` events: `"pan"` (carries `ges.pos`, `ges.relative`), `"pan_release"`, `"hold"`
+- Raw evdev (Phase C): open `/dev/input/eventX`, poll via `UIManager:scheduleIn`, use `ffi/linux_input_h`
+
+**Screen**
+- `require("device").screen:getSize()` → `{w, h}` Geom
+- `Screen:getWidth()`, `Screen:getHeight()`
+
+## Development Workflow
+
+KOReader has no unit test runner for UI widgets. Development is test-on-device (or emulator):
+
+```bash
+# Build the emulator (from koreader repo root)
+./kodev build
+
+# Run emulator
+./kodev run
+
+# The plugin loads automatically from plugins/fastnote.koplugin/
+# Access via: Menu → More tools → Fast Note
+# Or assign to a gesture: Menu → Gesture Manager → Open Fast Note Canvas
+```
+
+Iterating without a device: edit files, restart the emulator. `logger.dbg(...)` output goes to stdout.
+
+```lua
+local logger = require("logger")
+logger.dbg("fastnote: canvas opened, dimen =", self.dimen)
+```
+
+## Maintenance Notes
+
+**Phase A checklist** (implement `drawingcanvas.lua`):
+- [ ] `init()`: allocate full-screen `BlitBuffer`, fill white, register two touch zones (pan → draw, hold top-left → close)
+- [ ] `paintTo(bb, x, y)`: blit canvas buffer onto display
+- [ ] `onStroke(ges)`: extract prev/curr point from `ges.pos` and `ges.relative`, call `bb:paintLine`, call `UIManager:setDirty` with `"fast"` and tight bounding rect
+- [ ] Wire `main.lua` `onOpenFnoteCanvas` to show `DrawingCanvas:new{}` instead of `InfoMessage`
+- [ ] Wire `addToMainMenu` callback to the same canvas open call
+
+**Phase B** — add `strokebuffer.lua` with `penDown/penMove/penUp/toSVG`, add `pan_release` touch zone, add save+close gesture (hold bottom-left), write to `DataStorage:getDataDir() .. "/fastnote/"`.
+
+**Phase C** — add `openPenDevice()`, `startRawLoop()`, `rawTick()`, `processRawEvent()`, `digToScreen()`. Keep `use_raw_input` flag to fall back to gesture path. Full spec in `PLAN.md`.
+
+**Phase D** — add `showColorPicker()` using `ButtonDialog`, hold bottom-right corner to open. On grayscale: `Blitbuffer.gray()` shades. On color eink: `Blitbuffer.colorRGB()`. Detect at runtime with `Screen:isColorEnabled()`. Update `StrokeBuffer` to track per-stroke color in SVG output.
+
+## Integration Points
+
+- **Dispatcher action:** `open_fnote_canvas` → appears in Gesture Manager and Profile actions
+- **Main menu:** registered under `"more_tools"` sorting hint
+- **DataStorage** (Phase B+): `DataStorage:getDataDir()` for the save path — always resolves correctly across device types
+- **`/dev/input/eventX`** (Phase C): find via `/proc/bus/input/devices` — look for `"Wacom"` or `"[Pp]en"` in device name, extract `eventN` from Handlers line
+
+## Gotchas
+
+- `drawingcanvas.lua` must be required from `main.lua` as `require("plugins/fastnote.koplugin/drawingcanvas")` — relative requires don't work in KOReader plugins.
+- `InputContainer` touch zones are registered in `init()` via `self:registerTouchZones({...})` — not `onShow`.
+- `ges.relative` on a `pan` event is the **delta from the last event**, so the previous point is `ges.pos - ges.relative` (both are `Geom` objects supporting `-`).
+- On eink, `setDirty` with `"full"` on every stroke is too slow — always use `"fast"` per segment and `"ui"` on pen-up.
+- Phase C raw polling at 120 Hz: `UIManager:scheduleIn(0.008, ...)` re-schedules itself — always guard with `if not self._raw_active then return end` and clean up `pen_fd` in the close handler.
+- The digitizer coordinate range (EVIOCGABS) varies by device. Always query at open time; never hardcode `0–4095`.

--- a/plugins/fastnote.koplugin/AGENTS.md
+++ b/plugins/fastnote.koplugin/AGENTS.md
@@ -1,101 +1,251 @@
-# fastnote.koplugin — Maintenance Guide
+# AGENTS.md — fastnote.koplugin
 
-Full-screen pen drawing canvas for KOReader. Built in four phases: gesture-based drawing (A), SVG save (B), raw evdev input with pressure (C), color/shade picker (D).
+Read this before changing any code in this directory.
+Written for a coding agent or developer coming in cold.
 
-## Current Status
+---
 
-| Phase | Goal | Status |
-|-------|------|--------|
-| A | Minimal drawing canvas (gesture-based pan strokes) | 🔲 In progress — `drawingcanvas.lua` is empty |
-| B | Save drawing as SVG | 🔲 Not started |
-| C | Raw evdev input, pressure-sensitive line width | 🔲 Not started |
-| D | Ink color / shade picker overlay | 🔲 Not started |
+## What This Plugin Does
+
+`fastnote` is a KOReader plugin for the **Kobo Libra Colour** that provides a
+full-screen hand-drawn note-taking canvas. Features (planned):
+
+- Multi-page notebooks with a notebook browser
+- Wacom EMR pen input with pressure-sensitive line width
+- Palm rejection via two-device gating (pen + capacitive touch streams)
+- Eraser (physical eraser end of the stylus, stroke-level delete)
+- Undo / redo
+- 6-color palette (Kaleido 3 panel)
+- Pages saved as SVG with embedded JSON stroke data (round-trippable)
+
+**Source of truth for design decisions:** [`dev-plan-v2.md`](dev-plan-v2.md)  
+Read it before implementing any stage. It contains the open questions, the
+storage layout, the coordinate translation formula, and the palm rejection
+algorithm in detail.
+
+---
+
+## Current State
+
+**Stages 0, 1, 2, 3, 4 complete** (147/147 tests passing).
+
+Completed work:
+- Config system (`lib/config.lua`) with `finger_draw` toggle and `rotation_mode`
+- Hamburger menu button (bottom-right) with portrait/landscape rotation + keep/close
+- Orientation lock — canvas locks rotation on open; re-locks on system rotation events
+- Stroke model (`lib/stroke.lua`, `lib/strokebuffer.lua`) — source of truth for all drawing
+- SVG persistence (`lib/svg.lua`) — `svg.write`/`svg.read` with lossless `<metadata>` JSON round-trip
+- Palm rejection (`lib/palmreject.lua`) — pen-proximity gate + area threshold, injectable clock
+- Capacitive touch input (`input/touchdev.lua`) — MT protocol B, non-blocking poll
+- `drawingcanvas.lua` rewritten for Stages 3+4: StrokeBuffer integration, `_digToScreen` rotation-aware coordinate translation, finger-draw toggle in canvas menu, SVG save
+
+**Stage 5 (SVG load + continue editing) is next** — requires on-device testing of Stage 3/4 first.
+
+---
+
+## File Map
+
+```
+fastnote.koplugin/
+├── _meta.lua                  Plugin metadata — do not add logic here
+├── main.lua                   Entry point: config load, Dispatcher, canvas open
+├── drawingcanvas.lua          Drawing canvas widget — all input, rendering, menu, orientation
+├── fastnote.conf.example      Documented user config (finger_draw, rotation_mode)
+├── lib/
+│   ├── canvas_utils.lua       Pure math: compute_dirty_rect, point_in_zone, pressure_to_width
+│   ├── config.lua             Pure Lua config loader (loadfile + pcall + merge)
+│   ├── pen_statemachine.lua   Wacom evdev state machine → high-level pen events
+│   ├── json.lua               Pure Lua JSON encoder/decoder (no KOReader deps; busted-testable)
+│   ├── stroke.lua             Stroke object: points, hitTest, bbox, paintTo, toTable/fromTable
+│   ├── strokebuffer.lua       Stroke list, undo/redo stack, eraseAt, repaintTo, serialization
+│   ├── svg.lua                svg.write() + svg.read() with <metadata> JSON block
+│   └── palmreject.lua         Proximity-gated palm rejection state machine
+├── input/
+│   ├── pendev.lua             FFI: finds Wacom, opens fd, polls events → pen_statemachine
+│   ├── touchdev.lua           FFI: MT protocol B reader for capacitive touch
+│   └── buttondev.lua          [Stage 8] FFI: hardware page button reader
+├── model/
+│   ├── page.lua               [Stage 6] One page: StrokeBuffer + load/save path
+│   ├── notebook.lua           [Stage 6] One notebook: ordered page list + metadata
+│   └── library.lua            [Stage 6] All notebooks + app-wide state
+├── ui/
+│   ├── browser.lua            [Stage 9] Notebook list widget
+│   ├── colorpicker.lua        [Stage 12] Color palette overlay
+│   └── chrome.lua             [Stage 7] Always-visible canvas chrome (exit, page indicator)
+├── spec/
+│   ├── canvas_utils_spec.lua  20 tests ✅
+│   ├── config_spec.lua        14 tests ✅
+│   ├── pen_statemachine_spec.lua  30 tests ✅
+│   ├── palmreject_spec.lua    20 tests ✅
+│   ├── stroke_spec.lua        22 tests ✅
+│   ├── strokebuffer_spec.lua  24 tests ✅
+│   └── svg_spec.lua           17 tests ✅
+├── dev-plan-v2.md             ← canonical design doc (read before implementing any stage)
+├── landscape-research.md      ← analysis of 4 reference plugins
+└── PLAN.md                    ← superseded by dev-plan-v2.md (ignore)
+```
+
+Files marked `[Stage N]` do not exist yet; `model/` and `ui/` dirs do not exist yet.
+
+---
 
 ## Architecture
 
 ```
-fastnote.koplugin/
-├── _meta.lua              ← Plugin metadata (name, fullname, description)
-├── main.lua               ← WidgetContainer; registers Dispatcher action + menu entry
-├── drawingcanvas.lua      ← InputContainer canvas widget (Phase A–D)
-├── strokebuffer.lua       ← In-memory stroke list + SVG serializer (Phase B+)
-└── PLAN.md                ← Detailed per-phase implementation plan with code examples
+main.lua
+    └── UIManager:show(DrawingCanvas)
+            └── drawingcanvas.lua (InputContainer)
+                    ├── BlitBuffer (display cache — rebuilt by replaying StrokeBuffer)
+                    ├── StrokeBuffer (source of truth for stroke data)
+                    │       └── each Stroke → paintTo(bb) + toTable() + SVG polyline
+                    ├── input/ (raw evdev, Stages 2+)
+                    │       ├── pendev.lua    → pen_statemachine → {down/move/up/hover}
+                    │       ├── touchdev.lua  → MT slot events
+                    │       └── lib/palmreject.lua → filters touch through pen-proximity gate
+                    └── ui/chrome.lua [Stage 7] (drawn into the same BlitBuffer)
 ```
 
-`main.lua` is the plugin entry point. It delegates all drawing work to `DrawingCanvas` via `UIManager:show(DrawingCanvas:new{})`. The canvas is a self-contained widget — closing it returns to whatever screen was active before.
+**The BlitBuffer is a display cache** — it can be rebuilt at any time by replaying the StrokeBuffer.
+Never treat BlitBuffer as the source of truth for stroke data.
 
-## Key KOReader APIs
+**Dual-path invariant:** `use_raw_input = Device:isKobo()`. Emulator always uses the gesture
+layer (`onDrawStroke`/`onDrawStrokeEnd`). Device always uses raw evdev poll loop (`_pollPen`).
+Both paths must keep working. Do not break the emulator path when adding device features.
 
-**Drawing**
-- `Blitbuffer.new(w, h, Blitbuffer.TYPE_BB8)` — allocate an 8-bit grayscale pixel buffer
-- `bb:paintLine(x0, y0, x1, y1, width, color)` — draw a line segment
-- `bb:blitFrom(src, dx, dy, sx, sy, w, h)` — blit canvas onto the display buffer (called by `paintTo`)
+---
 
-**Display refresh**
-- `UIManager:setDirty(widget, mode, geom)` — schedule a partial screen refresh
-  - `"fast"` — low-latency, allows ghosting (use per stroke segment)
-  - `"ui"` — light partial refresh (use on pen-up)
-  - `"full"` — full refresh, no ghosting (use on canvas open/close)
+## Development Loop
 
-**Input**
-- `InputContainer:registerTouchZones({...})` — register gesture handlers in `init()`
-- `ges` events: `"pan"` (carries `ges.pos`, `ges.relative`), `"pan_release"`, `"hold"`
-- Raw evdev (Phase C): open `/dev/input/eventX`, poll via `UIManager:scheduleIn`, use `ffi/linux_input_h`
-
-**Screen**
-- `require("device").screen:getSize()` → `{w, h}` Geom
-- `Screen:getWidth()`, `Screen:getHeight()`
-
-## Development Workflow
-
-KOReader has no unit test runner for UI widgets. Development is test-on-device (or emulator):
+### In the SDL emulator (most work happens here)
 
 ```bash
-# Build the emulator (from koreader repo root)
-./kodev build
-
-# Run emulator
+cd /path/to/koreader
 ./kodev run
-
-# The plugin loads automatically from plugins/fastnote.koplugin/
-# Access via: Menu → More tools → Fast Note
-# Or assign to a gesture: Menu → Gesture Manager → Open Fast Note Canvas
 ```
 
-Iterating without a device: edit files, restart the emulator. `logger.dbg(...)` output goes to stdout.
+The emulator supports: widget rendering, BlitBuffer, file I/O, tap/pan gestures (via mouse).
 
+It does NOT support: `/dev/input/eventX`, `EVIOCGABS`, E-Ink waveform modes, `Screen:isColorEnabled()` returning true.
+
+**`use_raw_input` flag:** `drawingcanvas.lua` gates all evdev code behind
+`Device:isKobo()` (or an explicit config flag). When false, the gesture fallback
+path (`onTouch` / `onPan`) allows the canvas to work in the emulator. This
+fallback path must be kept working even after Stages 2+.
+
+### On device (for input stages)
+
+- `input/pendev.lua`, `input/touchdev.lua`, `input/buttondev.lua` require real hardware
+- Use `evtest` to inspect events before writing code: `evtest /dev/input/event0`
+- Capture a palm rejection test stream: `evtest --grab /dev/input/event1 > palm_session.bin`
+- Crash logs: `<onboard>/.adds/koreader/crash.log`
+- Plugin reload: re-trigger the activation gesture (no full KOReader restart needed)
+
+### Running unit tests
+
+```bash
+cd plugins/fastnote.koplugin
+busted spec/
+```
+
+All spec files under `spec/` are pure Lua — no KOReader runtime needed.
+The `lib/` modules have no KOReader/FFI dependencies. The `input/` modules
+do (they use FFI) and are not unit-testable; test them on device.
+
+---
+
+## Stage Checklist
+
+Each stage has a "Definition of done" in `dev-plan-v2.md`. Do not close a stage
+until all criteria pass. The stages in execution order:
+
+```
+0 ✅ → 1 ✅ → 2 ✅ → 4 ✅ → 5 → 6 → 9
+                ↓              ↓
+                3 ✅            7 → 8
+                               ↓
+                               10 → 11 → 12 → 13
+```
+
+Current position: **Stage 5 is next** (SVG load + continue editing).  
+Requires on-device validation of Stage 3/4 first (palm rejection, touch polling, SVG save).
+
+---
+
+## Coding Conventions
+
+- **Lua dialect:** LuaJIT / Lua 5.1. See `.github/instructions/lua.instructions.md` for the full rules.
+- **KOReader patterns:** See `.github/skills/koreader-plugin/SKILL.md` for widget hierarchy, BlitBuffer usage, raw evdev, coordinate translation, setDirty modes, and SVG persistence.
+- **`local` everything.** Global leaks in a long-running KOReader process are hard to debug.
+- **GC discipline in hot paths.** The pen poll loop runs at ~120 Hz. Do not allocate new tables per poll tick — use persistent scratch tables (see `lua.instructions.md` → Tables).
+- **Error handling:** Wrap file I/O and JSON decode in `pcall`. A corrupt page file should degrade gracefully, not crash the plugin.
+
+---
+
+## Open Questions (from dev-plan-v2.md)
+
+These need answers before the relevant stage is implemented. Do not guess —
+surface these to the user when the stage is reached.
+
+| # | Stage | Question | Status |
+|---|-------|----------|--------|
+| 1 | 4 | One SVG file per page, or SVG + separate data file? | **Resolved: one file** ✅ |
+| 2 | 3 | Fingers draw too, or pen-only? | **Resolved: pen-only default; `finger_draw = true` in config enables finger drawing** ✅ |
+| 3 | 7 | Chrome strip height — 56 px? Configurable? | 56 px, maybe configurable |
+| 4 | 8 | Auto-create page on end-of-notebook page-forward? | Auto-create |
+| 5 | 10 | Eraser radius — 24 px default? | 24 px |
+| 6 | — | Include a "Stage 14 — latency tuning" stage? | Side quest |
+| 7 | 2 | Trust EVIOCGABS range, or show first-launch corner calibration wizard? | Trust + fallback wizard in settings |
+
+---
+
+## Key Technical Notes
+
+### Coordinate translation
+Raw Wacom coordinates must be mapped to screen pixels. The formula is in
+`dev-plan-v2.md` → "Coordinate translation." Respect `Screen:getRotationMode()`.
+`drawingcanvas.lua:_digToScreen(rx, ry)` implements all four rotation modes using
+normalized coordinates: `nx = (rx - x_min) / (x_max - x_min)`.
+
+### SVG round-trip
+`svg.read(svg.write(buffer))` must be lossless. The `<metadata>` block contains
+the JSON stroke data. If the block is absent (file hand-edited externally),
+fall back to parsing `<polyline>` elements — never crash.
+
+### ffi.cdef idempotency
+`input/pendev.lua` defines `struct fn_input_absinfo` at module level guarded by
+`pcall(ffi.cdef, ...)`. LuaJIT throws on duplicate struct declarations; never
+put `ffi.cdef` inside a function that may be called more than once.
+
+### Chrome zone
+The top 56 px of the canvas is reserved for UI chrome (exit button, page
+indicator, tools icon). Pen strokes in this zone are ignored. All touch events
+in this zone go to chrome handlers, not to drawing.
+
+### Undo stack scope
+Undo is per-page. Crossing a page boundary clears the undo stack. This is a
+deliberate scope choice — document it in comments if anyone asks.
+
+### Orientation lock
+`drawingcanvas.lua` stores `self._rotation_mode` (the locked mode). On
+`onSetRotationMode(event)`, if the incoming mode differs from `self._rotation_mode`, the
+canvas calls `self:_reinitAtRotation(self._rotation_mode)` to re-lock. That re-lock call
+emits `SetRotationMode(self._rotation_mode)` again — but the handler's `new_mode ~=
+self._rotation_mode` check is false for the second call, so there is no loop. No extra guard
+is needed.
+
+### self.dimen mutation — IN-PLACE only
+GestureRange objects inside `self.ges_events` (DrawStroke, DrawStrokeEnd) hold a direct
+reference to the `self.dimen` table created at init. **Never assign a new table** to
+`self.dimen` — mutate its fields in-place:
 ```lua
-local logger = require("logger")
-logger.dbg("fastnote: canvas opened, dimen =", self.dimen)
+self.dimen.x = 0; self.dimen.y = 0
+self.dimen.w = new_w; self.dimen.h = new_h
 ```
+Only the `MenuTap` zone (which stores its own independent Geom) needs an explicit update
+via `_updateGestureZones()` after a rotation.
 
-## Maintenance Notes
-
-**Phase A checklist** (implement `drawingcanvas.lua`):
-- [ ] `init()`: allocate full-screen `BlitBuffer`, fill white, register two touch zones (pan → draw, hold top-left → close)
-- [ ] `paintTo(bb, x, y)`: blit canvas buffer onto display
-- [ ] `onStroke(ges)`: extract prev/curr point from `ges.pos` and `ges.relative`, call `bb:paintLine`, call `UIManager:setDirty` with `"fast"` and tight bounding rect
-- [ ] Wire `main.lua` `onOpenFnoteCanvas` to show `DrawingCanvas:new{}` instead of `InfoMessage`
-- [ ] Wire `addToMainMenu` callback to the same canvas open call
-
-**Phase B** — add `strokebuffer.lua` with `penDown/penMove/penUp/toSVG`, add `pan_release` touch zone, add save+close gesture (hold bottom-left), write to `DataStorage:getDataDir() .. "/fastnote/"`.
-
-**Phase C** — add `openPenDevice()`, `startRawLoop()`, `rawTick()`, `processRawEvent()`, `digToScreen()`. Keep `use_raw_input` flag to fall back to gesture path. Full spec in `PLAN.md`.
-
-**Phase D** — add `showColorPicker()` using `ButtonDialog`, hold bottom-right corner to open. On grayscale: `Blitbuffer.gray()` shades. On color eink: `Blitbuffer.colorRGB()`. Detect at runtime with `Screen:isColorEnabled()`. Update `StrokeBuffer` to track per-stroke color in SVG output.
-
-## Integration Points
-
-- **Dispatcher action:** `open_fnote_canvas` → appears in Gesture Manager and Profile actions
-- **Main menu:** registered under `"more_tools"` sorting hint
-- **DataStorage** (Phase B+): `DataStorage:getDataDir()` for the save path — always resolves correctly across device types
-- **`/dev/input/eventX`** (Phase C): find via `/proc/bus/input/devices` — look for `"Wacom"` or `"[Pp]en"` in device name, extract `eventN` from Handlers line
-
-## Gotchas
-
-- `drawingcanvas.lua` must be required from `main.lua` as `require("plugins/fastnote.koplugin/drawingcanvas")` — relative requires don't work in KOReader plugins.
-- `InputContainer` touch zones are registered in `init()` via `self:registerTouchZones({...})` — not `onShow`.
-- `ges.relative` on a `pan` event is the **delta from the last event**, so the previous point is `ges.pos - ges.relative` (both are `Geom` objects supporting `-`).
-- On eink, `setDirty` with `"full"` on every stroke is too slow — always use `"fast"` per segment and `"ui"` on pen-up.
-- Phase C raw polling at 120 Hz: `UIManager:scheduleIn(0.008, ...)` re-schedules itself — always guard with `if not self._raw_active then return end` and clean up `pen_fd` in the close handler.
-- The digitizer coordinate range (EVIOCGABS) varies by device. Always query at open time; never hardcode `0–4095`.
+### Gesture zone registration timing
+Touch zones must be registered in `init()` via `self:registerTouchZones({...})` — not in
+`onShow`. The DrawStroke/DrawStrokeEnd zones are **always registered**; the handler
+checks `self.use_raw_input` and `self.finger_draw` at runtime to decide whether to process
+or return early. This allows the `finger_draw` toggle to work without re-registering zones.

--- a/plugins/fastnote.koplugin/PLAN.md
+++ b/plugins/fastnote.koplugin/PLAN.md
@@ -1,0 +1,619 @@
+# fastnote.koplugin — Development Plan
+
+A KOReader plugin that provides a full-screen pen drawing canvas, built in four
+phases of increasing sophistication.
+
+---
+
+## Phase A — Minimal working drawing app
+
+**Goal:** Get a pen stroke on screen. Nothing else matters yet.
+
+### Files to create
+
+```
+plugins/fastnote.koplugin/
+├── _meta.lua
+├── main.lua
+└── drawingcanvas.lua
+```
+
+### `_meta.lua`
+
+Standard plugin metadata. No logic.
+
+```lua
+local _ = require("gettext")
+return {
+    name        = "fastnote",
+    fullname    = _("Ink Canvas"),
+    description = _([[Full-screen pen drawing canvas.]]),
+}
+```
+
+### `main.lua` — plugin skeleton
+
+- Extend `WidgetContainer`.
+- Register a `Dispatcher` action `open_ink_canvas` so it appears in KOReader's
+  gesture-assignment settings (Menu → Gesture Manager → assign to any swipe).
+- `addToMainMenu` adds an entry under **More tools** as a fallback activation method.
+- The action handler calls `UIManager:show(DrawingCanvas:new{})`.
+
+Key imports:
+```lua
+local Dispatcher      = require("dispatcher")
+local UIManager       = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local DrawingCanvas   = require("plugins/fastnote.koplugin/drawingcanvas")
+```
+
+### `drawingcanvas.lua` — the canvas widget
+
+Extend `InputContainer` (gives us touch zone registration and key events for free).
+
+**`init()`**
+
+1. Allocate full-screen `BlitBuffer`:
+   ```lua
+   local Screen = require("device").screen
+   self.dimen = Screen:getSize()
+   self.bb = Blitbuffer.new(self.dimen.w, self.dimen.h, Blitbuffer.TYPE_BB8)
+   self.bb:fill(Blitbuffer.COLOR_WHITE)
+   ```
+2. Register touch zones (see below).
+
+**`paintTo(bb, x, y)`**
+
+Blit the canvas onto whatever the UIManager passes in:
+```lua
+bb:blitFrom(self.bb, x, y, 0, 0, self.dimen.w, self.dimen.h)
+```
+
+**Touch zone: drawing**
+
+```lua
+{
+    id = "canvas_pan",
+    ges = "pan",
+    screen_zone = { ratio_x=0, ratio_y=0, ratio_w=1, ratio_h=1 },
+    handler = function(ges) self:onStroke(ges) end,
+}
+```
+
+`pan` events carry:
+- `ges.pos`      — current `Geom` point
+- `ges.relative` — delta from last point (so prev point = `ges.pos - ges.relative`)
+
+**Drawing a segment**
+
+```lua
+function DrawingCanvas:onStroke(ges)
+    local px = ges.pos.x - ges.relative.x
+    local py = ges.pos.y - ges.relative.y
+    local cx, cy = ges.pos.x, ges.pos.y
+
+    self.bb:paintLine(px, py, cx, cy, self.line_width, self.ink_color)
+
+    local margin = self.line_width + 1
+    UIManager:setDirty(self, "fast", Geom:new{
+        x = math.min(px, cx) - margin,
+        y = math.min(py, cy) - margin,
+        w = math.abs(cx - px) + 2*margin,
+        h = math.abs(cy - py) + 2*margin,
+    })
+end
+```
+
+**Touch zone: exit**
+
+Small hold zone in the top-left corner (60×60 px). On `hold`:
+```lua
+UIManager:close(self)
+```
+This pops the canvas off the widget stack and returns to whatever was open before
+(book, file browser, etc.) with no special cleanup needed.
+
+**Screen update modes (eink)**
+
+| Event               | setDirty mode | Reason                              |
+|---------------------|---------------|-------------------------------------|
+| Canvas open/close   | `"full"`      | Full refresh, no ghosting           |
+| Every stroke segment| `"fast"`      | Low-latency, accepts ghosting       |
+| Pen lift            | `"ui"`        | Light partial refresh               |
+
+### What to test at the end of Phase A
+
+- [ ] Plugin appears in More tools menu
+- [ ] Swipe gesture opens a white screen
+- [ ] Finger/pen draw leaves black lines
+- [ ] Hold top-left corner closes canvas and returns to previous screen
+- [ ] No crash on open/close cycle
+
+---
+
+## Phase B — Save to SVG
+
+**Goal:** Persist drawings as `.svg` files in a sensible location.
+
+### New file: `strokebuffer.lua`
+
+Maintains an in-memory list of strokes. A stroke is a sequence of `{x, y}` points
+(pressure data can be kept here too for future use).
+
+```lua
+StrokeBuffer = {}
+StrokeBuffer.__index = StrokeBuffer
+
+function StrokeBuffer.new()
+    return setmetatable({ strokes = {}, current = nil }, StrokeBuffer)
+end
+
+function StrokeBuffer:penDown(x, y)
+    self.current = { {x=x, y=y} }
+end
+
+function StrokeBuffer:penMove(x, y)
+    if self.current then
+        table.insert(self.current, {x=x, y=y})
+    end
+end
+
+function StrokeBuffer:penUp()
+    if self.current and #self.current > 1 then
+        table.insert(self.strokes, self.current)
+    end
+    self.current = nil
+end
+
+function StrokeBuffer:toSVG(width, height, color, stroke_width)
+    color = color or "#000000"
+    stroke_width = stroke_width or 2
+    local lines = {
+        string.format('<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d">', width, height),
+        string.format('<rect width="%d" height="%d" fill="white"/>', width, height),
+    }
+    for _, stroke in ipairs(self.strokes) do
+        local pts = {}
+        for i, p in ipairs(stroke) do
+            pts[i] = string.format("%d,%d", math.floor(p.x), math.floor(p.y))
+        end
+        table.insert(lines, string.format(
+            '<polyline points="%s" fill="none" stroke="%s" stroke-width="%d" stroke-linecap="round" stroke-linejoin="round"/>',
+            table.concat(pts, " "), color, stroke_width
+        ))
+    end
+    table.insert(lines, "</svg>")
+    return table.concat(lines, "\n")
+end
+```
+
+### Wiring saving into `drawingcanvas.lua`
+
+- Instantiate `StrokeBuffer` on canvas init.
+- On each `pan` event feed `penMove`. On `pan_release` or pen-up, call `penUp`.
+- Add a second exit zone (or a long hold in a different corner) that triggers save
+  before closing.
+
+**Save path:**
+```lua
+local DataStorage = require("datastorage")
+local save_dir = DataStorage:getDataDir() .. "/fastnote/"
+-- filename: fastnote_YYYY-MM-DD_HH-MM-SS.svg
+local filename = os.date("fastnote_%Y-%m-%d_%H-%M-%S") .. ".svg"
+```
+
+**Write:**
+```lua
+local f = io.open(save_dir .. filename, "w")
+f:write(self.stroke_buf:toSVG(self.dimen.w, self.dimen.h, "#000000", self.line_width))
+f:close()
+UIManager:show(InfoMessage:new{ text = "Saved: " .. filename, timeout = 2 })
+```
+
+**`pan_release` zone** — needed to reliably detect pen-up via the gesture path:
+```lua
+{
+    id = "canvas_pan_release",
+    ges = "pan_release",
+    screen_zone = { ratio_x=0, ratio_y=0, ratio_w=1, ratio_h=1 },
+    handler = function(ges)
+        self.stroke_buf:penUp()
+    end,
+}
+```
+
+### What to test at the end of Phase B
+
+- [ ] Each completed stroke is captured in the buffer
+- [ ] Save produces a valid `.svg` file
+- [ ] SVG opened in a desktop browser shows the same drawing
+- [ ] File is written to `<koreader_data>/fastnote/`
+- [ ] Save+close gesture is distinct from just-close gesture
+
+---
+
+## Phase C — Raw evdev input (educational)
+
+**Goal:** Bypass `GestureDetector` entirely. Read `struct input_event` directly from
+`/dev/input/eventX`, parse the Linux input protocol, and drive the canvas from that.
+
+This replicates what `frontend/device/input.lua` does internally, but under your
+direct control.
+
+### Finding the pen device
+
+Parse `/proc/bus/input/devices` at canvas open time:
+
+```lua
+local function find_pen_device()
+    local f = io.open("/proc/bus/input/devices", "r")
+    if not f then return nil end
+    local content = f:read("*a")
+    f:close()
+
+    local current_name, current_handlers
+    for line in content:gmatch("[^\n]+") do
+        local name = line:match('^N: Name="(.*)"')
+        if name then current_name = name end
+
+        local handlers = line:match("^H: Handlers=(.*)")
+        if handlers then current_handlers = handlers end
+
+        -- Kobo Elipsa/Sage: "Wacom I2C Digitizer"
+        -- Other Kobos: look for "Pen" in name
+        if current_name and current_handlers
+        and (current_name:match("[Pp]en") or current_name:match("Wacom")) then
+            local event_node = current_handlers:match("(event%d+)")
+            if event_node then
+                return "/dev/input/" .. event_node
+            end
+        end
+    end
+    return nil
+end
+```
+
+### FFI setup
+
+`ffi/linux_input_h` (already required by KOReader's `input.lua`) defines
+`struct input_event` and the `EV_*`, `ABS_*`, `BTN_*` constants. Reuse them:
+
+```lua
+local ffi = require("ffi")
+local C   = ffi.C
+require("ffi/posix_h")
+require("ffi/linux_input_h")
+```
+
+constants you'll use:
+```
+EV_SYN = 0   EV_KEY = 1   EV_ABS = 3
+ABS_X = 0    ABS_Y = 1    ABS_PRESSURE = 24
+BTN_TOUCH = 330    BTN_TOOL_PEN = 320
+SYN_REPORT = 0
+```
+
+### Opening the device and querying range
+
+```lua
+function DrawingCanvas:openPenDevice(path)
+    self.pen_fd = C.open(path, C.O_RDONLY + C.O_NONBLOCK)
+    if self.pen_fd < 0 then
+        logger.err("fastnote: cannot open pen device", path)
+        return false
+    end
+
+    -- Query the digitizer's absolute axis ranges via EVIOCGABS ioctl
+    local absinfo = ffi.new("struct input_absinfo")
+    if C.ioctl(self.pen_fd, C.EVIOCGABS(C.ABS_X), absinfo) >= 0 then
+        self.digi_x_min = absinfo.minimum
+        self.digi_x_max = absinfo.maximum
+    else
+        -- Safe fallback values (Kobo Elipsa is 0–4095)
+        self.digi_x_min, self.digi_x_max = 0, 4095
+    end
+    if C.ioctl(self.pen_fd, C.EVIOCGABS(C.ABS_Y), absinfo) >= 0 then
+        self.digi_y_min = absinfo.minimum
+        self.digi_y_max = absinfo.maximum
+    else
+        self.digi_y_min, self.digi_y_max = 0, 4095
+    end
+    if C.ioctl(self.pen_fd, C.EVIOCGABS(C.ABS_PRESSURE), absinfo) >= 0 then
+        self.digi_p_min = absinfo.minimum
+        self.digi_p_max = absinfo.maximum
+    else
+        self.digi_p_min, self.digi_p_max = 0, 1024
+    end
+
+    logger.dbg("fastnote: pen device opened:", path)
+    logger.dbg("  X range [%d, %d]", self.digi_x_min, self.digi_x_max)
+    logger.dbg("  Y range [%d, %d]", self.digi_y_min, self.digi_y_max)
+    logger.dbg("  P range [%d, %d]", self.digi_p_min, self.digi_p_max)
+    return true
+end
+```
+
+### Polling loop
+
+Schedule at ~120 Hz from UIManager's tick queue. Drains the entire kernel buffer
+each tick.
+
+```lua
+function DrawingCanvas:startRawLoop()
+    self._raw_active = true
+    UIManager:scheduleIn(0, function() self:rawTick() end)
+end
+
+function DrawingCanvas:rawTick()
+    if not self._raw_active then return end
+
+    local ev = ffi.new("struct input_event")
+    local ev_size = ffi.sizeof(ev)
+
+    while true do
+        local n = C.read(self.pen_fd, ev, ev_size)
+        if n < 0 then break end   -- EAGAIN: buffer empty
+        if n == ev_size then
+            self:processRawEvent(ev.type, ev.code, ev.value)
+        end
+    end
+
+    UIManager:scheduleIn(0.008, function() self:rawTick() end)
+end
+
+function DrawingCanvas:stopRawLoop()
+    self._raw_active = false
+    if self.pen_fd and self.pen_fd >= 0 then
+        C.close(self.pen_fd)
+        self.pen_fd = -1
+    end
+end
+```
+
+### Raw event state machine
+
+```lua
+function DrawingCanvas:processRawEvent(ev_type, code, value)
+    if ev_type == C.EV_ABS then
+        if code == C.ABS_X then
+            self._raw_x = value
+        elseif code == C.ABS_Y then
+            self._raw_y = value
+        elseif code == C.ABS_PRESSURE then
+            self._raw_p = value
+            -- drop hover events (pressure == 0 while pen not touching)
+            if value == 0 and self._pen_down then
+                self:onRawPenUp()
+            end
+        end
+
+    elseif ev_type == C.EV_KEY then
+        if code == C.BTN_TOUCH then
+            if value == 1 then
+                self:onRawPenDown(self._raw_x, self._raw_y, self._raw_p)
+            else
+                self:onRawPenUp()
+            end
+        end
+
+    elseif ev_type == C.EV_SYN then
+        if code == C.SYN_REPORT and self._pen_down then
+            self:onRawPenMove(self._raw_x, self._raw_y, self._raw_p)
+        end
+    end
+end
+```
+
+### Coordinate translation
+
+```lua
+-- Maps raw digitizer integers → screen pixels, respecting rotation.
+function DrawingCanvas:digToScreen(raw_x, raw_y)
+    local Screen = require("device").screen
+    local w = Screen:getWidth()
+    local h = Screen:getHeight()
+
+    local sx = (raw_x - self.digi_x_min) / (self.digi_x_max - self.digi_x_min) * w
+    local sy = (raw_y - self.digi_y_min) / (self.digi_y_max - self.digi_y_min) * h
+
+    -- TODO: account for screen rotation (Screen:getRotationMode())
+    return math.floor(sx), math.floor(sy)
+end
+```
+
+### Pen callbacks
+
+Replace Phase A's `onStroke(ges)` with these:
+
+```lua
+function DrawingCanvas:onRawPenDown(rx, ry, rp)
+    self._pen_down = true
+    local sx, sy = self:digToScreen(rx, ry)
+    self._last_sx, self._last_sy = sx, sy
+    self.stroke_buf:penDown(sx, sy)
+end
+
+function DrawingCanvas:onRawPenMove(rx, ry, rp)
+    local sx, sy = self:digToScreen(rx, ry)
+    local lx, ly = self._last_sx or sx, self._last_sy or sy
+
+    -- Pressure → line width
+    local norm = (rp - self.digi_p_min) / (self.digi_p_max - self.digi_p_min)
+    local width = math.floor(1 + norm^1.5 * 7)  -- 1–8 px
+
+    self.bb:paintLine(lx, ly, sx, sy, width, self.ink_color)
+    self.stroke_buf:penMove(sx, sy)
+
+    self._last_sx, self._last_sy = sx, sy
+
+    local m = width + 1
+    UIManager:setDirty(self, "fast", Geom:new{
+        x = math.min(lx, sx) - m, y = math.min(ly, sy) - m,
+        w = math.abs(sx - lx) + 2*m, h = math.abs(sy - ly) + 2*m,
+    })
+end
+
+function DrawingCanvas:onRawPenUp()
+    self._pen_down = false
+    self.stroke_buf:penUp()
+    self._last_sx, self._last_sy = nil, nil
+    UIManager:setDirty(self, "ui")
+end
+```
+
+### Replacing Phase A input without breaking the plugin structure
+
+Keep Phase A's touch-zone drawing active as a fallback flag:
+
+```lua
+self.use_raw_input = true  -- flip to false to revert to gesture path
+```
+
+In `init()`, branch on this flag to either call `self:openPenDevice(...)` +
+`self:startRawLoop()` or just use the `registerTouchZones` path from Phase A.
+
+### What to test at the end of Phase C
+
+- [ ] `/proc/bus/input/devices` parsing finds the correct `eventX` node
+- [ ] `EVIOCGABS` returns sane range values (log them at startup)
+- [ ] Strokes appear at the correct screen position (no offset or mirroring)
+- [ ] Pressure variation visibly changes line width
+- [ ] Hover (pen near screen, not touching) does not draw
+- [ ] Canvas still closes cleanly (fd is closed, rawTick loop exits)
+- [ ] Switching `use_raw_input = false` restores Phase A gesture behaviour
+
+---
+
+## Phase D — Color picker
+
+**Goal:** Let the user choose ink color before or during drawing.
+
+### Where to add UI
+
+Two sensible trigger spots:
+1. **Bottom-right corner hold** — opens a small color picker overlay on top of
+   the canvas. Non-destructive (canvas stays underneath, strokes continue on dismiss).
+2. **Menu entry** — for users who added the plugin to the main menu; set a
+   persistent default color in `G_reader_settings`.
+
+### Color representation
+
+KOReader's BlitBuffer operates in grayscale (TYPE_BB8) on most eink devices.
+On a grayscale display, "color" means gray level. On devices with color eink
+(Kobo Libra Colour etc.), you can use Blitbuffer.TYPE_BBRGB32 and full RGB.
+
+#### Grayscale-only path (safe everywhere)
+
+```lua
+local shade_list = {
+    { label = "Black",    color = Blitbuffer.COLOR_BLACK      },
+    { label = "Dark gray",color = Blitbuffer.gray(0.25)       },
+    { label = "Gray",     color = Blitbuffer.gray(0.5)        },
+    { label = "Light",    color = Blitbuffer.gray(0.75)       },
+}
+```
+
+#### Color eink path (Kobo Libra Colour, etc.)
+
+```lua
+local color_list = {
+    { label = "Black",  color = Blitbuffer.colorRGB(0,   0,   0  ) },
+    { label = "Red",    color = Blitbuffer.colorRGB(220, 20,  20 ) },
+    { label = "Blue",   color = Blitbuffer.colorRGB(30,  80,  200) },
+    { label = "Green",  color = Blitbuffer.colorRGB(20,  160, 20 ) },
+}
+```
+
+Detect at runtime:
+```lua
+local Screen = require("device").screen
+self.use_color = Screen:isColorEnabled()
+local palette = self.use_color and color_list or shade_list
+```
+
+### Color picker overlay widget
+
+A simple `ButtonDialog` or custom `OverlapGroup` — show it on top of the canvas
+without closing the canvas:
+
+```lua
+local ButtonDialog = require("ui/widget/buttondialog")
+
+function DrawingCanvas:showColorPicker()
+    local buttons = {}
+    for _, entry in ipairs(self.palette) do
+        table.insert(buttons, {{
+            text = entry.label,
+            callback = function()
+                self.ink_color = entry.color
+                UIManager:close(self._color_picker)
+                self._color_picker = nil
+            end,
+        }})
+    end
+    self._color_picker = ButtonDialog:new{
+        title    = "Ink color",
+        buttons  = buttons,
+    }
+    UIManager:show(self._color_picker)
+end
+```
+
+Register the trigger zone:
+
+```lua
+{
+    id = "canvas_color_picker",
+    ges = "hold",
+    screen_zone = {
+        ratio_x = 1 - (60/self.dimen.w),
+        ratio_y = 0,
+        ratio_w = 60/self.dimen.w,
+        ratio_h = 60/self.dimen.h,
+    },
+    handler = function() self:showColorPicker() end,
+}
+```
+
+### SVG color output update (links back to Phase B)
+
+`StrokeBuffer` needs to track per-stroke color. Add `color` as a field on each
+stroke entry, set at `penDown` time. In `toSVG`, use each stroke's `.color` field
+instead of the global parameter.
+
+### What to test at the end of Phase D
+
+- [ ] Hold bottom-right opens color picker without closing canvas
+- [ ] Selecting a new color affects only new strokes (old ones unchanged)
+- [ ] Saved SVG has correct per-stroke color values
+- [ ] On a grayscale device, all "colors" display as distinct visible shades
+- [ ] On a color device (if available), strokes render in the chosen color
+
+---
+
+## Summary of files and their phases
+
+| File                     | Created in | Modified in  |
+|--------------------------|------------|--------------|
+| `_meta.lua`              | A          | —            |
+| `main.lua`               | A          | —            |
+| `drawingcanvas.lua`      | A          | B, C, D      |
+| `strokebuffer.lua`       | B          | C (pressure), D (color) |
+
+---
+
+## Suggested test device: Kobo Elipsa 2E or Sage
+
+Both use the Wacom EMR pen via `wacom_protocol = true` in KOReader's Kobo device
+layer. The pen device is typically `/dev/input/event1` or `/dev/input/event2`.
+Cross-check with:
+
+```sh
+cat /proc/bus/input/devices | grep -A6 -i "wacom\|pen"
+```
+
+To watch raw events live from the shell (useful during Phase C debugging):
+
+```sh
+evtest /dev/input/event2
+```

--- a/plugins/fastnote.koplugin/_meta.lua
+++ b/plugins/fastnote.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "fastnote",
+    fullname = _("Fast Note"),
+    description = _([[Full-screen pen canvas for quick notes.]]),
+}

--- a/plugins/fastnote.koplugin/drawingcanvas.lua
+++ b/plugins/fastnote.koplugin/drawingcanvas.lua
@@ -1,0 +1,598 @@
+--[[--
+DrawingCanvas — Stage 3 / Stage 4 implementation.
+
+Full-screen drawing canvas backed by a BlitBuffer and a StrokeBuffer.
+
+Input paths (selected by use_raw_input flag):
+  • Gesture layer (use_raw_input = false, emulator / fallback):
+      pan gesture → draw segment; pan_release → flash refresh.
+      Always registered; on device the handler returns early unless
+      finger_draw is true — see onDrawStroke.
+  • Raw evdev (use_raw_input = true, device-only):
+      _pollPen loop at ~120 Hz reads Wacom events.
+      _pollTouch loop at ~60 Hz reads touch events, filtered by PalmReject.
+      Supports pressure-sensitive line width and palm rejection.
+
+Stage 4: StrokeBuffer is the source of truth.  BlitBuffer is a display cache
+rebuilt by repaintTo after undo/erase/rotation.
+
+Stage 3: PalmReject gates capacitive touch events through pen-proximity.
+Pen-only mode is the default; finger_draw can be toggled in the canvas menu.
+
+Exit zone: tap in the top-left EXIT_ZONE_SIZE × EXIT_ZONE_SIZE area closes
+the canvas.
+
+ASSUMES: InputContainer, GestureRange, UIManager, Screen, Blitbuffer are
+  available from the KOReader runtime (not required for unit tests of lib/).
+--]]--
+
+local Blitbuffer        = require("ffi/blitbuffer")
+local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local Device            = require("device")
+local GestureRange      = require("ui/gesturerange")
+local Geom              = require("ui/geometry")
+local InputContainer    = require("ui/widget/container/inputcontainer")
+local PenDev            = require("input/pendev")
+local Screen            = Device.screen
+local StrokeBuffer      = require("lib/strokebuffer")
+local UIManager         = require("ui/uimanager")
+local logger            = require("logger")
+local utils             = require("lib/canvas_utils")
+
+-- Exit-zone tap area (top-left square, in pixels)
+local EXIT_ZONE_SIZE = 60
+
+-- Menu button (bottom-right corner)
+local MENU_BTN_SIZE    = 80
+local MENU_BTN_MARGIN  = 24
+local MENU_BTN_HIT_PAD =  8
+
+-- Default stroke appearance
+local DEFAULT_LINE_WIDTH = 3
+local STROKE_COLOR       = Blitbuffer.COLOR_BLACK
+local DEFAULT_COLOR      = "#000000"
+
+-- Rotation mode constants
+local ROT_PORTRAIT  = 0  -- DEVICE_ROTATED_UPRIGHT
+local ROT_LANDSCAPE = 3  -- DEVICE_ROTATED_COUNTER_CLOCKWISE
+
+---@class DrawingCanvas : InputContainer
+local DrawingCanvas = InputContainer:extend{
+    on_close_callback  = nil,
+
+    _bb           = nil,           -- BlitBuffer (display cache)
+    _stroke_buf   = nil,           -- StrokeBuffer (source of truth, Stage 4)
+    _current_color = DEFAULT_COLOR,
+
+    use_raw_input      = false,    -- false = gesture layer; true = raw evdev
+    finger_draw        = false,    -- allow capacitive touch to draw (pen-only default)
+
+    init_rotation_mode = nil,
+    _rotation_mode     = nil,
+
+    _pendev    = nil,              -- PenDev instance
+    _touchdev  = nil,              -- TouchDev instance (Stage 3)
+    _palmreject = nil,             -- PalmReject instance (Stage 3)
+
+    -- Raw pen tracking (raw input path)
+    _last_pen_x = nil,
+    _last_pen_y = nil,
+
+    -- Gesture path tracking
+    _stroke_x     = nil,
+    _stroke_y     = nil,
+    _stroke_min_x = nil,
+    _stroke_min_y = nil,
+    _stroke_max_x = nil,
+    _stroke_max_y = nil,
+}
+
+-- ---------------------------------------------------------------------------
+-- Lifecycle
+-- ---------------------------------------------------------------------------
+
+function DrawingCanvas:init()
+    self.dimen = Geom:new{x=0, y=0,
+                          w=Screen:getWidth(), h=Screen:getHeight()}
+
+    local bbtype = Screen:isColorEnabled()
+        and Blitbuffer.TYPE_BBRGB32
+        or  Blitbuffer.TYPE_BB8
+    self._bb = Blitbuffer.new(self.dimen.w, self.dimen.h, bbtype)
+    self._bb:fill(Blitbuffer.COLOR_WHITE)
+
+    self._stroke_buf = StrokeBuffer.new()
+
+    logger.dbg("FastNote canvas: init", self.dimen.w, "x", self.dimen.h,
+               "color=", Screen:isColorEnabled())
+
+    self.use_raw_input = Device:isKobo()
+
+    -- Orientation lock
+    if type(self.init_rotation_mode) == "number" then
+        Screen:setRotationMode(self.init_rotation_mode)
+    end
+    self._rotation_mode = Screen:getRotationMode()
+    logger.dbg("FastNote canvas: orientation locked to mode", self._rotation_mode)
+
+    -- ── Gesture zones ──────────────────────────────────────────────────────
+
+    -- Exit zone: top-left corner tap
+    self.ges_events.ExitTap = {
+        GestureRange:new{
+            ges   = "tap",
+            range = Geom:new{x=0, y=0, w=EXIT_ZONE_SIZE, h=EXIT_ZONE_SIZE},
+        },
+    }
+
+    -- Menu button: bottom-right corner tap (always active, even in pen-only mode)
+    local bvx = self.dimen.w - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    local bvy = self.dimen.h - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    self.ges_events.MenuTap = {
+        GestureRange:new{
+            ges   = "tap",
+            range = Geom:new{
+                x = bvx - MENU_BTN_HIT_PAD,
+                y = bvy - MENU_BTN_HIT_PAD,
+                w = MENU_BTN_SIZE + MENU_BTN_HIT_PAD * 2,
+                h = MENU_BTN_SIZE + MENU_BTN_HIT_PAD * 2,
+            },
+        },
+    }
+
+    -- Drawing gesture zones: always registered.
+    -- On device (use_raw_input=true), onDrawStroke returns early unless
+    -- finger_draw is enabled, keeping the emulator path always working.
+    self.ges_events.DrawStroke = {
+        GestureRange:new{ges="pan", range=self.dimen},
+    }
+    self.ges_events.DrawStrokeEnd = {
+        GestureRange:new{ges="pan_release", range=self.dimen},
+    }
+
+    -- ── Raw input setup ────────────────────────────────────────────────────
+
+    if self.use_raw_input then
+        -- Pen device
+        local pen_path = PenDev.find()
+        if pen_path then
+            local pd, err = PenDev.open(pen_path)
+            if pd then
+                self._pendev = pd
+                UIManager:scheduleIn(0.008, function() self:_pollPen() end)
+                logger.dbg("FastNote canvas: raw pen enabled:", pen_path)
+            else
+                logger.warn("FastNote canvas: pendev open failed:", err)
+            end
+        else
+            logger.warn("FastNote canvas: Wacom not found; falling back to gestures")
+        end
+
+        -- Touch device (Stage 3 palm rejection)
+        local ok_touch, TouchDev = pcall(require, "input/touchdev")
+        if ok_touch then
+            local touch_path = TouchDev.find()
+            if touch_path then
+                local td, err = TouchDev.open(touch_path)
+                if td then
+                    self._touchdev = td
+                    local PalmReject = require("lib/palmreject")
+                    self._palmreject = PalmReject.new()
+                    UIManager:scheduleIn(0.016, function() self:_pollTouch() end)
+                    logger.dbg("FastNote canvas: touch + palm rejection enabled:", touch_path)
+                else
+                    logger.warn("FastNote canvas: touchdev open failed:", err)
+                end
+            end
+        end
+    end
+end
+
+function DrawingCanvas:onCloseWidget()
+    logger.dbg("FastNote canvas: onCloseWidget, freeing resources")
+    if self._pendev then
+        self._pendev:close()
+        self._pendev = nil
+    end
+    if self._touchdev then
+        self._touchdev:close()
+        self._touchdev = nil
+    end
+    if self._bb then
+        self._bb:free()
+        self._bb = nil
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Rendering
+-- ---------------------------------------------------------------------------
+
+function DrawingCanvas:paintTo(bb, x, y)
+    self.dimen.x = x
+    self.dimen.y = y
+    if not self._bb then return end
+    bb:blitFrom(self._bb, x, y, 0, 0, self.dimen.w, self.dimen.h)
+
+    -- Menu button drawn into the screen buffer so it's always on top
+    local bx = x + self.dimen.w - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    local by = y + self.dimen.h - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    bb:paintRect(bx, by, MENU_BTN_SIZE, MENU_BTN_SIZE, Blitbuffer.COLOR_BLACK)
+    local bar_w = math.floor(MENU_BTN_SIZE * 0.60)
+    local bar_h = 4
+    local bar_x = bx + math.floor((MENU_BTN_SIZE - bar_w) / 2)
+    bb:paintRect(bar_x, by + 22, bar_w, bar_h, Blitbuffer.COLOR_WHITE)
+    bb:paintRect(bar_x, by + 36, bar_w, bar_h, Blitbuffer.COLOR_WHITE)
+    bb:paintRect(bar_x, by + 50, bar_w, bar_h, Blitbuffer.COLOR_WHITE)
+end
+
+-- ---------------------------------------------------------------------------
+-- Gesture handlers
+-- ---------------------------------------------------------------------------
+
+function DrawingCanvas:onExitTap(_, ges)
+    if utils.point_in_zone(ges.pos.x, ges.pos.y, 0, 0, EXIT_ZONE_SIZE, EXIT_ZONE_SIZE) then
+        logger.dbg("FastNote canvas: exit tap")
+        self:_doClose()
+        return true
+    end
+end
+
+function DrawingCanvas:onMenuTap()
+    logger.dbg("FastNote canvas: menu tap")
+    local cur          = self._rotation_mode
+    local portrait_lbl  = (cur == ROT_PORTRAIT)  and "Portrait \xE2\x9C\x93"  or "Portrait"
+    local landscape_lbl = (cur == ROT_LANDSCAPE) and "Landscape \xE2\x9C\x93" or "Landscape"
+    local finger_lbl    = self.finger_draw and "Finger draw: on" or "Finger draw: off"
+    local menu
+
+    menu = ButtonDialogTitle:new{
+        title = "Fast Note",
+        buttons = {
+            {
+                {text = portrait_lbl,
+                 callback = function()
+                     UIManager:close(menu)
+                     self:_reinitAtRotation(ROT_PORTRAIT)
+                 end},
+                {text = landscape_lbl,
+                 callback = function()
+                     UIManager:close(menu)
+                     self:_reinitAtRotation(ROT_LANDSCAPE)
+                 end},
+            },
+            {
+                {text = finger_lbl,
+                 callback = function()
+                     UIManager:close(menu)
+                     self.finger_draw = not self.finger_draw
+                     logger.dbg("FastNote canvas: finger_draw =", self.finger_draw)
+                 end},
+                {text = "Save drawing",
+                 callback = function()
+                     UIManager:close(menu)
+                     self:_saveDrawing()
+                 end},
+            },
+            {
+                {text = "Keep drawing",
+                 callback = function() UIManager:close(menu) end},
+                {text = "Close canvas",
+                 callback = function()
+                     UIManager:close(menu)
+                     self:_doClose()
+                 end},
+            },
+        },
+    }
+    UIManager:show(menu)
+    return true
+end
+
+--- Block accelerometer auto-rotation while the canvas is open.
+function DrawingCanvas:onSetRotationMode(event)
+    local new_mode = type(event) == "number" and event
+                     or (type(event) == "table" and event[1] or nil)
+    if new_mode ~= nil and new_mode ~= self._rotation_mode then
+        logger.dbg("FastNote canvas: blocking auto-rotation to", new_mode)
+        Screen:setRotationMode(self._rotation_mode)
+        UIManager:setDirty(self, "full")
+    end
+    return true
+end
+
+function DrawingCanvas:onDrawStroke(_, ges)
+    -- On device, gesture path is only active when finger_draw is enabled.
+    if self.use_raw_input and not self.finger_draw then return end
+    if not self._bb then return end
+
+    local x = math.floor(ges.pos.x)
+    local y = math.floor(ges.pos.y)
+    local prev_x = self._stroke_x or x
+    local prev_y = self._stroke_y or y
+
+    -- StrokeBuffer: start or extend current stroke
+    if not self._stroke_buf.current then
+        self._stroke_buf:penDown(prev_x, prev_y, DEFAULT_LINE_WIDTH, self._current_color)
+    end
+    self._stroke_buf:penMove(x, y, DEFAULT_LINE_WIDTH)
+
+    self._bb:paintLine(prev_x, prev_y, x, y, DEFAULT_LINE_WIDTH, STROKE_COLOR)
+
+    self._stroke_min_x = math.min(self._stroke_min_x or x, prev_x, x)
+    self._stroke_min_y = math.min(self._stroke_min_y or y, prev_y, y)
+    self._stroke_max_x = math.max(self._stroke_max_x or x, prev_x, x)
+    self._stroke_max_y = math.max(self._stroke_max_y or y, prev_y, y)
+    self._stroke_x     = x
+    self._stroke_y     = y
+
+    local dirty = utils.compute_dirty_rect(prev_x, prev_y, x, y, DEFAULT_LINE_WIDTH)
+    UIManager:setDirty(self, function() return "fast", Geom:new(dirty) end)
+    return true
+end
+
+function DrawingCanvas:onDrawStrokeEnd(_, ges)
+    if self.use_raw_input and not self.finger_draw then return end
+    if not self._bb then return end
+
+    if ges and ges.pos then
+        local x = math.floor(ges.pos.x)
+        local y = math.floor(ges.pos.y)
+        if self._stroke_x and self._stroke_y then
+            self._stroke_buf:penMove(x, y, DEFAULT_LINE_WIDTH)
+            self._bb:paintLine(self._stroke_x, self._stroke_y,
+                               x, y, DEFAULT_LINE_WIDTH, STROKE_COLOR)
+        end
+        self._stroke_max_x = math.max(self._stroke_max_x or x, x)
+        self._stroke_max_y = math.max(self._stroke_max_y or y, y)
+        self._stroke_min_x = math.min(self._stroke_min_x or x, x)
+        self._stroke_min_y = math.min(self._stroke_min_y or y, y)
+    end
+
+    self._stroke_buf:penUp()
+
+    if self._stroke_min_x then
+        local stroke_rect = utils.compute_dirty_rect(
+            self._stroke_min_x, self._stroke_min_y,
+            self._stroke_max_x, self._stroke_max_y,
+            DEFAULT_LINE_WIDTH)
+        UIManager:setDirty(self, function() return "ui", Geom:new(stroke_rect) end)
+    end
+
+    self._stroke_x     = nil
+    self._stroke_y     = nil
+    self._stroke_min_x = nil
+    self._stroke_min_y = nil
+    self._stroke_max_x = nil
+    self._stroke_max_y = nil
+    return true
+end
+
+-- ---------------------------------------------------------------------------
+-- Internal helpers
+-- ---------------------------------------------------------------------------
+
+--- Translate raw Wacom digitizer coordinates to screen pixels.
+-- Handles all four rotation modes.  Uses the canvas-locked rotation
+-- (self._rotation_mode) rather than Screen:getRotationMode() to avoid
+-- any race with auto-rotation blocking.
+-- @number rx  raw digitizer x (from pendev)
+-- @number ry  raw digitizer y
+-- @return sx, sy  integer screen coordinates
+function DrawingCanvas:_digToScreen(rx, ry)
+    local pd  = self._pendev
+    local W   = Screen:getWidth()
+    local H   = Screen:getHeight()
+    local nx  = (rx - pd.x_min) / (pd.x_max - pd.x_min)
+    local ny  = (ry - pd.y_min) / (pd.y_max - pd.y_min)
+    -- Clamp to [0,1] in case of out-of-range values during fast movement
+    nx = math.max(0, math.min(1, nx))
+    ny = math.max(0, math.min(1, ny))
+
+    local rot = self._rotation_mode
+    if     rot == 0 then
+        return math.floor(nx * (W-1)), math.floor(ny * (H-1))
+    elseif rot == 1 then
+        return math.floor((1-ny) * (W-1)), math.floor(nx  * (H-1))
+    elseif rot == 2 then
+        return math.floor((1-nx) * (W-1)), math.floor((1-ny) * (H-1))
+    elseif rot == 3 then
+        return math.floor(ny     * (W-1)), math.floor((1-nx) * (H-1))
+    end
+    return math.floor(nx * (W-1)), math.floor(ny * (H-1))
+end
+
+function DrawingCanvas:_updateGestureZones()
+    if not (self.ges_events.MenuTap and self.ges_events.MenuTap[1]) then return end
+    local bvx = self.dimen.w - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    local bvy = self.dimen.h - MENU_BTN_MARGIN - MENU_BTN_SIZE
+    local r   = self.ges_events.MenuTap[1].range
+    r.x = bvx - MENU_BTN_HIT_PAD
+    r.y = bvy - MENU_BTN_HIT_PAD
+    r.w = MENU_BTN_SIZE + MENU_BTN_HIT_PAD * 2
+    r.h = MENU_BTN_SIZE + MENU_BTN_HIT_PAD * 2
+end
+
+--- Apply a rotation change from the canvas menu.
+-- After Stage 4: strokes are preserved via repaintTo.
+function DrawingCanvas:_reinitAtRotation(new_mode)
+    if new_mode == self._rotation_mode then return end
+    logger.dbg("FastNote canvas: rotating to mode", new_mode)
+
+    Screen:setRotationMode(new_mode)
+    self._rotation_mode = new_mode
+
+    self.dimen.w = Screen:getWidth()
+    self.dimen.h = Screen:getHeight()
+
+    local bbtype = Screen:isColorEnabled()
+        and Blitbuffer.TYPE_BBRGB32
+        or  Blitbuffer.TYPE_BB8
+    if self._bb then self._bb:free() end
+    self._bb = Blitbuffer.new(self.dimen.w, self.dimen.h, bbtype)
+    self._bb:fill(Blitbuffer.COLOR_WHITE)
+
+    -- Replay strokes into the new buffer (Stage 4: preserve on rotate)
+    if self._stroke_buf then
+        self._stroke_buf:repaintTo(self._bb)
+    end
+
+    -- Reset per-stroke state (old screen coords are invalid after rotation)
+    self._last_pen_x   = nil
+    self._last_pen_y   = nil
+    self._stroke_x     = nil
+    self._stroke_y     = nil
+    self._stroke_min_x = nil
+    self._stroke_min_y = nil
+    self._stroke_max_x = nil
+    self._stroke_max_y = nil
+
+    self:_updateGestureZones()
+    UIManager:setDirty(self, "full")
+end
+
+--- Raw pen poll loop at ~120 Hz.
+function DrawingCanvas:_pollPen()
+    if not self._pendev then return end
+
+    self._pendev:poll(function(ev)
+        -- Feed pen event to palm rejection state machine (Stage 3)
+        if self._palmreject then
+            self._palmreject:onPenEvent(ev)
+        end
+
+        if ev.type == "down" or ev.type == "move" then
+            local sx, sy = self:_digToScreen(ev.x, ev.y)
+            local lw     = utils.pressure_to_width(
+                ev.pressure, self._pendev.p_max, 1, 8)
+
+            -- StrokeBuffer accumulation (Stage 4)
+            if ev.type == "down" then
+                self._stroke_buf:penDown(sx, sy, lw, self._current_color)
+            else
+                self._stroke_buf:penMove(sx, sy, lw)
+            end
+
+            if self._last_pen_x then
+                self._bb:paintLine(
+                    self._last_pen_x, self._last_pen_y, sx, sy, lw, STROKE_COLOR)
+                local dirty = utils.compute_dirty_rect(
+                    self._last_pen_x, self._last_pen_y, sx, sy, lw)
+                UIManager:setDirty(self, function()
+                    return "fast", Geom:new(dirty)
+                end)
+            end
+            self._last_pen_x = sx
+            self._last_pen_y = sy
+
+        elseif ev.type == "up" then
+            self._stroke_buf:penUp()
+            self._last_pen_x = nil
+            self._last_pen_y = nil
+            UIManager:setDirty(self, "ui")
+
+        elseif ev.type == "eraser" or
+               (ev.type == "down" and ev.tool == "eraser") then
+            -- Eraser end of stylus: Stage 10 will implement stroke-level erase.
+            -- For now, commit any open stroke and ignore the eraser motion.
+            self._stroke_buf:penUp()
+            self._last_pen_x = nil
+            self._last_pen_y = nil
+        end
+    end)
+
+    if self._pendev then
+        UIManager:scheduleIn(0.008, function() self:_pollPen() end)
+    end
+end
+
+--- Raw touch poll loop at ~60 Hz (Stage 3).
+-- Events are filtered through PalmReject before acting on them.
+function DrawingCanvas:_pollTouch()
+    if not self._touchdev then return end
+
+    self._touchdev:poll(function(slot_ev)
+        -- Filter through palm rejection
+        local filtered = self._palmreject
+            and self._palmreject:onTouchEvent(slot_ev)
+            or  slot_ev
+
+        if filtered and self.finger_draw then
+            -- Touch drawing path (finger_draw is on):
+            -- treat touch events like pen events using DEFAULT_LINE_WIDTH.
+            if filtered.type == "down" then
+                self._stroke_buf:penDown(filtered.x, filtered.y,
+                                         DEFAULT_LINE_WIDTH, self._current_color)
+                self._last_pen_x = filtered.x
+                self._last_pen_y = filtered.y
+            elseif filtered.type == "move" then
+                self._stroke_buf:penMove(filtered.x, filtered.y, DEFAULT_LINE_WIDTH)
+                if self._last_pen_x then
+                    self._bb:paintLine(self._last_pen_x, self._last_pen_y,
+                                       filtered.x, filtered.y,
+                                       DEFAULT_LINE_WIDTH, STROKE_COLOR)
+                    local dirty = utils.compute_dirty_rect(
+                        self._last_pen_x, self._last_pen_y,
+                        filtered.x, filtered.y, DEFAULT_LINE_WIDTH)
+                    UIManager:setDirty(self, function()
+                        return "fast", Geom:new(dirty)
+                    end)
+                end
+                self._last_pen_x = filtered.x
+                self._last_pen_y = filtered.y
+            elseif filtered.type == "up" then
+                self._stroke_buf:penUp()
+                self._last_pen_x = nil
+                self._last_pen_y = nil
+                UIManager:setDirty(self, "ui")
+            end
+        end
+    end)
+
+    if self._touchdev then
+        UIManager:scheduleIn(0.016, function() self:_pollTouch() end)
+    end
+end
+
+--- Save current drawing to a timestamped SVG file.
+function DrawingCanvas:_saveDrawing()
+    if self._stroke_buf:isEmpty() then
+        logger.dbg("FastNote canvas: nothing to save")
+        return
+    end
+
+    local ok_svg, svg_module = pcall(require, "lib/svg")
+    if not ok_svg then
+        logger.warn("FastNote canvas: svg module unavailable:", svg_module)
+        return
+    end
+
+    local DataStorage = require("datastorage")
+    local save_dir    = DataStorage:getDataDir() .. "/fastnote/"
+
+    -- Ensure directory exists
+    os.execute("mkdir -p " .. save_dir)
+
+    local filename = os.date("fastnote_%Y-%m-%d_%H-%M-%S.svg")
+    local path     = save_dir .. filename
+    local f        = io.open(path, "w")
+    if not f then
+        logger.warn("FastNote canvas: cannot write to", path)
+        return
+    end
+    f:write(svg_module.write(self._stroke_buf, self.dimen.w, self.dimen.h))
+    f:close()
+
+    local InfoMessage = require("ui/widget/infomessage")
+    UIManager:show(InfoMessage:new{text = "Saved: " .. filename, timeout = 2})
+    logger.dbg("FastNote canvas: saved to", path)
+end
+
+function DrawingCanvas:_doClose()
+    UIManager:close(self)
+    if self.on_close_callback then
+        self.on_close_callback()
+    end
+end
+
+return DrawingCanvas

--- a/plugins/fastnote.koplugin/drawingcanvas.lua
+++ b/plugins/fastnote.koplugin/drawingcanvas.lua
@@ -162,10 +162,13 @@ function DrawingCanvas:init()
                 UIManager:scheduleIn(0.008, function() self:_pollPen() end)
                 logger.dbg("FastNote canvas: raw pen enabled:", pen_path)
             else
-                logger.warn("FastNote canvas: pendev open failed:", err)
+                logger.warn("FastNote canvas: pendev open failed:", err,
+                            "— falling back to gesture layer")
+                self.use_raw_input = false
             end
         else
-            logger.warn("FastNote canvas: Wacom not found; falling back to gestures")
+            logger.warn("FastNote canvas: pen digitizer not found — falling back to gesture layer")
+            self.use_raw_input = false
         end
 
         -- Touch device (Stage 3 palm rejection)

--- a/plugins/fastnote.koplugin/drawingcanvas.lua
+++ b/plugins/fastnote.koplugin/drawingcanvas.lua
@@ -589,7 +589,9 @@ function DrawingCanvas:_saveDrawing()
 end
 
 function DrawingCanvas:_doClose()
+    -- Full refresh after close so the underlying UI redraws cleanly.
     UIManager:close(self)
+    UIManager:setDirty(nil, "full")
     if self.on_close_callback then
         self.on_close_callback()
     end

--- a/plugins/fastnote.koplugin/input/pendev.lua
+++ b/plugins/fastnote.koplugin/input/pendev.lua
@@ -1,0 +1,206 @@
+--[[--
+input/pendev.lua
+FFI layer: find the Wacom EMR digitizer, open its /dev/input/eventX node,
+poll raw events, and delegate state transitions to lib/pen_statemachine.
+
+ASSUMES: KOReader FFI environment (ffi/posix_h + ffi/linux_input_h loaded).
+ASSUMES: Running on a device with a Wacom EMR digitizer (Kobo Libra Colour).
+ASSUMES: LuaJIT 2.1 (Lua 5.1) — uses bit.bor for O_RDONLY | O_NONBLOCK.
+
+Not directly busted-testable (needs real /dev/input device fd).
+The state machine logic in lib/pen_statemachine.lua IS testable.
+--]]--
+
+require("ffi/posix_h")         -- O_RDONLY, O_NONBLOCK, open, read, close, ioctl
+require("ffi/linux_input_h")   -- struct input_event, EV_KEY, EV_ABS, EV_SYN, …
+
+local ffi      = require("ffi")
+local bit      = require("bit")
+local logger   = require("logger")
+local SM       = require("lib/pen_statemachine")
+
+local C   = ffi.C
+local bor = bit.bor
+
+-- Wacom axis fallback ranges (if EVIOCGABS is not available or fails).
+-- Calibrated for Kobo Libra Colour Wacom I2C digitizer.
+local FALLBACK_X_MIN   = 0
+local FALLBACK_Y_MIN   = 0
+local FALLBACK_P_MIN   = 0
+local FALLBACK_X_MAX   = 4095
+local FALLBACK_Y_MAX   = 4095
+local FALLBACK_P_MAX   = 4095   -- Wacom pressure is commonly 0-4095 or 0-8191;
+                                 -- calibrate on device via evtest if needed.
+
+-- Declare struct once at module level so repeated PenDev.open() calls don't
+-- trigger a LuaJIT "attempt to redefine" error.
+-- pcall guards against benign re-definition if two modules require this file.
+pcall(ffi.cdef, [[
+    struct fn_input_absinfo {
+        int value;
+        int minimum;
+        int maximum;
+        int fuzz;
+        int flat;
+        int resolution;
+    };
+]])
+
+-- Read batch size: how many input_event records to attempt per poll call.
+local BATCH_SIZE = 64
+
+local PenDev = {}
+PenDev.__index = PenDev
+
+--- Scan /proc/bus/input/devices for the Wacom digitizer.
+-- @treturn string|nil  Path like "/dev/input/event2", or nil if not found.
+function PenDev.find()
+    local f = io.open("/proc/bus/input/devices", "r")
+    if not f then
+        logger.warn("FastNote pendev: cannot open /proc/bus/input/devices")
+        return nil
+    end
+
+    local found_wacom = false
+    local result      = nil
+
+    for line in f:lines() do
+        if line:find("^N:") then
+            -- N: Name="Wacom I2C Digitizer" (case-insensitive match)
+            found_wacom = line:lower():find("wacom") ~= nil
+        end
+        if found_wacom and line:find("^H:") then
+            -- H: Handlers=mouse0 event2 js0
+            local ev = line:match("(event%d+)")
+            if ev then
+                result = "/dev/input/" .. ev
+                break
+            end
+        end
+        if line == "" then
+            found_wacom = false
+        end
+    end
+
+    f:close()
+
+    if result then
+        logger.dbg("FastNote pendev: found Wacom at", result)
+    else
+        logger.warn("FastNote pendev: Wacom digitizer not found in /proc/bus/input/devices")
+    end
+    return result
+end
+
+--- Open a digitizer device node and create a PenDev instance.
+-- @string path   /dev/input/eventX path (typically from PenDev.find()).
+-- @treturn PenDev|nil, string?   Opened instance, or nil + error message.
+function PenDev.open(path)
+    if not path then
+        return nil, "pendev.open: nil path"
+    end
+
+    local fd = C.open(path, bor(C.O_RDONLY, C.O_NONBLOCK))
+    if fd < 0 then
+        local msg = "FastNote pendev: cannot open " .. path
+        logger.warn(msg)
+        return nil, msg
+    end
+
+    local self = setmetatable({
+        fd      = fd,
+        path    = path,
+        sm      = SM:new(),
+        -- Axis calibration (may be updated by _query_abs if ioctl is available)
+        x_min   = FALLBACK_X_MIN,
+        y_min   = FALLBACK_Y_MIN,
+        p_min   = FALLBACK_P_MIN,
+        x_max   = FALLBACK_X_MAX,
+        y_max   = FALLBACK_Y_MAX,
+        p_max   = FALLBACK_P_MAX,
+    }, PenDev)
+
+    -- Best-effort axis query — updates self.x_max / y_max / p_max if possible.
+    self:_query_abs()
+
+    logger.dbg("FastNote pendev: opened", path,
+               "x_max=" .. self.x_max,
+               "y_max=" .. self.y_max,
+               "p_max=" .. self.p_max)
+    return self
+end
+
+--- Attempt to read axis ranges via EVIOCGABS ioctl.
+-- Falls back to FALLBACK_* values silently if the ioctl is unavailable.
+-- EVIOCGABS(axis) = _IOR('E', 0x40 + axis, struct input_absinfo)
+-- On ARM/x86-64 Linux: sizeof(struct input_absinfo) = 24 bytes.
+function PenDev:_query_abs()
+    local function eviocgabs(axis)
+        -- _IOR('E', 0x40+axis, struct input_absinfo)
+        -- direction READ = 2, size = 24
+        return bit.bor(
+            bit.lshift(2, 30),
+            bit.lshift(0x45, 8),   -- 'E' = 0x45
+            bit.lshift(24, 16),
+            0x40 + axis
+        )
+    end
+
+    local absinfo = ffi.new("struct fn_input_absinfo")
+
+    local function query(axis)
+        local ret = C.ioctl(self.fd, eviocgabs(axis), absinfo)
+        if ret == 0 and absinfo.maximum > 0 then
+            return absinfo.minimum, absinfo.maximum
+        end
+        return nil, nil
+    end
+
+    local xmin, xm = query(0)  -- ABS_X
+    local ymin, ym = query(1)  -- ABS_Y
+    local pmin, pm = query(24) -- ABS_PRESSURE
+
+    if xm then self.x_min = xmin or 0; self.x_max = xm end
+    if ym then self.y_min = ymin or 0; self.y_max = ym end
+    if pm then self.p_min = pmin or 0; self.p_max = pm end
+end
+
+--- Non-blocking poll: read all available events, emit high-level events via cb.
+-- Intended to be called from a UIManager:scheduleIn loop (~120 Hz).
+-- @func cb   Callback receiving {type, x, y, pressure, tool} tables.
+function PenDev:poll(cb)
+    if not self.fd then return end
+
+    local ev_type = ffi.typeof("struct input_event[?]")
+    local buf     = ev_type(BATCH_SIZE)
+    local ev_sz   = ffi.sizeof("struct input_event")
+
+    while true do
+        local n = C.read(self.fd, buf, ev_sz * BATCH_SIZE)
+        if n <= 0 then break end
+
+        local count = math.floor(n / ev_sz)
+        for i = 0, count - 1 do
+            local e = buf[i]
+            local t = e.type
+            if t == C.EV_KEY then
+                self.sm:feed_key(e.code, e.value, cb)
+            elseif t == C.EV_ABS then
+                self.sm:feed_abs(e.code, e.value)
+            elseif t == C.EV_SYN then
+                self.sm:feed_syn(cb)
+            end
+        end
+    end
+end
+
+--- Close the device file descriptor.
+function PenDev:close()
+    if self.fd then
+        C.close(self.fd)
+        self.fd = nil
+        logger.dbg("FastNote pendev: closed", self.path)
+    end
+end
+
+return PenDev

--- a/plugins/fastnote.koplugin/input/pendev.lua
+++ b/plugins/fastnote.koplugin/input/pendev.lua
@@ -52,7 +52,20 @@ local BATCH_SIZE = 64
 local PenDev = {}
 PenDev.__index = PenDev
 
---- Scan /proc/bus/input/devices for the Wacom digitizer.
+--- Check if a KEY= bitmask hex string has BTN_TOOL_PEN (0x140 = bit 320) set.
+-- BTN_TOOL_PEN is set by all Wacom/EMR pen digitizers regardless of their name.
+-- Bit 320: hex digit from right = floor(320/4) = 80; bit within digit = 320%4 = 0.
+local function has_btn_tool_pen(key_hex)
+    key_hex = key_hex:gsub("%s", "")
+    local idx = #key_hex - 80   -- 1-indexed from left
+    if idx < 1 then return false end
+    local digit = tonumber(key_hex:sub(idx, idx), 16)
+    return digit ~= nil and bit.band(digit, 1) ~= 0
+end
+
+--- Scan /proc/bus/input/devices for the pen digitizer.
+-- Matches by name ("wacom") first; falls back to KEY= bitmask check for
+-- BTN_TOOL_PEN, which is set by all EMR pen digitizers regardless of name.
 -- @treturn string|nil  Path like "/dev/input/event2", or nil if not found.
 function PenDev.find()
     local f = io.open("/proc/bus/input/devices", "r")
@@ -61,33 +74,42 @@ function PenDev.find()
         return nil
     end
 
-    local found_wacom = false
-    local result      = nil
+    local result       = nil
+    local cur_name     = nil
+    local cur_key      = nil
+    local cur_handlers = nil
+
+    local function check_block()
+        if not cur_handlers then return end
+        local is_pen = (cur_name and cur_name:find("wacom", 1, true))
+                    or (cur_key  and has_btn_tool_pen(cur_key))
+        if is_pen then
+            local ev = cur_handlers:match("(event%d+)")
+            if ev then result = "/dev/input/" .. ev end
+        end
+    end
 
     for line in f:lines() do
         if line:find("^N:") then
-            -- N: Name="Wacom I2C Digitizer" (case-insensitive match)
-            found_wacom = line:lower():find("wacom") ~= nil
-        end
-        if found_wacom and line:find("^H:") then
-            -- H: Handlers=mouse0 event2 js0
-            local ev = line:match("(event%d+)")
-            if ev then
-                result = "/dev/input/" .. ev
-                break
-            end
-        end
-        if line == "" then
-            found_wacom = false
+            cur_name = line:lower()
+        elseif line:find("^B: KEY=") then
+            cur_key = line:match("KEY=(%x[%x ]*)")
+        elseif line:find("^H:") then
+            cur_handlers = line:match("H: Handlers=(.*)")
+        elseif line == "" then
+            check_block()
+            if result then break end
+            cur_name, cur_key, cur_handlers = nil, nil, nil
         end
     end
+    if not result then check_block() end  -- last block (no trailing blank line)
 
     f:close()
 
     if result then
-        logger.dbg("FastNote pendev: found Wacom at", result)
+        logger.dbg("FastNote pendev: found pen digitizer at", result)
     else
-        logger.warn("FastNote pendev: Wacom digitizer not found in /proc/bus/input/devices")
+        logger.warn("FastNote pendev: pen digitizer not found in /proc/bus/input/devices")
     end
     return result
 end

--- a/plugins/fastnote.koplugin/input/touchdev.lua
+++ b/plugins/fastnote.koplugin/input/touchdev.lua
@@ -1,0 +1,227 @@
+--[[--
+input/touchdev.lua
+FFI layer: find the capacitive touchscreen, open its /dev/input/eventX node,
+read multi-touch protocol B events, and emit per-slot events.
+
+ASSUMES: KOReader FFI environment (ffi/posix_h + ffi/linux_input_h loaded).
+ASSUMES: Running on a device with a capacitive multi-touch panel (Kobo Libra Colour).
+ASSUMES: LuaJIT 2.1 (Lua 5.1).
+
+Not directly busted-testable (needs real /dev/input device fd).
+The palm rejection logic in lib/palmreject.lua IS testable.
+
+Multi-touch protocol B summary:
+  EV_ABS, ABS_MT_SLOT            → selects active slot (0..N-1)
+  EV_ABS, ABS_MT_TRACKING_ID     → -1 = contact up; ≥0 = contact down/continuing
+  EV_ABS, ABS_MT_POSITION_X/Y    → contact coordinates (screen-space pixels)
+  EV_ABS, ABS_MT_TOUCH_MAJOR     → major axis of contact ellipse (approx. contact area)
+  EV_SYN, SYN_REPORT             → frame boundary; emit per-slot events for changed slots
+--]]--
+
+require("ffi/posix_h")
+require("ffi/linux_input_h")
+
+local ffi    = require("ffi")
+local bit    = require("bit")
+local logger = require("logger")
+
+local C   = ffi.C
+local bor = bit.bor
+
+-- MT axis codes (from linux/input-event-codes.h)
+local ABS_MT_SLOT        = 0x2f
+local ABS_MT_TRACKING_ID = 0x39
+local ABS_MT_POSITION_X  = 0x35
+local ABS_MT_POSITION_Y  = 0x36
+local ABS_MT_TOUCH_MAJOR = 0x30
+
+local MAX_SLOTS  = 10
+local BATCH_SIZE = 64
+
+local TouchDev = {}
+TouchDev.__index = TouchDev
+
+--- Scan /proc/bus/input/devices for the capacitive touchscreen.
+-- Identifies the device by the presence of ABS_MT_POSITION_X in its ABS= bitmask.
+-- On Kobo Libra Colour this is typically a FocalTech FT series chip.
+-- @treturn string|nil  Path like "/dev/input/event1", or nil if not found.
+function TouchDev.find()
+    local f = io.open("/proc/bus/input/devices", "r")
+    if not f then
+        logger.warn("FastNote touchdev: cannot open /proc/bus/input/devices")
+        return nil
+    end
+
+    local result     = nil
+    local cur_abs    = nil
+    local cur_handlers = nil
+
+    -- ABS_MT_POSITION_X = 0x35 = 53; bitmask bit 53 set means the device
+    -- reports MT position X.  The ABS= field is a hex bitmask of reported axes.
+    -- Bit 53 is in the second 32-bit word (word = bit/32 = 1, position = bit%32 = 21).
+    -- We check for the presence of "ABS_MT" by inspecting the bitmask value.
+    -- The ABS= line looks like "ABS=660800013ff" — parse the least-significant
+    -- bit-53 by checking (tonumber(hex, 16) >> 53) & 1, but Lua 5.1 lacks
+    -- bit-shifts on doubles.  Use bit library instead (LuaJIT).
+
+    local function has_mt_position(abs_hex)
+        -- Remove spaces; abs_hex may be e.g. "660800013ff"
+        abs_hex = abs_hex:gsub("%s", "")
+        -- We need bit 53 of the full bitmask.  The hex string is big-endian
+        -- (MSB first), so we work from the right: each hex digit is 4 bits.
+        -- Bit 53: hex digit index from right = floor(53/4) = 13.
+        -- Within digit position = 53 mod 4 = 1.
+        local n = #abs_hex
+        local digit_from_right = math.floor(53 / 4)  -- 0-indexed
+        local bit_in_digit     = 53 % 4
+
+        local idx = n - digit_from_right  -- 1-indexed from left
+        if idx < 1 then return false end
+        local digit = tonumber(abs_hex:sub(idx, idx), 16)
+        if not digit then return false end
+        return bit.band(digit, bit.lshift(1, bit_in_digit)) ~= 0
+    end
+
+    for line in f:lines() do
+        if line:find("^A:") then
+            -- A: Handlers=... ABS=...  (not all formats include this)
+            local abs = line:match("ABS=(%x+)")
+            if abs then cur_abs = abs end
+        elseif line:find("^H:") then
+            cur_handlers = line:match("H: Handlers=(.*)")
+        elseif line == "" then
+            -- End of device block: check if this device has MT position X
+            if cur_abs and cur_handlers and has_mt_position(cur_abs) then
+                local ev = cur_handlers:match("(event%d+)")
+                if ev then
+                    result = "/dev/input/" .. ev
+                    break
+                end
+            end
+            cur_abs, cur_handlers = nil, nil
+        end
+    end
+
+    f:close()
+
+    if result then
+        logger.dbg("FastNote touchdev: found touchscreen at", result)
+    else
+        logger.warn("FastNote touchdev: capacitive touchscreen not found")
+    end
+    return result
+end
+
+--- Open the touchscreen device node.
+-- @string path   /dev/input/eventX path (from TouchDev.find()).
+-- @treturn TouchDev|nil, string?
+function TouchDev.open(path)
+    if not path then return nil, "touchdev.open: nil path" end
+
+    local fd = C.open(path, bor(C.O_RDONLY, C.O_NONBLOCK))
+    if fd < 0 then
+        local msg = "FastNote touchdev: cannot open " .. path
+        logger.warn(msg)
+        return nil, msg
+    end
+
+    -- Per-slot state (MT protocol B)
+    local slots = {}
+    for i = 0, MAX_SLOTS - 1 do
+        slots[i] = {id=-1, x=0, y=0, touch_major=0, dirty=false}
+    end
+
+    local self = setmetatable({
+        fd           = fd,
+        path         = path,
+        _slot        = 0,      -- currently selected slot
+        _slots       = slots,
+    }, TouchDev)
+
+    logger.dbg("FastNote touchdev: opened", path)
+    return self
+end
+
+--- Non-blocking poll: read all available MT events, emit slot-level events via cb.
+-- Called from a UIManager:scheduleIn loop (~60 Hz is sufficient for touch).
+-- @func cb  Callback: receives {type, slot, id, x, y, touch_major} tables.
+--           type = "down" (new contact), "move" (position changed), "up" (contact ended)
+function TouchDev:poll(cb)
+    if not self.fd then return end
+
+    local ev_type  = ffi.typeof("struct input_event[?]")
+    local buf      = ev_type(BATCH_SIZE)
+    local ev_sz    = ffi.sizeof("struct input_event")
+
+    while true do
+        local n = C.read(self.fd, buf, ev_sz * BATCH_SIZE)
+        if n <= 0 then break end
+
+        local count = math.floor(n / ev_sz)
+        for i = 0, count - 1 do
+            local e = buf[i]
+            if e.type == C.EV_ABS then
+                local code = e.code
+                local val  = e.value
+                local slot = self._slots[self._slot]
+
+                if code == ABS_MT_SLOT then
+                    if val >= 0 and val < MAX_SLOTS then
+                        self._slot = val
+                    end
+                elseif code == ABS_MT_TRACKING_ID then
+                    if slot then
+                        slot.id    = val
+                        slot.dirty = true
+                    end
+                elseif code == ABS_MT_POSITION_X then
+                    if slot then slot.x = val; slot.dirty = true end
+                elseif code == ABS_MT_POSITION_Y then
+                    if slot then slot.y = val; slot.dirty = true end
+                elseif code == ABS_MT_TOUCH_MAJOR then
+                    if slot then slot.touch_major = val; slot.dirty = true end
+                end
+
+            elseif e.type == C.EV_SYN then
+                -- SYN_REPORT: flush changed slots
+                for si = 0, MAX_SLOTS - 1 do
+                    local s = self._slots[si]
+                    if s.dirty then
+                        s.dirty = false
+                        local prev_id = s._prev_id
+
+                        if s.id == -1 then
+                            -- Contact ended
+                            if prev_id and prev_id ~= -1 then
+                                cb({type="up", slot=si, id=prev_id,
+                                    x=s.x, y=s.y})
+                            end
+                            s._prev_id = -1
+                        elseif prev_id == nil or prev_id == -1 then
+                            -- New contact
+                            s._prev_id = s.id
+                            cb({type="down", slot=si, id=s.id,
+                                x=s.x, y=s.y, touch_major=s.touch_major})
+                        else
+                            -- Continuing contact
+                            s._prev_id = s.id
+                            cb({type="move", slot=si, id=s.id,
+                                x=s.x, y=s.y, touch_major=s.touch_major})
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+--- Close the device file descriptor.
+function TouchDev:close()
+    if self.fd then
+        C.close(self.fd)
+        self.fd = nil
+        logger.dbg("FastNote touchdev: closed", self.path)
+    end
+end
+
+return TouchDev

--- a/plugins/fastnote.koplugin/lib/json.lua
+++ b/plugins/fastnote.koplugin/lib/json.lua
@@ -1,0 +1,204 @@
+--[[--
+lib/json.lua — minimal JSON encoder/decoder for fastnote stroke data.
+
+Pure Lua; no KOReader or FFI dependencies — fully busted-testable.
+
+Only the subset needed by lib/svg.lua is implemented:
+  Encode: strings, numbers, booleans, arrays, objects, null (nil).
+  Decode: same types; all standard JSON accepted.
+
+Keys in encoded objects are sorted for deterministic output (useful in tests).
+--]]--
+
+local M = {}
+
+-- ---------------------------------------------------------------------------
+-- Encoder
+-- ---------------------------------------------------------------------------
+
+local function _encode(val)
+    local t = type(val)
+    if t == "nil" then
+        return "null"
+    elseif t == "boolean" then
+        return tostring(val)
+    elseif t == "number" then
+        if val ~= val then return "null" end          -- NaN → null
+        if val == math.huge or val == -math.huge then return "null" end
+        -- Use integer form when there's no fractional part, full precision otherwise
+        if math.floor(val) == val and math.abs(val) < 1e15 then
+            return string.format("%d", val)
+        end
+        return string.format("%.14g", val)
+    elseif t == "string" then
+        return '"' .. val
+            :gsub('\\', '\\\\')
+            :gsub('"',  '\\"')
+            :gsub('\n', '\\n')
+            :gsub('\r', '\\r')
+            :gsub('\t', '\\t')
+            .. '"'
+    elseif t == "table" then
+        -- Array: consecutive integer keys starting at 1 with no gaps
+        local n = #val
+        local is_array = (n > 0)
+        if is_array then
+            for k in pairs(val) do
+                if type(k) ~= "number" or k < 1 or k > n or math.floor(k) ~= k then
+                    is_array = false
+                    break
+                end
+            end
+        else
+            -- Empty table: check for any non-integer key to decide
+            for k in pairs(val) do
+                if type(k) ~= "number" then
+                    is_array = false
+                    break
+                end
+            end
+        end
+        if is_array then
+            local parts = {}
+            for i = 1, n do parts[i] = _encode(val[i]) end
+            return '[' .. table.concat(parts, ',') .. ']'
+        else
+            local parts = {}
+            for k, v in pairs(val) do
+                if type(k) == "string" then
+                    parts[#parts + 1] = '"' .. k .. '":' .. _encode(v)
+                end
+            end
+            table.sort(parts)
+            return '{' .. table.concat(parts, ',') .. '}'
+        end
+    end
+    error("json.encode: unsupported type " .. t)
+end
+
+function M.encode(val)
+    return _encode(val)
+end
+
+-- ---------------------------------------------------------------------------
+-- Decoder
+-- ---------------------------------------------------------------------------
+
+function M.decode(text)
+    local pos = 1
+    local len = #text
+
+    local function skip_ws()
+        while pos <= len do
+            local b = text:byte(pos)
+            if b == 32 or b == 9 or b == 10 or b == 13 then
+                pos = pos + 1
+            else
+                break
+            end
+        end
+    end
+
+    local parse  -- forward-declared
+
+    local function parse_string()
+        pos = pos + 1  -- skip opening '"'
+        local buf = {}
+        while pos <= len do
+            local c = text:sub(pos, pos)
+            if c == '"' then
+                pos = pos + 1
+                return table.concat(buf)
+            elseif c == '\\' then
+                pos = pos + 1
+                local e = text:sub(pos, pos)
+                local map = {['"']='"', ['\\']='\\',['/']='/',
+                             n='\n', r='\r', t='\t', b='\b', f='\f'}
+                buf[#buf + 1] = map[e] or e
+            else
+                buf[#buf + 1] = c
+            end
+            pos = pos + 1
+        end
+        error("json.decode: unterminated string")
+    end
+
+    local function parse_number()
+        local s, e = text:find("^-?%d+%.?%d*[eE]?[+%-]?%d*", pos)
+        if not s then error("json.decode: expected number at pos " .. pos) end
+        local n = tonumber(text:sub(s, e))
+        pos = e + 1
+        return n
+    end
+
+    local function parse_array()
+        pos = pos + 1  -- skip '['
+        local arr = {}
+        skip_ws()
+        if text:sub(pos, pos) == ']' then pos = pos + 1; return arr end
+        while true do
+            skip_ws()
+            arr[#arr + 1] = parse()
+            skip_ws()
+            local c = text:sub(pos, pos)
+            if     c == ']' then pos = pos + 1; break
+            elseif c == ',' then pos = pos + 1
+            else error("json.decode: expected ',' or ']' at pos " .. pos)
+            end
+        end
+        return arr
+    end
+
+    local function parse_object()
+        pos = pos + 1  -- skip '{'
+        local obj = {}
+        skip_ws()
+        if text:sub(pos, pos) == '}' then pos = pos + 1; return obj end
+        while true do
+            skip_ws()
+            if text:sub(pos, pos) ~= '"' then
+                error("json.decode: expected '\"' at pos " .. pos)
+            end
+            local key = parse_string()
+            skip_ws()
+            if text:sub(pos, pos) ~= ':' then
+                error("json.decode: expected ':' at pos " .. pos)
+            end
+            pos = pos + 1
+            skip_ws()
+            obj[key] = parse()
+            skip_ws()
+            local c = text:sub(pos, pos)
+            if     c == '}' then pos = pos + 1; break
+            elseif c == ',' then pos = pos + 1
+            else error("json.decode: expected ',' or '}' at pos " .. pos)
+            end
+        end
+        return obj
+    end
+
+    parse = function()
+        skip_ws()
+        local c = text:sub(pos, pos)
+        if c == '"' then
+            return parse_string()
+        elseif c == '[' then
+            return parse_array()
+        elseif c == '{' then
+            return parse_object()
+        elseif text:sub(pos, pos + 3) == "true" then
+            pos = pos + 4; return true
+        elseif text:sub(pos, pos + 4) == "false" then
+            pos = pos + 5; return false
+        elseif text:sub(pos, pos + 3) == "null" then
+            pos = pos + 4; return nil
+        else
+            return parse_number()
+        end
+    end
+
+    local result = parse()
+    return result
+end
+
+return M

--- a/plugins/fastnote.koplugin/lib/palmreject.lua
+++ b/plugins/fastnote.koplugin/lib/palmreject.lua
@@ -1,0 +1,122 @@
+--[[--
+lib/palmreject.lua — proximity-gated palm rejection state machine.
+
+Pure Lua; no KOReader or FFI dependencies — fully busted-testable.
+
+The machine maintains two independent inputs:
+  1. Pen events (from lib/pen_statemachine via input/pendev):
+       {type = "down"|"move"|"hover"|"up", ...}
+  2. Touch slot events (from input/touchdev):
+       {type = "down"|"move"|"up", slot, id, x, y, touch_major}
+
+Rejection rules (applied in order):
+  1. Pen-proximity gate: if the pen is "proximate" (down, hovering, or within
+     BLACKOUT_MS of its last lift), any new touch contact is rejected.
+  2. Area gate: if touch_major > area_threshold AND area_threshold > 0, the
+     contact is rejected regardless of pen state.
+
+"Proximate" persists for BLACKOUT_MS after a pen "up" event to cover the
+brief gap when the pen lifts between strokes (e.g. writing a "t" cross).
+
+The clock_fn parameter is injectable for testing (default: os.clock in ms).
+--]]--
+
+local PalmReject = {}
+PalmReject.__index = PalmReject
+
+--- Create a new PalmReject instance.
+-- @param opts  table  optional: {blackout_ms=250, area_threshold=0}
+-- @param clock_fn  function  returns current time in ms (injectable for tests)
+function PalmReject.new(opts, clock_fn)
+    opts = opts or {}
+    return setmetatable({
+        blackout_ms     = opts.blackout_ms    or 250,
+        area_threshold  = opts.area_threshold or 0,    -- 0 = disabled
+
+        _pen_proximate  = false,  -- pen is in proximity or in blackout
+        _pen_up_at      = nil,    -- clock value when pen last went up
+        _slots          = {},     -- tracking_id → {rejected=bool}
+
+        _clock = clock_fn or function()
+            return os.clock() * 1000  -- os.clock() → seconds; we want ms
+        end,
+    }, PalmReject)
+end
+
+-- ---------------------------------------------------------------------------
+-- Pen event feed
+-- ---------------------------------------------------------------------------
+
+--- Feed a high-level pen event (from pen_statemachine).
+-- Updates internal proximity state.
+-- @param ev  table  {type="down"|"move"|"hover"|"up", ...}
+function PalmReject:onPenEvent(ev)
+    if ev.type == "down" or ev.type == "move" or ev.type == "hover" then
+        self._pen_proximate = true
+        self._pen_up_at     = nil
+    elseif ev.type == "up" then
+        -- Keep proximate flag set; start blackout timer.
+        self._pen_up_at = self._clock()
+    end
+end
+
+--- True if the pen is currently considered proximate (down, hovering, or
+-- within the blackout window after lifting).
+function PalmReject:isPenProximate()
+    if self._pen_proximate then
+        if self._pen_up_at ~= nil then
+            -- Check if we're still within the blackout window
+            if (self._clock() - self._pen_up_at) >= self.blackout_ms then
+                self._pen_proximate = false
+                self._pen_up_at     = nil
+            end
+        end
+    end
+    return self._pen_proximate
+end
+
+-- ---------------------------------------------------------------------------
+-- Touch event filter
+-- ---------------------------------------------------------------------------
+
+--- Filter a touch slot event through the rejection rules.
+-- Returns the event unmodified if it should pass through, or nil if rejected.
+-- @param ev  table  {type, slot, id, x, y, touch_major}
+-- @return table|nil
+function PalmReject:onTouchEvent(ev)
+    local slot = ev.slot
+
+    if ev.type == "down" then
+        local rejected = false
+
+        -- Rule 1: pen proximity gate
+        if self:isPenProximate() then
+            rejected = true
+        end
+
+        -- Rule 2: area gate (large contact = palm)
+        if not rejected and self.area_threshold > 0
+                and (ev.touch_major or 0) > self.area_threshold then
+            rejected = true
+        end
+
+        self._slots[slot] = {rejected = rejected}
+        if rejected then return nil end
+        return ev
+
+    elseif ev.type == "move" then
+        local state = self._slots[slot]
+        if state and state.rejected then return nil end
+        return ev
+
+    elseif ev.type == "up" then
+        local state = self._slots[slot]
+        self._slots[slot] = nil  -- drop slot
+        if state and state.rejected then return nil end
+        return ev
+    end
+
+    return ev  -- unknown event type: pass through
+end
+
+return PalmReject

--- a/plugins/fastnote.koplugin/lib/stroke.lua
+++ b/plugins/fastnote.koplugin/lib/stroke.lua
@@ -1,0 +1,131 @@
+--[[--
+lib/stroke.lua — a single pen stroke.
+
+Pure Lua; no KOReader runtime dependencies for all methods except paintTo.
+paintTo(bb) requires the KOReader BlitBuffer and is not busted-testable.
+
+Storage format for points (compact flat array, 3 values per point):
+  pts = {x1, y1, w1, x2, y2, w2, ...}
+where w is the pre-computed line width at that sample (pressure-derived).
+
+ASSUMES: coordinates are screen-space integers.
+--]]--
+
+local Stroke = {}
+Stroke.__index = Stroke
+
+--- Create a new empty stroke.
+-- @string color  Hex color string, e.g. "#000000". Defaults to black.
+function Stroke.new(color)
+    return setmetatable({
+        color = color or "#000000",
+        pts   = {},  -- flat array: {x,y,w, x,y,w, ...}
+    }, Stroke)
+end
+
+--- Append a sample point to this stroke.
+-- @number x  screen x
+-- @number y  screen y
+-- @number w  line width at this sample (px)
+function Stroke:addPoint(x, y, w)
+    local n = #self.pts
+    self.pts[n + 1] = x
+    self.pts[n + 2] = y
+    self.pts[n + 3] = w
+end
+
+--- True when the stroke has fewer than 2 sample points.
+-- A single point cannot be painted as a line segment.
+function Stroke:isEmpty()
+    return #self.pts < 6  -- < 2 points (each point = 3 values)
+end
+
+--- Number of sample points.
+function Stroke:pointCount()
+    return #self.pts / 3
+end
+
+--- Bounding box of this stroke (padded by max line width).
+-- @return x, y, w, h  All integers.
+function Stroke:bbox()
+    local pts = self.pts
+    if #pts == 0 then return 0, 0, 0, 0 end
+
+    local min_x = pts[1]
+    local min_y = pts[2]
+    local max_x = pts[1]
+    local max_y = pts[2]
+    local max_w = pts[3]
+
+    for i = 4, #pts, 3 do
+        local x, y, w = pts[i], pts[i+1], pts[i+2]
+        if x < min_x then min_x = x end
+        if y < min_y then min_y = y end
+        if x > max_x then max_x = x end
+        if y > max_y then max_y = y end
+        if w > max_w then max_w = w end
+    end
+
+    local pad = max_w
+    return min_x - pad, min_y - pad,
+           (max_x - min_x) + pad * 2, (max_y - min_y) + pad * 2
+end
+
+--- True if any segment of this stroke passes within `radius` of (px, py).
+-- Uses point-to-segment distance.
+-- @number px  query x
+-- @number py  query y
+-- @number radius  hit radius in pixels
+function Stroke:hitTest(px, py, radius)
+    local pts = self.pts
+    local r2  = radius * radius
+    for i = 4, #pts, 3 do
+        local ax, ay = pts[i-3], pts[i-2]
+        local bx, by = pts[i],   pts[i+1]
+        local dx, dy = bx - ax, by - ay
+        local len2   = dx * dx + dy * dy
+        local t
+        if len2 < 1 then
+            t = 0
+        else
+            t = ((px - ax) * dx + (py - ay) * dy) / len2
+            if t < 0 then t = 0 elseif t > 1 then t = 1 end
+        end
+        local cx   = ax + t * dx
+        local cy   = ay + t * dy
+        local dist2 = (px - cx) * (px - cx) + (py - cy) * (py - cy)
+        if dist2 <= r2 then return true end
+    end
+    return false
+end
+
+--- Replay this stroke onto a BlitBuffer.
+-- KOReader runtime required; not busted-testable.
+-- Color support is deferred to Stage 12; all strokes render as black for now.
+-- @param bb  BlitBuffer  the destination buffer
+function Stroke:paintTo(bb)
+    local Blitbuffer = require("ffi/blitbuffer")
+    local color      = Blitbuffer.COLOR_BLACK  -- Stage 12: parse self.color
+    local pts        = self.pts
+    for i = 4, #pts, 3 do
+        local x1, y1     = pts[i-3], pts[i-2]
+        local x2, y2, w2 = pts[i],   pts[i+1], pts[i+2]
+        bb:paintLine(x1, y1, x2, y2, w2, color)
+    end
+end
+
+--- Serialise to a plain Lua table for JSON encoding.
+-- Points are stored as a flat array [x,y,w, x,y,w, ...] for compactness.
+function Stroke:toTable()
+    return {color = self.color, pts = self.pts}
+end
+
+--- Reconstruct a Stroke from a plain Lua table (from JSON decode).
+-- @param t  table  {color, pts=[flat array]}
+function Stroke.fromTable(t)
+    local s = Stroke.new(t.color)
+    s.pts   = t.pts or {}
+    return s
+end
+
+return Stroke

--- a/plugins/fastnote.koplugin/lib/strokebuffer.lua
+++ b/plugins/fastnote.koplugin/lib/strokebuffer.lua
@@ -1,0 +1,155 @@
+--[[--
+lib/strokebuffer.lua — in-memory list of committed strokes with undo/redo.
+
+Pure Lua; no KOReader runtime dependencies for all methods except repaintTo.
+repaintTo(bb) requires the KOReader BlitBuffer and is not busted-testable.
+
+Source of truth for all drawn content on a page. The BlitBuffer in
+drawingcanvas.lua is a display cache that is rebuilt by repaintTo after
+undo, erase, or rotation.
+
+ASSUMES: lib/stroke.lua available on the require path.
+--]]--
+
+local Stroke = require("lib/stroke")
+
+local StrokeBuffer = {}
+StrokeBuffer.__index = StrokeBuffer
+
+--- Create a new empty StrokeBuffer.
+function StrokeBuffer.new()
+    return setmetatable({
+        strokes = {},   -- committed strokes (source of truth)
+        undone  = {},   -- strokes moved here by undo (available for redo)
+        current = nil,  -- stroke in progress (not yet committed)
+    }, StrokeBuffer)
+end
+
+-- ---------------------------------------------------------------------------
+-- Live drawing
+-- ---------------------------------------------------------------------------
+
+--- Begin a new stroke at (x, y) with line width w and given color.
+-- Clears the redo stack — any new stroke discards redo history.
+-- @number x      screen x
+-- @number y      screen y
+-- @number w      line width at this sample
+-- @string color  hex color string (optional, defaults to black)
+function StrokeBuffer:penDown(x, y, w, color)
+    self.current = Stroke.new(color)
+    self.current:addPoint(x, y, w)
+    self.undone = {}  -- new stroke clears redo history
+end
+
+--- Extend the current stroke with a new sample.
+-- No-op if penDown has not been called.
+function StrokeBuffer:penMove(x, y, w)
+    if self.current then
+        self.current:addPoint(x, y, w)
+    end
+end
+
+--- Commit the current stroke to the strokes list.
+-- Discards single-point strokes (no segment to draw).
+function StrokeBuffer:penUp()
+    if self.current and not self.current:isEmpty() then
+        self.strokes[#self.strokes + 1] = self.current
+    end
+    self.current = nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Undo / redo
+-- ---------------------------------------------------------------------------
+
+--- Undo the last committed stroke.
+-- @return Stroke|nil  The removed stroke (caller uses its bbox for repaint).
+function StrokeBuffer:undo()
+    if #self.strokes == 0 then return nil end
+    local s = table.remove(self.strokes)
+    self.undone[#self.undone + 1] = s
+    return s
+end
+
+--- Redo the last undone stroke.
+-- @return Stroke|nil  The restored stroke (caller uses its bbox for repaint).
+function StrokeBuffer:redo()
+    if #self.undone == 0 then return nil end
+    local s = table.remove(self.undone)
+    self.strokes[#self.strokes + 1] = s
+    return s
+end
+
+-- ---------------------------------------------------------------------------
+-- Erase
+-- ---------------------------------------------------------------------------
+
+--- Remove all committed strokes whose hitTest passes within `radius` of (x, y).
+-- @return table  Array of removed Stroke objects; caller handles repaint.
+function StrokeBuffer:eraseAt(x, y, radius)
+    local removed = {}
+    local kept    = {}
+    for _, s in ipairs(self.strokes) do
+        if s:hitTest(x, y, radius) then
+            removed[#removed + 1] = s
+        else
+            kept[#kept + 1] = s
+        end
+    end
+    self.strokes = kept
+    -- Erase cannot be undone via redo (undo for erase is a Stage 11 concern)
+    self.undone = {}
+    return removed
+end
+
+-- ---------------------------------------------------------------------------
+-- Rendering (KOReader runtime required)
+-- ---------------------------------------------------------------------------
+
+--- Replay all committed strokes onto a BlitBuffer.
+-- Used after undo/erase/rotation to rebuild the display cache.
+-- @param bb  BlitBuffer  destination (should already be filled white)
+function StrokeBuffer:repaintTo(bb)
+    for _, s in ipairs(self.strokes) do
+        s:paintTo(bb)
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Queries
+-- ---------------------------------------------------------------------------
+
+--- True if there are no committed strokes and no stroke in progress.
+function StrokeBuffer:isEmpty()
+    return #self.strokes == 0 and self.current == nil
+end
+
+--- True if there are committed strokes (unsaved changes may exist).
+function StrokeBuffer:isDirty()
+    return #self.strokes > 0
+end
+
+-- ---------------------------------------------------------------------------
+-- Serialisation
+-- ---------------------------------------------------------------------------
+
+--- Serialise to a plain Lua table for JSON encoding.
+function StrokeBuffer:toTable()
+    local out = {}
+    for i, s in ipairs(self.strokes) do
+        out[i] = s:toTable()
+    end
+    return {strokes = out}
+end
+
+--- Reconstruct a StrokeBuffer from a plain Lua table (from JSON decode).
+-- @param t  table  {strokes=[array of stroke tables]}
+function StrokeBuffer.fromTable(t)
+    local sb = StrokeBuffer.new()
+    for _, st in ipairs(t.strokes or {}) do
+        sb.strokes[#sb.strokes + 1] = Stroke.fromTable(st)
+    end
+    return sb
+end
+
+return StrokeBuffer

--- a/plugins/fastnote.koplugin/lib/svg.lua
+++ b/plugins/fastnote.koplugin/lib/svg.lua
@@ -1,0 +1,125 @@
+--[[--
+lib/svg.lua — SVG serialisation for fastnote pages.
+
+Pure Lua; no KOReader or FFI dependencies — fully busted-testable.
+
+Format:
+  <svg width="W" height="H">
+    <rect width="W" height="H" fill="white"/>
+    <!-- one <polyline> per stroke — renders in any SVG viewer -->
+    <polyline points="x,y ..." stroke="#000000" stroke-width="N" .../>
+    <metadata>
+      <fn:data xmlns:fn="urn:fastnote:1">
+        {"version":1,"w":W,"h":H,"strokes":[...]}
+      </fn:data>
+    </metadata>
+  </svg>
+
+The <polyline> elements use the average line width per stroke. The
+<metadata> JSON block contains the full per-point data (including width)
+for lossless round-tripping.
+
+svg.read() recovers via the JSON block when present; falls back to
+parsing <polyline> elements for SVGs produced by other tools.
+--]]--
+
+local json = require("lib/json")
+
+local svg = {}
+
+-- ---------------------------------------------------------------------------
+-- Write
+-- ---------------------------------------------------------------------------
+
+--- Serialise a StrokeBuffer to an SVG string.
+-- @param  strokebuf  StrokeBuffer
+-- @param  w          number  canvas width in pixels
+-- @param  h          number  canvas height in pixels
+-- @return string  SVG text
+function svg.write(strokebuf, w, h)
+    local lines = {}
+
+    lines[#lines + 1] = string.format(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d">', w, h)
+    lines[#lines + 1] = string.format(
+        '<rect width="%d" height="%d" fill="white"/>', w, h)
+
+    -- Visual polylines -------------------------------------------------------
+    for _, stroke in ipairs(strokebuf.strokes) do
+        local pts = stroke.pts
+        if #pts >= 6 then  -- at least 2 points
+            -- Build points string and compute average width
+            local pts_parts = {}
+            local total_w = 0
+            local n_pts = #pts / 3
+            for i = 1, #pts, 3 do
+                pts_parts[#pts_parts + 1] = string.format("%d,%d", pts[i], pts[i+1])
+                total_w = total_w + pts[i+2]
+            end
+            local avg_w = math.max(1, math.floor(total_w / n_pts + 0.5))
+            lines[#lines + 1] = string.format(
+                '<polyline points="%s" fill="none" stroke="%s" stroke-width="%d"'
+                .. ' stroke-linecap="round" stroke-linejoin="round"/>',
+                table.concat(pts_parts, " "),
+                stroke.color or "#000000",
+                avg_w)
+        end
+    end
+
+    -- Metadata: full stroke data for lossless round-trip --------------------
+    local data = strokebuf:toTable()
+    data.version = 1
+    data.w       = w
+    data.h       = h
+
+    lines[#lines + 1] = '<metadata>'
+    lines[#lines + 1] = '<fn:data xmlns:fn="urn:fastnote:1">'
+    lines[#lines + 1] = json.encode(data)
+    lines[#lines + 1] = '</fn:data>'
+    lines[#lines + 1] = '</metadata>'
+    lines[#lines + 1] = '</svg>'
+
+    return table.concat(lines, "\n")
+end
+
+-- ---------------------------------------------------------------------------
+-- Read
+-- ---------------------------------------------------------------------------
+
+--- Recover a StrokeBuffer from an SVG string.
+-- Attempts JSON metadata first; falls back to <polyline> parsing.
+-- @param  text  string  SVG text
+-- @return StrokeBuffer, w|nil, h|nil
+function svg.read(text)
+    local StrokeBuffer = require("lib/strokebuffer")
+
+    -- Primary: JSON metadata block -------------------------------------------
+    local json_str = text:match('<fn:data[^>]*>(.-)</fn:data>')
+    if json_str then
+        local ok, data = pcall(json.decode, json_str:match("^%s*(.-)%s*$"))
+        if ok and type(data) == "table" and type(data.strokes) == "table" then
+            return StrokeBuffer.fromTable(data), data.w, data.h
+        end
+    end
+
+    -- Fallback: parse <polyline> elements ------------------------------------
+    -- Points carry no per-sample width; use stroke-width as a constant.
+    local Stroke = require("lib/stroke")
+    local sb     = StrokeBuffer.new()
+
+    for pts_str, color_str, width_str in text:gmatch(
+            '<polyline%s+points="([^"]*)"[^>]*stroke="([^"]*)"[^>]*stroke%-width="([^"]*)"') do
+        local w_val = tonumber(width_str) or 3
+        local stroke = Stroke.new(color_str)
+        for x_str, y_str in pts_str:gmatch("(%d+),(%d+)") do
+            stroke:addPoint(tonumber(x_str), tonumber(y_str), w_val)
+        end
+        if not stroke:isEmpty() then
+            sb.strokes[#sb.strokes + 1] = stroke
+        end
+    end
+
+    return sb, nil, nil
+end
+
+return svg

--- a/plugins/fastnote.koplugin/main.lua
+++ b/plugins/fastnote.koplugin/main.lua
@@ -1,0 +1,50 @@
+--[[--
+This is a plugin for quick notes with pen input.
+
+@module koplugin.FastNote
+--]]--
+
+
+local Dispatcher = require("dispatcher")  -- luacheck:ignore
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local DrawingCanvas = require("plugins/fastnote.koplugin/drawingcanvas")
+local _ = require("gettext")
+
+local FastNote = WidgetContainer:extend{
+    name = "fastnote",
+    is_doc_only = false,
+}
+
+function FastNote:onDispatcherRegisterActions()
+    Dispatcher:registerAction("open_fnote_canvas", {category="none", event="OpenFnoteCanvas", title=_("Open Fast Note Canvas"), general=true,})
+end
+
+function FastNote:init()
+    self:onDispatcherRegisterActions()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function FastNote:addToMainMenu(menu_items)
+    menu_items.fast_note = {
+        text = _("Fast Note"),
+        -- in which menu this should be appended
+        sorting_hint = "more_tools",
+        -- a callback when tapping
+        callback = function()
+            UIManager:show(InfoMessage:new{
+                text = _("Hello, plugin world -FastNote"),
+            })
+        end,
+    }
+end
+
+function FastNote:onOpenFnoteCanvas()
+    local popup = InfoMessage:new{
+        text = _("Fast Note Canvas first message confirmed!"),
+    }
+    UIManager:show(popup)
+end
+
+return FastNote

--- a/plugins/fastnote.koplugin/main.lua
+++ b/plugins/fastnote.koplugin/main.lua
@@ -6,7 +6,6 @@ This is a plugin for quick notes with pen input.
 
 
 local Dispatcher = require("dispatcher")  -- luacheck:ignore
-local InfoMessage = require("ui/widget/infomessage")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local DrawingCanvas = require("plugins/fastnote.koplugin/drawingcanvas")
@@ -29,22 +28,15 @@ end
 function FastNote:addToMainMenu(menu_items)
     menu_items.fast_note = {
         text = _("Fast Note"),
-        -- in which menu this should be appended
         sorting_hint = "more_tools",
-        -- a callback when tapping
         callback = function()
-            UIManager:show(InfoMessage:new{
-                text = _("Hello, plugin world -FastNote"),
-            })
+            self:onOpenFnoteCanvas()
         end,
     }
 end
 
 function FastNote:onOpenFnoteCanvas()
-    local popup = InfoMessage:new{
-        text = _("Fast Note Canvas first message confirmed!"),
-    }
-    UIManager:show(popup)
+    UIManager:show(DrawingCanvas:new{})
 end
 
 return FastNote

--- a/plugins/fastnote.koplugin/spec/palmreject_spec.lua
+++ b/plugins/fastnote.koplugin/spec/palmreject_spec.lua
@@ -1,0 +1,222 @@
+--[[--
+spec/palmreject_spec.lua — unit tests for lib/palmreject.lua
+Run: busted spec/palmreject_spec.lua   (from plugin root)
+--]]--
+
+package.path = package.path .. ";fastnote.koplugin/?.lua"
+
+local PalmReject = require("lib/palmreject")
+
+-- Injectable clock: a table holding a mutable "now" value in ms.
+-- Pass clock.fn to PalmReject.new(); advance with clock.advance(delta_ms).
+local function make_clock(start_ms)
+    local t = {now = start_ms or 0}
+    t.fn = function() return t.now end
+    t.advance = function(delta) t.now = t.now + delta end
+    return t
+end
+
+-- Helper: touch-down event
+local function touch_down(slot, id, x, y, major)
+    return {type="down", slot=slot, id=id, x=x, y=y, touch_major=major or 20}
+end
+local function touch_move(slot, id, x, y)
+    return {type="move", slot=slot, id=id, x=x, y=y}
+end
+local function touch_up(slot, id)
+    return {type="up", slot=slot, id=id}
+end
+
+describe("PalmReject", function()
+
+    -- ── Initial state ────────────────────────────────────────────────────────
+
+    describe("initial state", function()
+        it("pen is not proximate on creation", function()
+            local pr = PalmReject.new()
+            assert.is_false(pr:isPenProximate())
+        end)
+
+        it("touch events pass through when pen is not proximate", function()
+            local pr = PalmReject.new()
+            local ev = touch_down(0, 1, 100, 200)
+            assert.is_not_nil(pr:onTouchEvent(ev))
+        end)
+    end)
+
+    -- ── Pen proximity gate ───────────────────────────────────────────────────
+
+    describe("pen proximity gate", function()
+        it("pen 'down' makes pen proximate", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="down", x=0, y=0, pressure=100, tool="pen"})
+            assert.is_true(pr:isPenProximate())
+        end)
+
+        it("pen 'hover' makes pen proximate", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="hover", x=0, y=0})
+            assert.is_true(pr:isPenProximate())
+        end)
+
+        it("touch is rejected while pen is down", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="down", x=0, y=0, pressure=100, tool="pen"})
+            local result = pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            assert.is_nil(result)
+        end)
+
+        it("rejected slot's move events are also rejected", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="down", x=0, y=0, pressure=100, tool="pen"})
+            pr:onTouchEvent(touch_down(0, 1, 50, 50))  -- rejected
+            local result = pr:onTouchEvent(touch_move(0, 1, 55, 55))
+            assert.is_nil(result)
+        end)
+
+        it("rejected slot's up event is also rejected", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="down", x=0, y=0, pressure=100, tool="pen"})
+            pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            local result = pr:onTouchEvent(touch_up(0, 1))
+            assert.is_nil(result)
+        end)
+
+        it("touch passes after pen up + blackout elapsed", function()
+            local clock = make_clock(0)
+            local pr    = PalmReject.new({blackout_ms = 200}, clock.fn)
+
+            pr:onPenEvent({type="down"})
+            pr:onPenEvent({type="up"})
+            clock.advance(250)  -- past the 200 ms blackout
+
+            local result = pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            assert.is_not_nil(result)
+        end)
+
+        it("touch is rejected during blackout window", function()
+            local clock = make_clock(0)
+            local pr    = PalmReject.new({blackout_ms = 200}, clock.fn)
+
+            pr:onPenEvent({type="down"})
+            pr:onPenEvent({type="up"})
+            clock.advance(100)  -- still within 200 ms blackout
+
+            local result = pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            assert.is_nil(result)
+        end)
+
+        it("pen is not proximate exactly at blackout boundary", function()
+            local clock = make_clock(0)
+            local pr    = PalmReject.new({blackout_ms = 200}, clock.fn)
+
+            pr:onPenEvent({type="down"})
+            pr:onPenEvent({type="up"})
+            clock.advance(200)  -- exactly at boundary — not proximate
+            assert.is_false(pr:isPenProximate())
+        end)
+
+        it("new pen down resets the blackout timer", function()
+            local clock = make_clock(0)
+            local pr    = PalmReject.new({blackout_ms = 200}, clock.fn)
+
+            pr:onPenEvent({type="down"})
+            pr:onPenEvent({type="up"})
+            clock.advance(100)
+            -- Pen comes back down before blackout clears
+            pr:onPenEvent({type="down"})
+            assert.is_true(pr:isPenProximate())
+            -- _pen_up_at should be nil now (not in blackout, actively down)
+            assert.is_nil(pr._pen_up_at)
+        end)
+    end)
+
+    -- ── Area threshold gate ──────────────────────────────────────────────────
+
+    describe("area gate", function()
+        it("large contact is rejected when area_threshold is set", function()
+            local pr = PalmReject.new({area_threshold = 100})
+            local ev = touch_down(0, 1, 50, 50, 150)  -- touch_major=150 > 100
+            assert.is_nil(pr:onTouchEvent(ev))
+        end)
+
+        it("small contact passes when area_threshold is set", function()
+            local pr = PalmReject.new({area_threshold = 100})
+            local ev = touch_down(0, 1, 50, 50, 30)   -- touch_major=30 < 100
+            assert.is_not_nil(pr:onTouchEvent(ev))
+        end)
+
+        it("area gate is disabled when area_threshold is 0", function()
+            local pr = PalmReject.new({area_threshold = 0})
+            local ev = touch_down(0, 1, 50, 50, 9999)
+            assert.is_not_nil(pr:onTouchEvent(ev))
+        end)
+
+        it("area gate rejects even when pen is not proximate", function()
+            local pr = PalmReject.new({area_threshold = 50})
+            -- No pen events at all
+            local ev = touch_down(0, 1, 50, 50, 200)
+            assert.is_nil(pr:onTouchEvent(ev))
+        end)
+    end)
+
+    -- ── Multi-slot isolation ─────────────────────────────────────────────────
+
+    describe("multi-slot", function()
+        it("each slot is tracked independently", function()
+            local pr = PalmReject.new()
+            pr:onPenEvent({type="down"})  -- pen proximate
+
+            -- Slot 0 arrives while pen proximate → rejected
+            pr:onTouchEvent(touch_down(0, 10, 50, 50))
+
+            pr:onPenEvent({type="up"})
+            -- Use a zero-ms blackout for simplicity
+            local clock = make_clock(1000)
+            pr = PalmReject.new({blackout_ms = 0}, clock.fn)
+
+            -- Slot 1 arrives when pen is not proximate → passes
+            local result = pr:onTouchEvent(touch_down(1, 20, 100, 100))
+            assert.is_not_nil(result)
+        end)
+
+        it("slot state is cleared on up event", function()
+            local clock = make_clock(0)
+            local pr    = PalmReject.new({blackout_ms = 0}, clock.fn)
+
+            -- slot 0 passes
+            pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            pr:onTouchEvent(touch_up(0, 1))
+
+            -- slot 0 is gone — re-use same slot number, passes again
+            local result = pr:onTouchEvent(touch_down(0, 2, 60, 60))
+            assert.is_not_nil(result)
+        end)
+    end)
+
+    -- ── Pass-through when not rejected ──────────────────────────────────────
+
+    describe("pass-through", function()
+        it("returns the event unchanged when passing", function()
+            local pr = PalmReject.new()
+            local ev = touch_down(0, 1, 42, 84, 10)
+            local result = pr:onTouchEvent(ev)
+            assert.equals(ev, result)  -- same table reference
+        end)
+
+        it("move event passes when slot was not rejected", function()
+            local pr = PalmReject.new()
+            pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            local result = pr:onTouchEvent(touch_move(0, 1, 55, 55))
+            assert.is_not_nil(result)
+        end)
+
+        it("up event passes when slot was not rejected", function()
+            local pr = PalmReject.new()
+            pr:onTouchEvent(touch_down(0, 1, 50, 50))
+            local result = pr:onTouchEvent(touch_up(0, 1))
+            assert.is_not_nil(result)
+        end)
+    end)
+
+end)

--- a/plugins/fastnote.koplugin/spec/stroke_spec.lua
+++ b/plugins/fastnote.koplugin/spec/stroke_spec.lua
@@ -1,0 +1,189 @@
+--[[--
+spec/stroke_spec.lua — unit tests for lib/stroke.lua
+Run: busted spec/stroke_spec.lua   (from plugin root)
+--]]--
+
+package.path = package.path .. ";fastnote.koplugin/?.lua"
+
+local Stroke = require("lib/stroke")
+
+describe("Stroke", function()
+
+    -- ── Construction ────────────────────────────────────────────────────────
+
+    describe("new", function()
+        it("defaults to black", function()
+            local s = Stroke.new()
+            assert.equals("#000000", s.color)
+        end)
+
+        it("accepts a custom color", function()
+            local s = Stroke.new("#ff0000")
+            assert.equals("#ff0000", s.color)
+        end)
+
+        it("starts with no points", function()
+            local s = Stroke.new()
+            assert.equals(0, #s.pts)
+        end)
+    end)
+
+    -- ── addPoint / pointCount ────────────────────────────────────────────────
+
+    describe("addPoint", function()
+        it("appends a point (3 values per point)", function()
+            local s = Stroke.new()
+            s:addPoint(10, 20, 3)
+            assert.equals(3, #s.pts)
+            assert.equals(10, s.pts[1])
+            assert.equals(20, s.pts[2])
+            assert.equals(3,  s.pts[3])
+        end)
+
+        it("appending twice gives 6 values", function()
+            local s = Stroke.new()
+            s:addPoint(1, 2, 3)
+            s:addPoint(4, 5, 6)
+            assert.equals(6, #s.pts)
+        end)
+
+        it("pointCount reflects the number of samples", function()
+            local s = Stroke.new()
+            assert.equals(0, s:pointCount())
+            s:addPoint(0, 0, 1)
+            assert.equals(1, s:pointCount())
+            s:addPoint(1, 1, 1)
+            assert.equals(2, s:pointCount())
+        end)
+    end)
+
+    -- ── isEmpty ─────────────────────────────────────────────────────────────
+
+    describe("isEmpty", function()
+        it("is true for zero points", function()
+            assert.is_true(Stroke.new():isEmpty())
+        end)
+
+        it("is true for exactly one point", function()
+            local s = Stroke.new()
+            s:addPoint(5, 5, 2)
+            assert.is_true(s:isEmpty())
+        end)
+
+        it("is false when two or more points exist", function()
+            local s = Stroke.new()
+            s:addPoint(0, 0, 1)
+            s:addPoint(10, 10, 2)
+            assert.is_false(s:isEmpty())
+        end)
+    end)
+
+    -- ── bbox ────────────────────────────────────────────────────────────────
+
+    describe("bbox", function()
+        it("returns zeros for empty stroke", function()
+            local x, y, w, h = Stroke.new():bbox()
+            assert.equals(0, x)
+            assert.equals(0, y)
+            assert.equals(0, w)
+            assert.equals(0, h)
+        end)
+
+        it("single-point bbox is padded by that point's width", function()
+            local s = Stroke.new()
+            s:addPoint(50, 100, 4)
+            local x, y, w, h = s:bbox()
+            assert.equals(50 - 4, x)
+            assert.equals(100 - 4, y)
+            assert.equals(4 * 2, w)
+            assert.equals(4 * 2, h)
+        end)
+
+        it("two-point horizontal stroke", function()
+            local s = Stroke.new()
+            s:addPoint(10, 50, 2)
+            s:addPoint(90, 50, 2)
+            local x, y, w, h = s:bbox()
+            assert.equals(10 - 2, x)
+            assert.equals(50 - 2, y)
+            assert.equals((90 - 10) + 4, w)
+            assert.equals(4, h)
+        end)
+
+        it("uses the maximum width for padding", function()
+            local s = Stroke.new()
+            s:addPoint(0, 0, 1)
+            s:addPoint(10, 0, 8)  -- max width = 8
+            local x, y = s:bbox()
+            assert.equals(0 - 8, x)
+            assert.equals(0 - 8, y)
+        end)
+    end)
+
+    -- ── hitTest ─────────────────────────────────────────────────────────────
+
+    describe("hitTest", function()
+        it("returns false for empty stroke", function()
+            assert.is_false(Stroke.new():hitTest(5, 5, 10))
+        end)
+
+        it("returns false for single-point stroke", function()
+            local s = Stroke.new()
+            s:addPoint(5, 5, 2)
+            assert.is_false(s:hitTest(5, 5, 10))
+        end)
+
+        it("returns true when point is on the segment", function()
+            local s = Stroke.new()
+            s:addPoint(0, 50, 2)
+            s:addPoint(100, 50, 2)
+            assert.is_true(s:hitTest(50, 50, 5))
+        end)
+
+        it("returns true when point is within radius of endpoint", function()
+            local s = Stroke.new()
+            s:addPoint(0, 0, 2)
+            s:addPoint(100, 0, 2)
+            assert.is_true(s:hitTest(3, 3, 5))  -- near start
+        end)
+
+        it("returns false when point is outside radius", function()
+            local s = Stroke.new()
+            s:addPoint(0, 0, 2)
+            s:addPoint(100, 0, 2)
+            assert.is_false(s:hitTest(50, 20, 5))  -- 20 px away, radius 5
+        end)
+
+        it("hit is detected on a diagonal segment", function()
+            local s = Stroke.new()
+            s:addPoint(0, 0, 2)
+            s:addPoint(100, 100, 2)
+            -- Midpoint is (50,50), query at (52,48) — ~2.8 px away
+            assert.is_true(s:hitTest(52, 48, 5))
+        end)
+    end)
+
+    -- ── toTable / fromTable round-trip ───────────────────────────────────────
+
+    describe("toTable / fromTable", function()
+        it("round-trips color", function()
+            local s = Stroke.new("#aabbcc")
+            local s2 = Stroke.fromTable(s:toTable())
+            assert.equals("#aabbcc", s2.color)
+        end)
+
+        it("round-trips points exactly", function()
+            local s = Stroke.new()
+            s:addPoint(10, 20, 3)
+            s:addPoint(30, 40, 5)
+            local s2 = Stroke.fromTable(s:toTable())
+            assert.same(s.pts, s2.pts)
+        end)
+
+        it("fromTable with missing pts produces empty pts", function()
+            local s = Stroke.fromTable({color = "#000000"})
+            assert.equals(0, #s.pts)
+        end)
+    end)
+
+end)

--- a/plugins/fastnote.koplugin/spec/strokebuffer_spec.lua
+++ b/plugins/fastnote.koplugin/spec/strokebuffer_spec.lua
@@ -1,0 +1,240 @@
+--[[--
+spec/strokebuffer_spec.lua — unit tests for lib/strokebuffer.lua
+Run: busted spec/strokebuffer_spec.lua   (from plugin root)
+--]]--
+
+package.path = package.path .. ";fastnote.koplugin/?.lua"
+
+local StrokeBuffer = require("lib/strokebuffer")
+
+describe("StrokeBuffer", function()
+
+    -- ── Construction ────────────────────────────────────────────────────────
+
+    describe("new", function()
+        it("starts empty", function()
+            local sb = StrokeBuffer.new()
+            assert.is_true(sb:isEmpty())
+            assert.equals(0, #sb.strokes)
+            assert.equals(0, #sb.undone)
+            assert.is_nil(sb.current)
+        end)
+    end)
+
+    -- ── penDown / penMove / penUp ────────────────────────────────────────────
+
+    describe("live drawing", function()
+        it("penDown starts a current stroke", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(10, 20, 3, "#000000")
+            assert.is_not_nil(sb.current)
+            assert.equals(1, sb.current:pointCount())
+        end)
+
+        it("penMove before penDown is a no-op", function()
+            local sb = StrokeBuffer.new()
+            sb:penMove(5, 5, 2)
+            assert.is_nil(sb.current)
+        end)
+
+        it("penUp with a single-point stroke discards it", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(10, 10, 2)
+            sb:penUp()
+            assert.is_true(sb:isEmpty())
+        end)
+
+        it("penUp commits a multi-point stroke", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2)
+            sb:penMove(10, 10, 2)
+            sb:penUp()
+            assert.equals(1, #sb.strokes)
+            assert.is_nil(sb.current)
+        end)
+
+        it("committed stroke preserves color", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2, "#ff0000")
+            sb:penMove(10, 10, 2)
+            sb:penUp()
+            assert.equals("#ff0000", sb.strokes[1].color)
+        end)
+
+        it("multiple strokes accumulate", function()
+            local sb = StrokeBuffer.new()
+            for i = 1, 5 do
+                sb:penDown(i, i, 2)
+                sb:penMove(i+10, i+10, 2)
+                sb:penUp()
+            end
+            assert.equals(5, #sb.strokes)
+        end)
+    end)
+
+    -- ── isEmpty / isDirty ───────────────────────────────────────────────────
+
+    describe("isEmpty / isDirty", function()
+        it("isEmpty is false after committing a stroke", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2)
+            sb:penMove(5, 5, 2)
+            sb:penUp()
+            assert.is_false(sb:isEmpty())
+        end)
+
+        it("isDirty is false when empty", function()
+            assert.is_false(StrokeBuffer.new():isDirty())
+        end)
+
+        it("isDirty is true after committing", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2)
+            sb:penMove(5, 5, 2)
+            sb:penUp()
+            assert.is_true(sb:isDirty())
+        end)
+    end)
+
+    -- ── undo / redo ─────────────────────────────────────────────────────────
+
+    describe("undo / redo", function()
+        local function make_sb_with_strokes(n)
+            local sb = StrokeBuffer.new()
+            for i = 1, n do
+                sb:penDown(i*10, 0, 2)
+                sb:penMove(i*10 + 5, 5, 2)
+                sb:penUp()
+            end
+            return sb
+        end
+
+        it("undo returns nil on empty buffer", function()
+            assert.is_nil(StrokeBuffer.new():undo())
+        end)
+
+        it("undo removes the last stroke", function()
+            local sb = make_sb_with_strokes(3)
+            sb:undo()
+            assert.equals(2, #sb.strokes)
+        end)
+
+        it("undo moves the stroke to undone", function()
+            local sb = make_sb_with_strokes(1)
+            local removed = sb:undo()
+            assert.is_not_nil(removed)
+            assert.equals(1, #sb.undone)
+        end)
+
+        it("redo returns nil when nothing undone", function()
+            assert.is_nil(StrokeBuffer.new():redo())
+        end)
+
+        it("redo restores the last undone stroke", function()
+            local sb = make_sb_with_strokes(2)
+            sb:undo()
+            sb:redo()
+            assert.equals(2, #sb.strokes)
+            assert.equals(0, #sb.undone)
+        end)
+
+        it("multiple undo/redo cycles are stable", function()
+            local sb = make_sb_with_strokes(3)
+            sb:undo(); sb:undo()
+            assert.equals(1, #sb.strokes)
+            assert.equals(2, #sb.undone)
+            sb:redo()
+            assert.equals(2, #sb.strokes)
+            assert.equals(1, #sb.undone)
+        end)
+
+        it("penDown clears redo history", function()
+            local sb = make_sb_with_strokes(2)
+            sb:undo()
+            assert.equals(1, #sb.undone)
+            -- New stroke clears redo
+            sb:penDown(99, 99, 2)
+            sb:penMove(100, 100, 2)
+            sb:penUp()
+            assert.equals(0, #sb.undone)
+        end)
+    end)
+
+    -- ── eraseAt ─────────────────────────────────────────────────────────────
+
+    describe("eraseAt", function()
+        it("returns empty list when nothing hit", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(100, 100, 2)
+            sb:penMove(200, 100, 2)
+            sb:penUp()
+            local removed = sb:eraseAt(0, 0, 5)
+            assert.equals(0, #removed)
+            assert.equals(1, #sb.strokes)
+        end)
+
+        it("removes a stroke whose segment is within radius", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 50, 2)
+            sb:penMove(100, 50, 2)
+            sb:penUp()
+            local removed = sb:eraseAt(50, 50, 10)
+            assert.equals(1, #removed)
+            assert.equals(0, #sb.strokes)
+        end)
+
+        it("only removes strokes that are hit", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2); sb:penMove(10, 0, 2); sb:penUp()
+            sb:penDown(100, 100, 2); sb:penMove(110, 100, 2); sb:penUp()
+            local removed = sb:eraseAt(5, 0, 5)
+            assert.equals(1, #removed)
+            assert.equals(1, #sb.strokes)
+        end)
+
+        it("eraseAt clears redo history", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 50, 2); sb:penMove(100, 50, 2); sb:penUp()
+            sb:penDown(0, 0, 2); sb:penMove(10, 0, 2); sb:penUp()
+            sb:undo()
+            assert.equals(1, #sb.undone)
+            sb:eraseAt(50, 50, 10)
+            assert.equals(0, #sb.undone)
+        end)
+    end)
+
+    -- ── toTable / fromTable round-trip ───────────────────────────────────────
+
+    describe("serialisation", function()
+        it("empty buffer round-trips", function()
+            local sb = StrokeBuffer.new()
+            local sb2 = StrokeBuffer.fromTable(sb:toTable())
+            assert.is_true(sb2:isEmpty())
+        end)
+
+        it("strokes are preserved through round-trip", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(1, 2, 3, "#abcdef")
+            sb:penMove(4, 5, 6)
+            sb:penUp()
+            sb:penDown(10, 20, 1)
+            sb:penMove(30, 40, 2)
+            sb:penUp()
+            local sb2 = StrokeBuffer.fromTable(sb:toTable())
+            assert.equals(2, #sb2.strokes)
+            assert.equals("#abcdef", sb2.strokes[1].color)
+            assert.same(sb.strokes[1].pts, sb2.strokes[1].pts)
+            assert.same(sb.strokes[2].pts, sb2.strokes[2].pts)
+        end)
+
+        it("undone strokes are not serialised", function()
+            local sb = StrokeBuffer.new()
+            sb:penDown(0, 0, 2); sb:penMove(5, 5, 2); sb:penUp()
+            sb:penDown(10, 10, 2); sb:penMove(15, 15, 2); sb:penUp()
+            sb:undo()
+            local sb2 = StrokeBuffer.fromTable(sb:toTable())
+            assert.equals(1, #sb2.strokes)
+        end)
+    end)
+
+end)

--- a/plugins/fastnote.koplugin/spec/svg_spec.lua
+++ b/plugins/fastnote.koplugin/spec/svg_spec.lua
@@ -1,0 +1,181 @@
+--[[--
+spec/svg_spec.lua — unit tests for lib/svg.lua
+Run: busted spec/svg_spec.lua   (from plugin root)
+--]]--
+
+package.path = package.path .. ";fastnote.koplugin/?.lua"
+
+local svg          = require("lib/svg")
+local StrokeBuffer = require("lib/strokebuffer")
+
+-- Helper: build a StrokeBuffer with known strokes
+local function make_sb()
+    local sb = StrokeBuffer.new()
+    -- Stroke 1: black, 4 points
+    sb:penDown(10,  20, 3, "#000000")
+    sb:penMove(30,  40, 4)
+    sb:penMove(50,  60, 5)
+    sb:penMove(70,  80, 3)
+    sb:penUp()
+    -- Stroke 2: colored, 2 points
+    sb:penDown(100, 200, 2, "#ff0000")
+    sb:penMove(300, 400, 2)
+    sb:penUp()
+    return sb
+end
+
+describe("svg.write", function()
+
+    it("produces a string starting with <svg", function()
+        local sb  = make_sb()
+        local out = svg.write(sb, 1080, 1440)
+        assert.is_string(out)
+        assert.is_truthy(out:match("^<svg"))
+    end)
+
+    it("includes correct width and height attributes", function()
+        local out = svg.write(make_sb(), 800, 600)
+        assert.is_truthy(out:match('width="800"'))
+        assert.is_truthy(out:match('height="600"'))
+    end)
+
+    it("includes a white background rect", function()
+        local out = svg.write(make_sb(), 100, 100)
+        assert.is_truthy(out:match('<rect'))
+        assert.is_truthy(out:match('fill="white"'))
+    end)
+
+    it("produces a <polyline> for each non-empty stroke", function()
+        local sb  = make_sb()
+        local out = svg.write(sb, 1080, 1440)
+        local count = 0
+        for _ in out:gmatch('<polyline') do count = count + 1 end
+        assert.equals(2, count)
+    end)
+
+    it("includes stroke color in polyline", function()
+        local out = svg.write(make_sb(), 1080, 1440)
+        assert.is_truthy(out:match('stroke="#ff0000"'))
+    end)
+
+    it("includes all sample points in the polyline", function()
+        local sb = StrokeBuffer.new()
+        sb:penDown(10, 20, 2); sb:penMove(30, 40, 2); sb:penMove(50, 60, 2); sb:penUp()
+        local out = svg.write(sb, 500, 500)
+        assert.is_truthy(out:match("10,20"))
+        assert.is_truthy(out:match("30,40"))
+        assert.is_truthy(out:match("50,60"))
+    end)
+
+    it("includes a <metadata> block", function()
+        local out = svg.write(make_sb(), 1080, 1440)
+        assert.is_truthy(out:match('<metadata>'))
+        assert.is_truthy(out:match('<fn:data'))
+    end)
+
+    it("includes version, w, h in metadata JSON", function()
+        local out = svg.write(make_sb(), 1080, 1440)
+        local json_str = out:match('<fn:data[^>]*>(.-)</fn:data>')
+        assert.is_truthy(json_str)
+        assert.is_truthy(json_str:match('"version"'))
+        assert.is_truthy(json_str:match('"w"'))
+        assert.is_truthy(json_str:match('"h"'))
+    end)
+
+    it("skips strokes with fewer than 2 points", function()
+        local sb = StrokeBuffer.new()
+        sb:penDown(5, 5, 2)
+        -- Don't call penMove — single-point stroke, but we bypass penUp
+        -- by directly inserting a stub: use a real single-point stroke via penDown+penUp
+        sb:penUp()  -- single-point, not committed
+        local out = svg.write(sb, 100, 100)
+        local count = 0
+        for _ in out:gmatch('<polyline') do count = count + 1 end
+        assert.equals(0, count)
+    end)
+
+end)
+
+describe("svg.read", function()
+
+    it("returns a StrokeBuffer", function()
+        local sb_in  = make_sb()
+        local text   = svg.write(sb_in, 1080, 1440)
+        local sb_out = svg.read(text)
+        assert.is_not_nil(sb_out)
+    end)
+
+    it("recovers w and h from metadata", function()
+        local text         = svg.write(make_sb(), 1080, 1440)
+        local _, w_out, h_out = svg.read(text)
+        assert.equals(1080, w_out)
+        assert.equals(1440, h_out)
+    end)
+
+    it("round-trips stroke count", function()
+        local sb_in  = make_sb()
+        local text   = svg.write(sb_in, 1080, 1440)
+        local sb_out = svg.read(text)
+        assert.equals(#sb_in.strokes, #sb_out.strokes)
+    end)
+
+    it("round-trips stroke colors", function()
+        local sb_in  = make_sb()
+        local text   = svg.write(sb_in, 1080, 1440)
+        local sb_out = svg.read(text)
+        assert.equals(sb_in.strokes[1].color, sb_out.strokes[1].color)
+        assert.equals(sb_in.strokes[2].color, sb_out.strokes[2].color)
+    end)
+
+    it("round-trips point data losslessly", function()
+        local sb_in  = make_sb()
+        local text   = svg.write(sb_in, 1080, 1440)
+        local sb_out = svg.read(text)
+        assert.same(sb_in.strokes[1].pts, sb_out.strokes[1].pts)
+        assert.same(sb_in.strokes[2].pts, sb_out.strokes[2].pts)
+    end)
+
+    it("handles an empty StrokeBuffer", function()
+        local sb_in  = StrokeBuffer.new()
+        local text   = svg.write(sb_in, 500, 400)
+        local sb_out = svg.read(text)
+        assert.is_true(sb_out:isEmpty())
+    end)
+
+    it("falls back to polyline parsing when metadata is absent", function()
+        -- Craft an SVG without fn:data
+        local plain_svg = [[
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+<polyline points="10,20 30,40 50,60" fill="none" stroke="#000000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>]]
+        local sb = svg.read(plain_svg)
+        assert.equals(1, #sb.strokes)
+        assert.equals("#000000", sb.strokes[1].color)
+        assert.equals(3, sb.strokes[1]:pointCount())
+    end)
+
+end)
+
+describe("svg round-trip property", function()
+
+    it("write then read is a no-op on point data for any stroke count", function()
+        for n_strokes = 0, 5 do
+            local sb = StrokeBuffer.new()
+            for i = 1, n_strokes do
+                sb:penDown(i * 10, 0, 2, "#000000")
+                sb:penMove(i * 10 + 5, 5, 3)
+                sb:penMove(i * 10 + 10, 10, 2)
+                sb:penUp()
+            end
+            local text   = svg.write(sb, 200, 200)
+            local sb2, _ = svg.read(text)
+            assert.equals(#sb.strokes, #sb2.strokes,
+                "stroke count mismatch for n=" .. n_strokes)
+            for j = 1, #sb.strokes do
+                assert.same(sb.strokes[j].pts, sb2.strokes[j].pts,
+                    "pts mismatch for stroke " .. j .. " (n=" .. n_strokes .. ")")
+            end
+        end
+    end)
+
+end)


### PR DESCRIPTION
This pull request introduces the initial infrastructure for the pen input subsystem of the `fastnote` KOReader plugin, specifically targeting the Kobo Libra Colour device. The main focus is on adding a robust, device-aware FFI-based pen input layer, along with comprehensive developer documentation and plugin metadata. These changes lay the groundwork for reliable, low-latency pen event handling and clarify the project's architecture and development practices.

**Key additions and improvements:**

### Pen Input Infrastructure

* Added `input/pendev.lua`, a new module that uses FFI to discover, open, and poll the Wacom EMR pen digitizer device. It translates raw Linux input events into high-level pen events using a state machine, with careful handling of device quirks and calibration. The code is robust against device differences and includes fallback logic for axis calibration.

### Developer Documentation

* Added `AGENTS.md`, a thorough developer guide for the `fastnote.koplugin` directory. This document explains the plugin's purpose, architecture, file structure, development workflow (including emulator/device/test strategies), coding conventions, technical notes, and open design questions. It is intended to help future contributors quickly understand the codebase and design rationale.

### Plugin Metadata

* Added `_meta.lua` for the plugin, providing its name, display name, and a localized description for KOReader's plugin management UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15424)
<!-- Reviewable:end -->
