### PR TITLE
screensaver: add option for extra refreshes to avoid sleep screen ghosting

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -36,6 +36,8 @@ local Device = {
     -- For Kobo, wait at least 15 seconds before calling suspend script. Otherwise, suspend might
     -- fail and the battery will be drained while we are in screensaver mode
     suspend_wait_timeout = 15,
+    -- Bumped when screensaver_extra_flash is enabled, to account for ~2s of extra refresh activity
+    suspend_wait_timeout_extra_flash = 17,
 
     -- hardware feature tests: (these are functions!)
     hasBattery = yes,

--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -22,6 +22,14 @@ local eink_settings_table = {
                 G_reader_settings:flipNilOrFalse("avoid_flashing_ui")
             end,
         },
+        {
+            text = _("Double flash sleep screen"),
+            help_text = _("Flash the sleep screen twice after it is shown to reduce ghosting. May not be needed on all devices."),
+            checked_func = function() return G_reader_settings:isTrue("screensaver_extra_flash") end,
+            callback = function()
+                G_reader_settings:flipNilOrFalse("screensaver_extra_flash")
+            end,
+        },
     },
 }
 

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -659,6 +659,16 @@ function Screensaver:show()
         self.screensaver_widget.dithered = true
 
         UIManager:show(self.screensaver_widget, "full")
+        if G_reader_settings:isTrue("screensaver_extra_flash") then
+            Device.suspend_wait_timeout = Device.suspend_wait_timeout_extra_flash
+            local screen_w2, screen_h2 = Screen:getWidth(), Screen:getHeight()
+            UIManager:scheduleIn(0.5, function()
+                Screen:refreshFull(0, 0, screen_w2, screen_h2)
+            end)
+            UIManager:scheduleIn(1.5, function()
+                Screen:refreshFull(0, 0, screen_w2, screen_h2)
+            end)
+        end
     end
 
     -- Setup the gesture lock through an additional invisible widget, so that it works regardless of the configuration.


### PR DESCRIPTION
Fixes discussion #12950. https://github.com/koreader/koreader/discussions/12950.

Flashes black then white before showing the cover, matching native Kobo behavior. 

I tested it in my Kobo Libra 2 and it's at least as good (ghosting wise) as the default Kobo OS. Much better than Koreader before.

Potentially fixes https://github.com/koreader/koreader/issues/14687 but I do not have a kindle to test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15568)
<!-- Reviewable:end -->
