### PR TITLE
kindle: Stop awesome regardless whether KOReader was launched from KUAL or not

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -270,11 +270,9 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
                     logmsg "Title bar geometry: '${TITLEBAR_GEOMETRY}' -> '$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')'"
                     USED_WMCTRL="yes"
                 fi
-                if [ "${FROM_KUAL}" = "yes" ]; then
-                    logmsg "Stopping awesome . . ."
-                    killall -STOP awesome
-                    AWESOME_STOPPED="yes"
-                fi
+                logmsg "Stopping awesome . . ."
+                killall -STOP awesome
+                AWESOME_STOPPED="yes"
             fi
         else
             logmsg "Hiding the status bar . . ."


### PR DESCRIPTION
This is necessary for KOReader's screensaver handling to work on Kindles. KUAL is no longer the only way in which KOReader can be launched (scriptlets & KPM now exist) and I see no reason not to do this by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15608)
<!-- Reviewable:end -->
