### PR TITLE
[ReaderKeySelection] NT: add indicator overlay

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1896,8 +1896,8 @@ function ReaderHighlight:onHoldPan(_, ges)
         self.view.highlight.temp[self.hold_pos.page] = self.selected_text.sboxes
     end
     -- Ensure indicator overlay does not restore stale background over updated highlights.
-    if self.ui.keyselection._indicator_overlay then
-        self.ui.keyselection._indicator_overlay:freeSavedBB()
+    if self.ui.keyselection:isActive() then
+        self.ui.keyselection:clearOverlay()
     end
     UIManager:setDirty(self.dialog, "ui")
 end

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1895,6 +1895,10 @@ function ReaderHighlight:onHoldPan(_, ges)
     if self.ui.paging and self.selected_text then
         self.view.highlight.temp[self.hold_pos.page] = self.selected_text.sboxes
     end
+    -- Ensure indicator overlay does not restore stale background over updated highlights.
+    if self.ui.keyselection._indicator_overlay then
+        self.ui.keyselection._indicator_overlay:freeSavedBB()
+    end
     UIManager:setDirty(self.dialog, "ui")
 end
 

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local Blitbuffer = require("ffi/blitbuffer")
 local Device = require("device")
 local DoubleSpinWidget = require("ui/widget/doublespinwidget")
 local Geom = require("ui/geometry")
@@ -21,6 +22,127 @@ local math_abs = math.abs
 local math_max = math.max
 local math_min = math.min
 local math_floor = math.floor
+
+-- Minimal overlay that draws the crosshairs without touching the document
+-- render layer. Captures the page as its background on first paint, then
+-- restores only the previous indicator region before drawing the new one.
+local IndicatorOverlay = InputContainer:extend{
+    parent_ui = nil,
+    handleEvent = true,
+    indicator_rect = nil,
+    _prev_rect     = nil,
+    _saved_bb      = nil,
+    covers_fullscreen = false,
+}
+
+local function getIndicatorSaveRect(rect, max_w, max_h)
+    if not rect then return nil end
+    local save_r = rect:copy()
+    local bt2 = math_floor(Size.border.thick / 2)
+    save_r.x = math_floor(save_r.x - bt2)
+    save_r.y = math_floor(save_r.y - bt2)
+    save_r.w = save_r.w + Size.border.thick * 2
+    save_r.h = save_r.h + Size.border.thick * 2
+    save_r = save_r:intersect(Geom:new{ x = 0, y = 0, w = max_w, h = max_h })
+    if not save_r or save_r.w <= 0 or save_r.h <= 0 then
+        return nil
+    end
+    return save_r
+end
+
+local function getIndicatorDirtyRect(old_rect, new_rect, max_w, max_h)
+    local old_save = getIndicatorSaveRect(old_rect, max_w, max_h)
+    local new_save = getIndicatorSaveRect(new_rect, max_w, max_h)
+    if old_save and new_save then
+        return Geom.boundingBox({ old_save, new_save })
+    end
+    return old_save or new_save
+end
+
+function IndicatorOverlay:freeSavedBB()
+    if self._saved_bb then
+        self._saved_bb:free()
+        self._saved_bb = nil
+    end
+    self._prev_rect = nil
+end
+
+function IndicatorOverlay:handleEvent(event)
+    if not event or not event.handler then return false end
+    -- Only forward input events that would otherwise be swallowed by us, being
+    -- the topmost layer. Broadcast events reach parent_ui directly via UIManager.
+    local input_events = {
+        onKeyPress = true,
+        onKeyRepeat = true,
+        onKeyRelease = true,
+        -- onGesture = true,
+    }
+    if input_events[event.handler] and self.parent_ui then
+        return self.parent_ui:handleEvent(event)
+    end
+    return false
+end
+
+function IndicatorOverlay:drawCrosshairs(bb, rect)
+    if not rect then return end
+    bb:invertRect(
+        rect.x,
+        math.floor(rect.y + rect.h / 2 - Size.border.thick / 2),
+        rect.w,
+        Size.border.thick
+    )
+    bb:invertRect(
+        math.floor(rect.x + rect.w / 2 - Size.border.thick / 2),
+        rect.y,
+        Size.border.thick,
+        rect.h
+    )
+end
+
+function IndicatorOverlay:getSize()
+    return self.dimen or Screen:getSize()
+end
+
+function IndicatorOverlay:paintTo(bb, x, y, is_dirty)
+    -- If is_dirty is nil, the parent ReaderUI painted over us with new content.
+    -- The background we saved is now invalid, so we clear it.
+    if is_dirty == nil then
+        self:freeSavedBB()
+    end
+
+    -- Restore previous unblemished page background
+    if self._prev_rect and self._saved_bb then
+        local r = self._prev_rect
+        bb:blitFrom(self._saved_bb, r.x, r.y, 0, 0, r.w, r.h)
+    end
+
+    if self.indicator_rect then
+        local r = self.indicator_rect
+        local save_r = getIndicatorSaveRect(r, bb:getWidth(), bb:getHeight())
+        if save_r and self.dimen then
+            save_r = save_r:intersect(self.dimen)
+        end
+        if not save_r or save_r.w <= 0 or save_r.h <= 0 then
+            self._prev_rect = nil
+            return
+        end
+
+        -- Resize the saved Blitbuffer if necessary
+        if not self._saved_bb or self._saved_bb:getWidth() < save_r.w or self._saved_bb:getHeight() < save_r.h then
+            self:freeSavedBB()
+            self._saved_bb = Blitbuffer.new(save_r.w, save_r.h, bb:getType())
+        end
+
+        -- Copy clean background from screen
+        self._saved_bb:blitFrom(bb, 0, 0, save_r.x, save_r.y, save_r.w, save_r.h)
+
+        -- Draw the crosshair natively overriding the background
+        self:drawCrosshairs(bb, self.indicator_rect)
+        self._prev_rect = save_r
+    else
+        self._prev_rect = nil
+    end
+end
 
 local ReaderKeySelection = InputContainer:extend{}
 
