### PR TITLE
fix: appload quirk workaround

### DIFF
--- a/.ci/check.sh
+++ b/.ci/check.sh
@@ -39,6 +39,6 @@ if [ "${untagged_todo}" ]; then
 fi
 
 echo -e "\n${ANSI_GREEN}Luacheck results${ANSI_RESET}"
-luacheck ${PARALLEL_JOBS:+-j "${PARALLEL_JOBS}"} -q {reader,setupkoenv,datastorage}.lua frontend plugins spec || exit_code=1
+luacheck ${PARALLEL_JOBS:+-j "${PARALLEL_JOBS}"} -q {reader,setupkoenv,datastorage}.lua frontend plugins spec platform/remarkable/qtfb_keep_alive.lua || exit_code=1
 
 exit ${exit_code}

--- a/make/remarkable.mk
+++ b/make/remarkable.mk
@@ -14,6 +14,7 @@ update-prepare: all
 	# Remarkable scripts
 	$(SYMLINK) $(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(REMARKABLE_DIR)/koreader.sh $(INSTALL_DIR)/koreader/
+	$(SYMLINK) $(REMARKABLE_DIR)/qtfb_keep_alive.lua $(INSTALL_DIR)/koreader/
 	$(SYMLINK) resources/koreader.png $(INSTALL_DIR)/koreader/icon.png
 	$(SYMLINK) $(REMARKABLE_DIR)/external.manifest.json $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(REMARKABLE_DIR)/external.manifest.shim.json $(INSTALL_DIR)/koreader/

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -166,6 +166,21 @@ if [ -e crash.log ]; then
     mv -f crash.log.new crash.log
 fi
 
+# since AppLoad unloads framebuffer when first launched app using QTFB exits, run a keep-alive process to prevent this from happening.
+BG_KEEP_ALIVE_PID=""
+if [ -n "${KO_USE_QTFB}" ] && [ -n "${QTFB_KEY}" ]; then
+    SHM_TYPE=0
+    IFS= read -r MACHINE_TYPE <"/sys/devices/soc0/machine"
+    if [ "reMarkable Ferrari" = "${MACHINE_TYPE}" ]; then
+        SHM_TYPE=3
+    elif [ "reMarkable Chiappa" = "${MACHINE_TYPE}" ]; then
+        SHM_TYPE=6
+    fi
+
+    ./luajit -e "local ffi=require('ffi');ffi.cdef[[typedef int FBKey;struct InitMessageContents{FBKey framebufferKey;uint8_t framebufferType;};struct ClientMessage{uint8_t type;union{struct InitMessageContents init;};};int socket(int,int,int);int connect(int,const void*,int);int send(int,const void*,size_t,int);int close(int);unsigned int sleep(unsigned int);]];local C=ffi.C;local addr=ffi.new('char[110]','\x01\x00/tmp/qtfb.sock');local sock=C.socket(1,5,0);if sock>=0 then while C.connect(sock,addr,110)~=0 do C.sleep(1) end;local msg=ffi.new('struct ClientMessage');msg.type=0;msg.init.framebufferKey=tonumber(os.getenv('QTFB_KEY'));msg.init.framebufferType=${SHM_TYPE};C.send(sock,msg,ffi.sizeof(msg),0);while true do C.sleep(86400) end;C.close(sock);end" >/dev/null 2>&1 &
+    BG_KEEP_ALIVE_PID=$!
+fi
+
 CRASH_COUNT=0
 CRASH_TS=0
 CRASH_PREV_TS=0
@@ -275,6 +290,11 @@ if [ -z "${KO_DONT_SET_DEPTH}" ] && [ -z "${KO_USE_QTFB}" ]; then
         echo "Restoring original fb rotation @ ${ORIG_FB_ROTA}" >>crash.log 2>&1
         ./fbdepth -r "${ORIG_FB_ROTA}" >>crash.log 2>&1
     fi
+fi
+
+if [ -n "${BG_KEEP_ALIVE_PID}" ]; then
+    echo "Stopping QTFB connection keep-alive..." >>crash.log 2>&1
+    kill "${BG_KEEP_ALIVE_PID}" 2>/dev/null
 fi
 
 exit ${RETURN_VALUE}

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -169,15 +169,7 @@ fi
 # since AppLoad unloads framebuffer when first launched app using QTFB exits, run a keep-alive process to prevent this from happening.
 BG_KEEP_ALIVE_PID=""
 if [ -n "${KO_USE_QTFB}" ] && [ -n "${QTFB_KEY}" ]; then
-    SHM_TYPE=0
-    IFS= read -r MACHINE_TYPE <"/sys/devices/soc0/machine"
-    if [ "reMarkable Ferrari" = "${MACHINE_TYPE}" ]; then
-        SHM_TYPE=3
-    elif [ "reMarkable Chiappa" = "${MACHINE_TYPE}" ]; then
-        SHM_TYPE=6
-    fi
-
-    ./luajit -e "local ffi=require('ffi');ffi.cdef[[typedef int FBKey;struct InitMessageContents{FBKey framebufferKey;uint8_t framebufferType;};struct ClientMessage{uint8_t type;union{struct InitMessageContents init;};};int socket(int,int,int);int connect(int,const void*,int);int send(int,const void*,size_t,int);int close(int);unsigned int sleep(unsigned int);]];local C=ffi.C;local addr=ffi.new('char[110]','\x01\x00/tmp/qtfb.sock');local sock=C.socket(1,5,0);if sock>=0 then while C.connect(sock,addr,110)~=0 do C.sleep(1) end;local msg=ffi.new('struct ClientMessage');msg.type=0;msg.init.framebufferKey=tonumber(os.getenv('QTFB_KEY'));msg.init.framebufferType=${SHM_TYPE};C.send(sock,msg,ffi.sizeof(msg),0);while true do C.sleep(86400) end;C.close(sock);end" >/dev/null 2>&1 &
+    ./luajit qtfb_keep_alive.lua >/dev/null 2>&1 &
     BG_KEEP_ALIVE_PID=$!
 fi
 

--- a/platform/remarkable/koreader.sh
+++ b/platform/remarkable/koreader.sh
@@ -169,6 +169,7 @@ fi
 # since AppLoad unloads framebuffer when first launched app using QTFB exits, run a keep-alive process to prevent this from happening.
 BG_KEEP_ALIVE_PID=""
 if [ -n "${KO_USE_QTFB}" ] && [ -n "${QTFB_KEY}" ]; then
+    echo "Starting QTFB connection keep-alive..." >>crash.log 2>&1
     ./luajit qtfb_keep_alive.lua >/dev/null 2>&1 &
     BG_KEEP_ALIVE_PID=$!
 fi
@@ -286,7 +287,7 @@ fi
 
 if [ -n "${BG_KEEP_ALIVE_PID}" ]; then
     echo "Stopping QTFB connection keep-alive..." >>crash.log 2>&1
-    kill "${BG_KEEP_ALIVE_PID}" 2>/dev/null
+    kill "${BG_KEEP_ALIVE_PID}" >>crash.log 2>&1
 fi
 
 exit ${RETURN_VALUE}

--- a/platform/remarkable/qtfb_keep_alive.lua
+++ b/platform/remarkable/qtfb_keep_alive.lua
@@ -1,0 +1,44 @@
+-- qtfb_keep_alive.lua
+-- Background process to keep the QTFB socket connection active across KOReader restarts.
+-- This prevents the rm-appload launcher from destroying the QML window canvas.
+
+local ffi = require("ffi")
+require("ffi/posix_h")
+local qtfb = require("ffi/qtfb")
+local C = ffi.C
+
+local key_str = os.getenv("QTFB_KEY")
+local key = key_str and tonumber(key_str) or 245209899 -- QTFB_DEFAULT_FRAMEBUFFER
+
+local shmType = 0 -- FBFMT_RM2FB as default
+if qtfb.is_rmpp then
+    shmType = 3 -- FBFMT_RMPP_RGB565
+elseif qtfb.is_rmppm then
+    shmType = 6 -- FBFMT_RMPPM_RGB565
+end
+
+-- Create UNIX domain socket
+local sock = C.socket(C.AF_UNIX, C.SOCK_SEQPACKET, 0)
+assert(sock >= 0, "Failed to create UNIX socket")
+
+local addr = ffi.new("struct sockaddr_un", C.AF_UNIX, "/tmp/qtfb.sock")
+
+-- Retry loop to wait for the QTFB server (xochitl/rm-appload) to start listening
+while C.connect(sock, ffi.cast("const struct sockaddr *", addr), ffi.sizeof(addr)) ~= 0 do
+    C.sleep(1)
+end
+
+-- Send MESSAGE_INITIALIZE (0)
+local initMsg = ffi.new("struct ClientMessage")
+initMsg.type = qtfb.MESSAGE_INITIALIZE
+initMsg.init.framebufferKey = key
+initMsg.init.framebufferType = shmType
+
+local bytes_sent = C.send(sock, initMsg, ffi.sizeof(initMsg), 0)
+assert(bytes_sent >= 0, "Failed to send init message to QTFB server")
+
+-- Keep the socket open indefinitely until killed by the parent process.
+-- C.sleep is wrapped in a loop because signals (e.g. SIGCHLD) interrupt C.sleep.
+while true do
+    C.sleep(86400)
+end

--- a/platform/remarkable/qtfb_keep_alive.lua
+++ b/platform/remarkable/qtfb_keep_alive.lua
@@ -38,7 +38,8 @@ local bytes_sent = C.send(sock, initMsg, ffi.sizeof(initMsg), 0)
 assert(bytes_sent >= 0, "Failed to send init message to QTFB server")
 
 -- Keep the socket open indefinitely until killed by the parent process.
--- C.sleep is wrapped in a loop because signals (e.g. SIGCHLD) interrupt C.sleep.
+-- pause() blocks the process indefinitely until a signal is received.
+ffi.cdef[[int pause(void);]]
 while true do
-    C.sleep(86400)
+    C.pause()
 end


### PR DESCRIPTION
AppLoad's quirk of removing framebuffer when nothing's holding framebuffer even though app is running prevented crash handling and restarting KOReader to fail, so introduce a keep-alive process (which was LLM assisted, and it's very cursed, but it works!) to work around this issue.

It wasn't a problem for shimmed version since shim loaded even for sh handling shell script too, which acted as keep-alive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15475)
<!-- Reviewable:end -->
