### PR TITLE
fix(cloudstorage): webdav not listing folders

### DIFF
--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -95,13 +95,13 @@ function WebDavApi:listFolder(address, user, pass, folder_path, folder_mode)
             local item_name = ffiUtil.basename(util.htmlEntitiesToUtf8(util.urlDecode(item_fullpath)))
             local is_current_dir = self.trim_slashes(item_fullpath) == webdav_url_path
             local is_not_collection = item:find("<[^:]*:resourcetype%s*/>") or
-                                      item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
+                                      item:find("<[^:]*:resourcetype>%s*</[^:]*:resourcetype>")
             local item_path = path .. "/" .. item_name
 
             -- only available for files, not directories/collections
             local item_filesize = item:match("<[^:]*:getcontentlength[^>]*>(%d+)</[^:]*:getcontentlength>")
 
-            if item:find("<[^:]*:collection[^<]*/>") then
+            if item:find("<[^:]*:collection[^<]*/>") or item:find("<[^:]*:collection>%s*</[^:]*:collection>") then
                 item_name = item_name .. "/"
                 if not is_current_dir then
                     table.insert(webdav_list, {

--- a/plugins/cloudstorage.koplugin/providers/webdav.lua
+++ b/plugins/cloudstorage.koplugin/providers/webdav.lua
@@ -102,7 +102,7 @@ function WebDavApi.listFolder(address, user, pass, folder_path, include_folders)
         local item_fullpath = util.urlDecode(item:match("<[^:]*:href[^>]*>(.*)</[^:]*:href>"))
         local item_name = ffiUtil.basename(util.htmlEntitiesToUtf8(item_fullpath))
         local is_not_collection = item:find("<[^:]*:resourcetype%s*/>") or
-                                  item:find("<[^:]*:resourcetype></[^:]*:resourcetype>")
+                                  item:find("<[^:]*:resourcetype>%s*</[^:]*:resourcetype>")
         if is_not_collection then
             if show_unsupported or DocumentRegistry:hasProvider(item_name) then
                 local file_size = tonumber(item:match("<[^:]*:getcontentlength[^>]*>(%d+)</[^:]*:getcontentlength>"))
@@ -123,7 +123,7 @@ function WebDavApi.listFolder(address, user, pass, folder_path, include_folders)
                     mandatory = mandatory,
                 })
             end
-        elseif item:find("<[^:]*:collection[^<]*/>") then
+        elseif item:find("<[^:]*:collection[^<]*/>") or item:find("<[^:]*:collection>%s*</[^:]*:collection>") then
             if include_folders then
                 local is_not_current_dir = WebDavApi.trim_slashes(item_fullpath) ~= webdav_url_path
                 if is_not_current_dir then


### PR DESCRIPTION
fixes some webdav connections not listing directories in both the old cloud storage and new cloud storage+

my webdav server (using [dav-server](https://crates.io/crates/dav-server/)) returns
```xml
<D:collection></D:collection>
```
instead of
```xml
<D:collection/>
```
which should still be supported. i think there are probably other issues with the regex xml parsing but this seems to be enough to make it work for me

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15532)
<!-- Reviewable:end -->