@@ -48,6 +170,11 @@ end
 
 function ReaderKeySelection:onSetDimensions(dimen)
     self.screen_w, self.screen_h = dimen.w, dimen.h
+    if self._indicator_overlay then
+        local overlay_rect = getIndicatorSaveRect(self._current_indicator_pos, dimen.w, dimen.h)
+        self._indicator_overlay.dimen = overlay_rect or Geom:new{ x = 0, y = 0, w = dimen.w, h = dimen.h }
+        self._indicator_overlay:freeSavedBB()
+    end
 end
 
 function ReaderKeySelection:registerKeyEvents()
@@ -243,10 +370,24 @@ function ReaderKeySelection:startHighlightIndicator()
             rect.h = rect.w
         end
         self._current_indicator_pos = rect
+
+        -- Compute padded saved region (match paintTo padding)
+        local max_w = self.screen_w or Screen:getWidth()
+        local max_h = self.screen_h or Screen:getHeight()
+        local save_r = getIndicatorSaveRect(rect, max_w, max_h)
+        -- Fallback to minimal rect if intersection collapsed
+        if not save_r then
+            save_r = Geom:new{ x = math.floor(rect.x), y = math.floor(rect.y), w = rect.w, h = rect.h }
+        end
+        self._indicator_overlay = IndicatorOverlay:new{
+            dimen = Geom:new{ x = save_r.x, y = save_r.y, w = save_r.w, h = save_r.h },
+            parent_ui = self.ui,
+        }
+        UIManager:show(self._indicator_overlay)
         if self.ui.paging then
             self._last_indicator_move_args = {dx = 0, dy = 0, distance = 0, time = time:now()}
-            self.view.highlight.indicator = rect
-            UIManager:setDirty(self.dialog, "ui", rect)
+            self._indicator_overlay.indicator_rect = rect
+            UIManager:setDirty(self._indicator_overlay, "ui", rect)
             return true
         end
         local center_x = rect.x + rect.w * 0.5
@@ -285,6 +426,11 @@ function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
     self._edge_dx, self._edge_dy = nil, nil
     self._last_move_was_quick_move = nil
     self._previous_indicator_word = nil
+    if self._indicator_overlay then
+        self._indicator_overlay:freeSavedBB()
+        UIManager:close(self._indicator_overlay)
+        self._indicator_overlay = nil
+    end
     self._last_indicator_move_args = nil
     UIManager:setDirty(self.dialog, "ui", rect)
     if need_clear_selection then
@@ -421,6 +567,14 @@ function ReaderKeySelection:pageTurnDuringSelection()
     self._edge_dx, self._edge_dy = nil, nil
     self._previous_indicator_word = nil
     local last_pos = self._current_indicator_pos
+    if self._indicator_overlay then
+        local old_dirty = getIndicatorSaveRect(last_pos, self.screen_w, self.screen_h)
+        self._indicator_overlay:freeSavedBB()
+        self._indicator_overlay.indicator_rect = nil
+        if old_dirty then
+            UIManager:setDirty(self.dialog, "ui", old_dirty)
+        end
+    end
     local target_x = last_pos.x + last_pos.w * 0.5
     local target_y = last_pos.y + last_pos.h * 0.5
 
@@ -577,10 +731,21 @@ function ReaderKeySelection:_setIndicatorToWord(word)
 end
 
 function ReaderKeySelection:_setIndicatorRect(rect)
-    UIManager:setDirty(self.dialog, "fast", self._current_indicator_pos)
+    local old_rect = self._current_indicator_pos
     self._current_indicator_pos = rect
