### PR TITLE
NewsDownloader: fix for shadowing _()

### DIFF
--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -688,7 +688,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 src = img.src2x
             end
             logger.dbg("Getting img ", src)
-            local success, _, content = getUrlContent(src)
+            local success, __, content = getUrlContent(src)
             -- success, _, content = getUrlContent(src..".unexistant") -- to simulate failure
             if success then
                 logger.dbg("success, size:", #content)


### PR DESCRIPTION
fixes hiding of an import:

`
local _ = require("gettext")
`

actual fix for https://github.com/koreader/koreader/issues/15573

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15597)
<!-- Reviewable:end -->
