### PR TITLE
kindle: Make keepalive plugin call pause_auto_suspend

### DIFF
--- a/plugins/keepalive.koplugin/main.lua
+++ b/plugins/keepalive.koplugin/main.lua
@@ -35,9 +35,11 @@ if Device:isCervantes() or Device:isKobo() then
     disable = function() PluginShare.pause_auto_suspend = false end
 elseif Device:isKindle() then
     disable = function()
+        PluginShare.pause_auto_suspend = false
         os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 0")
     end
     enable = function()
+        PluginShare.pause_auto_suspend = true
         os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 1")
     end
 elseif Device:isSDL() then


### PR DESCRIPTION
Not calling pause_auto_suspend in the isKindle() branch is likely on oversight as we want to both disable KOReader's native auto suspend and Kindle's screen saver when we use the keepalive plugin.

This workaround suggest that both keepalive and pause_auto_suspend will be used at the same time:

https://github.com/koreader/koreader/blob/50a7fc66a6ccf004ffa9c632bebb4640bce21eb5/plugins/autosuspend.koplugin/main.lua#L133-L138

So I figured this is what we might want to do?

Looking at Kobo's branch also points in that direction...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15497)
<!-- Reviewable:end -->
