### PR TITLE
move kosync plugin settings into a separate file

### DIFF
--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20260517
+local CURRENT_MIGRATION_DATE = 202606023
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -1010,6 +1010,29 @@ if last_migration_date < 20260517 then
         })
         settings:flush()
     end
+end
+
+-- 20260623, Move Kosync plugin settings into a separate file
+if last_migration_date < 20260623 then
+    logger.info("Performing one-time migration for 20260623")
+    -- c.f., PluginLoader
+    local package_path = package.path
+    package.path = string.format("%s/?.lua;%s", "plugins/kosync.koplugin", package_path)
+    local ok, KOSync = pcall(dofile, "plugins/kosync.koplugin/main.lua")
+    package.path = package_path
+    if not ok or not KOSync then
+        logger.warn("Error when loading plugins/kosync.koplugin/main.lua:", KOSync)
+        return
+    end
+    local kosync_setting = G_reader_settings:readSetting("kosync")
+    if kosync_setting then
+        G_reader_settings:delSetting("kosync")
+    else
+        kosync_setting = KOSync.default_settings
+    end
+    local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
+    settings:saveSetting("settings" , kosync_setting)
+    settings:flush()
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -1013,6 +1013,7 @@ if last_migration_date < 20260517 then
 end
 
 -- 20260623, Move Kosync plugin settings into a separate file
+-- https://github.com/koreader/koreader/pull/15591
 if last_migration_date < 20260623 then
     logger.info("Performing one-time migration for 20260623")
     -- c.f., PluginLoader

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 202606023
+local CURRENT_MIGRATION_DATE = 20260623
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -1019,7 +1019,7 @@ if last_migration_date < 20260623 then
     local kosync_setting = G_reader_settings:readSetting("kosync")
     if kosync_setting then
         local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
-        settings:saveSetting("settings" , kosync_setting)
+        settings:saveSetting("kosync" , kosync_setting)
         settings:flush()
         G_reader_settings:delSetting("kosync")
     end

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -1016,24 +1016,13 @@ end
 -- https://github.com/koreader/koreader/pull/15591
 if last_migration_date < 20260623 then
     logger.info("Performing one-time migration for 20260623")
-    -- c.f., PluginLoader
-    local package_path = package.path
-    package.path = string.format("%s/?.lua;%s", "plugins/kosync.koplugin", package_path)
-    local ok, KOSync = pcall(dofile, "plugins/kosync.koplugin/main.lua")
-    package.path = package_path
-    if not ok or not KOSync then
-        logger.warn("Error when loading plugins/kosync.koplugin/main.lua:", KOSync)
-        return
-    end
     local kosync_setting = G_reader_settings:readSetting("kosync")
     if kosync_setting then
+        local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
+        settings:saveSetting("settings" , kosync_setting)
+        settings:flush()
         G_reader_settings:delSetting("kosync")
-    else
-        kosync_setting = KOSync.default_settings
     end
-    local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
-    settings:saveSetting("settings" , kosync_setting)
-    settings:flush()
 end
 
 -- We're done, store the current migration date

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -1019,7 +1019,7 @@ if last_migration_date < 20260623 then
     local kosync_setting = G_reader_settings:readSetting("kosync")
     if kosync_setting then
         local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
