### PR TITLE
[InputDialog] NT: remove separator from widget's layout

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1586,7 +1586,7 @@ function ReaderBookmark:onSearchBookmark()
             }
         },
     }
-    input_dialog:addWidget(separator)
+    input_dialog:addWidget(separator, nil, true) -- don't add to focus_manager.layout.
     check_button_highlight = CheckButton:new{
         text = " " .. self.display_prefix["highlight"] .. self.display_type["highlight"],
         checked = true,

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -522,9 +522,11 @@ function InputDialog:reinit()
     UIManager:setDirty("all", "flashui")
 end
 
-function InputDialog:addWidget(widget, re_init)
+function InputDialog:addWidget(widget, re_init, skip_fm_layout)
     local is_text_height_adjustable = self.fullscreen or self.use_available_height
-    table.insert(self.layout, #self.layout, {widget})
+    if not skip_fm_layout then
+        table.insert(self.layout, #self.layout, {widget})
+    end
     if not re_init then -- backup widget for re-init
         widget = CenterContainer:new{
             dimen = Geom:new{

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -522,9 +522,9 @@ function InputDialog:reinit()
     UIManager:setDirty("all", "flashui")
 end
 
-function InputDialog:addWidget(widget, re_init, skip_fm_layout)
+function InputDialog:addWidget(widget, re_init, skip_focus_layout)
     local is_text_height_adjustable = self.fullscreen or self.use_available_height
-    if not skip_fm_layout then
+    if not skip_focus_layout then
         table.insert(self.layout, #self.layout, {widget})
     end
     if not re_init then -- backup widget for re-init


### PR DESCRIPTION
### what's new

* [`frontend/ui/widget/inputdialog.lua`](diffhunk://#diff-3eef50b3aeb91931018e7130dbe3f72d2b970745707d766db252fed949a62492L525-R529): Updated `InputDialog:addWidget` to accept a new `skip_fm_layout` parameter, which, when set to `true`, prevents the widget from being added to the focus manager's layout.

* [`frontend/apps/reader/modules/readerbookmark.lua`](diffhunk://#diff-489ecdf0fa00063ecc5dff3753350c106ec18c86d056b4655f6bf12b7f96f283L1589-R1589): Modified `ReaderBookmark:onSearchBookmark()` to add the separator widget with `skip_fm_layout` set to `true`, ensuring it is not managed by the focus manager, i.e., a ghost step during settings selection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15602)
<!-- Reviewable:end -->
