### PR TITLE
[DictQuick, Paging, Rolling] Eclectic fixes for 'find In Definition' and key Events

### DIFF
--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,21 +52,23 @@ end
 function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
-    local nextKey = BD.mirroredUILayout() and "Left" or "Right"
-    local prevKey = BD.mirroredUILayout() and "Right" or "Left"
+    local prev_key, next_key = "Left", "Right"
+    if BD.mirroredUILayout() then
+        next_key, prev_key = prev_key, next_key
+    end
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", nextKey, " " } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", next_key, " " } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", prev_key } }, event = "GotoViewRel", args = -1, }
         elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
-            self.key_events.GotoNextChapter = { { nextKey }, event = "GotoNextChapter", args = 1, }
-            self.key_events.GotoPrevChapter = { { prevKey }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextChapter = { { next_key }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { prev_key }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", " " } }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack" } }, event = "GotoViewRel", args = -1, }
         end
     elseif Device:hasKeys() then
-        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and nextKey } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and prevKey } }, event = "GotoViewRel", args = -1, }
+        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and next_key } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and prev_key } }, event = "GotoViewRel", args = -1, }
         self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
         self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
     end

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -576,7 +576,7 @@ function ReaderRolling:onPan(_, ges)
             -- Mouse wheel generates a Pan event: in page mode, move one
             -- page per event. Scroll mode is handled in the 'else' branch
             -- and use the wheeled distance.
-            UIManager:broadcastEvent(Event:new("GotoViewRel", -1 * ges.mousewheel_direction))
+            self:onGotoViewRel(-1 * ges.mousewheel_direction)
         elseif self.view.view_mode == "scroll" then
             if not self._pan_started then
                 self._pan_started = true
@@ -953,7 +953,7 @@ end
 function ReaderRolling:onPanning(args, _)
     local _, dy = unpack(args)
     if self.view.view_mode ~= "scroll" then
-        UIManager:broadcastEvent(Event:new("GotoViewRel", dy))
+        self:onGotoViewRel(dy)
         return
     end
     self:_gotoPos(self.current_pos + dy * self.panning_steps.normal)

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -116,15 +116,17 @@ end
 function ReaderRolling:onGesture() end
 
 function ReaderRolling:registerKeyEvents()
