### PR TITLE
kosync: avoid stale auto-push before wake pull

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -33,6 +33,11 @@ local KOSync = WidgetContainer:extend{
     last_page_turn_timestamp = nil,
     periodic_push_task = nil,
     periodic_push_scheduled = nil,
+    auto_pull_block_until = nil,
+    auto_pull_failed = nil,
+    pull_in_flight = nil,
+    remote_progress_pending = nil,
+    deferred_auto_push = nil,
 
     settings = nil,
 }
@@ -50,6 +55,8 @@ local CHECKSUM_METHOD = {
 
 -- Debounce push/pull attempts
 local API_CALL_DEBOUNCE_DELAY = time.s(25)
+-- keep automatic pushes behind reconnect-triggered pulls; NetworkMgr may wait up to 45s.
+local AUTO_PULL_BLOCK_DELAY = time.s(60)
 
 -- NOTE: This is used in a migration script by ui/data/onetime_migration,
 --       which is why it's public.
@@ -87,6 +94,11 @@ function KOSync:init()
     self.last_page = -1
     self.last_page_turn_timestamp = 0
     self.periodic_push_scheduled = false
+    self.auto_pull_block_until = 0
+    self.auto_pull_failed = false
+    self.pull_in_flight = false
+    self.remote_progress_pending = false
+    self.deferred_auto_push = nil
 
     -- Like AutoSuspend, we need an instance-specific task for scheduling/resource management reasons.
     self.periodic_push_task = function()
@@ -189,9 +201,7 @@ end
 
 function KOSync:onReaderReady()
     if self.settings.auto_sync then
-        UIManager:nextTick(function()
-            self:getProgress(true, false)
-        end)
+        self:scheduleAutoPull(0, true, true)
     end
     -- NOTE: Keep in mind that, on Android, turning on WiFi requires a focus switch, which will trip a Suspend/Resume pair.
     --       NetworkMgr will attempt to hide the damage to avoid a useless pull -> push -> pull dance instead of the single pull requested.
@@ -702,7 +712,38 @@ function KOSync:getMetadata()
     }
 end
 
+function KOSync:scheduleAutoPull(delay, ensure_networking, block_pushes)
+    if block_pushes then
+        -- automatic pulls must win races against suspend/disconnect auto-pushes.
+        self.auto_pull_block_until = UIManager:getElapsedTimeSinceBoot() + AUTO_PULL_BLOCK_DELAY
+    end
+    UIManager:scheduleIn(delay, function()
+        self:getProgress(ensure_networking, false, block_pushes)
+    end)
+end
+
+function KOSync:runDeferredAutoPush()
+    -- A successful pull must win before replaying queued writes. Drop any queued
+    -- snapshot for the open document and replace it with the current state below.
+    local current_document_was_queued = self:drainQueue()
+    if self.remote_progress_pending then return end
+
+    if self.deferred_auto_push then
+        local deferred_auto_push = self.deferred_auto_push
+        self.deferred_auto_push = nil
+        -- Suspend-time Wi-Fi teardown already happened when this push was deferred.
+        -- Replaying with on_suspend=true after resume would disable Wi-Fi again.
+        self:updateProgress(deferred_auto_push.ensure_networking, false)
+    elseif current_document_was_queued then
+        self:updateProgress(false, false)
+    end
+end
+
 function KOSync:syncToProgress(progress)
+    self.auto_pull_block_until = 0
+    self.auto_pull_failed = false
+    self.remote_progress_pending = false
+    self.deferred_auto_push = nil
     logger.dbg("KOSync: [Sync] progress to", progress)
     if self.ui.document.info.has_pages then
         self.ui:handleEvent(Event:new("GotoPage", tonumber(progress)))
@@ -720,6 +761,20 @@ function KOSync:updateProgress(ensure_networking, interactive, on_suspend)
     end
 
     local now = UIManager:getElapsedTimeSinceBoot()
+    if not interactive and (now < self.auto_pull_block_until or self.remote_progress_pending) then
+        -- do not clobber a newer remote location while a pull or prompt is pending.
+        logger.dbg("KOSync: Skipping automatic progress push while remote progress is pending")
+        if now < self.auto_pull_block_until and not self.remote_progress_pending then
+            self.deferred_auto_push = {
+                ensure_networking = ensure_networking,
+            }
+        end
+        if on_suspend and Device:hasWifiManager() then
+            NetworkMgr:disableWifi()
+        end
+        return
+    end
+
     if not interactive and now - self.push_timestamp <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pushed progress less than 25s ago!")
         return
@@ -809,21 +864,39 @@ function KOSync:updateProgress(ensure_networking, interactive, on_suspend)
     self.push_timestamp = now
 end
 
