### PR TITLE
Highlights: temporary highlight color

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -411,7 +411,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
             radio = true,
             callback = function()
                 self.view.highlight.saved_drawer = style
-                self:setTempHighlightColor()
+                self:setSelectionColor()
             end,
             hold_callback = function(touchmenu_instance)
                 G_reader_settings:saveSetting("highlight_drawing_style", style)
@@ -448,7 +448,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 bg_colors = self:getHighlightColorList(),
                 callback = function(value)
                     self.view.highlight.saved_color = value
-                    self:setTempHighlightColor()
+                    self:setSelectionColor()
                     touchmenu_instance:updateItems()
                 end,
             })
@@ -487,38 +487,38 @@ function ReaderHighlight:addToMainMenu(menu_items)
         end,
     })
     table.insert(hl_sub_item_table, {
-        text = _("Use highlight color for temporary highlight"),
+        text = _("Use highlight color for selection"),
         enabled_func = function()
             return self.view.highlight.saved_drawer ~= "invert"
         end,
         checked_func = function()
-            return self.view.highlight.saved_drawer ~= "invert" and G_reader_settings:isTrue("highlight_temp_use_main_color")
+            return self.view.highlight.saved_drawer ~= "invert" and G_reader_settings:isTrue("highlight_selection_use_highlight_color")
         end,
         callback = function()
-            G_reader_settings:flipNilOrFalse("highlight_temp_use_main_color")
-            self:setTempHighlightColor()
+            G_reader_settings:flipNilOrFalse("highlight_selection_use_highlight_color")
+            self:setSelectionColor()
         end,
     })
     table.insert(hl_sub_item_table, {
         text_func = function()
-            return T(_("Gray temporary highlight opacity: %1"), G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2)
+            return T(_("Gray selection opacity: %1"), G_reader_settings:readSetting("highlight_selection_lighten_factor") or 0.2)
         end,
         keep_menu_open = true,
         callback = function(touchmenu_instance)
             UIManager:show(SpinWidget:new{
-                value = G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2,
+                value = G_reader_settings:readSetting("highlight_selection_lighten_factor") or 0.2,
                 value_min = 0,
                 value_max = 1,
                 precision = "%.2f",
                 value_step = 0.1,
                 value_hold_step = 0.05,
                 default_value = 0.2,
-                title_text = _("Gray temporary highlight opacity"),
+                title_text = _("Gray selection opacity"),
                 info_text = _("The higher the value, the darker the gray."),
                 callback = function(spin)
                     local value = spin.value ~= 0.2 and spin.value or nil
-                    G_reader_settings:saveSetting("highlight_temp_lighten_factor", value)
-                    self:setTempHighlightColor()
+                    G_reader_settings:saveSetting("highlight_selection_lighten_factor", value)
+                    self:setSelectionColor()
                     touchmenu_instance:updateItems()
                 end,
             })
@@ -2693,7 +2693,7 @@ function ReaderHighlight:onReadSettings(config)
     self.view.highlight.saved_color = config:readSetting("highlight_color")
         or G_reader_settings:readSetting("highlight_color") or self.view.highlight.saved_color
     self.view.highlight.disabled = G_reader_settings:readSetting("default_highlight_action") == "nothing"
-    self:setTempHighlightColor()
+    self:setSelectionColor()
     self.allow_corner_scroll = G_reader_settings:nilOrTrue("highlight_corner_scroll")
 
     -- panel zoom settings isn't supported in EPUB
@@ -2721,10 +2721,10 @@ function ReaderHighlight:onReadSettings(config)
     end
 end
 
-function ReaderHighlight:setTempHighlightColor()
+function ReaderHighlight:setSelectionColor()
     if self.ui.paging then return end
     local color = self.view.highlight.saved_drawer ~= "invert"
-        and G_reader_settings:isTrue("highlight_temp_use_main_color")
+        and G_reader_settings:isTrue("highlight_selection_use_highlight_color")
         and Blitbuffer.HIGHLIGHT_COLORS[self.view.highlight.saved_color]
     if color then
         if Screen.night_mode then
@@ -2732,7 +2732,7 @@ function ReaderHighlight:setTempHighlightColor()
             color = string.format("#%02x%02x%02x", 255 - tonumber(r, 16), 255 - tonumber(g, 16), 255 - tonumber(b, 16))
         end
     else -- gray
-        local lighten_factor = G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2
+        local lighten_factor = G_reader_settings:readSetting("highlight_selection_lighten_factor") or 0.2
         if lighten_factor == 0 then
             color = "#FFFFFF"
         elseif lighten_factor == 1 then

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -411,6 +411,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
             radio = true,
             callback = function()
                 self.view.highlight.saved_drawer = style
+                self:setTempHighlightColor()
             end,
             hold_callback = function(touchmenu_instance)
                 G_reader_settings:saveSetting("highlight_drawing_style", style)
@@ -447,6 +448,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 bg_colors = self:getHighlightColorList(),
                 callback = function(value)
                     self.view.highlight.saved_color = value
+                    self:setTempHighlightColor()
                     touchmenu_instance:updateItems()
                 end,
             })
