### PR TITLE
Page overlap: no indicator; actions for gestures/profiles

### DIFF
--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -219,7 +219,7 @@ function ReaderView:paintTo(bb, x, y)
         if self.page_overlap_style == "dim" then
             -- NOTE: "dim", as in make black text fainter, e.g., lighten the rect
             bb:lightenRect(self.dim_area.x, self.dim_area.y, self.dim_area.w, self.dim_area.h)
-        else
+        elseif self.page_overlap_style ~= "none" then
             -- Paint at the proper y origin depending on whether we paged forward (dim_area.y == 0) or backward
             local paint_y = self.dim_area.y == 0 and self.dim_area.h or self.dim_area.y
             if self.page_overlap_style == "arrow" then
@@ -1318,13 +1318,43 @@ function ReaderView:checkAutoSaveSettings()
 end
 
 function ReaderView:isOverlapAllowed()
-    if self.ui.paging then
-        return not self.page_scroll
-            and (self.ui.paging.zoom_mode ~= "page"
-                or (self.ui.paging.zoom_mode == "page" and self.document.configurable.text_wrap == 1))
-            and not self.ui.paging.zoom_mode:find("height")
-    else
+    if self.ui.rolling then
         return self.view_mode ~= "page"
+    end
+    -- paging
+    if self.page_scroll then -- continuous mode
+        return false
+    end
+    if self.ui.paging.zoom_mode == "page" then -- page full
+        return self.document.configurable.text_wrap == 1 -- reflow on
+    end
+    if self.ui.paging.zoom_mode:find("height") then -- page/content fit to height
+        return false
+    end
+    return true
+end
+
+local overlap_styles = { "none", "dim", "arrow", "line", "dashed_line" }
+local overlap_style_texts = { _("No indicator"), _("Gray out"), _("Arrow"), _("Solid line"), _("Dashed line") }
+function ReaderView.getOverlapStyles()
+    return overlap_styles, overlap_style_texts
+end
+
+function ReaderView:onSetOverlapStyle(style, no_notification)
+    if self.page_overlap_style ~= style then
+        self.page_overlap_style = style
+        UIManager:setDirty(self.dialog, "ui")
+        if not no_notification then
+            local index = util.arrayContains(overlap_styles, style)
+            Notification:notify(T(_("Page overlap style set to: %1"), overlap_style_texts[index]))
+        end
+    end
+end
+
+function ReaderView:onCycleOverlapStyle()
+    local index = util.arrayContains(overlap_styles, self.page_overlap_style)
+    if index then
+        self:onSetOverlapStyle(overlap_styles[index + 1] or overlap_styles[1])
     end
 end
 

--- a/frontend/apps/reader/modules/readerzooming.lua
+++ b/frontend/apps/reader/modules/readerzooming.lua
@@ -384,6 +384,7 @@ function ReaderZooming:onDefineZoom(btn, when_applied_callback)
     end
     settings.right_to_left = nil
 
+    local old_zoom_mode = self.zoom_mode -- self.zoom_mode is changed in onSetZoomPan()
     if zoom_mode == "columns" or zoom_mode == "rows" then
         if btn ~= "columns" and btn ~= "rows" then
             self.ui:handleEvent(Event:new("SetZoomPan", settings, true))
@@ -406,6 +407,7 @@ function ReaderZooming:onDefineZoom(btn, when_applied_callback)
             self.ui:handleEvent(Event:new("SetZoomPan", settings, true))
         end
     end
