### PR TITLE
OPDSParser: handle self-closing content tags

### DIFF
--- a/plugins/opds.koplugin/opdsparser.lua
+++ b/plugins/opds.koplugin/opdsparser.lua
@@ -95,6 +95,10 @@ function OPDSParser:parse(text)
     --       because it doesn't really deal well with various XHTML quirks, as the list of crappy replacements above attests to...
     --       There's also a high probability of finding orphaned tags or badly nested ones in there, which would screw everything up.
     --       In any case, we just want to treat the whole thing as a single text node anyway, so, just mangle the markup to force luxl's hand.
+    -- A self-closing content tag (e.g. <content type="text"/>) has no text. Turn it
+    -- into an empty element first, otherwise the lazy ".-" in the rewrite below runs
+    -- past it to the next entry's content tag and swallows everything in between.
+    text = text:gsub("<content%s+[^<>]-/>", "<content />")
     text = text:gsub('<content type=".-">', "<content>")
     text = text:gsub("<content>(.-)</content>", function (s)
         return '<content type="text">' .. s:gsub("%p", {["<"] = "&lt;", [">"] = "&gt;", ['"'] = "&quot;", ["'"] = "&apos;"}) .. "</content>"

--- a/spec/unit/opds_spec.lua
+++ b/spec/unit/opds_spec.lua
@@ -398,6 +398,39 @@ describe("OPDS module", function()
             assert.are.same(entry.link[1].href, "https://www.gutenberg.org/ebooks/42474.epub.images")
             assert.are.same(entry.link[1].title, "EPUB (with images)")
         end)
+        it("should not desync entries when a content tag is self-closing", function()
+            -- Regression for #15511: a self-closing <content type="text"/> used to make
+            -- the content rewrite over-match into the next entry, dropping entries and
+            -- pairing covers with the wrong titles.
+            local self_closing_content_sample = [[
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Self-closing content</title>
+<entry>
+<title>First</title>
+<id>urn:first</id>
+<content type="text"/>
+<link type="image/png" rel="http://opds-spec.org/image/thumbnail" href="FIRST_IMG"/>
+</entry>
+<entry>
+<title>Second</title>
+<id>urn:second</id>
+<content type="text">A description.</content>
+<link type="image/png" rel="http://opds-spec.org/image/thumbnail" href="SECOND_IMG"/>
+</entry>
+</feed>
+]]
+            local catalog = OPDSParser:parse(self_closing_content_sample)
+            local feed = catalog.feed
+            assert.truthy(feed)
+            local entries = feed.entry
+            assert.truthy(entries)
+            assert.are.same(#entries, 2)
+            assert.are.same(entries[1].title, "First")
+            assert.are.same(entries[1].link[1].href, "FIRST_IMG")
+            assert.are.same(entries[2].title, "Second")
+            assert.are.same(entries[2].link[1].href, "SECOND_IMG")
+        end)
     end)
 
     describe("OPDS browser module", function()


### PR DESCRIPTION
A self-closing content tag (`<content type="text"/>`) has no `">` of its own, so the lazy `.-` in

```lua
text = text:gsub('<content type=".-">', "<content>")
```

runs forward to the *next* entry's `<content type="...">` and rewrites everything in between — the entry's links included — into a single `<content>`. luxl then parses a mangled tree: entries are dropped and covers get paired with the wrong titles (the reported symptom: correct title, cover taken from a neighbouring entry).

Normalize self-closing content tags to an empty `<content />` element before that rewrite, so the `.-` no longer escapes the tag. The `[^<>]` bound keeps the new pattern from matching across normal (non-self-closing) content tags.

Added a regression test with a self-closing content tag between two entries. Verified against the actual luxl parser: before the change the two entries collapse into one (`First` paired with the second entry's cover), after it both entries parse correctly with their own covers. The existing OPDS parser tests still pass.

Fixes #15511

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15515)
<!-- Reviewable:end -->
