### PR TITLE
OPDS: support per-catalog sync folders

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -249,9 +249,13 @@ function OPDSBrowser:genItemTableFromRoot()
     return item_table
 end
 
+function OPDSBrowser:getServerFromRootItem(item)
+    return item and item.idx and self.servers[item.idx - 1]
+end
+
 -- Shows dialog to edit properties of the new/existing catalog
 function OPDSBrowser:addEditCatalog(item)
-    local server = item and self.servers[item.idx - 1]
+    local server = self:getServerFromRootItem(item)
     local fields = {
         {
             hint = _("Catalog name"),
@@ -357,7 +361,7 @@ end
 
 -- Saves catalog properties from input dialog
 function OPDSBrowser:editCatalogFromInput(fields, item, no_refresh)
-    local old_server = item and self.servers[item.idx - 1]
+    local old_server = self:getServerFromRootItem(item)
     local new_server = {
         title     = fields[1],
         url       = fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2],
@@ -1442,7 +1446,7 @@ function OPDSBrowser:downloadDownloadList()
 end
 
 function OPDSBrowser:showSyncSettingsDialog(item)
-    local server = self.servers[item.idx - 1]
+    local server = self:getServerFromRootItem(item)
     local sync_dialog
     local catalog_sync_dir = server.sync_dir and BD.dirpath(server.sync_dir) or _("not set")
     local default_sync_dir = self.settings.sync_dir and BD.dirpath(self.settings.sync_dir) or _("not set")

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -251,6 +251,7 @@ end
 
 -- Shows dialog to edit properties of the new/existing catalog
 function OPDSBrowser:addEditCatalog(item)
+    local server = item and self.servers[item.idx - 1]
     local fields = {
         {
             hint = _("Catalog name"),
@@ -269,10 +270,10 @@ function OPDSBrowser:addEditCatalog(item)
     local title
     if item then
         title = _("Edit OPDS catalog")
-        fields[1].text = item.text
-        fields[2].text = item.url
-        fields[3].text = item.username
-        fields[4].text = item.password
+        fields[1].text = server.title
+        fields[2].text = server.url
+        fields[3].text = server.username
+        fields[4].text = server.password
     else
         title = _("Add OPDS catalog")
     end
@@ -305,12 +306,12 @@ function OPDSBrowser:addEditCatalog(item)
     }
     check_button_raw_names = CheckButton:new{
         text = _("Use server filenames"),
-        checked = item and item.raw_names,
+        checked = server and server.raw_names,
         parent = dialog,
     }
     check_button_sync_catalog = CheckButton:new{
         text = _("Sync catalog"),
-        checked = item and item.sync,
+        checked = server and server.sync,
         parent = dialog,
     }
     dialog:addWidget(check_button_raw_names)
@@ -356,6 +357,7 @@ end
 
 -- Saves catalog properties from input dialog
 function OPDSBrowser:editCatalogFromInput(fields, item, no_refresh)
+    local old_server = item and self.servers[item.idx - 1]
     local new_server = {
         title     = fields[1],
         url       = fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2],
@@ -364,6 +366,12 @@ function OPDSBrowser:editCatalogFromInput(fields, item, no_refresh)
         raw_names = fields[5],
         sync      = fields[6],
     }
+    if old_server then
+        new_server.sync_dir = old_server.sync_dir
+        if old_server.url == new_server.url then
+            new_server.last_download = old_server.last_download
+        end
+    end
     local new_item = buildRootEntry(new_server)
     local new_idx, itemnumber
     if item then
@@ -989,10 +997,14 @@ function OPDSBrowser.getFiletype(link)
     return filetype
 end
 
+function OPDSBrowser:getSyncDir(server)
+    return server and server.sync_dir or self.settings.sync_dir
+end
+
 -- Returns user selected or last opened folder
 function OPDSBrowser:getCurrentDownloadDir()
     if self.sync then
-        return self.settings.sync_dir
+        return self:getSyncDir(self.sync_server)
     else
         return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
     end
@@ -1136,6 +1148,16 @@ function OPDSBrowser:onMenuHold(item)
                             self.sync_force = false
                             self:checkSyncDownload(item.idx)
                         end)
+                    end,
+                },
+            },
+            {},
+            {
+                {
+                    text = _("Sync settings"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        self:showSyncSettingsDialog(item)
                     end,
                 },
             },
@@ -1419,6 +1441,44 @@ function OPDSBrowser:downloadDownloadList()
     end
 end
 
+function OPDSBrowser:showSyncSettingsDialog(item)
+    local server = self.servers[item.idx - 1]
+    local sync_dialog
+    local catalog_sync_dir = server.sync_dir and BD.dirpath(server.sync_dir) or _("not set")
+    local default_sync_dir = self.settings.sync_dir and BD.dirpath(self.settings.sync_dir) or _("not set")
+    sync_dialog = ButtonDialog:new{
+        title = server.title .. "\n\n" .. T(_("Catalog sync folder:\n%1\n\nDefault sync folder:\n%2"),
+            catalog_sync_dir, default_sync_dir),
+        title_align = "center",
+        buttons = {
+            {
+                {
+                    text = _("Choose catalog folder"),
+                    callback = function()
+                        UIManager:close(sync_dialog)
+                        self:setSyncDir(server, function()
+                            self:showSyncSettingsDialog(item)
+                        end)
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Use default folder"),
+                    enabled = server.sync_dir ~= nil,
+                    callback = function()
+                        server.sync_dir = nil
+                        self._manager.updated = true
+                        UIManager:close(sync_dialog)
+                        self:showSyncSettingsDialog(item)
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(sync_dialog)
+end
+
 function OPDSBrowser:setMaxSyncDownload()
     local current_max_dl = self.settings.sync_max_dl or 50
     local spin = SpinWidget:new{
@@ -1440,17 +1500,27 @@ function OPDSBrowser:setMaxSyncDownload()
     UIManager:show(spin)
 end
 
-function OPDSBrowser:setSyncDir()
+function OPDSBrowser:setSyncDir(server, callback)
     local force_chooser_dir
     if Device:isAndroid() then
         force_chooser_dir = Device.home_dir
+    elseif server then
+        force_chooser_dir = self:getSyncDir(server)
     end
 
     require("ui/downloadmgr"):new{
         onConfirm = function(inbox)
-            logger.info("set opds sync folder", inbox)
-            self.settings.sync_dir = inbox
+            if server then
+                logger.info("set opds catalog sync folder", server.title, inbox)
+                server.sync_dir = inbox
+            else
+                logger.info("set opds sync folder", inbox)
+                self.settings.sync_dir = inbox
+            end
             self._manager.updated = true
+            if callback then
+                callback()
+            end
         end,
     }:chooseDir(force_chooser_dir)
 end
@@ -1509,24 +1579,51 @@ function OPDSBrowser:updateFieldInCatalog(item, name, value)
 end
 
 function OPDSBrowser:checkSyncDownload(idx)
-    if self.settings.sync_dir then
-        self.sync = true
-        local info = InfoMessage:new{
+    local servers_to_sync = {}
+    if idx then
+        local server = self.servers[idx-1] -- First item is "Downloads"
+        if server and self:getSyncDir(server) then
+            table.insert(servers_to_sync, server)
+        end
+    else
+        for _, server in ipairs(self.servers) do
+            if server.sync and self:getSyncDir(server) then
+                table.insert(servers_to_sync, server)
+            end
+        end
+    end
+
+    if #servers_to_sync == 0 then
+        UIManager:show(InfoMessage:new{
+            text = idx and _("Please choose a folder for this catalog's sync downloads first")
+                or _("Please choose a folder for sync downloads first"),
+        })
+        return
+    end
+
+    self.sync = true
+    self.sync_server_list = {}
+    local info
+    local ok, err = pcall(function()
+        info = InfoMessage:new{
             text = _("Synchronizing lists…"),
         }
         UIManager:show(info)
         UIManager:forceRePaint()
-        if idx then
-            self:fillPendingSyncs(self.servers[idx-1]) -- First item is "Downloads"
-        else
-            for _, item in ipairs(self.servers) do
-                if item.sync then
-                    self:fillPendingSyncs(item)
-                end
-            end
+        for _, server in ipairs(servers_to_sync) do
+            self:fillPendingSyncs(server)
         end
         UIManager:close(info)
-        if #self.pending_syncs > 0 then
+        info = nil
+
+        local has_pending_syncs = false
+        for _, item in ipairs(self.pending_syncs) do
+            if self.sync_server_list[item.catalog] then
+                has_pending_syncs = true
+                break
+            end
+        end
+        if has_pending_syncs then
             Trapper:wrap(function()
                 self:downloadPendingSyncs()
             end)
@@ -1535,11 +1632,13 @@ function OPDSBrowser:checkSyncDownload(idx)
                 text = _("Up to date!"),
             })
         end
-        self.sync = false
-    else
-        UIManager:show(InfoMessage:new{
-            text = _("Please choose a folder for sync downloads first"),
-        })
+    end)
+    if info then
+        UIManager:close(info)
+    end
+    self.sync = false
+    if not ok then
+        error(err, 0)
     end
 end
 

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1474,6 +1474,14 @@ function OPDSBrowser:showSyncSettingsDialog(item)
                     end,
                 },
             },
+            {
+                {
+                    text = _("OK"),
+                    callback = function()
+                        UIManager:close(sync_dialog)
+                    end,
+                },
+            },
         },
     }
     UIManager:show(sync_dialog)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -254,9 +254,18 @@ function OPDSBrowser:getServerFromRootItem(item)
     return item and item.idx and self.servers[item.idx - 1]
 end
 
+function OPDSBrowser:refreshRootItemFromServer(item, server)
+    if item and item.idx and server then
+        local new_item = buildRootEntry(server)
+        new_item.idx = item.idx
+        self.item_table[item.idx] = new_item
+        return new_item
+    end
+    return item
+end
+
 -- Shows dialog to edit properties of the new/existing catalog
 function OPDSBrowser:addEditCatalog(item)
-    local server = self:getServerFromRootItem(item)
     local fields = {
         {
             hint = _("Catalog name"),
@@ -275,10 +284,10 @@ function OPDSBrowser:addEditCatalog(item)
     local title
     if item then
         title = _("Edit OPDS catalog")
-        fields[1].text = server.title
-        fields[2].text = server.url
-        fields[3].text = server.username
-        fields[4].text = server.password
+        fields[1].text = item.text
+        fields[2].text = item.url
+        fields[3].text = item.username
+        fields[4].text = item.password
     else
         title = _("Add OPDS catalog")
     end
@@ -311,12 +320,12 @@ function OPDSBrowser:addEditCatalog(item)
     }
     check_button_raw_names = CheckButton:new{
         text = _("Use server filenames"),
-        checked = server and server.raw_names,
+        checked = item and item.raw_names,
         parent = dialog,
     }
     check_button_sync_catalog = CheckButton:new{
         text = _("Sync catalog"),
-        checked = server and server.sync,
+        checked = item and item.sync,
         parent = dialog,
     }
     dialog:addWidget(check_button_raw_names)
@@ -1462,6 +1471,7 @@ function OPDSBrowser:showSyncSettingsDialog(item)
                     callback = function()
                         UIManager:close(sync_dialog)
                         self:setSyncDir(server, function()
+                            item = self:refreshRootItemFromServer(item, server)
                             self:showSyncSettingsDialog(item)
                         end)
                     end,
@@ -1473,6 +1483,7 @@ function OPDSBrowser:showSyncSettingsDialog(item)
                     enabled = server.sync_dir ~= nil,
                     callback = function()
                         server.sync_dir = nil
+                        item = self:refreshRootItemFromServer(item, server)
                         self._manager.updated = true
                         UIManager:close(sync_dialog)
                         self:showSyncSettingsDialog(item)

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -232,6 +232,7 @@ local function buildRootEntry(server)
         raw_names  = server.raw_names, -- use server raw filenames for download
         searchable = server.url and server.url:match("%%s") and true or false,
         sync       = server.sync,
+        sync_dir   = server.sync_dir,
     }
 end
 

--- a/spec/unit/opds_spec.lua
+++ b/spec/unit/opds_spec.lua
@@ -504,5 +504,80 @@ describe("OPDS module", function()
             -- And must NOT have an extra .pdf appended after the query string.
             assert(not href:match("opds%.pdf$"))
         end)
+
+        describe("sync settings", function()
+            it("should prefer a catalog sync folder and fall back to the default sync folder", function()
+                local browser = OPDSBrowser:extend{
+                    settings = {
+                        sync_dir = "/default",
+                    },
+                }
+
+                assert.are.same("/catalog", browser:getSyncDir{
+                    sync_dir = "/catalog",
+                })
+                assert.are.same("/default", browser:getSyncDir{})
+            end)
+
+            it("should preserve sync metadata when editing a catalog", function()
+                local browser = OPDSBrowser:extend{
+                    servers = {
+                        {
+                            title = "Old catalog",
+                            url = "http://example.org/opds",
+                            sync_dir = "/catalog",
+                            last_download = "http://example.org/book.epub",
+                        },
+                    },
+                    item_table = {
+                        {},
+                        {},
+                    },
+                    _manager = {},
+                }
+
+                browser:editCatalogFromInput({
+                    "New catalog",
+                    "http://example.org/opds",
+                    "",
+                    "",
+                    nil,
+                    true,
+                }, { idx = 2 }, true)
+
+                assert.are.same("/catalog", browser.servers[1].sync_dir)
+                assert.are.same("http://example.org/book.epub", browser.servers[1].last_download)
+            end)
+
+            it("should reset last download when editing a catalog URL", function()
+                local browser = OPDSBrowser:extend{
+                    servers = {
+                        {
+                            title = "Old catalog",
+                            url = "http://example.org/opds",
+                            sync_dir = "/catalog",
+                            last_download = "http://example.org/book.epub",
+                        },
+                    },
+                    item_table = {
+                        {},
+                        {},
+                    },
+                    _manager = {},
+                }
+
+                browser:editCatalogFromInput({
+                    "New catalog",
+                    "http://example.com/opds",
+                    "",
+                    "",
+                    nil,
+                    true,
+                }, { idx = 2 }, true)
+
+                assert.are.same("/catalog", browser.servers[1].sync_dir)
+                assert.is_nil(browser.servers[1].last_download)
+            end)
+        end)
     end)
 end)

