### PR TITLE
Highlights: pre-highlighting prompt

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1998,11 +1998,11 @@ function ReaderHighlight:onHoldRelease()
         if self.selected_text then
             self.select_mode = false
             self:extendSelection()
-            if default_highlight_action == "select" then
-                self:showHighlightPrompt()
-            elseif self.selected_text.is_extended then
+            if self.selected_text.is_extended then
                 self:saveHighlight(true)
                 self:clear()
+            elseif default_highlight_action == "select" then
+                self:showHighlightPrompt()
             else
                 self:onShowHighlightMenu()
             end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -464,7 +464,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
             return self.view.highlight.saved_drawer == "lighten"
         end,
         callback = function(touchmenu_instance)
-            local spin_widget = SpinWidget:new{
+            UIManager:show(SpinWidget:new{
                 value = G_reader_settings:readSetting("highlight_lighten_factor"),
                 value_min = 0,
                 value_max = 1,
@@ -481,8 +481,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     UIManager:setDirty(self.dialog, "ui")
                     touchmenu_instance:updateItems()
                 end,
-            }
-            UIManager:show(spin_widget)
+            })
         end,
     })
     table.insert(hl_sub_item_table, {
@@ -493,7 +492,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
             return self.view.highlight.saved_drawer == "lighten" or self.view.highlight.saved_drawer == "invert"
         end,
         callback = function(touchmenu_instance)
-            local spin_widget = SpinWidget:new{
+            UIManager:show(SpinWidget:new{
                 value = G_reader_settings:readSetting("highlight_height_pct") or 100,
                 value_min = 0,
                 value_max = 100,
@@ -510,8 +509,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                     UIManager:setDirty(self.dialog, "ui")
                     touchmenu_instance:updateItems()
                 end,
-            }
-            UIManager:show(spin_widget)
+            })
         end,
     })
     table.insert(hl_sub_item_table, {
@@ -732,9 +730,9 @@ If you wish your highlights to be saved in the document, just move it to a writa
         })
     end
     -- highlight dialog position
-    local sub_item_table = {}
+    local position_sub_item_table = {}
     for i, v in ipairs(highlight_dialog_position) do
-        table.insert(sub_item_table, {
+        position_sub_item_table[i] = {
             text = v[1],
             checked_func = function()
                 return G_reader_settings:readSetting("highlight_dialog_position", "center") == v[2]
@@ -743,7 +741,7 @@ If you wish your highlights to be saved in the document, just move it to a writa
             callback = function()
                 G_reader_settings:saveSetting("highlight_dialog_position", v[2])
             end,
-        })
+        }
     end
     table.insert(menu_items.long_press.sub_item_table, {
         text_func = function()
@@ -754,7 +752,7 @@ If you wish your highlights to be saved in the document, just move it to a writa
                 end
             end
         end,
-        sub_item_table = sub_item_table,
+        sub_item_table = position_sub_item_table,
     })
     -- highlight prompt
     local prompt_sub_item_table = {}
@@ -790,7 +788,7 @@ If you wish your highlights to be saved in the document, just move it to a writa
             end,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
-                local items = SpinWidget:new{
+                UIManager:show(SpinWidget:new{
                     title_text = _("Highlight very-long-press interval"),
                     info_text = _("If a long-press is not released in this interval, it is considered a very-long-press. On document text, single word selection will not be triggered."),
                     width = math.floor(self.screen_w * 0.75),
@@ -809,8 +807,7 @@ If you wish your highlights to be saved in the document, just move it to a writa
                         G_reader_settings:saveSetting("highlight_long_hold_threshold_s", value)
                         touchmenu_instance:updateItems()
                     end,
-                }
-                UIManager:show(items)
+                })
             end,
         })
     end
@@ -2269,7 +2266,8 @@ end
 
 function ReaderHighlight:editHighlightStyle(index)
     local item = self.ui.annotation.annotations[index]
-    UIManager:show(ButtonSelector:new{
+    local style_selector
+    style_selector = ButtonSelector:new{
         current_value = item.drawer,
         values = highlight_style,
         callback = function(value)
@@ -2284,12 +2282,17 @@ function ReaderHighlight:editHighlightStyle(index)
             UIManager:setDirty(self.dialog, "ui")
             self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
         end,
-    })
+        anchor = function()
+            return self:_getDialogAnchor(style_selector, index)
+        end,
+    }
+    UIManager:show(style_selector)
 end
 
 function ReaderHighlight:editHighlightColor(index)
     local item = self.ui.annotation.annotations[index]
