### PR TITLE
Updated the czech debian dictionary url

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -94,7 +94,7 @@ local dictionaries = {
         name = "GNU/FDL Anglicko/Český slovník",
         lang_in = "eng",
         lang_out = "ces",
-        entries = 178904, -- ~90000 each way
+        entries = 216756, -- ~90000 each way
         license = _("GNU/FDL"),
         url = "http://deb.debian.org/debian/pool/non-free/s/stardict-english-czech/stardict-english-czech_20210401.orig.tar.gz",
     },

--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -96,7 +96,7 @@ local dictionaries = {
         lang_out = "ces",
         entries = 178904, -- ~90000 each way
         license = _("GNU/FDL"),
-        url = "http://http.debian.net/debian/pool/non-free/s/stardict-english-czech/stardict-english-czech_20161201.orig.tar.gz",
+        url = "http://deb.debian.org/debian/pool/non-free/s/stardict-english-czech/stardict-english-czech_20210401.orig.tar.gz",
     },
     {
         name = "GNU/FDL Anglicko/Český slovník",


### PR DESCRIPTION
The previous url was deprecated, and it did not point to any content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15474)
<!-- Reviewable:end -->