-        settings:saveSetting("kosync" , kosync_setting)
+        settings:saveSetting("settings" , kosync_setting)
         settings:flush()
         G_reader_settings:delSetting("kosync")
     end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -24,7 +24,6 @@ local KOSync = WidgetContainer:extend{
     is_doc_only = true,
     title = _("Register/login to KOReader server"),
     settings_file = DataStorage:getSettingsDir() .. "/kosync.lua",
-    settings_key = "kosync",
     updated = nil,
 
     push_timestamp = nil,
@@ -71,7 +70,7 @@ function KOSync:loadSettings()
     if not KOSync.settings_obj then
         KOSync.settings_obj = LuaSettings:open(self.settings_file)
     end
-    self.settings = KOSync.settings_obj:readSetting(KOSync.settings_key, KOSync.default_settings)
+    self.settings = KOSync.settings_obj:readSetting("settings", KOSync.default_settings)
 end
 
 function KOSync:onFlushSettings()

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -24,6 +24,7 @@ local KOSync = WidgetContainer:extend{
     is_doc_only = true,
     title = _("Register/login to KOReader server"),
     settings_key = "kosync",
+    updated = nil,
 
     push_timestamp = nil,
     pull_timestamp = nil,
@@ -65,13 +66,11 @@ KOSync.default_settings = {
     send_metadata = false,
 }
 
-function KOSync:readSettings()
-    self.kosync_setting = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
-    return self.kosync_setting
-end
-
-function KOSync:flushSettings()
-    self.kosync_setting:flush()
+function KOSync:onFlushSettings()
+    if self.updated then
+        self.kosync_setting:flush()
+        self.updated = nil
+    end
 end
 
 function KOSync:init()
@@ -89,8 +88,8 @@ function KOSync:init()
         -- We do *NOT* want to make sure networking is up here, as the nagging would be extremely annoying; we're leaving that to the network activity check...
         self:updateProgress(false, false)
     end
-
-    self.settings = self:readSettings():readSetting("settings")
+    self.kosync_setting = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
+    self.settings = self.kosync_setting:readSetting(KOSync.settings_key, KOSync.default_settings)
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...
@@ -211,7 +210,7 @@ function KOSync:addToMainMenu(menu_items)
                         input = self.settings.custom_server or "https://",
                         callback = function(input)
                             self:setCustomServer(input)
-                            self:flushSettings()
+                            self.updated = true
                         end,
                     }
                 end,
@@ -242,7 +241,7 @@ function KOSync:addToMainMenu(menu_items)
                                         local hostname = dialog:getInputText()
                                         logger.dbg("KOSync: Setting custom hostname to:", hostname)
                                         self.settings.kosync_hostname = hostname ~= "" and hostname or nil
-                                        self:flushSettings()
+                                        self.updated = true
                                         UIManager:close(dialog)
                                     end,
                                 },
@@ -263,12 +262,11 @@ function KOSync:addToMainMenu(menu_items)
                     if self.settings.userkey then
                         return function(menu)
                             self:logout(menu)
-                            self:flushSettings()
+                            self.updated = true
                         end
                     else
                         return function(menu)
                             self:login(menu)
-                            self:flushSettings()
                         end
                     end
                 end,
@@ -280,7 +278,7 @@ function KOSync:addToMainMenu(menu_items)
                 help_text = _([[This may lead to nagging about toggling WiFi on document close and suspend/resume, depending on the device's connectivity.]]),
                 callback = function()
                     self:onKOSyncToggleAutoSync(nil, true)
-                    self:flushSettings()
+                    self.updated = true
                 end,
             },
             {
@@ -307,7 +305,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         callback = function(spin)
                             self:setPagesBeforeUpdate(spin.value)
                             if touchmenu_instance then touchmenu_instance:updateItems() end
-                            self:flushSettings()
+                            self.updated = true
                         end
                     }
                     UIManager:show(items)
@@ -330,7 +328,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.SILENT)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -340,7 +338,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.PROMPT)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -350,7 +348,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.DISABLE)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                         }
@@ -367,7 +365,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.SILENT)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -377,7 +375,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.PROMPT)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -387,7 +385,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.DISABLE)
-                                    self:flushSettings()
+                                    self.updated = true
                                 end,
                             },
                         }
@@ -424,7 +422,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.BINARY)
-                            self:flushSettings()
+                            self.updated = true
                         end,
                     },
                     {
@@ -434,7 +432,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.FILENAME)
-                            self:flushSettings()
+                            self.updated = true
                         end,
                     },
                 }
@@ -445,7 +443,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                 help_text = _([[When enabled, document metadata (filename, title, and authors) will be sent along with progress sync requests. This data is ignored by the official sync server but may be used by custom sync servers.]]),
                 callback = function()
                     self.settings.send_metadata = not self.settings.send_metadata
-                    self:flushSettings()
+                    self.updated = true
                 end,
             },
         }
@@ -580,6 +578,7 @@ function KOSync:doRegister(username, password, menu)
         if menu then
             menu:updateItems()
         end
+        self.updated = true
         UIManager:show(InfoMessage:new{
             text = _("Registered to KOReader server."),
         })
