### PR TITLE
feat: add sort option "Title natural"

### DIFF
--- a/frontend/ui/widget/booklist.lua
+++ b/frontend/ui/widget/booklist.lua
@@ -190,6 +190,21 @@ BookList.collates = {
             end
         end,
     },
+    title_natural = {
+        text = _("Title natural"),
+        menu_order = 100,
+        item_func = function(item, ui)
+            local doc_props = ui.bookinfo:getDocProps(item.path or item.file)
+            item.doc_props = doc_props
+        end,
+        init_sort_func = function()
+            local natsort
+            natsort, cache = sort.natsort_cmp(cache)
+            return function(a, b)
+                return natsort(a.doc_props.display_title, b.doc_props.display_title)
+            end, cache
+        end,
+    },
     authors = {
         text = _("Authors"),
         menu_order = 110,


### PR DESCRIPTION
I also suggest replacing the current `natural_sort` algorithm in the `sort` module with the faster and more accurate `https://github.com/tachibana-shin/natord-plus-lua`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15523)
<!-- Reviewable:end -->
