### PR TITLE
[ReaderLink, Back] clear page links with Back key

### DIFF
--- a/frontend/apps/reader/modules/readerback.lua
+++ b/frontend/apps/reader/modules/readerback.lua
@@ -115,6 +115,12 @@ ReaderBack.onViewRecalculate = ReaderBack._onViewPossiblyUpdated
 ReaderBack.onPagePositionUpdated = ReaderBack._onViewPossiblyUpdated
 
 function ReaderBack:onBack()
+    -- If a link is selected, clear it first
+    if self.ui.link:isPageLinkSelected() then
+        self.ui.link:clearSelectedPageLink(true)
+        return true
+    end
+
     local back_in_reader = G_reader_settings:readSetting("back_in_reader", "previous_location")
     local back_to_exit = G_reader_settings:readSetting("back_to_exit", "prompt")
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1368,7 +1368,7 @@ end
 
 function ReaderLink:onPageUpdate()
     if self.cur_selected_link then
-        self:clearSelectedPageLink(true)
+        self:clearSelectedPageLink()
     end
 end
 ReaderLink.onPosUpdate = ReaderLink.onPageUpdate

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1283,6 +1283,20 @@ function ReaderLink:onSelectPrevPageLink()
     return self:selectRelPageLink(-1)
 end
 
+function ReaderLink:isPageLinkSelected()
+    return self.cur_selected_page_link_num ~= nil
+end
+
+function ReaderLink:clearSelectedPageLink(dirty_ui)
+    self.cur_selected_page_link_num = nil
+    self.cur_selected_link = nil
+    self.document:highlightXPointer()
+    if dirty_ui then
+        UIManager:setDirty(self.dialog, "ui")
+    end
+    return true
+end
+
 function ReaderLink:selectRelPageLink(rel)
     if self.ui.paging then
         -- not implemented for now (see at doing like in showLinkBox()
@@ -1312,9 +1326,7 @@ function ReaderLink:selectRelPageLink(rel)
         end
     end
     if not self.cur_selected_page_link_num then
-        self.cur_selected_link = nil
-        self.document:highlightXPointer()
-        UIManager:setDirty(self.dialog, "ui")
+        self:clearSelectedPageLink(true)
         return
     end
     local selected_link = links[self.cur_selected_page_link_num]
@@ -1356,19 +1368,10 @@ end
 
 function ReaderLink:onPageUpdate()
     if self.cur_selected_link then
-        self.document:highlightXPointer()
-        self.cur_selected_page_link_num = nil
-        self.cur_selected_link = nil
+        self:clearSelectedPageLink(true)
     end
 end
-
-function ReaderLink:onPosUpdate()
-    if self.cur_selected_link then
-        self.document:highlightXPointer()
-        self.cur_selected_page_link_num = nil
-        self.cur_selected_link = nil
-    end
-end
+ReaderLink.onPosUpdate = ReaderLink.onPageUpdate
 
 function ReaderLink:onGoToLatestBookmark(ges)
     local latest_bookmark = self.ui.bookmark:getLatestBookmark()

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1288,6 +1288,7 @@ function ReaderLink:isPageLinkSelected()
 end
 
 function ReaderLink:clearSelectedPageLink(dirty_ui)
+    if self.ui.paging then return end
     self.cur_selected_page_link_num = nil
     self.cur_selected_link = nil
     self.document:highlightXPointer()


### PR DESCRIPTION
### what's new

* Added `isPageLinkSelected` and `clearSelectedPageLink` methods to the `ReaderLink` class to encapsulate and standardize the logic for checking and clearing selected page links, including updating UI state when necessary.
* Refactored code in `selectRelPageLink`, `onPageUpdate`, and `onPosUpdate` to use the new `clearSelectedPageLink` method, reducing duplication and ensuring consistent behavior when deselecting links. 

* Updated `ReaderBack:onBack` to clear a selected page link (if present) before performing other back navigation action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15613)
<!-- Reviewable:end -->
