### PR TITLE
Book metadata archive: fix saving

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1142,8 +1142,11 @@ function FileManager:showDeleteFileDialog(filepath, post_delete_callback, pre_de
             end
         end,
     }
-    if not is_file or BookList.hasBookBeenOpened(file) then
-        self.addMetadataArcCheckButton(confirmbox)
+    if is_file then
+        local doc_settings = BookList.hasBookBeenOpened(file) and BookList.getDocSettings(file)
+        if doc_settings and doc_settings:has("doc_props") and doc_settings:has("partial_md5_checksum") then
+            self.addMetadataArcCheckButton(confirmbox)
+        end
     end
     UIManager:show(confirmbox)
 end

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -762,6 +762,7 @@ function BookInfo:editSummary(doc_settings_or_file, book_props)
                         local note = input_dialog:getInputText()
                         summary.note = note ~= "" and note or nil
                         doc_settings_or_file = filemanagerutil.saveSummary(doc_settings_or_file, summary)
+                        BookList.setBookInfoCacheProperty(doc_settings_or_file:readSetting("doc_path"), "been_opened", true)
                         self.summary_updated = true
                         self.kvp_widget:onClose()
                         self:show(doc_settings_or_file, book_props)

--- a/frontend/docsettings.lua
+++ b/frontend/docsettings.lua
@@ -624,6 +624,7 @@ function DocSettings.saveSettingsArcFile(doc_settings, custom_metadata_file, on_
         end
         custom_metadata_file = DocSettings:findCustomMetadataFile(doc_settings:readSetting("doc_path"))
     end
+    if doc_settings:hasNot("doc_props") or doc_settings:hasNot("partial_md5_checksum") then return end
     local arc_file = DocSettings.getSettingsArcFile(doc_settings:readSetting("partial_md5_checksum"))
     if not on_closing then -- on deletion, called by DocSettings.updateLocation()
         if G_reader_settings:hasNot("document_metadata_arc_on_deletion") then


### PR DESCRIPTION
Disable saving book metadata to the archive when doc props or md5 are absent in sdr file.
This happens when the status, rating or review of a new book are changed in the file browser via the popup dialog or the Book information window.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15445)
<!-- Reviewable:end -->
