### PR TITLE
fix(cloudstorage): choose folder not showing for empty dirs

### DIFF
--- a/plugins/cloudstorage.koplugin/cloudstorage.lua
+++ b/plugins/cloudstorage.koplugin/cloudstorage.lua
@@ -125,21 +125,25 @@ end
 
 function CloudStorage:sortItemTable(tbl, url)
     tbl = tbl or self.item_table
-    if #tbl == 0 then return end
+
     local folder_mode_item
-    if self.choose_folder_callback and tbl[1].is_folder_long_press then
+    if self.choose_folder_callback and #tbl > 0 and tbl[1].is_folder_long_press then
         folder_mode_item = table.remove(tbl, 1)
     end
-    local sort_func = self.collates[self.collate].sort_func
-    table.sort(tbl, function(a, b)
-        if a.is_file and b.is_file then
-            return sort_func(a, b)
-        elseif a.is_folder and b.is_folder then
-            return ffiUtil.strcoll(a.text, b.text)
-        else -- folders first
-            return a.is_folder
-        end
-    end)
+
+    if #tbl > 1 then
+        local sort_func = self.collates[self.collate].sort_func
+        table.sort(tbl, function(a, b)
+            if a.is_file and b.is_file then
+                return sort_func(a, b)
+            elseif a.is_folder and b.is_folder then
+                return ffiUtil.strcoll(a.text, b.text)
+            else -- folders first
+                return a.is_folder
+            end
+        end)
+    end
+
     if self.choose_folder_callback then
         table.insert(tbl, 1, folder_mode_item or {
             is_folder_long_press = true,


### PR DESCRIPTION
sorry for the pull request spam but these were all related issues i had when trying to debug the one thing

this fixes a regression with the cloud storage+ where it wouldn't show the "long-press here to choose current folder" cell if the current cloud folder was empty (it does correctly with the old cloud storage). it's not necessary for me personally after #15532, but i thought it would be more correct to have

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15533)
<!-- Reviewable:end -->
