### PR TITLE
fix(vocabbuilder): leaked db conn breaking sync

### DIFF
--- a/plugins/vocabbuilder.koplugin/db.lua
+++ b/plugins/vocabbuilder.koplugin/db.lua
@@ -309,6 +309,7 @@ function VocabularyBuilder:hasWord(word)
     stmt:bind(word)
     local result = stmt:step()
     stmt:close()
+    conn:close()
     if result then
         return {
             book_title = result[1],
@@ -426,6 +427,7 @@ function VocabularyBuilder.onSync(local_path, cached_path, income_path)
     if not ok1 or tonumber(v1) == 0 then
         -- no income db or wrong db, first time sync
         logger.dbg("vocabbuilder open income DB failed", v1)
+        conn_income:close()
         return true
     end
 
@@ -466,6 +468,7 @@ function VocabularyBuilder.onSync(local_path, cached_path, income_path)
     if not ok3 or tonumber(v3) == 0 then
         -- no local db, this is an error
         logger.err("vocabbuilder open local DB", v3)
+        conn:close()
         return false
     end
 


### PR DESCRIPTION
closes #14002

i was making a tool that takes advantage of the vocab builder cloud syncing, and this issue was bothering me. appears to be fixed just by properly closing the opened db connections before returning results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15531)
<!-- Reviewable:end -->
