### PR TITLE
ReadCollection: fix per-collection write filter typo on removeItem

### DIFF
--- a/frontend/readcollection.lua
+++ b/frontend/readcollection.lua
@@ -191,7 +191,7 @@ function ReadCollection:removeItem(file, collection_name, no_write) -- FM: delet
         if self.coll[collection_name][file] then
             self.coll[collection_name][file] = nil
             if not no_write then
-                self:write({ collection_name = true })
+                self:write({ [collection_name] = true })
             end
             return true
         end


### PR DESCRIPTION
## Summary

`ReadCollection:removeItem(file, collection_name)` called `self:write({ collection_name = true })` — a literal-string key, not the variable's value. `write()` uses the table as a per-collection allowlist (`updated_collections[coll_name]`), so the gate never matched any real collection and the per-collection `saveSetting` branch was silently skipped. The in-memory removal succeeded but didn't reach disk.

Fixes #15453.

## Test plan

- [ ] In the stock FileManager, open a book's collection dialog, untick a single collection, confirm the change persists across restart.
- [ ] With a plugin that calls `ReadCollection:removeItem(file, collection_name)` directly, confirm the removal persists without an extra full `write()` workaround.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15454)
<!-- Reviewable:end -->