-function KOSync:getProgress(ensure_networking, interactive)
+function KOSync:getProgress(ensure_networking, interactive, auto_pull)
+    local function finishAutoPull(clear_block)
+        if auto_pull then
+            if clear_block == false then
+                self.auto_pull_failed = true
+            else
+                self.auto_pull_failed = false
+                self.auto_pull_block_until = 0
+                self:runDeferredAutoPush()
+            end
+        end
+    end
+    local function finishPull(clear_block)
+        self.pull_in_flight = false
+        finishAutoPull(clear_block)
+    end
+
     if not self.settings.username or not self.settings.userkey then
         if interactive then
             promptLogin()
         end
+        finishAutoPull()
         return
     end
 
     local now = UIManager:getElapsedTimeSinceBoot()
     if not interactive and now - self.pull_timestamp <= API_CALL_DEBOUNCE_DELAY then
         logger.dbg("KOSync: We've already pulled progress less than 25s ago!")
+        finishAutoPull(not self.pull_in_flight and not self.auto_pull_failed)
         return
     end
 
-    if ensure_networking and NetworkMgr:willRerunWhenOnline(function() self:getProgress(ensure_networking, interactive) end) then
+    if ensure_networking and NetworkMgr:willRerunWhenOnline(function() self:getProgress(ensure_networking, interactive, auto_pull) end) then
         return
     end
 
@@ -833,6 +906,7 @@ function KOSync:getProgress(ensure_networking, interactive)
         service_spec = self.path .. "/api.json"
     }
     local doc_digest = self:getDocumentDigest()
+    self.pull_in_flight = true
     local ok, err = pcall(client.get_progress,
         client,
         self.settings.username,
@@ -845,27 +919,32 @@ function KOSync:getProgress(ensure_networking, interactive)
                 if interactive then
                     showSyncError()
                 end
+                finishPull(false)
                 return
             end
 
             if not body.percentage then
+                self.remote_progress_pending = false
                 if interactive then
                     UIManager:show(InfoMessage:new{
                         text = _("No progress found for this document."),
                         timeout = 3,
                     })
                 end
+                finishPull()
                 return
             end
 
             if body.device == Device.model
             and body.device_id == self.device_id then
+                self.remote_progress_pending = false
                 if interactive then
                     UIManager:show(InfoMessage:new{
                         text = _("Latest progress is coming from this device."),
                         timeout = 3,
                     })
                 end
+                finishPull()
                 return
             end
 
@@ -876,12 +955,14 @@ function KOSync:getProgress(ensure_networking, interactive)
 
             if percentage == body.percentage
             or body.progress == progress then
+                self.remote_progress_pending = false
                 if interactive then
                     UIManager:show(InfoMessage:new{
                         text = _("The progress has already been synchronized."),
                         timeout = 3,
                     })
                 end
+                finishPull()
                 return
             end
 
@@ -891,6 +972,7 @@ function KOSync:getProgress(ensure_networking, interactive)
                 -- we always update the progress without further confirmation.
                 self:syncToProgress(body.progress)
                 showSyncedMessage()
+                finishPull()
                 return
             end
 
@@ -905,17 +987,23 @@ function KOSync:getProgress(ensure_networking, interactive)
                 if self.settings.sync_forward == SYNC_STRATEGY.SILENT then
                     self:syncToProgress(body.progress)
                     showSyncedMessage()
-                elseif self.settings.sync_forward == SYNC_STRATEGY.PROMPT then
-                    UIManager:show(ConfirmBox:new{
-                        text = T(_("Sync to latest location %1% from device '%2'?"),
-                                 Math.round(body.percentage * 100),
-                                 body.device),
-                        ok_callback = function()
-                            self:syncToProgress(body.progress)
-                        end,
-                    })
+                else
+                    -- do not let automatic pushes overwrite a remote location that is
+                    -- further ahead before the user accepts it or makes a new local page turn.
+                    self.remote_progress_pending = body.percentage > percentage
+                    if self.settings.sync_forward == SYNC_STRATEGY.PROMPT then
+                        UIManager:show(ConfirmBox:new{
+                            text = T(_("Sync to latest location %1% from device '%2'?"),
+                                     Math.round(body.percentage * 100),
+                                     body.device),
+                            ok_callback = function()
+                                self:syncToProgress(body.progress)
+                            end,
+                        })
+                    end
                 end
             else -- if not self_older then
+                self.remote_progress_pending = false
                 if self.settings.sync_backward == SYNC_STRATEGY.SILENT then
                     self:syncToProgress(body.progress)
                     showSyncedMessage()
@@ -930,10 +1018,12 @@ function KOSync:getProgress(ensure_networking, interactive)
                     })
                 end
             end
+            finishPull()
         end)
     if not ok then
         if interactive then showSyncError() end
         if err then logger.dbg("err:", err) end
+        finishPull(false)
     end
 
     self.pull_timestamp = now
