### PR TITLE
[feat] Add Acorny highlight exporter

### DIFF
--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -77,6 +77,7 @@ local function updateMyClippings(clippings, new_clippings)
 end
 
 local targets = {
+    acorny = require("target/acorny"),
     html = require("target/html"),
     joplin = require("target/joplin"),
     json = require("target/json"),

--- a/plugins/exporter.koplugin/target/acorny.lua
+++ b/plugins/exporter.koplugin/target/acorny.lua
@@ -1,0 +1,116 @@
+local InputDialog = require("ui/widget/inputdialog")
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local _ = require("gettext")
+
+local AcornyExporter = require("base"):new {
+    name = "acorny",
+    is_remote = true,
+}
+
+function AcornyExporter:isReadyToExport()
+    if self.settings.token then return true end
+    return false
+end
+
+function AcornyExporter:getMenuTable()
+    return {
+        text = _("Acorny"),
+        checked_func = function() return self:isEnabled() end,
+        sub_item_table = {
+            {
+                text = _("Set authorization token"),
+                keep_menu_open = true,
+                callback = function()
+                    local auth_dialog
+                    auth_dialog = InputDialog:new {
+                        title = _("Set authorization token for Acorny"),
+                        input = self.settings.token,
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    callback = function()
+                                        UIManager:close(auth_dialog)
+                                    end
+                                },
+                                {
+                                    text = _("Set token"),
+                                    callback = function()
+                                        self.settings.token = auth_dialog:getInputText()
+                                        self:saveSettings()
+                                        UIManager:close(auth_dialog)
+                                    end
+                                }
+                            }
+                        }
+                    }
+                    UIManager:show(auth_dialog)
+                    auth_dialog:onShowKeyboard()
+                end
+            },
+            {
+                text = _("Export to Acorny"),
+                checked_func = function() return self:isEnabled() end,
+                callback = function() self:toggleEnabled() end,
+            },
+            {
+                text = _("Help"),
+                keep_menu_open = true,
+                callback = function()
+                    UIManager:show(InfoMessage:new {
+                        text = _([[To export highlights to Acorny, sign in to Acorny and open Settings > Import API tokens. Create a token, copy it immediately, then paste it into KOReader with "Set authorization token".]])
+                    })
+                end
+            },
+        }
+    }
+end
+
+function AcornyExporter:createHighlights(booknotes)
+    local highlights = {}
+    local author = booknotes.author
+
+    local json_headers = {
+        ["Authorization"] = "Token " .. self.settings.token,
+    }
+
+    for _, chapter in ipairs(booknotes) do
+        for _, clipping in ipairs(chapter) do
+            local highlight = {
+                text = clipping.text,
+                title = booknotes.title,
+                author = author and author ~= "" and author:gsub("\n", ", ") or nil,
+                source_type = "koreader",
+                category = "books",
+                note = clipping.note,
+                location = clipping.page,
+                location_type = "order",
+                highlighted_at = os.date("!%Y-%m-%dT%TZ", clipping.time),
+            }
+            table.insert(highlights, highlight)
+        end
+    end
+
+    local result, err = self:makeJsonRequest("https://acorny.io/api/v2/highlights/", "POST",
+         { highlights = highlights }, json_headers)
+
+    if not result then
+        logger.warn("error creating highlights", err)
+        return false
+    end
+    return true
+end
+
+function AcornyExporter:export(t)
+    if not self:isReadyToExport() then return false end
+
+    for _, booknotes in ipairs(t) do
+        local ok = self:createHighlights(booknotes)
+        if not ok then return false end
+    end
+    return true
+end
+
+return AcornyExporter

--- a/spec/unit/exporter_plugin_main_spec.lua
+++ b/spec/unit/exporter_plugin_main_spec.lua
@@ -93,5 +93,40 @@ describe("Exporter plugin module", function()
         assert.not_truthy(ok)
         ok = readerui.exporter.targets["readwise"]:export(sample_clippings)
         assert.not_truthy(ok)
+        ok = readerui.exporter.targets["acorny"]:export(sample_clippings)
+        assert.not_truthy(ok)
+    end)
+
+    it("should export highlights to Acorny using the Readwise-compatible API", function()
+        local acorny = readerui.exporter.targets["acorny"]
+        local endpoint, method, body, headers
+        acorny.settings.token = "test-token"
+        acorny.makeJsonRequest = function(_, request_endpoint, request_method, request_body, request_headers)
+            endpoint = request_endpoint
+            method = request_method
+            body = request_body
+            headers = request_headers
+            return {}
+        end
+
+        local ok = acorny:createHighlights(sample_clippings.Title1)
+
+        assert.is_truthy(ok)
+        assert.are.equal("https://acorny.io/api/v2/highlights/", endpoint)
+        assert.are.equal("POST", method)
+        assert.are.equal("Token test-token", headers["Authorization"])
+        assert.are.equal(2, #body.highlights)
+        assert.are.equal("Some important stuff 1", body.highlights[1].text)
+        assert.are.equal("Title1", body.highlights[1].title)
+        assert.are.equal("koreader", body.highlights[1].source_type)
+    end)
+
+    it("should show Acorny setup help", function()
+        local acorny_menu = readerui.exporter.targets["acorny"]:getMenuTable()
+        local help_item = acorny_menu.sub_item_table[3]
+
+        assert.are.equal("Help", help_item.text)
+        assert.is_true(help_item.keep_menu_open)
+        assert.is_function(help_item.callback)
     end)
 end)


### PR DESCRIPTION
## Summary

Adds Acorny as a KOReader highlight export target using Acorny's Readwise-compatible API.

- Registers a new acorny exporter target in the exporter plugin.
- Adds token setup and enable/disable menu entries for Acorny.
- Posts highlights to https://acorny.io/api/v2/highlights/ with Authorization: Token <token>.
- Adds exporter unit coverage for unconfigured Acorny export and request mapping.

## Validation

- lua -e assert(loadfile(...)) for the changed Lua/spec files
- git diff --cached --check

Note: bash ./kodev test front exporter_plugin_main_spec.lua could not run in this Windows environment because bash falls through to WSL and no WSL distro is installed/configured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15447)
<!-- Reviewable:end -->