@@ -616,6 +615,7 @@ function KOSync:doLogin(username, password, menu)
     elseif status then
         self.settings.username = username
         self.settings.userkey = userkey
+        self.updated = true
         if menu then
             menu:updateItems()
         end
@@ -1009,6 +1009,7 @@ function KOSync:onKOSyncToggleAutoSync(toggle, from_menu)
         return true
     end
     self.settings.auto_sync = not self.settings.auto_sync
+    self.updated = true
     self:registerEvents()
 
     if self.settings.auto_sync then

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -68,18 +68,18 @@ KOSync.default_settings = {
 }
 
 function KOSync:loadSettings()
-    if not KOSync.settings then
-        KOSync.settings = LuaSettings:open(self.settings_file)
-        if not next(KOSync.settings.data) then
+    if not KOSync.settings_obj then
+        KOSync.settings_obj = LuaSettings:open(self.settings_file)
+        if not next(KOSync.settings_obj.data) then
             self.updated = true -- first run, force flush
         end
     end
-    self.settings = KOSync.settings:readSetting(KOSync.settings_key, KOSync.default_settings)
+    self.settings = KOSync.settings_obj:readSetting(KOSync.settings_key, KOSync.default_settings)
 end
 
 function KOSync:onFlushSettings()
     if self.updated then
-        KOSync.settings:flush()
+        KOSync.settings_obj:flush()
         self.updated = nil
     end
 end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -1,9 +1,11 @@
 local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
 local Device = require("device")
 local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
+local LuaSettings = require("luasettings")
 local Math = require("optmath")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local NetworkMgr = require("ui/network/manager")
@@ -63,6 +65,15 @@ KOSync.default_settings = {
     send_metadata = false,
 }
 
+function KOSync:readSettings()
+    self.kosync_setting = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
+    return self.kosync_setting
+end
+
+function KOSync:flushSettings()
+    self.kosync_setting:flush()
+end
+
 function KOSync:init()
     self.push_timestamp = 0
     self.pull_timestamp = 0
@@ -79,11 +90,11 @@ function KOSync:init()
         self:updateProgress(false, false)
     end
 
-    self.settings = G_reader_settings:readSetting(self.settings_key, self.default_settings)
+    self.settings = self:readSettings():readSetting("settings")
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...
-    if self.settings.auto_sync and Device:hasSeamlessWifiToggle() and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" then
+    if self.settings.auto_sync and Device:hasSeamlessWifiToggle() and self.kosync_settings:readSetting("wifi_enable_action") ~= "turn_on" then
         self.settings.auto_sync = false
         logger.warn("KOSync: Automatic sync has been disabled because wifi_enable_action is *not* turn_on")
     end
@@ -200,6 +211,7 @@ function KOSync:addToMainMenu(menu_items)
                         input = self.settings.custom_server or "https://",
                         callback = function(input)
                             self:setCustomServer(input)
+                            self:flushSettings()
                         end,
                     }
                 end,
@@ -230,6 +242,7 @@ function KOSync:addToMainMenu(menu_items)
                                         local hostname = dialog:getInputText()
                                         logger.dbg("KOSync: Setting custom hostname to:", hostname)
                                         self.settings.kosync_hostname = hostname ~= "" and hostname or nil
+                                        self:flushSettings()
                                         UIManager:close(dialog)
                                     end,
                                 },
@@ -250,10 +263,12 @@ function KOSync:addToMainMenu(menu_items)
                     if self.settings.userkey then
                         return function(menu)
                             self:logout(menu)
+                            self:flushSettings()
                         end
                     else
                         return function(menu)
                             self:login(menu)
+                            self:flushSettings()
                         end
                     end
                 end,
