### PR TITLE
Screen rotation: always show rotation mode options

### DIFF
--- a/frontend/ui/elements/screen_rotation_menu_table.lua
+++ b/frontend/ui/elements/screen_rotation_menu_table.lua
@@ -1,6 +1,5 @@
 local Device = require("device")
 local Event = require("ui/event")
-local FileManager = require("apps/filemanager/filemanager")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
 local Screen = Device.screen
@@ -77,11 +76,9 @@ When unchecked, the default rotation of the file browser and the default/saved r
             separator = true,
         })
 
-        if FileManager.instance then
-            local optionsutil = require("ui/data/optionsutil")
-            for i, mode in ipairs(optionsutil.rotation_modes) do
-                table.insert(rotation_table, genMenuItem(optionsutil.rotation_labels[i], mode))
-            end
+        local optionsutil = require("ui/data/optionsutil")
+        for i, mode in ipairs(optionsutil.rotation_modes) do
+            table.insert(rotation_table, genMenuItem(optionsutil.rotation_labels[i], mode))
         end
 
         rotation_table[#rotation_table].separator = true


### PR DESCRIPTION
Previously the rotation mode options (landscape, portrait, etc.) in the screen rotation menu were gated behind `FileManager.instance`, which is set to `nil` when the Reader is opened — `ReaderUI:doShowReader` explicitly closes the FileManager. This made manual rotation inaccessible from the Reader view on all platforms, and was especially noticeable on Android where `hasGSensor` is false and the menu otherwise offers no way to change orientation.

This removes the `FileManager.instance` guard so the rotation mode options are always visible, regardless of whether the menu is opened from the FileManager or the Reader.

## Changes

- Removed the `FileManager.instance` conditional that wrapped the rotation mode entries in `screen_rotation_menu_table.lua`
- Removed the now-unused `FileManager` import

## Testing

- Built `android-arm64` and verified on device that rotation options appear both in the file browser and inside the Reader

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15505)
<!-- Reviewable:end -->
