### PR TITLE
NewsDownloader: check relative urls using socket.url.parse()

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -425,7 +425,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local function is_relative(url_string)
         -- Parse the URL into its constituent components
         local parsed = socket_url.parse(url_string)
-        
+
         -- If there is no scheme component, it is a relative URL
         return parsed and parsed.scheme == nil
     end
@@ -695,7 +695,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 src = img.src2x
             end
             logger.dbg("Getting img ", src)
-            local success, _content_type, content = getUrlContent(src)
+            local success, __, content = getUrlContent(src)
             -- success, _, content = getUrlContent(src..".unexistant") -- to simulate failure
             if success then
                 logger.dbg("success, size:", #content)

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -423,10 +423,8 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local imagenum = 1
     local cover_imgid = nil -- best candidate for cover among our images
     local function is_relative(url_string)
-        -- Parse the URL into its constituent components
         local parsed = socket_url.parse(url_string)
-
-        -- If there is no scheme component, it is a relative URL
+        -- If there is no scheme component, it is a relative URL.
         return parsed and parsed.scheme == nil
     end
     local processImg = function(img_tag)

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -422,6 +422,13 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local seen_images = {}
     local imagenum = 1
     local cover_imgid = nil -- best candidate for cover among our images
+    local function is_relative(url_string)
+        -- Parse the URL into its constituent components
+        local parsed = socket_url.parse(url_string)
+        
+        -- If there is no scheme component, it is a relative URL
+        return parsed and parsed.scheme == nil
+    end
     local processImg = function(img_tag)
         local src = img_tag:match([[src="([^"]*)"]])
         if src == nil or src == "" then
@@ -434,7 +441,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
         end
         if src:sub(1,2) == "//" then
             src = "https:" .. src -- Wikipedia redirects from http to https, so use https
-        elseif src:sub(1,1) == "/" then -- non absolute url
+        elseif is_relative(src) then -- non absolute url
             src = socket_url.absolute(base_url, src)
         end
         local cur_image
@@ -688,7 +695,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 src = img.src2x
             end
             logger.dbg("Getting img ", src)
-            local success, _, content = getUrlContent(src)
+            local success, _content_type, content = getUrlContent(src)
             -- success, _, content = getUrlContent(src..".unexistant") -- to simulate failure
             if success then
                 logger.dbg("success, size:", #content)

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -693,7 +693,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 src = img.src2x
             end
             logger.dbg("Getting img ", src)
-            local success, __, content = getUrlContent(src)
+            local success, _, content = getUrlContent(src)
             -- success, _, content = getUrlContent(src..".unexistant") -- to simulate failure
             if success then
                 logger.dbg("success, size:", #content)

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -422,7 +422,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     local seen_images = {}
     local imagenum = 1
     local cover_imgid = nil -- best candidate for cover among our images
-    local function is_relative(url_string)
+    local function isRelative(url_string)
         local parsed = socket_url.parse(url_string)
         -- If there is no scheme component, it is a relative URL.
         return parsed and parsed.scheme == nil
@@ -439,7 +439,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
         end
         if src:sub(1,2) == "//" then
             src = "https:" .. src -- Wikipedia redirects from http to https, so use https
-        elseif is_relative(src) then -- non absolute url
+        elseif isRelative(src) then -- non absolute url
             src = socket_url.absolute(base_url, src)
         end
         local cur_image


### PR DESCRIPTION
This PR changes how relative urls are determined in  the news downloader plugin. Instead of assumption that relative urls always come from a base domain, it checks if a url is relative using a schema check. 

Also, the PR fixes an issue with a global variable visibility.

closes https://github.com/koreader/koreader/issues/15573

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15595)
<!-- Reviewable:end -->
