### PR TITLE
fix(kindle): prevent crash in getNetworkList when currentEssid access fails

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -483,7 +483,7 @@ function Kindle:initNetworkManager(NetworkMgr)
 
         local network_list = {}
         local saved_profiles = kindleGetSavedNetworks()
-        local current_profile = kindleGetCurrentProfile()
+        local current_profile = kindleGetCurrentProfile() or {}
         for _, network in ipairs(scan_list) do
             local password = nil
             if network.known == "yes" then


### PR DESCRIPTION
### Description
A crash occurs on Kindle devices when the LIPC backend cannot retrieve the current Wi‑Fi profile. `kindleGetCurrentProfile()` now returns `nil` on failure, but `NetworkMgr:getNetworkList()` still indexes the result, causing:

```
attempt to index local 'current_profile' (a nil value)
```
### Root Cause
1. **#14817** added `pcall` around the LIPC query, so the function returns `nil` and logs a warning when the query fails.
2. `NetworkMgr:getNetworkList()` accesses `current_profile.netid` and `current_profile.essid` without checking for `nil`.

### Solution
Default `current_profile` to an empty table if `kindleGetCurrentProfile()` returns `nil`:

`local current_profile = kindleGetCurrentProfile() or {}`

## Testing
I have tested this change on a Kindle PW3 for **one week** with the following scenarios and observed no further crashes:
1. **Wi‑Fi disabled** – No crash; `NetworkMgr:getNetworkList()` returns an empty list.
2. **Wi‑Fi enabled** – Network list is populated as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15567)
<!-- Reviewable:end -->