@@ -470,10 +472,10 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 value_max = 1,
                 precision = "%.2f",
                 value_step = 0.1,
-                value_hold_step = 0.2,
+                value_hold_step = 0.05,
                 default_value = 0.2,
                 keep_shown_on_apply = true,
-                title_text =  _("Gray highlight opacity"),
+                title_text = _("Gray highlight opacity"),
                 info_text = _("The higher the value, the darker the gray."),
                 callback = function(spin)
                     G_reader_settings:saveSetting("highlight_lighten_factor", spin.value)
@@ -483,6 +485,45 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 end,
             })
         end,
+    })
+    table.insert(hl_sub_item_table, {
+        text = _("Use highlight color for temporary highlight"),
+        enabled_func = function()
+            return self.view.highlight.saved_drawer ~= "invert"
+        end,
+        checked_func = function()
+            return self.view.highlight.saved_drawer ~= "invert" and G_reader_settings:isTrue("highlight_temp_use_main_color")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("highlight_temp_use_main_color")
+            self:setTempHighlightColor()
+        end,
+    })
+    table.insert(hl_sub_item_table, {
+        text_func = function()
+            return T(_("Gray temporary highlight opacity: %1"), G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2)
+        end,
+        keep_menu_open = true,
+        callback = function(touchmenu_instance)
+            UIManager:show(SpinWidget:new{
+                value = G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2,
+                value_min = 0,
+                value_max = 1,
+                precision = "%.2f",
+                value_step = 0.1,
+                value_hold_step = 0.05,
+                default_value = 0.2,
+                title_text = _("Gray temporary highlight opacity"),
+                info_text = _("The higher the value, the darker the gray."),
+                callback = function(spin)
+                    local value = spin.value ~= 0.2 and spin.value or nil
+                    G_reader_settings:saveSetting("highlight_temp_lighten_factor", value)
+                    self:setTempHighlightColor()
+                    touchmenu_instance:updateItems()
+                end,
+            })
+        end,
+        separator = true,
     })
     table.insert(hl_sub_item_table, {
         text_func = function()
@@ -501,7 +542,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
                 default_value = 100,
                 unit = "%",
                 keep_shown_on_apply = true,
-                title_text =  _("Highlight line height"),
+                title_text = _("Highlight line height"),
                 info_text = _("Percentage of the text line height."),
                 callback = function(spin)
                     local value = spin.value ~= 100 and spin.value or nil
@@ -2652,7 +2693,7 @@ function ReaderHighlight:onReadSettings(config)
     self.view.highlight.saved_color = config:readSetting("highlight_color")
         or G_reader_settings:readSetting("highlight_color") or self.view.highlight.saved_color
     self.view.highlight.disabled = G_reader_settings:readSetting("default_highlight_action") == "nothing"
-
+    self:setTempHighlightColor()
     self.allow_corner_scroll = G_reader_settings:nilOrTrue("highlight_corner_scroll")
 
     -- panel zoom settings isn't supported in EPUB
@@ -2678,6 +2719,30 @@ function ReaderHighlight:onReadSettings(config)
             self.panel_zoom_fallback_to_text_selection = G_reader_settings:getSettingForExt("panel_zoom_fallback_to_text_selection", ext) or false
         end
     end
+end
+
+function ReaderHighlight:setTempHighlightColor()
+    if self.ui.paging then return end
+    local color = self.view.highlight.saved_drawer ~= "invert"
+        and G_reader_settings:isTrue("highlight_temp_use_main_color")
+        and Blitbuffer.HIGHLIGHT_COLORS[self.view.highlight.saved_color]
+    if color then
+        if Screen.night_mode then
+            local r, g, b = color:match("#(..)(..)(..)")
+            color = string.format("#%02x%02x%02x", 255 - tonumber(r, 16), 255 - tonumber(g, 16), 255 - tonumber(b, 16))
+        end
+    else -- gray
+        local lighten_factor = G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2
+        if lighten_factor == 0 then
+            color = "#FFFFFF"
+        elseif lighten_factor == 1 then
+            color = "#000000"
+        else
+            color = string.format("%X", math.floor(256 * (1 - lighten_factor)))
+            color = "#" .. color:rep(3)
+        end
+    end
+    self.document._document:setStringProperty("crengine.highlight.selection.color", color)
 end
 
 function ReaderHighlight:onUpdateHoldPanRate()

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -526,7 +526,7 @@ end
 
 function ReaderView:drawTempHighlight(bb, x, y)
     local color = self.highlight.saved_drawer ~= "invert"
-        and G_reader_settings:isTrue("highlight_temp_use_main_color")
+        and G_reader_settings:isTrue("highlight_selection_use_highlight_color")
         and Blitbuffer.colorFromName(self.highlight.saved_color) or nil
     for page, boxes in pairs(self.highlight.temp) do
         for i = 1, #boxes do
@@ -689,7 +689,7 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
     end
     if drawer == "lighten" then
         local lighten_factor = self.highlight.temp and next(self.highlight.temp)
-            and (G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2) or self.highlight.lighten_factor
+            and (G_reader_settings:readSetting("highlight_selection_lighten_factor") or 0.2) or self.highlight.lighten_factor
         if not color then
             bb:darkenRect(x, y, w, h, lighten_factor)
         else

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -95,7 +95,7 @@ function ReaderView:init()
         visible_boxes = nil, -- array; visible boxes in the current page, used by ReaderHighlight:onTap()
         lighten_factor = G_reader_settings:readSetting("highlight_lighten_factor", 0.2),
         note_mark = G_reader_settings:readSetting("highlight_note_marker"),
-        temp_drawer = "invert",
+        temp_drawer = "lighten",
         temp = {},
         saved_drawer = "lighten",
         -- NOTE: Unfortunately, yellow tends to look like absolute ass on Kaleido panels...
@@ -241,7 +241,7 @@ function ReaderView:paintTo(bb, x, y)
         colorful = self:drawSavedHighlight(bb, x, y)
     end
     -- draw temporary highlight
-    if self.highlight.temp then
+    if self.highlight.temp and next(self.highlight.temp) then
         self:drawTempHighlight(bb, x, y)
     end
     -- draw highlight position indicator for non-touch
@@ -525,11 +525,14 @@ function ReaderView:drawHighlightIndicator(bb, x, y)
 end
 
 function ReaderView:drawTempHighlight(bb, x, y)
+    local color = self.highlight.saved_drawer ~= "invert"
+        and G_reader_settings:isTrue("highlight_temp_use_main_color")
+        and Blitbuffer.colorFromName(self.highlight.saved_color) or nil
     for page, boxes in pairs(self.highlight.temp) do
         for i = 1, #boxes do
             local rect = self:pageToScreenTransform(page, boxes[i])
             if rect then
-                self:drawHighlightRect(bb, x, y, rect, self.highlight.temp_drawer)
+                self:drawHighlightRect(bb, x, y, rect, self.highlight.temp_drawer, color)
             end
         end
     end
@@ -685,15 +688,17 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
         end
     end
     if drawer == "lighten" then
+        local lighten_factor = self.highlight.temp and next(self.highlight.temp)
+            and (G_reader_settings:readSetting("highlight_temp_lighten_factor") or 0.2) or self.highlight.lighten_factor
         if not color then
-            bb:darkenRect(x, y, w, h, self.highlight.lighten_factor)
+            bb:darkenRect(x, y, w, h, lighten_factor)
         else
             if bb:getInverse() == 1 then
                 -- MUL doesn't really work on a black background, so, switch to OVER if we're in software nightmode...
                 -- NOTE: If we do *not* invert the color here, it *will* get inverted by the blitter given that the target bb is inverted.
                 --       While not particularly pretty, this (roughly) matches with hardware nightmode, *and* how MuPDF renders highlights...
                 --       But it's *really* not pretty (https://github.com/koreader/koreader/pull/11044#issuecomment-1902886069), so we'll fix it ;p.
-                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * self.highlight.lighten_factor):invert()
+                local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF * lighten_factor):invert()
                 bb:blendRectRGB32(x, y, w, h, c)
             else
                 bb:multiplyRectRGB(x, y, w, h, color)

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -18,7 +18,7 @@ function DeviceListener:onToggleNightMode()
     if self.ui and self.ui.document and self.ui.document.provider == "crengine" then
         self.ui.document:resetCallCache()
         if self.ui.highlight then