-    self.view.highlight.indicator = self._current_indicator_pos
-    UIManager:setDirty(self.dialog, "fast", self._current_indicator_pos)
+    if not self._indicator_overlay then
+        logger.warn("ReaderKeySelection: _setIndicatorRect: no overlay")
+        return
+    end
+    logger.dbg("ReaderKeySelection: _setIndicatorRect: dirtying overlay, rect=", rect)
+    self._indicator_overlay.indicator_rect = rect
+    local dirty = getIndicatorDirtyRect(old_rect, rect, self.screen_w, self.screen_h)
+    if dirty then
+        self._indicator_overlay.dimen = dirty
+        UIManager:setDirty(self._indicator_overlay, "fast", dirty)
+    else
+        UIManager:setDirty(self._indicator_overlay, "fast", rect)
+    end
 end
 
 function ReaderKeySelection:_getWordAnchorCoordinates(word)

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -75,7 +75,8 @@ function IndicatorOverlay:handleEvent(event)
         onKeyPress = true,
         onKeyRepeat = true,
         onKeyRelease = true,
-        -- onGesture = true,
+        onGesture = true,
+        onPan = true, -- mouse wheel pan via sendEvent
     }
     if input_events[event.handler] and self.parent_ui then
         return self.parent_ui:handleEvent(event)

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -356,6 +356,11 @@ function ReaderKeySelection:isActive()
     return self._current_indicator_pos ~= nil
 end
 
+function ReaderKeySelection:clearOverlay()
+    if not self._indicator_overlay then return end
+    self._indicator_overlay:freeSavedBB()
+end
+
 function ReaderKeySelection:startHighlightIndicator()
     -- disable long-press icon (poke-ball), as it is triggered constantly due to NT devices needing a workaround for text selection to work.
     self.ui.highlight.long_hold_reached_action = function() end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -100,7 +100,6 @@ function ReaderView:init()
         saved_drawer = "lighten",
         -- NOTE: Unfortunately, yellow tends to look like absolute ass on Kaleido panels...
         saved_color = Screen:isColorEnabled() and "yellow" or "gray",
-        indicator = nil, -- geom: non-touch highlight position indicator: {x = 50, y=50}
     }
     self.page_states = {}
     self.page_gap = {
@@ -243,10 +242,6 @@ function ReaderView:paintTo(bb, x, y)
     -- draw temporary highlight
     if self.highlight.temp and next(self.highlight.temp) then
         self:drawTempHighlight(bb, x, y)
-    end
-    -- draw highlight position indicator for non-touch
-    if self.highlight.indicator then
-        self:drawHighlightIndicator(bb, x, y)
     end
     -- paint dogear
     if self.dogear_visible then
@@ -505,23 +500,6 @@ function ReaderView:drawScrollView(bb, x, y)
         y + self.state.offset.y,
         self.visible_area,
         self.state.pos)
-end
-
-function ReaderView:drawHighlightIndicator(bb, x, y)
-    local rect = self.highlight.indicator
-    -- paint big cross line +
-    bb:paintRect(
-        rect.x,
-        rect.y + rect.h / 2 - Size.border.thick / 2,
-        rect.w,
-        Size.border.thick
-    )
-    bb:paintRect(
-        rect.x + rect.w / 2 - Size.border.thick / 2,
-        rect.y,
-        Size.border.thick,
-        rect.h
-    )
 end
 
 function ReaderView:drawTempHighlight(bb, x, y)


### PR DESCRIPTION
### what's new

- Added a new `IndicatorOverlay` class in `readerkeyselection.lua` that is responsible for rendering the highlight indicator crosshairs independently of the main document layer. This overlay captures the relevant region of the page as its background and restores only the necessary area when redrawing the indicator, minimising expensive calls to `drawCurrentView`. 

- Removed the indicator rendering logic from `ReaderView`, including the `highlight.indicator` property and the `drawHighlightIndicator` method, and moved all indicator drawing responsibilities to the new overlay. 
- Updated the highlight indicator's lifecycle: creation, update, and removal are now managed through the overlay, with appropriate cleanup and UI invalidation to avoid leaving stale graphics. 

- Ensured that the overlay's saved background is freed and refreshed whenever the underlying content changes or the overlay is moved, preventing the restoration of outdated visuals.

These changes significantly improve usage and speed on older hardware, top to bottom traversal is almost halved using this overlay vs going through `readerview` (3.x secs vs 6.x secs).

Benchmarks with overlay found https://github.com/koreader/koreader/pull/15377#issuecomment-4498845797 and https://github.com/koreader/koreader/pull/15377#issuecomment-4519515984
and without overlay https://github.com/koreader/koreader/pull/15377#issuecomment-4482402671

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15547)
<!-- Reviewable:end -->
