### PR TITLE
[reMarkable] fix: native QTFB OTA update

### DIFF
--- a/make/remarkable.mk
+++ b/make/remarkable.mk
@@ -12,7 +12,7 @@ update-prepare: all
 	# ensure that the binaries were built for ARM
 	file --dereference $(INSTALL_DIR)/koreader/luajit | grep ARM
 	# Remarkable scripts
-	$(SYMLINK) $(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader/
+	$(SYMLINK) $(REMARKABLE_DIR)/spinning_zsync $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(REMARKABLE_DIR)/koreader.sh $(INSTALL_DIR)/koreader/
 	$(SYMLINK) $(REMARKABLE_DIR)/qtfb_keep_alive.lua $(INSTALL_DIR)/koreader/
 	$(SYMLINK) resources/koreader.png $(INSTALL_DIR)/koreader/icon.png

--- a/platform/remarkable/spinning_zsync
+++ b/platform/remarkable/spinning_zsync
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# We're going to need to remember failures from the *left* side of a pipeline...
+# But because we can't have nice things, some devices (hi, Kindle) may use an extremely old busybox build,
+# one in which pipefail was not yet implemented,
+# (it appeared in busybox 1.16.0, and is contingent on bash compatibility being enabled in ash).
+
+# NOTE: We inherit WITH_PIPEFAIL from the env via OTAManager, because of course old busybox ash versions abort on set -o failures...
+#       c.f., https://github.com/koreader/koreader/pull/5844
+if [ "${WITH_PIPEFAIL}" = "true" ]; then
+    # shellcheck disable=SC3040
+    set -o pipefail
+fi
+
+fbink_wrapped() {
+    if [ -n "${KO_USE_QTFB}" ]; then
+        LD_PRELOAD="/home/root/shims/qtfb-shim.so" \
+            QTFB_SHIM_MODEL="false" \
+            QTFB_SHIM_INPUT_MODE="NATIVE" \
+            QTFB_SHIM_MODE="N_RGB565" \
+            QTFB_SHIM_RESPECT_FULL_REFRESH_REQUESTS="1" \
+            ./fbink "$@"
+    else
+        ./fbink "$@"
+    fi
+}
+
+# Figure out whether that's a delta or a full download given the number of arguments passed...
+if [ $# -lt 7 ]; then
+    ZSYNC_MESSAGE="Downloading update data"
+else
+    ZSYNC_MESSAGE="Computing zsync delta"
+fi
+
+# Clear screen before start
+fbink_wrapped --cls
+# Small zsync wrapper so we can print its output while it works...
+fbink_wrapped -q -y -7 -pmh "${ZSYNC_MESSAGE} . . ."
+# Clear any potential leftover from the local OTA tarball creation.
+fbink_wrapped -q -y -6 -pm ' '
+
+# Launch zsync2, and remember its exit code...
+# We'll be piping its output to FBInk in order to print it live, in a smaller font than usual...
+# NOTE: This depends on an undocumented FBInk hack (-z) in order to deal with the progress bars (and their CR) sanely.
+rc=0
+
+if [ "${WITH_PIPEFAIL}" = "true" ]; then
+    # We can use pipefail, let the shell do the heavy lifting for us...
+    ./zsync2 "$@" 2>&1 | tee -a ./crash.log | fbink_wrapped -q -z -pm -F scientifica
+    rc=$?
+else
+    # We cannot use pipefail, extreme shell wizardry is required...
+    # Pure magic courtesy of https://unix.stackexchange.com/a/70675
+    # Much more compact than the stock answer from the Usenet shell FAQ: http://cfajohnson.com/shell/cus-faq-2.html#Q11
+    { { { {
+        ./zsync2 "$@" 2>&1 3>&- 4>&-
+        echo $? >&3
+    } | fbink_wrapped -q -z -pm -F scientifica >&4; } 3>&1; } | {
+        read -r xs
+        exit "${xs}"
+    }; } 4>&1
+
+    rc=$?
+fi
+
+# And return with zsync's exit code
+exit ${rc}


### PR DESCRIPTION
fbink wrapping also needed for spinning_zsync script, missed that, oops!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15538)
<!-- Reviewable:end -->
