### PR TITLE
kindle: fix issues when running from nonstandard location

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -2,7 +2,9 @@
 
 export LC_ALL="en_US.UTF-8"
 
-UNPACK_DIR='/mnt/us'
+if [ ! -n "${UNPACK_DIR+x}" ]; then
+    UNPACK_DIR='/mnt/us'
+fi
 # KOReader's working directory.
 KOREADER_DIR="${UNPACK_DIR}/koreader"
 
@@ -260,9 +262,9 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
                 # FIXME: There's apparently a nasty side-effect on FW >= 5.12.4 which somehow softlocks the UI on exit (despite wmctrl succeeding). Don't have the HW to investigate, so, just drop it. (#6117)
                 if [ "$(version "${FW_VERSION}")" -lt "$(version "5.12.4")" ]; then
                     logmsg "Hiding the title bar . . ."
-                    TITLEBAR_GEOMETRY="$(${KOREADER_DIR}/wmctrl -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')"
-                    ${KOREADER_DIR}/wmctrl -r ":titleBar_ID:" -e "${TITLEBAR_GEOMETRY%,*},1"
-                    logmsg "Title bar geometry: '${TITLEBAR_GEOMETRY}' -> '$(${KOREADER_DIR}/wmctrl -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')'"
+                    TITLEBAR_GEOMETRY="$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')"
+                    "${KOREADER_DIR}/wmctrl" -r ":titleBar_ID:" -e "${TITLEBAR_GEOMETRY%,*},1"
+                    logmsg "Title bar geometry: '${TITLEBAR_GEOMETRY}' -> '$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')'"
                     USED_WMCTRL="yes"
                 fi
                 if [ "${FROM_KUAL}" = "yes" ]; then
@@ -396,17 +398,17 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
         # NOTE: Wait and retry for a bit, because apparently there may be timing issues (c.f., #5990)?
         usleep 250000
         WMCTRL_COUNT=0
-        until [ "$(${KOREADER_DIR}/wmctrl -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')" = "${TITLEBAR_GEOMETRY}" ]; do
+        until [ "$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')" = "${TITLEBAR_GEOMETRY}" ]; do
             # Abort after 5s
             if [ ${WMCTRL_COUNT} -gt 20 ]; then
                 log "Giving up on restoring the title bar geometry!"
                 break
             fi
-            ${KOREADER_DIR}/wmctrl -r ":titleBar_ID:" -e "${TITLEBAR_GEOMETRY}"
+            "${KOREADER_DIR}/wmctrl" -r ":titleBar_ID:" -e "${TITLEBAR_GEOMETRY}"
             usleep 250000
             WMCTRL_COUNT=$((WMCTRL_COUNT + 1))
         done
-        logmsg "Title bar geometry restored to '$(${KOREADER_DIR}/wmctrl -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')' (ought to be: '${TITLEBAR_GEOMETRY}') [after ${WMCTRL_COUNT} attempts]"
+        logmsg "Title bar geometry restored to '$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')' (ought to be: '${TITLEBAR_GEOMETRY}') [after ${WMCTRL_COUNT} attempts]"
     fi
 fi
 

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -2,11 +2,11 @@
 
 export LC_ALL="en_US.UTF-8"
 
-if [ ! -n "${UNPACK_DIR+x}" ]; then
-    UNPACK_DIR='/mnt/us'
-fi
-# KOReader's working directory.
-KOREADER_DIR="${UNPACK_DIR}/koreader"
+# Compute our working directory in an extremely defensive manner
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
+# NOTE: We need to remember the *actual* KOREADER_DIR, not the relocalized version in /tmp...
+export KOREADER_DIR="${KOREADER_DIR:-${SCRIPT_DIR}}"
+UNPACK_DIR="${KOREADER_DIR%/*}"
 
 # NOTE: Stupid workaround to make sure the script we end up running is a *copy*,
 # living in a magical land that doesn't suffer from gross filesystem deficiencies.

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -21,6 +21,7 @@ if [ "$(dirname "${0}")" != "/var/tmp" ]; then
     exec /var/tmp/koreader.sh "$@"
 fi
 
+# We rely on starting from our working directory, and it needs to be set, sane and absolute.
 cd "${KOREADER_DIR:-/dev/null}" || exit
 
 PROC_KEYPAD="/proc/keypad"

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -21,6 +21,8 @@ if [ "$(dirname "${0}")" != "/var/tmp" ]; then
     exec /var/tmp/koreader.sh "$@"
 fi
 
+cd "${KOREADER_DIR:-/dev/null}" || exit
+
 PROC_KEYPAD="/proc/keypad"
 PROC_FIVEWAY="/proc/fiveway"
 [ -e "${PROC_KEYPAD}" ] && echo unlock >"${PROC_KEYPAD}"


### PR DESCRIPTION
Fixes issues when KOReader is installed in a location other than `/mnt/us/koreader`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15579)
<!-- Reviewable:end -->