@@ -980,6 +1070,7 @@ function KOSync:_onPageUpdate(page)
     if self.last_page ~= page then
         self.last_page = page
         self.last_page_turn_timestamp = os.time()
+        self.remote_progress_pending = false
         self.page_update_counter = self.page_update_counter + 1
         -- If we've already scheduled a push, regardless of the counter's state, delay it until we're *actually* idle
         if self.periodic_push_scheduled or self.settings.pages_before_update and self.page_update_counter >= self.settings.pages_before_update then
@@ -998,9 +1089,7 @@ function KOSync:_onResume()
 
     -- And if we don't, this *will* (attempt to) trigger a connection and as such a NetworkConnected event,
     -- but only a single pull will happen, since getProgress debounces itself.
-    UIManager:scheduleIn(1, function()
-        self:getProgress(true, false)
-    end)
+    self:scheduleAutoPull(1, true, true)
 end
 
 function KOSync:_onSuspend()
@@ -1011,25 +1100,29 @@ end
 
 function KOSync:_onNetworkConnected()
     logger.dbg("KOSync: onNetworkConnected")
-    UIManager:scheduleIn(0.5, function()
-        -- Drain any queued progress updates first
-        self:drainQueue()
-        -- Then pull as normal
-        self:getProgress(false, false)
-    end)
+    -- Network is supposed to be on already, don't wrap this in willRerunWhenOnline
+    self:scheduleAutoPull(0.5, false, true)
 end
 
 function KOSync:drainQueue()
+    if not self.settings.username or not self.settings.userkey then return false end
+
     local KOSyncQueue = require("KOSyncQueue")
-    if KOSyncQueue:count() == 0 then return end
+    if KOSyncQueue:count() == 0 then return false end
 
     local KOSyncClient = require("KOSyncClient")
     local client = KOSyncClient:new{
         custom_url = self.settings.custom_server,
         service_spec = self.path .. "/api.json"
     }
+    local current_document = self:getDocumentDigest()
+    local current_document_was_queued = false
 
     KOSyncQueue:drain(function(item)
+        if item.document == current_document then
+            current_document_was_queued = true
+            return true
+        end
         local ok = pcall(client.update_progress,
             client,
             self.settings.username,
@@ -1043,6 +1136,7 @@ function KOSync:drainQueue()
             function() end)
         return ok
     end)
+    return current_document_was_queued
 end
 
 function KOSync:_onNetworkDisconnecting()


### PR DESCRIPTION
## summary

- prevent stale non-interactive kosync pushes while an automatic pull is pending after reader ready, resume, or network reconnect
- keep the push block active if the automatic pull fails, or if a duplicate automatic pull is debounced while another pull is still in flight
- remember unapplied newer remote progress and block automatic pushes until the user accepts it or makes a new local page turn
- drain queued writes only after the pull wins; replace a queued snapshot for the open document with its current state

## problem

On Kindle wake/reconnect, NetworkMgr broadcasts `NetworkConnected` before running callbacks that were waiting for connectivity. kosync reacts by scheduling a pull, but a previously deferred suspend push can run first and overwrite newer remote progress.

There is a second stale-overwrite path when a pull finds newer remote progress but the local device has not applied it yet. A later automatic suspend/disconnect push can still send the stale local location.

## fix

- route automatic pulls through `scheduleAutoPull`, which temporarily blocks non-interactive pushes while the pull should win the reconnect race
- track an in-flight pull so duplicate debounced pulls do not clear the temporary block too early
- keep the temporary block if an automatic pull fails, allowing it to expire instead of immediately permitting a stale push
- set `remote_progress_pending` when newer remote progress is found but not applied
- clear pending remote state when progress is applied or when the user makes a new local page turn
- preserve suspend Wi-Fi cleanup when a suspend push is skipped, without replaying that teardown after resume
- skip stale queued state for the open document and send its current state only after a successful pull

## test plan

- `luajit -e "assert(loadfile('plugins/kosync.koplugin/main.lua'))"`
- `luajit -bl plugins/kosync.koplugin/main.lua`
- `git diff --check`
- full emulator build with `gmake -j8`
- `luacheck -q {reader,setupkoenv,datastorage}.lua frontend plugins spec` — 0 warnings / 0 errors in 560 files
- `./base/utils/fake_tty.py gmake --assume-old=base testfront` — 79/79 passed

## manual test plan

- on device A, sync a book to a later location
- on a Kindle with the same book behind device A, enable automatic progress sync
- sleep and wake the Kindle with Wi-Fi restore enabled
- confirm the Kindle pulls or prompts for the newer remote location before any automatic push can overwrite it
- dismiss the prompt and let Wi-Fi disconnect or suspend again
- confirm the remote location is not overwritten until the Kindle location is applied or the user makes a new local page turn

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15469)
<!-- Reviewable:end -->