@@ -265,6 +280,7 @@ function KOSync:addToMainMenu(menu_items)
                 help_text = _([[This may lead to nagging about toggling WiFi on document close and suspend/resume, depending on the device's connectivity.]]),
                 callback = function()
                     self:onKOSyncToggleAutoSync(nil, true)
+                    self:flushSettings()
                 end,
             },
             {
@@ -291,6 +307,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         callback = function(spin)
                             self:setPagesBeforeUpdate(spin.value)
                             if touchmenu_instance then touchmenu_instance:updateItems() end
+                            self:flushSettings()
                         end
                     }
                     UIManager:show(items)
@@ -313,6 +330,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.SILENT)
+                                    self:flushSettings()
                                 end,
                             },
                             {
@@ -322,6 +340,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.PROMPT)
+                                    self:flushSettings()
                                 end,
                             },
                             {
@@ -331,6 +350,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.DISABLE)
+                                    self:flushSettings()
                                 end,
                             },
                         }
@@ -347,6 +367,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.SILENT)
+                                    self:flushSettings()
                                 end,
                             },
                             {
@@ -356,6 +377,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.PROMPT)
+                                    self:flushSettings()
                                 end,
                             },
                             {
@@ -365,6 +387,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.DISABLE)
+                                    self:flushSettings()
                                 end,
                             },
                         }
@@ -401,6 +424,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.BINARY)
+                            self:flushSettings()
                         end,
                     },
                     {
@@ -410,6 +434,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.FILENAME)
+                            self:flushSettings()
                         end,
                     },
                 }
@@ -420,6 +445,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                 help_text = _([[When enabled, document metadata (filename, title, and authors) will be sent along with progress sync requests. This data is ignored by the official sync server but may be used by custom sync servers.]]),
                 callback = function()
                     self.settings.send_metadata = not self.settings.send_metadata
+                    self:flushSettings()
                 end,
             },
         }

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -23,6 +23,7 @@ local KOSync = WidgetContainer:extend{
     name = "kosync",
     is_doc_only = true,
     title = _("Register/login to KOReader server"),
+    settings_file = DataStorage:getSettingsDir() .. "/kosync.lua",
     settings_key = "kosync",
     updated = nil,
 
@@ -66,9 +67,19 @@ KOSync.default_settings = {
     send_metadata = false,
 }
 
+function KOSync:loadSettings()
+    if not KOSync.settings then
+        KOSync.settings = LuaSettings:open(self.settings_file)
+        if not next(KOSync.settings.data) then
+            self.updated = true -- first run, force flush
+        end
+    end
+    self.settings = KOSync.settings:readSetting(KOSync.settings_key, KOSync.default_settings)
+end
+
 function KOSync:onFlushSettings()
     if self.updated then
-        self.kosync_setting:flush()
+        KOSync.settings:flush()
         self.updated = nil
     end
 end
@@ -88,8 +99,7 @@ function KOSync:init()
         -- We do *NOT* want to make sure networking is up here, as the nagging would be extremely annoying; we're leaving that to the network activity check...
         self:updateProgress(false, false)
     end
-    self.kosync_setting = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
-    self.settings = self.kosync_setting:readSetting(KOSync.settings_key, KOSync.default_settings)
+    self:loadSettings()
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -70,9 +70,6 @@ KOSync.default_settings = {
 function KOSync:loadSettings()
     if not KOSync.settings_obj then
         KOSync.settings_obj = LuaSettings:open(self.settings_file)
-        if not next(KOSync.settings_obj.data) then
-            self.updated = true -- first run, force flush
-        end
     end
     self.settings = KOSync.settings_obj:readSetting(KOSync.settings_key, KOSync.default_settings)
 end

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -94,7 +94,7 @@ function KOSync:init()
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...
-    if self.settings.auto_sync and Device:hasSeamlessWifiToggle() and self.kosync_settings:readSetting("wifi_enable_action") ~= "turn_on" then
+    if self.settings.auto_sync and Device:hasSeamlessWifiToggle() and G_reader_settings:readSetting("wifi_enable_action") ~= "turn_on" then
         self.settings.auto_sync = false
         logger.warn("KOSync: Automatic sync has been disabled because wifi_enable_action is *not* turn_on")
     end


### PR DESCRIPTION
Moves kosync plugin settings into a separate file (kosync.lua) located in the settings folder. 
It removes the setting key from a global configuration file using one-time migration. And updates the setting in the kosync.lua on every change done by a user.

closes [#15570](https://github.com/koreader/koreader/issues/15570)

AI disclosure: it was used only for understating the flow. Code is written manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15591)
<!-- Reviewable:end -->
