### PR TITLE
[NT] Add onHome key events

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -863,6 +863,7 @@ FileManager.onRefreshContent = FileManager.onRefresh
 FileManager.onBookMetadataChanged = FileManager.onRefresh
 
 function FileManager:onHome()
+    UIManager:setSuspendRepaints(false)
     if not self.file_chooser:goHome() then
         self:setHome()
     end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -927,6 +927,7 @@ function ReaderUI:dealWithLoadDocumentFailure()
 end
 
 function ReaderUI:onHome()
+    UIManager:setSuspendRepaints(false)
     local file = self.document.file
     self:onClose()
     self:showFileManager(file)

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -141,7 +141,7 @@ local Input = {
             "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
             "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
             "Up", "Down", "Left", "Right", "Press", "Backspace", "End",
-            "Back", "Sym", "AA", "Menu", "Home", "Del", "ScreenKB",
+            "Back", "Sym", "AA", "Menu", "KeyHome", "Del", "ScreenKB",
             "LPgBack", "RPgBack", "LPgFwd", "RPgFwd"
         },
     },

--- a/frontend/device/sdl/event_map_sdl2.lua
+++ b/frontend/device/sdl/event_map_sdl2.lua
@@ -78,7 +78,7 @@ return {
     [1073741905] = "Down", -- arrow down
     [1073741902] = "RPgFwd", -- normal PageDown
 
-    [1073741898] = "Home",
+    [1073741898] = os.getenv("DISABLE_TOUCH") == "1" and "Home" or "KeyHome",
     [1073741901] = "End",
     [1073741897] = "Insert",
 

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -16,6 +16,10 @@ local Screen = Device.screen
 
 local DEFAULT_FULL_REFRESH_COUNT = 6
 
+-- used to temporarily stop screen refreshes and repaint during fast unwinding events
+local NOP = function() return end
+local SUSPEND_REPAINTS_FUNCTIONS_TO_NOP = { "setDirty", "_refresh", "_repaint" }
+
 -- This is a singleton
 local UIManager = {
     -- trigger a full refresh when counter reaches FULL_REFRESH_COUNT
@@ -43,6 +47,8 @@ local UIManager = {
     _prevent_standby_count = 0,
     _prev_prevent_standby_count = 0,
     _input_gestures_disabled = false,
+
+    _repaint_watchdog_func = nil,
 
     event_hook = require("ui/hook_container"):new()
 }
@@ -122,6 +128,59 @@ end
 function UIManager:setIgnoreTouchInput(state)
     local InputContainer = require("ui/widget/container/inputcontainer")
     InputContainer:setIgnoreTouchInput(state)
+end
+
+local function restore_functions(self, func_list)
+    for _, name in ipairs(func_list) do
+        self[name] = self._orig_funcs[name]
+    end
+    self._orig_funcs = nil
+end
+
+--[[--
+Suspends repaints and refreshes
+
+-- Note: The watchdog enforces a strict global deadline for the UI suspension.
+-- If a watchdog is already armed, subsequent requests to suspend repaints will
+-- deliberately not reset the timer. This ensures the timeout ticks down from the
+-- initial caller's request, preventing a chain of events from compounding the
+-- delay and freezing the screen indefinitely.
+
+@boolean `state`: `true` to suspend repaints, `false` to resume them
+@number `timeout`: optional suspension duration in seconds (default: 2) before repaints are resumed automatically
+]]
+function UIManager:setSuspendRepaints(state, timeout)
+    if not state and not self._repaint_watchdog_func then return end
+    if state and self._repaint_watchdog_func then return end
+    -- Suspending repaints can be incredibly dangerous, we must
+    -- ensure we don't get stuck in this state forever, otherwise
+    -- we might end up with a frozen screen and no way out.
+    if not state then
+        -- The chain completed or halted legitimately. Disarm the watchdog.
+        self:unschedule(self._repaint_watchdog_func)
+        self._repaint_watchdog_func = nil
+        restore_functions(self, SUSPEND_REPAINTS_FUNCTIONS_TO_NOP)
+    else
+        -- The chain has just started. Arm the watchdog for a strict timeout (or 2 sec) deadline.
+        self._repaint_watchdog_func = function()
+            logger.warn("UIManager: Repaint suspension watchdog expired; forcing UI recovery.")
+            self._repaint_watchdog_func = nil
+            restore_functions(self, SUSPEND_REPAINTS_FUNCTIONS_TO_NOP)
+            self:setDirty(nil, "full")
+        end
+        self._orig_funcs = {}
+        for _, name in ipairs(SUSPEND_REPAINTS_FUNCTIONS_TO_NOP) do
+            self._orig_funcs[name] = self[name]
+            self[name] = NOP
+        end
+        timeout = math.max(0, math.min(timeout or 2, 10))
+        self:scheduleIn(timeout, self._repaint_watchdog_func)
+    end
+    logger.dbg("UIManager: Repaints and refreshes suspended:", state)
+end
+
+function UIManager:getSuspendRepaints()
+    return self._repaint_watchdog_func
 end
 
 function UIManager:setSilentMode(toggle)

--- a/frontend/ui/widget/container/inputcontainer.lua
+++ b/frontend/ui/widget/container/inputcontainer.lua
@@ -32,6 +32,10 @@ This example illustrates how to listen for a key press input event via the `key_
 It is recommended to reference configurable sequences from another table
 and to store that table as a configuration setting.
 
+key_events is a table of event names, each of which maps to a list of key sequences.
+This class creates said table and populates it with a default Home key binding,
+Developers should avoid overriding the default key_events table to cleanly inherit the binding.
+
 ]]
 
 local DepGraph = require("depgraph")
@@ -54,6 +58,9 @@ function InputContainer:_init()
     -- These should be instance-specific
     if not self.key_events then
         self.key_events = {}
+    end
+    if Device:hasKeys() then
+        self.key_events.Home = { { "Home" } }
     end
     if not self.ges_events then
         self.ges_events = {}
@@ -393,6 +400,35 @@ function InputContainer:onInput(input, ignore_first_hold_release)
     }
     UIManager:show(self.input_dialog)
     self.input_dialog:onShowKeyboard(ignore_first_hold_release)
+end
+
+function InputContainer:onHome()
+    if self.toast then return false end -- e.g., Notifications
+    -- GUARD: Only window-level widgets are allowed to participate in the daisy-chain.
+    -- This prevents sub-widgets from intercepting the event and causing an infinite loop.
+    if not UIManager:isWidgetShown(self) then
+        return false
+    end
+    local initial_top = UIManager:getTopmostVisibleWidget()
+    UIManager:setSuspendRepaints(true)
+    -- Safely dismantle the window-level widget
+    if type(self.onClose) == "function" then
+        logger.dbg("InputContainer:onHome triggered for widget:", self.name or tostring(self))
+        self:onClose()
+    end
+    local current_top = UIManager:getTopmostVisibleWidget()
+    if initial_top == current_top then
+        logger.dbg("InputContainer:onHome - Top widget unchanged. Halting daisy-chain.")
+        -- Lift the muzzle and force a redraw to show the updated internal state
+        UIManager:setSuspendRepaints(false)
+        UIManager:setDirty(initial_top, "full")
+        return true
+    end
+    -- Daisy-chain: defer the next dispatch to cleanly unwind the stack
+    UIManager:nextTick(function()
+        UIManager:sendEvent(Event:new("Home"))
+    end)
+    return true
 end
 
 function InputContainer:closeInputDialog()

--- a/frontend/ui/widget/filechooser.lua
+++ b/frontend/ui/widget/filechooser.lua
@@ -364,6 +364,22 @@ function FileChooser:changeToPath(path, focused_path)
     end
 end
 
+function FileChooser:onHome()
+    local FileManager = require("apps/filemanager/filemanager")
+    UIManager:setSuspendRepaints(true)
+    if FileManager.instance then
+        -- FileChooser is a Booklist (which in turn is a Menu), we need
+        -- to redirect Home calls otherwise we will unalive ourselves,
+        -- taking the whole application down with us.
+        return FileManager.instance:onHome()
+    end
+    self:onClose()
+    UIManager:nextTick(function()
+        UIManager:sendEvent(Event:new("Home"))
+    end)
+    return true
+end
+
 function FileChooser:goHome()
     local home_dir = G_reader_settings:readSetting("home_dir")
     if not home_dir or lfs.attributes(home_dir, "mode") ~= "directory" then

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -59,6 +59,7 @@ local function populateEventMappings()
 
         table.insert(event_keys, { "FocusLeft",  { { "Left" },  event = "FocusMove", args = {-1, 0} } })
 
+        table.insert(event_keys, { "Home",           { { "Home" },         event = "Home" } })
         -- Advanced features: more event handlers can be enabled via settings.reader.lua in a similar manner
         table.insert(event_keys, { "HoldContext",    { { "ContextMenu" },  event = "Hold" } })
         table.insert(event_keys, { "HoldShift",      { { "Shift", "Press" }, event = "Hold" } })

--- a/frontend/ui/widget/imageviewer.lua
+++ b/frontend/ui/widget/imageviewer.lua
@@ -101,6 +101,7 @@ function ImageViewer:init()
                 PanRight = { { "Right" }, event = "CursorPan", args="right" },
             }
         end
+        self.key_events.Home = { { "Home" } }
     end
     if Device:isTouchDevice() then
         local range = Geom:new{

--- a/frontend/ui/widget/infomessage.lua
+++ b/frontend/ui/widget/infomessage.lua
@@ -311,5 +311,6 @@ function InfoMessage:onTapClose()
     end
 end
 InfoMessage.onAnyKeyPressed = InfoMessage.onTapClose
+InfoMessage.onClose = InfoMessage.onTapClose -- for onHome event
 
 return InfoMessage

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -100,6 +100,7 @@ local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local CheckButton = require("ui/widget/checkbutton")
 local Device = require("device")
+local Event = require("ui/event")
 local FocusManager = require("ui/widget/focusmanager")
 local Font = require("ui/font")
 local FrameContainer = require("ui/widget/container/framecontainer")
@@ -748,6 +749,28 @@ end
 
 InputDialog.onKeyboardHeightChanged = InputDialog.reinit
 
+function InputDialog:onHome()
+    if self._text_modified then
+        self._home_pending = true
+        -- If we are in the middle of the stack, being called by the Home unwind
+        -- mechanism, we need to halt and yield back control to the user.
+        if UIManager:getSuspendRepaints() then
+            UIManager:setSuspendRepaints(false)
+            UIManager:setDirty(self, function()
+                return "ui", self.dialog_frame.dimen
+            end)
+        end
+        self:onCloseDialog()
+    else
+        UIManager:setSuspendRepaints(true)
+        self:onCloseDialog()
+        UIManager:nextTick(function()
+            UIManager:sendEvent(Event:new("Home"))
+        end)
+    end
+    return true
+end
+
 function InputDialog:onCloseDialog()
     local close_button = self.button_table:getButtonById("close")
     if close_button and close_button.enabled then
@@ -906,13 +929,25 @@ function InputDialog:_addSaveCloseButtons()
                 UIManager:show(MultiConfirmBox:new{
                     text = self.close_unsaved_confirm_text or _("You have unsaved changes."),
                     cancel_text = self.close_cancel_button_text or _("Cancel"),
+                    cancel_callback = function()
+                        if self._home_pending then
+                            self._home_pending = nil
+                        end
+                    end,
                     choice1_text = self.close_discard_button_text or _("Discard"),
                     choice1_callback = function()
+                        if self._home_pending then UIManager:setSuspendRepaints(true) end
                         if self.close_callback then self.close_callback(false) end
                         UIManager:close(self)
                         UIManager:show(Notification:new{
                             text = self.close_discarded_notif_text or _("Changes discarded"),
                         })
+                        if self._home_pending then
+                            self._home_pending = nil
+                            UIManager:nextTick(function()
+                                UIManager:sendEvent(Event:new("Home"))
+                            end)
+                        end
                     end,
                     choice2_text = self.close_save_button_text or _("Save"),
                     choice2_callback = function()
@@ -927,11 +962,20 @@ function InputDialog:_addSaveCloseButtons()
                                     })
                                 end
                             else -- nil or true
+                                if self._home_pending then UIManager:setSuspendRepaints(true) end
                                 if self.close_callback then self.close_callback(true) end
                                 UIManager:close(self)
                                 UIManager:show(Notification:new{
                                     text = msg or _("Saved"),
                                 })
+                                if self._home_pending then
+                                    self._home_pending = nil
+                                    -- Allow readerUI to catch up: ApplyStyleSheet is delayed
+                                    -- by 0.2s when used by ReaderStyleTweak:onEditBookTweak()
+                                    UIManager:scheduleIn(0.5, function()
+                                        UIManager:sendEvent(Event:new("Home"))
+                                    end)
+                                end
                             end
                         end)
                     end,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -849,7 +849,16 @@ function InputText:onKeyPress(key)
         elseif key["End"] then
             self:goToEnd()
         elseif key["Home"] then
+            -- If our parent handles Home (e.g., InputDialog), delegate entirely
+            -- to avoid double-firing: once here and once via FocusManager routing.
+            if self.parent and self.parent.onHome then
+                return self.parent:onHome()
+            end
             self:keyBack()
+            local Event = require("ui/event")
+            UIManager:nextTick(function()
+                UIManager:sendEvent(Event:new("Home"))
+            end)
         elseif key["KeyHome"] then
             self:goToHome()
         elseif key["Press"] then
@@ -892,7 +901,7 @@ function InputText:onKeyPress(key)
             self:downLine()
         elseif key["Press"] then
             self:holdTextBox()
-        elseif key["Home"] then
+        elseif key["Home"] or key["KeyHome"] then
             self:toggleKeyboard()
         elseif key["."] and Device:hasSymKey() then
             -- Kindle does not have a dedicated button for commas

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -776,6 +776,14 @@ function InputText:focus()
     Device:startTextInput()
 end
 
+function InputText:keyBack()
+    if self.parent.onCloseDialog then
+        self.parent:onCloseDialog()
+    else
+        UIManager:close(self.parent)
+    end
+end
+
 -- NOTE: This key_map can be used for keyboards without numeric keys, such as on Kindles with keyboards. It is loosely 'inspired' by the symbol layer on the virtual keyboard but,
 --       we have taken the liberty of making some adjustments since:
 --       * K3 does not have numeric keys (top row) and,
@@ -841,17 +849,15 @@ function InputText:onKeyPress(key)
         elseif key["End"] then
             self:goToEnd()
         elseif key["Home"] then
+            self:keyBack()
+        elseif key["KeyHome"] then
             self:goToHome()
         elseif key["Press"] then
             self:addChars("\n")
         elseif key["Tab"] then
             self:addChars("    ")
         elseif key["Back"] then
-            if self.parent.onCloseDialog then
-                self.parent:onCloseDialog()
-            else
-                UIManager:close(self.parent)
-            end
+            self:keyBack()
         else
             handled = false
         end

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -1447,6 +1447,19 @@ function Menu:onShowingReader()
 end
 Menu.onSetupShowReader = Menu.onShowingReader
 
+-- Although Menu inherits this method from InputContainer and it is pretty
+-- much identical to that one, we need to override it here due to the
+-- complexity of the module (multiple FocusManagers and InputContainers).
+function Menu:onHome()
+    UIManager:setSuspendRepaints(true)
+    self:onClose()
+    local Event = require("ui/event")
+    UIManager:nextTick(function()
+        UIManager:sendEvent(Event:new("Home"))
+    end)
+    return true
+end
+
 function Menu:onCloseWidget()
     --- @fixme
     -- we cannot refresh regionally using the dimen field

--- a/frontend/ui/widget/pathchooser.lua
+++ b/frontend/ui/widget/pathchooser.lua
@@ -53,6 +53,16 @@ function PathChooser:init()
     FileChooser.init(self)
 end
 
+function PathChooser:onHome()
+    UIManager:setSuspendRepaints(true)
+    self:onClose()
+    local Event = require("ui/event")
+    UIManager:nextTick(function()
+        UIManager:sendEvent(Event:new("Home"))
+    end)
+    return true
+end
+
 function PathChooser:onMenuSelect(item)
     local path = item.path
     if path:sub(-2, -1) == "/." then -- with show_current_dir_for_hold

--- a/frontend/ui/widget/progressbardialog.lua
+++ b/frontend/ui/widget/progressbardialog.lua
@@ -59,6 +59,7 @@ local ProgressbarDialog = InputContainer:extend {
     dismissable = true,
     dismiss_callback = nil,
     dismiss_text = nil,
+    _home_pending_callback = nil,
     refresh_time_seconds = 3,
 }
 
@@ -69,6 +70,13 @@ function ProgressbarDialog:init()
     if self.dismissable then
         if Device:hasKeys() then
             self.key_events.AnyKeyPressed = { { Input.group.Any } }
+            self._home_pending_callback = function()
+                self._home_pending = nil
+                local Event = require("ui/event")
+                UIManager:nextTick(function()
+                    UIManager:sendEvent(Event:new("Home"))
+                end)
+            end
         end
         if Device:isTouchDevice() then
             self.ges_events.TapClose = {
@@ -219,20 +227,35 @@ function ProgressbarDialog:onDismiss()
             cancel_text = _("Cancel"),
             cancel_callback = function()
                 self.dismiss_box = nil
+                if self._home_pending then UIManager:setSuspendRepaints(true) end
                 UIManager:close(self)
+                if self._home_pending then
+                    self._home_pending_callback()
+                end
             end,
             ok_text = _("Continue"),
             ok_callback = function()
                 self.dismiss_box = nil
+                self._home_pending = nil
             end,
             dismissable = false,
         }
         UIManager:show(self.dismiss_box)
     else
+        if self._home_pending then UIManager:setSuspendRepaints(true) end
         UIManager:close(self)
+        if self._home_pending then
+            self._home_pending_callback()
+        end
     end
 end
 ProgressbarDialog.onAnyKeyPressed = ProgressbarDialog.onDismiss
 ProgressbarDialog.onTapClose = ProgressbarDialog.onDismiss
+
+function ProgressbarDialog:onHome()
+    self._home_pending = true
+    self:onDismiss()
+    return true
+end
 
 return ProgressbarDialog

--- a/frontend/ui/widget/qrmessage.lua
+++ b/frontend/ui/widget/qrmessage.lua
@@ -116,5 +116,6 @@ function QRMessage:onTapClose()
     return true
 end
 QRMessage.onAnyKeyPressed = QRMessage.onTapClose
+QRMessage.onClose = QRMessage.onTapClose -- for onHome event
 
 return QRMessage

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -972,6 +972,18 @@ function TouchMenu:onCloseWidget()
     end
 end
 
+-- Although TouchMenu inherits this method from InputContainer and it is pretty
+-- much identical to that one, we need to override it here due to the
+-- complexity of the module (multiple FocusManagers and InputContainers).
+function TouchMenu:onHome()
+    UIManager:setSuspendRepaints(true)
+    self:onClose()
+    UIManager:nextTick(function()
+        UIManager:sendEvent(Event:new("Home"))
+    end)
+    return true
+end
+
 -- Menu search feature
 function TouchMenu:search(search_for)
     local found_menu_items = {}

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -25,6 +25,17 @@ local HotKeys = InputContainer:extend{
 local hotkeys_path = ffiUtil.joinPath(DataStorage:getSettingsDir(), "hotkeys.lua")
 local hotkeys_list, base_keys, key_emitter_actions
 
+-- This function determines the appropriate "Home" key,
+-- as a 'Home' button on eink devices and a 'Home' key on a keyboard
+-- are treated differently in the codebase.
+local function getHomeKey()
+    local isSDL = Device:isSDL()
+    if isSDL and os.getenv("DISABLE_TOUCH") == "1" then
+        return "Home"
+    end
+    return isSDL and "KeyHome" or "Home"
+end
+
 local function buildHotkeysList()
     -- Define hotkeys_list
     hotkeys_list = {}
@@ -32,7 +43,7 @@ local function buildHotkeysList()
         up = "Up", down = "Down", left = "Left", right = "Right",
         left_page_back = "LPgBack", left_page_forward = "LPgFwd",
         right_page_back = "RPgBack", right_page_forward = "RPgFwd",
-        back = "Back", home = "Home", press = "Press"
+        back = "Back", home = getHomeKey(), press = "Press"
     }
     key_emitter_actions = {
         key_up = { key = "Up", title = T(_("Send key: %1"), _("Up")) },
@@ -202,7 +213,8 @@ function HotKeys:registerKeyEvents()
     self:overrideConflictingKeyEvents()
     local cursor_keys = { "Up", "Down", "Left", "Right" }
     local page_turn_keys = { "LPgBack", "LPgFwd", "RPgBack", "RPgFwd" }
-    local function_keys = { "Back", "Home", "Press", "Menu" }
+    local home_key = getHomeKey()
+    local function_keys = { "Back", home_key, "Press", "Menu" }
     local key_name_mapping = {
         LPgBack = "left_page_back",    RPgBack = "right_page_back",
         LPgFwd  = "left_page_forward", RPgFwd  = "right_page_forward",
@@ -228,7 +240,7 @@ function HotKeys:registerKeyEvents()
         end
     end
     addKeyEvent(modifier, "Back", "HotkeyAction", "modifier_plus_back")
-    addKeyEvent(modifier, "Home", "HotkeyAction", "modifier_plus_home")
+    addKeyEvent(modifier, home_key, "HotkeyAction", "modifier_plus_home")
     -- remember, screenkb+menu is already used for screenshots (on k4), don't add it here.
 
     if Device:hasKeyboard() then


### PR DESCRIPTION
### what's new

This pull request introduces a robust, unified "Home" key handling mechanism across the UI stack, with a focus on safely unwinding nested UI widgets and preventing unnecessary screen repaints. It adds a new `setSuspendRepaints` feature to the `UIManager` to temporarily halt repaints during complex UI transitions, with watchdog protection to avoid UI freezes.

For Plugin/Patch developers, this should be inherited provided they do not override the key events table, or have an overly complex module that would require a dedicated `onHome` event

* Implemented a standardised `onHome` method enabling safe, daisy-chained unwinding of UI layers when the Home key is pressed. This ensures consistent behavior and prevents accidental application termination or UI stack corruption.

* Updated key event mappings and input handling so that the Home key is mapped and routed correctly, distinguishing between "Home" (UI navigation) and "KeyHome" (text navigation), and ensuring widgets delegate or intercept Home events as appropriate.

* Added `UIManager:setSuspendRepaints(state, timeout)` and related logic to temporarily suspend screen repaints during Home event unwinding, with a watchdog to auto-resume in case of errors, preventing frozen screens. Integrated checks in `setDirty` and `_refresh` to respect this suspension.

* Enhanced `InputDialog` and `InputText` to properly handle Home key events, including unsaved changes prompts and correct propagation of Home events after user 

#LongLiveTheHomeButton

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15600)
<!-- Reviewable:end -->