-    UIManager:show(ButtonSelector:new{
+    local color_selector
+    color_selector = ButtonSelector:new{
         current_value = item.color,
         values = self.highlight_colors,
         bg_colors = self:getHighlightColorList(),
@@ -2305,7 +2308,11 @@ function ReaderHighlight:editHighlightColor(index)
             UIManager:setDirty(self.dialog, "ui")
             self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
         end,
-    })
+        anchor = function()
+            return self:_getDialogAnchor(color_selector, index)
+        end,
+    }
+    UIManager:show(color_selector)
 end
 
 function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
@@ -2333,7 +2340,8 @@ function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
     prompt = prompt or G_reader_settings:readSetting("highlight_prompt")
     if prompt then
         if prompt == "color" then
-            UIManager:show(ButtonSelector:new{
+            local color_selector
+            color_selector = ButtonSelector:new{
                 current_value = self.view.highlight.saved_color,
                 values = self.highlight_colors,
                 bg_colors = self:getHighlightColorList(),
@@ -2345,9 +2353,14 @@ function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
                 tap_close_callback = function()
                     do_highlight()
                 end,
-            })
+                anchor = function()
+                    return self:_getDialogAnchor(color_selector)
+                end,
+            }
+            UIManager:show(color_selector)
         else -- "style", "all"
-            UIManager:show(ButtonSelector:new{
+            local style_selector
+            style_selector = ButtonSelector:new{
                 current_value = self.view.highlight.saved_drawer,
                 values = highlight_style,
                 apply_current_value = true,
@@ -2358,7 +2371,11 @@ function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
                 tap_close_callback = function()
                     do_highlight(prompt == "all" and self.selected_text.drawer ~= "invert")
                 end,
-            })
+                anchor = function()
+                    return self:_getDialogAnchor(style_selector)
+                end,
+            }
+            UIManager:show(style_selector)
         end
     else
         do_highlight()

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -108,8 +108,7 @@ function ReaderHighlight:init()
                 text = _("Highlight"),
                 enabled = this.hold_pos ~= nil,
                 callback = function()
-                    this:saveHighlight(true)
-                    this:onClose()
+                    this:showHighlightPrompt()
                 end,
             }
         end,
@@ -135,7 +134,6 @@ function ReaderHighlight:init()
                 enabled = this.hold_pos ~= nil,
                 callback = function()
                     this:addNote()
-                    this:onClose()
                 end,
             }
         end,
@@ -377,6 +375,13 @@ local long_press_action = {
 -- we need to expose this table to readerkeyselection
 -- as here it is hidden under a isTouchDevice cap
 ReaderHighlight.long_press_action = long_press_action
+
+local highlight_prompt = {
+    {_("none"), nil},
+    {_("style"), "style"},
+    {_("color"), "color"},
+    {_("style, color"), "all"},
+}
 
 local highlight_dialog_position = {
     {_("Top"), "top"},
@@ -750,6 +755,31 @@ If you wish your highlights to be saved in the document, just move it to a writa
             end
         end,
         sub_item_table = sub_item_table,
+    })
+    -- highlight prompt
+    local prompt_sub_item_table = {}
+    for i, v in ipairs(highlight_prompt) do
+        prompt_sub_item_table[i] = {
+            text = v[1],
+            checked_func = function()
+                return G_reader_settings:readSetting("highlight_prompt") == v[2]
+            end,
+            radio = true,
+            callback = function()
+                G_reader_settings:saveSetting("highlight_prompt", v[2])
+            end,
+        }
+    end
+    table.insert(menu_items.long_press.sub_item_table, {
+        text_func = function()
+            local prompt = G_reader_settings:readSetting("highlight_prompt")
+            for __, v in ipairs(highlight_prompt) do
+                if v[2] == prompt then
+                    return T(_("Highlight prompt: %1"), v[1])
+                end
+            end
+        end,
+        sub_item_table = prompt_sub_item_table,
     })
     if Device:isTouchDevice() then
         -- highlight very-long-press interval
@@ -1971,7 +2001,9 @@ function ReaderHighlight:onHoldRelease()
         if self.selected_text then
             self.select_mode = false
             self:extendSelection()
-            if default_highlight_action == "select" or self.selected_text.is_extended then
+            if default_highlight_action == "select" then
+                self:showHighlightPrompt()
+            elseif self.selected_text.is_extended then
                 self:saveHighlight(true)
                 self:clear()
             else
