### PR TITLE
Enable 'Saturation' option if 'Color rendering' is on

### DIFF
--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -516,7 +516,8 @@ Some of the other settings are only available when reflow mode is enabled.]]),
                 event = "SaturationUpdate",
                 args =   {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
                 labels = {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
-                show_func = function()
+                show = Device:hasColorScreen(),
+                enabled_func = function()
                     return G_reader_settings:isTrue("color_rendering")
                 end,
                 name_text_hold_callback = optionsutil.showValues,

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -518,7 +518,7 @@ Some of the other settings are only available when reflow mode is enabled.]]),
                 labels = {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
                 show = Device:hasColorScreen(),
                 enabled_func = function()
-                    return Device.screen.isColorEnabled()
+                    return Device.screen:isColorEnabled()
                 end,
                 name_text_hold_callback = optionsutil.showValues,
                 more_options = true,

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -518,7 +518,7 @@ Some of the other settings are only available when reflow mode is enabled.]]),
                 labels = {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
                 show = Device:hasColorScreen(),
                 enabled_func = function()
-                    return G_reader_settings:isTrue("color_rendering")
+                    return Device.screen.isColorEnabled()
                 end,
                 name_text_hold_callback = optionsutil.showValues,
                 more_options = true,

--- a/frontend/ui/data/koptoptions.lua
+++ b/frontend/ui/data/koptoptions.lua
@@ -516,7 +516,9 @@ Some of the other settings are only available when reflow mode is enabled.]]),
                 event = "SaturationUpdate",
                 args =   {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
                 labels = {0.2, 0.5, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0},
-                show = Device:hasColorScreen(),
+                show_func = function()
+                    return G_reader_settings:isTrue("color_rendering")
+                end,
                 name_text_hold_callback = optionsutil.showValues,
                 more_options = true,
                 more_options_param = {


### PR DESCRIPTION
Saturation makes no sense for black & white rendering. I have a black & white device which is erroneously detected as a color one (so I have 'color rendering' off), and I guess some people might have 'color rendering' off even on an actual color device, so it's better to bind the saturation visibility to the color rendering option, not the device spec

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15542)
<!-- Reviewable:end -->
