### PR TITLE
kindle: More non-standard installation fixes and default NO_EIPS_SLEEP when not launched from KUAL

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -149,7 +149,7 @@ ko_update_check() {
         #       which we cannot use because it's been mounted noexec for a few years now...
         cp -pf "${KOREADER_DIR}/tar" /var/tmp/gnutar
         # shellcheck disable=SC2016
-        /var/tmp/gnutar --no-same-permissions --no-same-owner --checkpoint="${CPOINTS}" --checkpoint-action=exec='printf "%s" $((TAR_CHECKPOINT / CPOINTS)) > ${FBINK_NAMED_PIPE}' -C "/mnt/us" -xf "${NEWUPDATE}"
+        /var/tmp/gnutar --no-same-permissions --no-same-owner --checkpoint="${CPOINTS}" --checkpoint-action=exec='printf "%s" $((TAR_CHECKPOINT / CPOINTS)) > ${FBINK_NAMED_PIPE}' -C "${UNPACK_DIR}" -xf "${NEWUPDATE}"
         fail=$?
         kill -TERM "${FBINK_PID}"
         # And remove our temporary tar binary...

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -83,7 +83,6 @@ if [ "${1}" = "--kual" ]; then
     shift 1
     FROM_KUAL="yes"
     REEXEC_FLAGS="${REEXEC_FLAGS} --kual"
-    export EIPS_NO_SLEEP="no"
 else
     FROM_KUAL="no"
     export EIPS_NO_SLEEP="yes"

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -83,8 +83,10 @@ if [ "${1}" = "--kual" ]; then
     shift 1
     FROM_KUAL="yes"
     REEXEC_FLAGS="${REEXEC_FLAGS} --kual"
+    export EIPS_NO_SLEEP="no"
 else
     FROM_KUAL="no"
+    export EIPS_NO_SLEEP="yes"
 fi
 
 # By default, don't stop the framework.
@@ -98,8 +100,7 @@ elif [ "${1}" = "--asap" ]; then
     shift 1
     NO_SLEEP="yes"
     REEXEC_FLAGS="${REEXEC_FLAGS} --asap"
-    # Don't sleep during eips calls either...
-    export EIPS_NO_SLEEP="true"
+    export EIPS_NO_SLEEP="yes"
 else
     NO_SLEEP="no"
 fi

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -57,7 +57,7 @@ eips_print_bottom_centered() {
     # Sleep a tiny bit to workaround the logic in the 'new' (K4+) eInk controllers that tries to bundle updates,
     # otherwise it may drop part of our messages because of other screen updates from KUAL...
     # Unless we really don't want to sleep, for special cases...
-    if [ -z "${EIPS_NO_SLEEP}" ]; then
+    if [ "${EIPS_NO_SLEEP}" = "no" ]; then
         usleep 150000 # 150ms
     fi
 

--- a/platform/kindle/libkohelper.sh
+++ b/platform/kindle/libkohelper.sh
@@ -57,7 +57,7 @@ eips_print_bottom_centered() {
     # Sleep a tiny bit to workaround the logic in the 'new' (K4+) eInk controllers that tries to bundle updates,
     # otherwise it may drop part of our messages because of other screen updates from KUAL...
     # Unless we really don't want to sleep, for special cases...
-    if [ "${EIPS_NO_SLEEP}" = "no" ]; then
+    if [ -z "${EIPS_NO_SLEEP}" ]; then
         usleep 150000 # 150ms
     fi
 


### PR DESCRIPTION
- Fixes OTA installation when installed in a non-standard location (though I may look into adding a flag to disable OTA entirely for KPM)
- The `NO_EIPS_SLEEP` flag disables behaviour which seems to only be useful when launched by KUAL, so it should be set by default when KOReader is _not_ launched from KUAL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15601)
<!-- Reviewable:end -->