@@ -1995,8 +2027,7 @@ function ReaderHighlight:onHoldRelease()
                 -- bypass default action and show popup if long final hold
                 self:onShowHighlightMenu()
             elseif default_highlight_action == "highlight" then
-                self:saveHighlight(true)
-                self:onClose()
+                self:showHighlightPrompt()
             elseif default_highlight_action == "select" then
                 self:startSelection()
                 self:onClose()
@@ -2219,11 +2250,12 @@ function ReaderHighlight:deleteHighlight(index)
 end
 
 function ReaderHighlight:addNote(text)
-    local index = self:saveHighlight(true)
-    if text then -- called from Translator to save translation to note
-        self:clear()
-    end
-    self:editNote(index, true, text)
+    self:showHighlightPrompt(function(index)
+        if text then -- called from Translator to save translation to note
+            self:clear()
+        end
+        self:editNote(index, true, text)
+    end)
 end
 
 function ReaderHighlight:editNote(index, is_new_note, text)
@@ -2274,6 +2306,63 @@ function ReaderHighlight:editHighlightColor(index)
             self.ui:handleEvent(Event:new("AnnotationsModified", { item }))
         end,
     })
+end
+
+function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
+    if self.highlight_dialog then
+        UIManager:close(self.highlight_dialog)
+        self.highlight_dialog = nil
+    end
+    if self.hold_pos and not self.selected_text then
+        self:highlightFromHoldPos()
+    end
+    if not (self.selected_text and self.selected_text.pos0 and self.selected_text.pos1) then return end
+
+    local do_highlight = function(select_color)
+        if select_color then
+            self:showHighlightPrompt(caller_callback, "color")
+        else
+            local index = self:saveHighlight(true)
+            self:clear()
+            if caller_callback then
+                caller_callback(index)
+            end
+        end
+    end
+
+    prompt = prompt or G_reader_settings:readSetting("highlight_prompt")
+    if prompt then
+        if prompt == "color" then
+            UIManager:show(ButtonSelector:new{
+                current_value = self.view.highlight.saved_color,
+                values = self.highlight_colors,
+                bg_colors = self:getHighlightColorList(),
+                apply_current_value = true,
+                callback = function(value)
+                    self.selected_text.color = value
+                    do_highlight()
+                end,
+                tap_close_callback = function()
+                    do_highlight()
+                end,
+            })
+        else -- "style", "all"
+            UIManager:show(ButtonSelector:new{
+                current_value = self.view.highlight.saved_drawer,
+                values = highlight_style,
+                apply_current_value = true,
+                callback = function(value)
+                    self.selected_text.drawer = value
+                    do_highlight(prompt == "all" and self.selected_text.drawer ~= "invert")
+                end,
+                tap_close_callback = function()
+                    do_highlight(prompt == "all" and self.selected_text.drawer ~= "invert")
+                end,
+            })
+        end
+    else
+        do_highlight()
+    end
 end
 
 function ReaderHighlight:startSelection(index)

--- a/frontend/ui/widget/buttonselector.lua
+++ b/frontend/ui/widget/buttonselector.lua
@@ -8,6 +8,7 @@ local ButtonSelector = ButtonDialog:extend{
     current_value = nil, -- value; or for multi_choice: hash table { value_key = true }
     values = nil, -- array { { value_text, value_key } } - buttons in order
     bg_colors = nil, -- array { color }, corresponding to values
+    apply_current_value = nil, -- set to true to apply the callback when value == current_value
     keep_open_on_apply = nil,
     width_factor = 0.4,
 }
@@ -41,7 +42,7 @@ function ButtonSelector:init()
                     curr_values[value_key] = not curr_values[value_key] or nil
                 else
                     UIManager:close(self)
-                    if self.current_value ~= value_key then
+                    if self.apply_current_value or self.current_value ~= value_key then
                         self.callback(value_key)
                     end
                     if self.keep_open_on_apply then


### PR DESCRIPTION
A setting to choose the prompt (dialog) that is shown before saving a highlight:
none (current and default behaviour) / style / color / style, color one by one.

Applicable to the actions: Highlight; Select; Add note; Save translation to note.

- Closes #15349 

-----

<img width="400" height="201" alt="1" src="https://github.com/user-attachments/assets/019b926a-78eb-41e2-857a-57bc5a3a5f84" />

-----

<img width="400" height="202" alt="2" src="https://github.com/user-attachments/assets/5f243408-75cd-4b51-8bd8-23aaac1e5437" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15473)
<!-- Reviewable:end -->