--- a/spec/unit/opds_spec.lua
+++ b/spec/unit/opds_spec.lua
@@ -578,6 +578,33 @@ describe("OPDS module", function()
                 assert.are.same("/catalog", browser.servers[1].sync_dir)
                 assert.is_nil(browser.servers[1].last_download)
             end)
+
+            it("should refresh catalog sync folder on the root item", function()
+                local browser = OPDSBrowser:extend{
+                    servers = {
+                        {
+                            title = "Catalog",
+                            url = "http://example.org/opds",
+                            sync_dir = "/catalog",
+                        },
+                    },
+                    item_table = {
+                        {},
+                        {
+                            idx = 2,
+                            text = "Catalog",
+                            url = "http://example.org/opds",
+                            sync_dir = "/old",
+                        },
+                    },
+                }
+
+                local item = browser:refreshRootItemFromServer(browser.item_table[2], browser.servers[1])
+
+                assert.are.same("/catalog", item.sync_dir)
+                assert.are.same("/catalog", browser.item_table[2].sync_dir)
+                assert.are.same(2, browser.item_table[2].idx)
+            end)
         end)
     end)
 end)


### PR DESCRIPTION
### Why

Closes #14201.

OPDS sync used one global download folder for all catalogs. That made it hard to keep downloads separated when syncing multiple libraries, such as Komga `Comics` and `Ebooks`.