-    local nextKey = BD.mirroredUILayout() and "Left" or "Right"
-    local prevKey = BD.mirroredUILayout() and "Right" or "Left"
+    local prev_key, next_key = "Left", "Right"
+    if BD.mirroredUILayout() then
+        next_key, prev_key = prev_key, next_key
+    end
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
-            self.key_events.GotoNextView = { { { "LPgFwd", nextKey } }, event = "GotoViewRel", args = 1, }
-            self.key_events.GotoPrevView = { { { "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextView = { { { "LPgFwd", next_key } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "LPgBack", prev_key } }, event = "GotoViewRel", args = -1, }
         elseif G_reader_settings:nilOrFalse("left_right_keys_turn_pages") then
-            self.key_events.GotoNextChapter = { { nextKey }, event = "GotoNextChapter", args = 1, }
-            self.key_events.GotoPrevChapter = { { prevKey }, event = "GotoPrevChapter", args = -1, }
+            self.key_events.GotoNextChapter = { { next_key }, event = "GotoNextChapter", args = 1, }
+            self.key_events.GotoPrevChapter = { { prev_key }, event = "GotoPrevChapter", args = -1, }
             self.key_events.GotoNextView = { { "LPgFwd" }, event = "GotoViewRel", args = 1, }
             self.key_events.GotoPrevView = { { "LPgBack" }, event = "GotoViewRel", args = -1, }
         end
@@ -135,8 +137,8 @@ function ReaderRolling:registerKeyEvents()
         self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
     end
     if (Device:hasDPad() and not Device:useDPadAsActionKeys()) or (Device:hasKeys() and not Device:useDPadAsActionKeys()) then
-        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", nextKey } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", prevKey } }, event = "GotoViewRel", args = -1, }
+        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", next_key } }, event = "GotoViewRel", args = 1, }
+        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", prev_key } }, event = "GotoViewRel", args = -1, }
     end
     if Device:hasKeyboard() and not Device.k3_alt_plus_key_kernel_translated then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1822,6 +1822,19 @@ function DictQuickLookup:lookupInputWord(hint)
     local buttons = {
         {
             {
+                text = _("Find in definition"),
+                callback = function()
+                    local text = self.input_dialog:getInputText()
+                    if text ~= "" and not text:match("^%s*$") then
+                        UIManager:close(self.input_dialog)
+                        self:searchInDefinition(text)
+                    end
+                end,
+            },
+            -- 'Search with preset' will be inserted here
+        },
+        {
+            {
                 text = _("Translate"),
                 callback = function()
                     local text = self.input_dialog:getInputText()
@@ -1843,19 +1856,6 @@ function DictQuickLookup:lookupInputWord(hint)
                     end
                 end,
             },
-        },
-        {
-            {
-                text = _("Find in definition"),
-                callback = function()
-                    local text = self.input_dialog:getInputText()
-                    if text ~= "" and not text:match("^%s*$") then
-                        UIManager:close(self.input_dialog)
-                        self:searchInDefinition(text)
-                    end
-                end,
-            },
-            -- 'Search with preset' will be inserted here
         },
         {
             {
@@ -1881,7 +1881,7 @@ function DictQuickLookup:lookupInputWord(hint)
     }
     local preset_names = Presets.getPresets(self.ui.dictionary.preset_obj)
     if preset_names and #preset_names > 0 then
-        table.insert(buttons[2], {
+        table.insert(buttons[1], {
             text = _("Search with preset"),
             callback = function()
                 local text = self.input_dialog:getInputText()

--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -339,7 +339,13 @@ function DictQuickLookup:init()
         title = self.displaydictname,
         with_bottom_line = true,
         bottom_v_padding = 0, -- padding handled below
-        close_callback = function() self:onClose() end,
+        close_callback = function()
+            if self.in_definition_search then
+                self:endFindInDefinition()
+                return true
+            end
+            self:onClose()
+        end,
         close_hold_callback = function() self:onHoldClose() end,
         -- visual hint: title left aligned for dict, centered for Wikipedia
         align = self.is_wiki and "center" or "left",
@@ -1643,10 +1649,7 @@ end
 
 function DictQuickLookup:onCloseWithKeys(no_clear)
     if self.in_definition_search then
-        local _, content_widget = self:_getScrollAndContentWidgets()
-        if content_widget and content_widget.clearSearch then
-            content_widget:clearSearch(true)
-        end
+        self:endFindInDefinition()
         return true
     end
     if self.allow_key_text_selection and self.nt_text_selector_indicator then
@@ -1769,6 +1772,16 @@ function DictQuickLookup:findInDefinitionNextOrPreviousPage(direction)
     return false
 end
 
+function DictQuickLookup:endFindInDefinition(content_widget)
+    if not content_widget then
+        local dummy
+        dummy, content_widget = self:_getScrollAndContentWidgets()
+    end
+    if content_widget and content_widget.clearSearch then
+        content_widget:clearSearch(true)
+    end
+end
+
 function DictQuickLookup:searchInDefinition(text)
     if not text then return end
 
@@ -1790,7 +1803,7 @@ function DictQuickLookup:searchInDefinition(text)
             timeout = 2,
         })
         if self.in_definition_search then
-            content_widget:clearSearch(true)
+            self:endFindInDefinition(content_widget)
         end
     end
 end


### PR DESCRIPTION
### what's new

* Refactored key assignment logic in `ReaderPaging` and `ReaderRolling` to use correct variable names (`prev_key`, `next_key`) and simplified the logic for mirrored UI layouts. 
* Updated event handling in `ReaderRolling` so that page navigation events (`GotoViewRel`) are now handled directly by the class method instead of broadcasting via `UIManager`, ensuring more consistent and encapsulated event processing. https://github.com/koreader/koreader/issues/4329#issuecomment-4597600410
* Centralised the logic for ending a "Find in definition" search into a new `endFindInDefinition` method, and updated all relevant places (`close_callback`, `onCloseWithKeys`, and `searchInDefinition`) to use this, ensuring consistent cleanup and reducing code duplication.  https://github.com/koreader/koreader/pull/15356#issuecomment-4586787001
* Rearranged `lookupInputWord` such that  "Find in definition" is now the primary row, and "Search with preset" is properly inserted alongside it.  https://github.com/koreader/koreader/pull/15356#issuecomment-4586775686

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15498)
<!-- Reviewable:end -->
