### PR TITLE
android: add Nook Glowlight 4 Plus (bnrv1300) lights support

### DIFF
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -137,7 +137,11 @@ end
 
 function Device:init()
     self.screen = require("ffi/framebuffer_android"):new{device = self, debug = logger.dbg}
-    self.powerd = require("device/android/powerd"):new{device = self}
+    self.powerd = require("device/android/powerd"):new{
+        device = self,
+        -- GL4 Plus sysfs warmth node resets on every app start/resume
+        volatile_warmth = android.prop.model == "bnrv1300",
+    }
 
     local event_map = dofile("frontend/device/android/event_map.lua")
 
@@ -177,6 +181,12 @@ function Device:init()
             elseif ev.code == C.APP_CMD_RESUME then
                 if not android.prop.brokenLifecycle then
                     UIManager:broadcastEvent(Event:new("Resume"))
+                end
+                if this.device:hasNaturalLight() and this.device.powerd.volatile_warmth then
+                    local powerd = this.device.powerd
+                    if powerd.fl_warmth and powerd.fl_warmth > 0 then
+                        android.setScreenWarmth(powerd:toNativeWarmth(powerd.fl_warmth))
+                    end
                 end
                 if external.when_back_callback then
                     external.when_back_callback()

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -4,6 +4,9 @@ local _, android = pcall(require, "android")
 local AndroidPowerD = BasePowerD:new{
     fl_min = 0,
     fl_max = 100,
+    -- Set to true on devices whose sysfs warmth node resets on every app start/resume
+    -- (e.g. Nook GL4 Plus). Enables restore-on-init and per-change flush for crash safety.
+    volatile_warmth = false,
 }
 
 function AndroidPowerD:frontlightIntensityHW()
@@ -34,11 +37,25 @@ function AndroidPowerD:init()
         self.fl_warmth_min = android.getScreenMinWarmth()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
+        if self.volatile_warmth then
+            -- Warmth node resets on every app start; restore the saved value now
+            -- so frontlightWarmthHW() returns the correct state immediately.
+            local saved = G_reader_settings:readSetting("frontlight_warmth") or 0
+            if saved > 0 then
+                android.setScreenWarmth(math.floor(saved * self.warm_diff / 100))
+            end
+        end
     end
 end
 
 function AndroidPowerD:setWarmthHW(warmth)
     android.setScreenWarmth(warmth)
+    if self.volatile_warmth and self.fl_warmth then
+        -- Flush immediately so the value survives a process kill before the
+        -- normal settings flush on exit (needed for the restore-on-init path).
+        G_reader_settings:saveSetting("frontlight_warmth", self.fl_warmth)
+        G_reader_settings:flush()
+    end
 end
 
 function AndroidPowerD:frontlightWarmthHW()


### PR DESCRIPTION
Adds brightness and warmth (colour temperature) support for the Nook Glowlight 4 Plus (bnrv1300, Android 8.1).

**Depends on:** android-luajit-launcher [#596](https://github.com/koreader/android-luajit-launcher/pull/596) (EPD thread-safety fix) and [#592](https://github.com/koreader/android-luajit-launcher/pull/592) (NookEmperorEPDController).
Also see koreader #15563 (submodule bump for the EPD fix).

## Implementation

**Brightness** — `Settings.System.SCREEN_BRIGHTNESS` (same approach as `TolinoNtxController`).
Requires the "Modify system settings" special app permission:
```
adb shell appops set org.koreader.launcher WRITE_SETTINGS allow
```

**Warmth** — `com.nook.partner GlowLightService` (exported, no new permissions, no root).
Sends `action_set_color_temperature` on a 0–100 scale; the service rescales ÷10 for the lm3630a hardware and applies it under its own `DEVICE_POWER` privilege.

**Volatile warmth** — the lm3630a warmth register resets on every app start and resume. `volatile_warmth = true` in `AndroidPowerD` enables restore-on-init and a per-change settings flush so the value survives a process kill.

## Hardware ranges
- Brightness: 0–100 (`/sys/class/backlight/lm3630a_led/max_brightness`)
- Warmth: 0–10 (`/sys/class/backlight/lm3630a_led/max_color`)

Fixes https://github.com/koreader/koreader/issues/14574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15561)
<!-- Reviewable:end -->