This also likely addresses the per-catalog folder request raised in https://github.com/koreader/koreader/pull/13946#issuecomment-3183923191.

This is a small follow-up to #13946. The issue also came up while syncing multiple Komga libraries to an e-reader: all synced books had to go into the same default folder, which made it harder to keep libraries organized.

With this change, users can keep the existing behavior and sync everything into the global folder, or choose a specific sync folder per catalog when they want libraries separated.

### What changed

- Added an optional sync folder per OPDS catalog.
- Exposed the setting from the catalog hold menu under `Sync settings`.
- Stores the selected folder in the catalog settings and uses it for that catalog's sync downloads.
- Keeps the existing global sync folder as the fallback when a catalog has no custom folder.
- Preserves sync metadata when editing a catalog unless the catalog URL changes.
- Added an `OK` action to close the sync settings dialog without changing folders.
- Added unit coverage for folder precedence, global fallback, catalog edits, and URL-change behavior.

### Testing

- `./kodev test front`: passed, 76/76 tests.
- `make static-check`: passed, 0 warnings / 0 errors in 556 files.
- Manual OPDS sync with a local Komga server containing two libraries: `Comics` and `Ebooks`.

Verified manual flow:

1. Add Komga as an OPDS catalog in KOReader.
2. Add Komga `Comics` and `Ebooks` as separate KOReader catalogs.
3. Open `Komga - comics` -> `Sync settings`.
4. Set a catalog-specific sync folder.
5. Run sync for `Komga - comics`.
6. Confirm KOReader reports `1 book downloaded`.
7. Confirm the comic is saved in the selected catalog folder.