-            self.ui.highlight:setTempHighlightColor()
+            self.ui.highlight:setSelectionColor()
         end
     end
     UIManager:setDirty("all", "full")

--- a/frontend/device/devicelistener.lua
+++ b/frontend/device/devicelistener.lua
@@ -17,6 +17,9 @@ function DeviceListener:onToggleNightMode()
     -- Make sure CRe will bypass the call cache
     if self.ui and self.ui.document and self.ui.document.provider == "crengine" then
         self.ui.document:resetCallCache()
+        if self.ui.highlight then
+            self.ui.highlight:setTempHighlightColor()
+        end
     end
     UIManager:setDirty("all", "full")
     UIManager:ToggleNightMode(not night_mode)


### PR DESCRIPTION
(1) Settings to use main highlight color for temporary highlights and to adjust opacity of gray temporary highlights.
(2) Identical temporary highlights in EPUB and PDF.

-----

<img width="400" height="406" alt="1" src="https://github.com/user-attachments/assets/1bdf55be-e8fe-4ea5-a9e8-63aa380cf4ae" />

-----

<img width="400" height="494" alt="2" src="https://github.com/user-attachments/assets/fc0631ef-6159-4ef9-a3a2-e36011a7f7d0" />

-----

<img width="400" height="494" alt="3" src="https://github.com/user-attachments/assets/bb7a6a8f-4441-4d9c-9a40-212c31292be5" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15486)
<!-- Reviewable:end -->
