### PR TITLE
ReaderDictionary: prettify dict download list

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local BookList = require("ui/widget/booklist")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
@@ -1636,33 +1637,44 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
 end
 
 function ReaderDictionary:showDownload(downloadable_dicts)
-    local kv_pairs = {}
-    for dummy, dict in ipairs(downloadable_dicts) do
-        table.insert(kv_pairs, {dict.name, "",
-            callback = function()
-                local connect_callback = function()
-                    self:downloadDictionaryPrep(dict)
-                end
-                NetworkMgr:runWhenOnline(connect_callback)
-            end})
-        local lang
-        if dict.lang_in == dict.lang_out then
-            lang = string.format("    %s", dict.lang_in)
-        else
-            lang = string.format("    %s–%s", dict.lang_in, dict.lang_out)
-        end
-        table.insert(kv_pairs, {lang, ""})
-        table.insert(kv_pairs, {"    ".._("License"), dict.license})
-        table.insert(kv_pairs, {"    ".._("Entries"), dict.entries, separator = true})
+    local item_table = {}
+    for i, dict in ipairs(downloadable_dicts) do
+        item_table[i] = {
+            text = dict.name,
+            mandatory = dict.entries,
+            dict = dict,
+        }
     end
-    self.download_window = KeyValuePage:new{
-        title = _("Tap dictionary name to download"),
-        kv_pairs = kv_pairs,
-    }
-    UIManager:show(self.download_window)
+    UIManager:show(BookList:new{
+        title = T(_("Available dictionaries (%1)"), #item_table),
+        item_table = item_table,
+        _manager = self,
+        onMenuSelect = self.onTapDownloadDict,
+    })
 end
 
-function ReaderDictionary:downloadDictionaryPrep(dict, size)
+function ReaderDictionary:onTapDownloadDict(item)
+    local dict = item.dict
+    local t = {
+        dict.name,
+        "",
+        T(_("Language: %1–%2"), dict.lang_in, dict.lang_out),
+        T(_("Entries: %1"), dict.entries),
+        T(_("License: %1"), dict.license),
+        "",
+    }
+    UIManager:show(ConfirmBox:new{
+        text = table.concat(t, "\n"),
+        ok_text = _("Download"),
+        ok_callback = function()
+            NetworkMgr:runWhenOnline(function()
+                self._manager:downloadDictionaryPrep(dict)
+            end)
+        end,
+    })
+end
+
+function ReaderDictionary:downloadDictionaryPrep(dict)
     local dummy, filename = util.splitFilePathName(dict.url)
     local download_location = string.format("%s/%s", self.data_dir, filename)
 

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local BookList = require("ui/widget/booklist")
 local ButtonDialog = require("ui/widget/buttondialog")
+local ButtonSelector = require("ui/widget/buttonselector")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
@@ -1637,20 +1638,52 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
 end
 
 function ReaderDictionary:showDownload(lang, downloadable_dicts)
-    local item_table = {}
-    for i, dict in ipairs(downloadable_dicts) do
-        item_table[i] = {
-            text = dict.name,
-            mandatory = dict.entries,
-            dict = dict,
-        }
-    end
-    UIManager:show(BookList:new{
-        title = T(_("Available dictionaries (%1)"), #item_table),
-        subtitle = T(_("Language: %1"), lang),
-        item_table = item_table,
+    self.dl_dict_list = BookList:new{
+        lang = lang,
+        dicts = downloadable_dicts,
+        filter = nil,
         _manager = self,
+        title_bar_left_icon = "appbar.menu",
+        onLeftButtonTap = function()
+            self:filterDownloadDict()
+        end,
         onMenuSelect = self.onTapDownloadDict,
+    }
+    self:updateDownloadDictItemTable()
+    UIManager:show(self.dl_dict_list)
+end
+
+function ReaderDictionary:updateDownloadDictItemTable()
+    local item_table = {}
+    for _, dict in ipairs(self.dl_dict_list.dicts) do
+        if self.dl_dict_list.filter == nil or self.dl_dict_list.filter == (dict.lang_in == dict.lang_out) then
+            table.insert(item_table, {
+                text = dict.name,
+                mandatory = dict.entries,
+                dict = dict,
+            })
+        end
+    end
+    local title = T(_("Available dictionaries (%1)"), #item_table)
+    local subtitle = T(_("Language: %1"), self.dl_dict_list.lang)
+    if self.dl_dict_list.filter ~= nil then
+        subtitle = subtitle .. " \u{F0B0}"
+    end
+    self.dl_dict_list:switchItemTable(title, item_table, nil, nil, subtitle)
+end
+
+function ReaderDictionary:filterDownloadDict()
+    UIManager:show(ButtonSelector:new{
+        current_value = self.dl_dict_list.filter,
+        values = {
+            { _("all"), nil },
+            { self.dl_dict_list.lang, true },
+            { _("bilingual"), false },
+        },
+        callback = function(value)
+            self.dl_dict_list.filter = value
+            self:updateDownloadDictItemTable()
+        end,
     })
 end
 

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -959,7 +959,7 @@ function ReaderDictionary:_genDownloadDictionariesMenu()
             keep_menu_open = true,
             text = lang_key,
             callback = function()
-                self:showDownload(available_langs)
+                self:showDownload(lang_key, available_langs)
             end
         })
     end
@@ -1636,7 +1636,7 @@ function ReaderDictionary:showNoResultsDialog(word, dict_names, fuzzy_search, bo
     return true
 end
 
-function ReaderDictionary:showDownload(downloadable_dicts)
+function ReaderDictionary:showDownload(lang, downloadable_dicts)
     local item_table = {}
     for i, dict in ipairs(downloadable_dicts) do
         item_table[i] = {
@@ -1647,6 +1647,7 @@ function ReaderDictionary:showDownload(downloadable_dicts)
     end
     UIManager:show(BookList:new{
         title = T(_("Available dictionaries (%1)"), #item_table),
+        subtitle = T(_("Language: %1"), lang),
         item_table = item_table,
         _manager = self,
         onMenuSelect = self.onTapDownloadDict,


### PR DESCRIPTION
Before (74 pages to turn)
<img width="400" height="494" alt="1" src="https://github.com/user-attachments/assets/fa0c9a7b-d9ff-4764-8e0c-c0235306923c" />

-----

After (23 pages, compact view)
<img width="400" height="494" alt="2" src="https://github.com/user-attachments/assets/87510520-45f8-41ea-9fb5-27dd572c21b8" />

-----
Usual search in dict names is available
<img width="400" height="494" alt="3" src="https://github.com/user-attachments/assets/bc0f7c36-55f6-4bee-b2ac-1466ff505d04" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15452)
<!-- Reviewable:end -->
