### PR TITLE
minor wording and button corrections

### DIFF
--- a/frontend/apps/reader/modules/readerstatus.lua
+++ b/frontend/apps/reader/modules/readerstatus.lua
@@ -149,7 +149,7 @@ function ReaderStatus:onEndOfBook()
     elseif settings == "mark_read" then
         self:markBook(true)
         UIManager:show(InfoMessage:new{
-            text = _("You've reached the end of the document.\nThe current book is marked as finished."),
+            text = _("You've reached the end of the document.\nThe current book has been marked as finished."),
             timeout = 3
         })
     elseif settings == "book_status_file_browser" then

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -621,7 +621,9 @@ function WordInfoDialog:init()
     }
 
     table.insert(self.layout, {copy_button})
-    table.insert(self.layout, {self.book_title_button})
+    if self.vocabbuilder then
+        table.insert(self.layout, {self.book_title_button})
+    end
     self:mergeLayoutInVertical(focus_button)
 
     local has_context = self.prev_context or self.next_context


### PR DESCRIPTION
### what's new

  * Updated the end-of-book message in `ReaderStatus:onEndOfBook()` to use clearer language: "The current book has been marked as finished."

  * Modified the Vocab Builder plugin to only add the `book_title_button` to the layout if `vocabbuilder` is available.
  
https://github.com/koreader/koreader/blob/896646bf8bb00ef2dcc1fb2ed338d63e311f1a0c/plugins/vocabbuilder.koplugin/main.lua#L612-L619

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15582)
<!-- Reviewable:end -->
