### PR TITLE
bump base & crengine: support for initial-letter, and other fixes

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1714,7 +1714,7 @@ function CreDocument:setupCallCache()
             return time.now()
         end
         addStatMiss = function(name, starttime, not_cached)
-            local duration = time.since(starttime)
+            local duration = time.to_s(time.since(starttime))
             if not self._call_cache_stats[name] then
                 self._call_cache_stats[name] = {0, 0.0, 1, duration, not_cached}
             else
@@ -1724,7 +1724,7 @@ function CreDocument:setupCallCache()
             end
         end
         addStatHit = function(name, starttime)
-            local duration = time.since(starttime)
+            local duration = time.to_s(time.since(starttime))
             if not self._call_cache_stats[name] then
                 self._call_cache_stats[name] = {1, duration, 0, 0.0}
             else


### PR DESCRIPTION
Includes:
- fix GCC 16 warnings (-Wunused-but-set-variable) https://github.com/koreader/crengine/pull/663
- https://github.com/koreader/crengine/pull/666 :
  - ldomXRange::getRangeText(): newline on <br/>
  - createXPointer(pt)/getRect(): use formatter src->t.text
  - getRect(): unify one-char-long word width handling
  - CSS ::first-letter: use non-letter char if no letter in first text node
  - CSS ::first-line: properly handle inline-block
  - createXPointer(pt): return source text node on pseudoElem[FirstLetter]
  - getSegmentRects(): compare .bottom additionally to .top
  - lvfntman: add getCapHeight()
  - CSS initial-letter: add CSS parsing and style slot
  - CSS initial-letter: render ::first-letter via inline-box

Also includes:
- MuPDF: check if page has smask before applying it https://github.com/koreader/koreader-base/pull/2364

credocument: fix call cache statistics (not updated after the bit time.lua refactor years ago - https://github.com/koreader/koreader/pull/15377#discussion_r3261339666).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15429)
<!-- Reviewable:end -->