### Figures

<details>
<summary>Manual testing screenshots</summary>

**Figure 1. Komga libraries: `Comics` and `Ebooks`.**  
<img width="360" alt="Komga libraries" src="https://github.com/user-attachments/assets/35baffb3-a43a-4074-a482-4b38de23b024" />

**Figure 2. Komga added in KOReader OPDS catalogs.**  
<img width="360" alt="Komga OPDS catalog in KOReader" src="https://github.com/user-attachments/assets/62a74bc5-160b-427d-8a26-35e2cb0783e9" />

**Figure 3. Adding `Komga - comics` as a catalog.**  
<img width="520" alt="Add OPDS catalog dialog" src="https://github.com/user-attachments/assets/b41c5557-3fe5-43cb-b9b5-954df685ffd0" />

**Figure 4. KOReader catalog list with Komga, comics, and ebooks.**  
<img width="520" alt="KOReader OPDS catalog list" src="https://github.com/user-attachments/assets/c93cafac-ea49-440a-b1bf-2a00217045a8" />

**Figure 5. Hold menu with `Sync settings`.**  
<img width="500" alt="Catalog hold menu with Sync settings" src="https://github.com/user-attachments/assets/6f9ca2bb-dc1f-4f47-bc15-293e3ff94e0e" />

**Figure 6. Sync settings before choosing a catalog folder.**  
<img width="360" alt="Sync settings before choosing catalog folder" src="https://github.com/user-attachments/assets/aa83789b-5c05-4b5a-a81d-85afb43178f0" />

**Figure 7. Folder picker confirmation.**  
<img width="360" alt="Folder picker confirmation" src="https://github.com/user-attachments/assets/06cd708a-4c78-4d5d-9b7c-19ce7bd3201a" />

**Figure 8. Sync settings after choosing the catalog folder.**  
<img width="360" alt="Sync settings after choosing catalog folder" src="https://github.com/user-attachments/assets/5115d438-1a36-42d5-98de-2bf9220b1dc4" />

**Figure 9. Sync result: `1 book downloaded`.**  
<img width="360" alt="Sync result showing one book downloaded" src="https://github.com/user-attachments/assets/234e3ca9-ec9a-45dd-8508-6e2ad8187db6" />

**Figure 10. Downloaded comic in the selected folder.**  
<img width="520" alt="Downloaded comic in selected folder" src="https://github.com/user-attachments/assets/e77d75ff-24a0-4be1-9756-d9d8e72873de" />

</details>


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15615)
<!-- Reviewable:end -->
