### PR TITLE
[TextViewer] NT: add page turn events for easier navigation

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1229,6 +1229,16 @@ function ReaderBookmark:showBookmarkDetails(item_or_index)
             self:showBookmarkDetails(idx)
         end
     end
+    local function _showPrevBookmarkDetails()
+        if item_idx > 1 then
+            _showBookmarkDetails(item_idx - 1)
+        end
+    end
+    local function _showNextBookmarkDetails()
+        if item_idx < items_nb then
+            _showBookmarkDetails(item_idx + 1)
+        end
+    end
     local function edit_details_callback()
         self.details_updated = true
         UIManager:close(textviewer)
@@ -1268,14 +1278,14 @@ function ReaderBookmark:showBookmarkDetails(item_or_index)
                 text = label_prev,
                 enabled = item_idx > 1,
                 callback = function()
-                    _showBookmarkDetails(item_idx - 1)
+                    _showPrevBookmarkDetails()
                 end,
             },
             {
                 text = label_next,
                 enabled = item_idx < items_nb,
                 callback = function()
-                    _showBookmarkDetails(item_idx + 1)
+                    _showNextBookmarkDetails()
                 end,
             },
             {
@@ -1355,6 +1365,8 @@ function ReaderBookmark:showBookmarkDetails(item_or_index)
         text_type = "bookmark",
         buttons_table = buttons_table,
         close_callback = close_callback,
+        page_turn_callback_prev = items_nb > 1 and _showPrevBookmarkDetails or nil,
+        page_turn_callback_next = items_nb > 1 and _showNextBookmarkDetails or nil,
     }
     UIManager:show(textviewer)
     return true

--- a/frontend/ui/widget/textviewer.lua
+++ b/frontend/ui/widget/textviewer.lua
@@ -45,6 +45,8 @@ local TextViewer = InputContainer:extend{
     width = nil,
     height = nil,
     buttons_table = nil,
+    page_turn_callback_prev = nil,
+    page_turn_callback_next = nil,
     -- See TextBoxWidget for details about these options
     -- We default to justified and auto_para_direction to adapt
     -- to any kind of text we are given (book descriptions,
@@ -118,6 +120,13 @@ function TextViewer:init(reinit)
     if Device:hasKeys() then
         self.key_events.Close = { { Device.input.group.Back } }
         self.key_events.ShowMenu = { { "Menu" } }
+        self.key_events.ScrollOrPrev = { { Device.input.group.PgBack }, event = "ScrollOrNavigate", args = -1 }
+        self.key_events.ScrollOrNext = { { Device.input.group.PgFwd  }, event = "ScrollOrNavigate", args =  1 }
+        if Device:hasScreenKB() or Device:hasKeyboard() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.PrevItem = { { modifier, Device.input.group.PgBack } }
+            self.key_events.NextItem = { { modifier, Device.input.group.PgFwd  } }
+        end
     end
 
     if Device:isTouchDevice() then
@@ -516,6 +525,40 @@ function TextViewer:onSwipe(arg, ges)
     end
     -- Let our MovableContainer handle swipe outside of text
     return self.movable:onMovableSwipe(arg, ges)
+end
+
+function TextViewer:onScrollOrNavigate(direction)
+    if not self.scroll_text_w then return false end
+    if direction > 0 then
+        if self.scroll_text_w:onScrollDown() then
+            return true
+        end
+        if self.page_turn_callback_next then
+            self.page_turn_callback_next()
+            return true
+        end
+    else
+        if self.scroll_text_w:onScrollUp() then
+            return true
+        end
+        if self.page_turn_callback_prev then
+            self.page_turn_callback_prev()
+            return true
+        end
+    end
+    return false
+end
+
+function TextViewer:onNextItem()
+    if not self.page_turn_callback_next then return false end
+    self.page_turn_callback_next()
+    return true
+end
+
+function TextViewer:onPrevItem()
+    if not self.page_turn_callback_prev then return false end
+    self.page_turn_callback_prev()
+    return true
 end
 
 -- The following handlers are similar to the ones in DictQuickLookup:


### PR DESCRIPTION
### what's new

* Added `_showPrevBookmarkDetails` and `_showNextBookmarkDetails` helper functions in `ReaderBookmark:showBookmarkDetails` to encapsulate navigation logic and simplify callback usage.
* Updated the previous and next button callbacks to use these new helper functions.
* Passed the new navigation callbacks (`page_turn_callback_prev` and `page_turn_callback_next`) to the `TextViewer` widget, enabling external control over navigation.

* Added `page_turn_callback_prev` and `page_turn_callback_next` properties to `TextViewer`, allowing it to handle external navigation requests.
* Expanded key event handling to support navigation between items using keyboard modifiers (Shift or ScreenKB + Page keys), and mapped scroll/page keys to navigation events.
* Implemented new methods (`onScrollOrNavigate`, `onNextItem`, `onPrevItem`) in `TextViewer` to handle navigation logic, falling back to page-turn callbacks if scrolling is not possible.

### related issue

* fixes #15499

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15504)
<!-- Reviewable:end -->