+    self.zoom_mode = old_zoom_mode -- self.zoom_mode is updated in onSetZoomMode()
     self.ui:handleEvent(Event:new("SetZoomMode", zoom_mode))
     if btn == "columns" or btn == "rows" then
         config.zoom_range_number = self:getNumberOf(

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -39,6 +39,7 @@ local ReaderDictionary = require("apps/reader/modules/readerdictionary")
 local ReaderFooter = require("apps/reader/modules/readerfooter")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local ReaderTypography = require("apps/reader/modules/readertypography")
+local ReaderView = require("apps/reader/modules/readerview")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
 local Screen = Device.screen
 local UIManager = require("ui/uimanager")
@@ -223,6 +224,9 @@ local settingsList = {
     set_highlight_action = {category="string", event="SetHighlightAction", title=_("Set highlight action"), args_func=ReaderHighlight.getHighlightActions, reader=true},
     cycle_highlight_action = {category="none", event="CycleHighlightAction", title=_("Cycle highlight action"), reader=true},
     cycle_highlight_style = {category="none", event="CycleHighlightStyle", title=_("Cycle highlight style"), reader=true, separator=true},
+    ----
+    set_overlap_style = {category="string", event="SetOverlapStyle", title=_("Set page overlap style"), args_func=ReaderView.getOverlapStyles, reader=true},
+    cycle_overlap_style = {category="none", event="CycleOverlapStyle", title=_("Cycle page overlap style"), reader=true, separator=true},
     ----
     flush_settings = {category="none", event="FlushSettings", arg=true, title=_("Save book metadata"), reader=true, separator=true},
     ----
@@ -483,6 +487,9 @@ local dispatcher_menu_order = {
     "set_highlight_action",
     "cycle_highlight_action",
     "cycle_highlight_style",
+    ----
+    "set_overlap_style",
+    "cycle_overlap_style",
     ----
     "flush_settings",
     ----

--- a/frontend/ui/elements/page_overlap.lua
+++ b/frontend/ui/elements/page_overlap.lua
@@ -1,8 +1,8 @@
-local FFIUtil = require("ffi/util")
-local ReaderUI = require("apps/reader/readerui")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
-local T = FFIUtil.template
+local T = require("ffi/util").template
+
+local ui = require("apps/reader/readerui").instance
 
 local PageOverlap = {
     text = _("Page overlap"),
@@ -16,15 +16,14 @@ local PageOverlap = {
                 return text
             end,
             checked_func = function()
-                return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
+                return ui.view:isOverlapAllowed() and ui.view.page_overlap_enable
             end,
             callback = function()
-                local view = ReaderUI.instance.view
-                if view:isOverlapAllowed() then
-                    if view.page_overlap_enable then
-                        view.dim_area:clear()
+                if ui.view:isOverlapAllowed() then
+                    if ui.view.page_overlap_enable then
+                        ui.view.dim_area:clear()
                     end
-                    view.page_overlap_enable = not view.page_overlap_enable
+                    ui.view.page_overlap_enable = not ui.view.page_overlap_enable
                 else
                     UIManager:show(require("ui/widget/infomessage"):new{
                         text = _("Page overlap cannot be enabled in the current view mode."),
@@ -37,64 +36,58 @@ local PageOverlap = {
                 touchmenu_instance:updateItems()
             end,
         },
-    }
-}
-
-table.insert(PageOverlap.sub_item_table, {
-    keep_menu_open = true,
-    text_func = function()
-        return T(_("Number of lines: %1"), G_reader_settings:readSetting("copt_overlap_lines") or 1)
-    end,
-    enabled_func = function()
-        return not ReaderUI.instance.document.info.has_pages and
-            ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
-    end,
-    callback = function(touchmenu_instance)
-        local SpinWidget = require("ui/widget/spinwidget")
-        UIManager:show(SpinWidget:new{
-            title_text =  _("Number of overlapped lines"),
-            info_text = _([[
+        {
+            text_func = function()
+                return T(_("Number of overlapped lines: %1"), G_reader_settings:readSetting("copt_overlap_lines") or 1)
+            end,
+            enabled_func = function()
+                return not ui.document.info.has_pages -- ReaderMenu is registered before paging/rolling
+                    and ui.view:isOverlapAllowed() and ui.view.page_overlap_enable
+            end,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local SpinWidget = require("ui/widget/spinwidget")
+                UIManager:show(SpinWidget:new{
+                    title_text =  _("Number of overlapped lines"),
+                    info_text = _([[
 When page overlap is enabled, some lines from the previous page will be displayed on the next page.
 You can set how many lines are shown.]]),
-            value = G_reader_settings:readSetting("copt_overlap_lines") or 1,
-            value_min = 1,
-            value_max = 10,
-            default_value = 1,
-            precision = "%d",
-            callback = function(spin)
-                G_reader_settings:saveSetting("copt_overlap_lines", spin.value)
-                touchmenu_instance:updateItems()
+                    value = G_reader_settings:readSetting("copt_overlap_lines") or 1,
+                    value_min = 1,
+                    value_max = 10,
+                    default_value = 1,
+                    precision = "%d",
+                    callback = function(spin)
+                        G_reader_settings:saveSetting("copt_overlap_lines", spin.value)
+                        touchmenu_instance:updateItems()
+                    end,
+                })
             end,
-        })
-    end,
-    separator = true,
-})
-
-local page_overlap_styles = {
-    {_("Arrow"), "arrow"},
-    {_("Gray out"), "dim"},
-    {_("Solid line"), "line"},
-    {_("Dashed line"), "dashed_line"},
+            separator = true,
+        },
+        -- styles
+    },
 }
-for _, v in ipairs(page_overlap_styles) do
-    local style_text, style = unpack(v)
+
+local styles, style_texts = ui.view.getOverlapStyles()
+for i, style in ipairs(styles) do
     table.insert(PageOverlap.sub_item_table, {
         text_func = function()
-            local text = style_text
+            local text = style_texts[i]
             if G_reader_settings:readSetting("page_overlap_style") == style then
                 text = text .. "   ★"
             end
             return text
         end,
         enabled_func = function()
-            return ReaderUI.instance.view:isOverlapAllowed() and ReaderUI.instance.view.page_overlap_enable
+            return ui.view:isOverlapAllowed() and ui.view.page_overlap_enable
         end,
         checked_func = function()
-            return ReaderUI.instance.view.page_overlap_style == style
+            return ui.view.page_overlap_style == style
         end,
         radio = true,
         callback = function()
-            ReaderUI.instance.view.page_overlap_style = style
+            ui.view:onSetOverlapStyle(style, true) -- no notification
         end,
         hold_callback = function(touchmenu_instance)
             G_reader_settings:saveSetting("page_overlap_style", style)


### PR DESCRIPTION
1. "No indicator" option. Closes #15537 
2. Actions for gestures/profiles. Closes #10647 
3. Minor fix: page overlap couldn't be enabled after setting Zoom to "manual", reopening/restart was required.
4. Refactoring `isOverlapAllowed()` for readability (logic unchanged).
5. Refactoring page_overlap menu module to follow the up-to-date code style.

-----

<img width="400" height="304" alt="1" src="https://github.com/user-attachments/assets/22ba592e-fa7b-44a9-a116-6be33e594c79" />

-----

<img width="400" height="404" alt="2" src="https://github.com/user-attachments/assets/38a63210-c899-4ceb-82d4-dc70697fe45d" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15541)
<!-- Reviewable:end -->
