### PR TITLE
bump base & crengine, enhanced search on CreDocuments

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -2258,7 +2258,7 @@ function ReaderHighlight:onHighlightSearch()
     end
     self:highlightFromHoldPos()
     if self.selected_text then
-        local text = util.stripPunctuation(util.cleanupSelectedText(self.selected_text.text))
+        local text = util.cleanupSelectedText(self.selected_text.text)
         self.ui.search:searchText(text)
     end
 end

--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -1,11 +1,16 @@
 local BD = require("ui/bidi")
+local Blitbuffer = require("ffi/blitbuffer")
 local ButtonDialog = require("ui/widget/buttondialog")
+local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
 local Device = require("device")
+local Geom = require("ui/geometry")
 local InfoMessage = require("ui/widget/infomessage")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local InputDialog = require("ui/widget/inputdialog")
+local LineWidget = require("ui/widget/linewidget")
 local Menu = require("ui/widget/menu")
+local Size = require("ui/size")
 local Notification = require("ui/widget/notification")
 local SpinWidget = require("ui/widget/spinwidget")
 local TextBoxWidget = require("ui/widget/textboxwidget")
@@ -22,6 +27,27 @@ local icon_size = Screen:scaleBySize(0.8 * G_defaults:readSetting("DGENERIC_ICON
 local ReaderSearch = InputContainer:extend{
     direction = 0, -- 0 for search forward, 1 for search backward
     case_insensitive = true, -- default to case insensitive
+
+    -- For CreDocuments, different search features are available:
+    -- Enhanced search flags:
+    --   MATCH_ACROSS_TEXT_NODES     = 0x0001
+    --   COLLAPSE_CONSECUTIVE_SPACES = 0x0002
+    --   NORMALIZE_CANONICAL         = 0x0004
+    --   NORMALIZE_COMPATIBILITY     = 0x0008
+    --   IGNORE_FORMAT_CONTROL_CHARS = 0x0010
+    --   FOLD_SPACES                 = 0x0020
+    --   FOLD_APOSTROPHES            = 0x0040
+    --   FOLD_HYPHENS                = 0x0080
+    --   IGNORE_DIACRITICS           = 0x0100
+    -- Make a few types of search available as (mutually exclusive) check buttons
+    -- (These are available to be updated/extended by user-patches)
+    search_types = {
+        { text = _("Ignore diacritics and accents"), flags = 0x01FF, regex = false },
+        -- { text = _("As typed"), flags = 0x0017, regex = false },
+        -- { text = _("Legacy search"), flags = 0x0000, regex = false },
+        { text = _("Regular expression (long-press for help)"), flags = 0x0001, regex = true },
+    },
+    default_search_type = { flags = 0x00FF, regex = false }, -- Most except IGNORE_DIACRITICS
 
     -- For a regex like [a-z\. ] many many hits are found, maybe the number of chars on a few pages.
     -- We don't try to catch them all as this is a reader and not a computer science playground. ;)
@@ -46,10 +72,12 @@ function ReaderSearch:init()
     self.findall_results_per_page = G_reader_settings:readSetting("fulltext_search_results_per_page") or 10
     self.findall_results_max_lines = G_reader_settings:readSetting("fulltext_search_results_max_lines")
 
+    self.current_search_type = self.default_search_type
+
     self.ui.menu:registerToMainMenu(self)
 end
 
-local help_text = _([[
+local regex_help_text = _([[
 Regular expressions allow you to search for a matching pattern in a text. The simplest pattern is a simple sequence of characters, such as `James Bond`. There are many different varieties of regular expressions, but we support the ECMAScript syntax. The basics will be explained below.
 
 If you want to search for all occurrences of 'Mister Moore', 'Sir Moore' or 'Alfons Moore' but not for 'Lady Moore'.
@@ -226,21 +254,21 @@ function ReaderSearch:searchCallback(reverse, text)
     self.last_search_text = search_text
     self.start_page = self.ui.paging and self.view.state.page or self.ui.document:getXPointer()
 
-    local regex_error
     if text then -- from highlight dialog
-        self.use_regex = false
         self.case_insensitive = true
+        self.current_search_type = self.default_search_type
     else -- from input dialog
         -- search_text comes from our keyboard, and may contain multiple diacritics ordered
         -- in any order: we'd rather have them normalized, and expect the book content to
         -- be proper and normalized text.
         search_text = Utf8Proc.normalize_NFC(search_text)
-        self.use_regex = self.check_button_regex.checked
         self.case_insensitive = not self.check_button_case.checked
-        regex_error = self.use_regex and self.ui.document:checkRegex(search_text)
+        -- self.current_search_type is used as it is (from previous search, or updated by the buttons)
     end
+    local use_regex = self.current_search_type.regex
+    local regex_error = use_regex and self.ui.document:checkRegex(search_text)
 
-    if self.use_regex and regex_error ~= 0 then
+    if use_regex and regex_error ~= 0 then
         logger.dbg("ReaderSearch: regex error", regex_error, SRELL_ERROR_CODES[regex_error])
         local error_message
         if SRELL_ERROR_CODES[regex_error] then
@@ -251,9 +279,9 @@ function ReaderSearch:searchCallback(reverse, text)
         UIManager:show(InfoMessage:new{ text = error_message })
     else
         UIManager:close(self.input_dialog)
-        if reverse then
+        if reverse then -- provided as 0 or 1
             self.last_search_hash = nil
-            self:onShowSearchDialog(search_text, reverse, self.use_regex, self.case_insensitive)
+            self:onShowSearchDialog(search_text, reverse, self.current_search_type, self.case_insensitive)
         else
             local Trapper = require("ui/trapper")
             Trapper:wrap(function()
@@ -308,26 +336,70 @@ function ReaderSearch:onShowFulltextSearchInput(search_string)
         parent = self.input_dialog,
     }
     self.input_dialog:addWidget(self.check_button_case)
-    self.check_button_regex = CheckButton:new{
-        text = _("Regular expression (long-press for help)"),
-        checked = self.use_regex,
-        parent = self.input_dialog,
-        hold_callback = function()
-            UIManager:show(InfoMessage:new{
-                text = help_text,
-                width = Screen:getWidth() * 0.9,
-            })
-        end,
-    }
+
     if self.ui.rolling then
-        self.input_dialog:addWidget(self.check_button_regex)
+        -- Add mutually exclusive check buttons, to select one of our search types
+        -- (or none and use our default_search_type)
+        local separator_width = self.input_dialog:getAddedWidgetAvailableWidth()
+        local separator = CenterContainer:new{
+            dimen = Geom:new{
+                w = separator_width,
+                h = 2 * Size.span.vertical_large,
+            },
+            LineWidget:new{
+                background = Blitbuffer.COLOR_DARK_GRAY,
+                dimen = Geom:new{
+                    w = separator_width,
+                    h = Size.line.medium,
+                }
+            },
+        }
+        self.input_dialog:addWidget(separator)
+
+        local search_type_buttons = {}
+        local search_type_buttons_refresh = function()
+            for _, button in ipairs(search_type_buttons) do
+                button.checked = button.checked_func()
+                button:enable() -- this updates its state
+            end
+        end
+        for _, search_type in ipairs(self.search_types) do
+            local button = CheckButton:new{
+                text = search_type.text,
+                checked_func = function()
+                    return search_type == self.current_search_type
+                end,
+                callback = function()
+                    -- Our buttons are mutually exclusive, but we can have
+                    -- none of them checked
+                    if self.current_search_type == search_type then
+                        -- All unchecked: back to default search type
+                        self.current_search_type = self.default_search_type
+                    else
+                        self.current_search_type = search_type
+                    end
+                    search_type_buttons_refresh()
+                end,
+                hold_callback = search_type.regex and function()
+                    UIManager:show(InfoMessage:new{
+                        text = regex_help_text,
+                        width = Screen:getWidth() * 0.9,
+                    })
+                end,
+                parent = self.input_dialog,
+            }
+            button.checked = button.checked_func()
+            table.insert(search_type_buttons, button)
+            self.input_dialog:addWidget(button)
+        end
+        search_type_buttons_refresh() -- update all buttons states
     end
 
     UIManager:show(self.input_dialog)
     self.input_dialog:onShowKeyboard()
 end
 
-function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitive)
+function ReaderSearch:onShowSearchDialog(text, direction, search_type, case_insensitive)
     local zoom_to_page = G_reader_settings:isTrue("fulltext_search_zoom_to_page")
     local neglect_current_location = false
     local current_page
@@ -345,7 +417,7 @@ function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitiv
                 self.ui.paging:enterSkimMode() -- "page" view
             end
             local no_results = true -- for notification
-            local res = search_func(self, search_term, param, regex, case_insensitive)
+            local res = search_func(self, search_term, param, search_type, case_insensitive)
             if res then
                 if self.ui.paging then
                     if not current_page then -- initial search
@@ -453,6 +525,7 @@ function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitiv
     self.wait_button = ButtonDialog:new{
         buttons = {{{ text = "⌛" }}},
     }
+    local regex = search_type.regex
     local function search(func, pattern, param)
         if regex and isSlowRegex(pattern) then
             return function()
@@ -537,24 +610,27 @@ function ReaderSearch:onShowSearchDialog(text, direction, regex, case_insensitiv
     return true
 end
 
--- if regex == true, use regular expression in pattern
 -- if case == true or nil, the search is case insensitive
-function ReaderSearch:search(pattern, origin, regex, case_insensitive)
+function ReaderSearch:search(pattern, origin, search_type, case_insensitive)
     logger.dbg("search pattern", pattern)
     local direction = self.direction
     local page = self.view.state.page
     if case_insensitive == nil then
         case_insensitive = true
     end
+    -- (search_type should be provided all along this module, but
+    -- unit tests don't: fallback for them to legacy search)
+    local search_flags = search_type and search_type.flags or 0x0000
+    local regex = search_type and search_type.regex or false
     Device:setIgnoreInput(true)
-    local retval, words_found = self.ui.document:findText(pattern, origin, direction, case_insensitive, page, regex, self.max_hits)
+    local retval, words_found = self.ui.document:findText(pattern, origin, direction, case_insensitive, page, regex, self.max_hits, search_flags)
     Device:setIgnoreInput(false)
     self:showErrorNotification(words_found, regex, self.max_hits)
     return retval
 end
 
 function ReaderSearch:showErrorNotification(words_found, regex, max_hits)
-    regex = regex or self.use_regex
+    regex = regex or self.current_search_type.regex
     max_hits = max_hits or self.findall_max_hits
     local regex_retval = regex and self.ui.document:getAndClearRegexSearchError()
     if regex and regex_retval ~= 0 then
@@ -576,33 +652,36 @@ function ReaderSearch:showErrorNotification(words_found, regex, max_hits)
     end
 end
 
-function ReaderSearch:searchFromStart(pattern, _, regex, case_insensitive)
+function ReaderSearch:searchFromStart(pattern, _, search_type, case_insensitive)
     self.direction = 0
     self._expect_back_results = true
-    return self:search(pattern, -1, regex, case_insensitive)
+    return self:search(pattern, -1, search_type, case_insensitive)
 end
 
-function ReaderSearch:searchFromEnd(pattern, _, regex, case_insensitive)
+function ReaderSearch:searchFromEnd(pattern, _, search_type, case_insensitive)
     self.direction = 1
     self._expect_back_results = false
-    return self:search(pattern, -1, regex, case_insensitive)
+    return self:search(pattern, -1, search_type, case_insensitive)
 end
 
-function ReaderSearch:searchFromCurrent(pattern, direction, regex, case_insensitive)
+function ReaderSearch:searchFromCurrent(pattern, direction, search_type, case_insensitive)
     self.direction = direction
     self._expect_back_results = direction == 1
-    return self:search(pattern, 0, regex, case_insensitive)
+    return self:search(pattern, 0, search_type, case_insensitive)
 end
 
 -- ignore current page and search next occurrence
-function ReaderSearch:searchNext(pattern, direction, regex, case_insensitive)
+function ReaderSearch:searchNext(pattern, direction, search_type, case_insensitive)
     self.direction = direction
     self._expect_back_results = direction == 1
-    return self:search(pattern, 1, regex, case_insensitive)
+    return self:search(pattern, 1, search_type, case_insensitive)
 end
 
 function ReaderSearch:findAllText(search_text)
-    local last_search_hash = (self.last_search_text or "") .. tostring(self.case_insensitive) .. tostring(self.use_regex)
+    local search_flags = self.current_search_type.flags
+    local use_regex = self.current_search_type.regex
+    local last_search_hash = (self.last_search_text or "") .. tostring(self.case_insensitive) ..
+                                tostring(search_flags) .. tostring(use_regex)
     local not_cached = self.last_search_hash ~= last_search_hash
     if not_cached then
         local Trapper = require("ui/trapper")
@@ -611,7 +690,7 @@ function ReaderSearch:findAllText(search_text)
         UIManager:forceRePaint()
         local completed, res = Trapper:dismissableRunInSubprocess(function()
             return self.ui.document:findAllText(search_text,
-                self.case_insensitive, self.findall_nb_context_words, self.findall_max_hits, self.use_regex)
+                self.case_insensitive, self.findall_nb_context_words, self.findall_max_hits, use_regex, search_flags)
         end, info)
         if not completed then return end
         UIManager:close(info)

--- a/frontend/apps/reader/modules/readertypography.lua
+++ b/frontend/apps/reader/modules/readertypography.lua
@@ -76,6 +76,7 @@ local LANGUAGES = {
     { "lv",               {"lav"},   "H   ",   _("Latvian"),                "Latvian.pattern" },
     { "lt",               {"lit"},   "H   ",   _("Lithuanian"),             "Lithuanian.pattern" },
     { "mk",                  {""},   "H   ",   _("Macedonian"),             "Macedonian.pattern" },
+    { "ml",               {"mal"},   "H   ",   _("Malayalam"),              "Malayalam.pattern" },
     { "no",               {"nor"},   "H   ",   _("Norwegian"),              "Norwegian.pattern" },
     { "oc",               {"oci"},   "H   ",   _("Occitan"),                "Occitan.pattern" },
     { "pl",               {"pol"},   "HB  ",   _("Polish"),                 "Polish.pattern" },

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1434,14 +1434,14 @@ function CreDocument:getAndClearRegexSearchError()
     return retval
 end
 
-function CreDocument:findText(pattern, origin, direction, case_insensitive, page, regex, max_hits)
-    logger.dbg("CreDocument: find text", pattern, origin, direction == 1, case_insensitive, regex, max_hits)
-    return self._document:findText(pattern, origin, direction == 1, case_insensitive, regex, max_hits)
+function CreDocument:findText(pattern, origin, direction, case_insensitive, page, regex, max_hits, search_flags)
+    logger.dbg("CreDocument: find text", pattern, origin, direction == 1, case_insensitive, regex, max_hits, search_flags)
+    return self._document:findText(pattern, origin, direction == 1, case_insensitive, regex, max_hits, search_flags)
 end
 
-function CreDocument:findAllText(pattern, case_insensitive, nb_context_words, max_hits, regex)
-    logger.dbg("CreDocument: find all text", pattern, case_insensitive, regex, max_hits, true, nb_context_words)
-    return self._document:findAllText(pattern, case_insensitive, regex, max_hits, true, nb_context_words)
+function CreDocument:findAllText(pattern, case_insensitive, nb_context_words, max_hits, regex, search_flags)
+    logger.dbg("CreDocument: find all text", pattern, case_insensitive, regex, max_hits, true, nb_context_words, search_flags)
+    return self._document:findAllText(pattern, case_insensitive, regex, max_hits, true, nb_context_words, search_flags)
 end
 
 function CreDocument:enableInternalHistory(toggle)


### PR DESCRIPTION
#### bump base: ffi-cdecl and ffi tweaks and updates

Also:
- ffi/loadlib: fix loading SSL library in monolibtic mode
- ci/circle: bump docker images (new ffi-cdecl version)
- ffi/zstd: allow setting compression level
- ffi/hashoir: new module for hashing memory
- ffi/util: add bidirectional support to `runInSubProcess`
- utils: improve `inkview_h` generator script

(Too many PRs to add links to each of them :/ :))

#### bump crengine: enhanced findText(); Malayalam hypnehation

Includes:
- TextLang, hyphenation: add Malayalam (ml) https://github.com/koreader/crengine/pull/672
- https://github.com/koreader/crengine/pull/673
  - `findText()`: return list of ldomXRange instead of ldomWord
  - `findText()`: implement tweakable enhanced search
- https://github.com/koreader/koreader-base/pull/2411
  - cre.cpp findText() and findAllText():
    Updated to handle returned ldomXRange instead of ldomWord,
    and added optional searchFlags params.

ReaderTypography: add Malayalam to the list of supported languages.

#### ReaderSearch: enhanced search on CreDocuments

See https://github.com/koreader/koreader/issues/10366#issuecomment-4642735530 (flags re-ordered since this post - don't trust them there).

I settled on:
<img width="544" height="245" alt="image" src="https://github.com/user-attachments/assets/3725c972-943e-4424-8d64-a09f256b66ec" />

2 others commented out would give:
<img width="546" height="313" alt="image" src="https://github.com/user-attachments/assets/6957ab49-e2aa-42e0-b40d-b91fbfae91a7" />

```lua
    -- For CreDocuments, different search features are available:
    -- Enhanced search flags:
    --   MATCH_ACROSS_TEXT_NODES     = 0x0001
    --   COLLAPSE_CONSECUTIVE_SPACES = 0x0002
    --   NORMALIZE_CANONICAL         = 0x0004
    --   NORMALIZE_COMPATIBILITY     = 0x0008
    --   IGNORE_FORMAT_CONTROL_CHARS = 0x0010
    --   FOLD_SPACES                 = 0x0020
    --   FOLD_APOSTROPHES            = 0x0040
    --   FOLD_HYPHENS                = 0x0080
    --   IGNORE_DIACRITICS           = 0x0100
    -- Make a few types of search available as radion buttons
    -- (These are available to be updated/extended by user-patches)
    search_types = {
        -- Title of the radio button , search_flags, use_regex
        { _("Ignore accents / stress marks"), 0x01FF, false },
        -- { _("As typed"), 0x0017, false },
        -- { _("Legacy search"), 0x0000, false },
        { _("Regular expression (long-press for help)"), 0x0001, true },
    },
    default_search_type = { "", 0x00FF, false }, -- Most except IGNORE_DIACRITICS
```

These Radio buttons (each setting a set of flags) are mutually exclusive, but they can also be all unchecked (in which case, we use the defaults we seem to have all agreed on). `Case insensitive` is an independant one that works with all others (and the default of none).
**Should they be squared checkboxes ?**

**Also, I'm not sure about `Ignore accents / stress marks`** (that's what tha AI spits out reading the issue), they are technically diacritics / combined marks. They could also be vowels in arabic I think. Any better wording for this one (I think it should keep "ignore accents" as that speaks to most western people).


Closes https://github.com/koreader/koreader/issues/10366
Closes https://github.com/koreader/koreader/issues/13250
Closes https://github.com/koreader/koreader-base/issues/2126

(ReaderSearch is quite nightmarish, grad I could just hijack the passing of use_regex and have it working as it did, but it's quite hard to follow...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15543)
<!-- Reviewable:end -->
