### PR TITLE
SDL: shell-escape openLink and external dict lookup args

### DIFF
--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -6,6 +6,7 @@ local SDL = require("ffi/SDL3")
 local ffi = require("ffi")
 local logger = require("logger")
 local time = require("ui/time")
+local util = require("util")
 
 -- SDL computes WM_CLASS on X11/Wayland based on process's binary name.
 -- Some desktop environments rely on WM_CLASS to name the app and/or to assign the proper icon.
@@ -87,7 +88,7 @@ local Device = Generic:extend{
     openLink = function(self, link)
         local enabled, tool = getLinkOpener()
         if not enabled or not tool or not link or type(link) ~= "string" then return end
-        return runCommand(tool .. " '" .. link .. "'")
+        return runCommand(util.shell_escape{tool, link})
     end,
     canExternalDictLookup = yes,
     getExternalDictLookupList = function() return external.dicts end,
@@ -98,7 +99,7 @@ local Device = Generic:extend{
             if isUrl(app) and getLinkOpener() then
                 ok = self:openLink(app..text)
             elseif isCommand(app) then
-                ok = runCommand(app .. " " .. text .. " &")
+                ok = runCommand(util.shell_escape{app, text} .. " &")
             end
         end
         if ok and external.when_back_callback then


### PR DESCRIPTION
A PDF-controlled URL flowed into `os.execute` via single-quote concatenation in `Device:openLink`. An embedded `'` in the URL closed the intended quoting and the remainder was interpreted by the shell, giving arbitrary command execution as the KOReader user once the victim chose "Open in browser" on an external link. The same pattern existed in `doExternalDictLookup`'s direct-command path: the dictionary text was concatenated into the shell command and `cleanSelection` does not strip shell metacharacters.

Use `util.shell_escape` at both sinks. The helper has been in the codebase for years (e.g. `util.lua:928` for `df -kP`) and single-quotes args with `'\''` escaping.

`SDL_OpenURL` would be a structurally cleaner replacement for the `openLink` path (no shell at all) but requires the binding in `koreader-base` first, so it's not blocking this fix.

Fixes #15490

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15491)
<!-- Reviewable:end -->
