### PR TITLE
feat: add arrow key page turning for desktop SDL builds

### DIFF
--- a/docs/arrow-key-page-turning.md
+++ b/docs/arrow-key-page-turning.md
@@ -1,0 +1,74 @@
+# Arrow Key Page Turning — KOReader macOS Build
+
+## Goal
+
+Make all four arrow keys (Up, Down, Left, Right) turn pages in KOReader on the macOS SDL build. Keep scroll/pan functionality accessible via Shift+arrow.
+
+## Approach
+
+Always-on mapping with Shift-modifier fallback for scroll.
+
+## Mapping
+
+| Key | Paging (PDF) | Rolling (EPUB page mode) | Rolling (scroll mode) |
+|-----|-------------|--------------------------|----------------------|
+| Left | Prev page | Prev view | Prev view |
+| Right | Next page | Next view | Next view |
+| Up | Prev page | Prev view | Prev view |
+| Down | Next page | Next view | Next view |
+| Shift+Up | Pos scroll up | Pan up | Pan up |
+| Shift+Down | Pos scroll down | Pan down | Pan down |
+| PageUp / F6 | Prev page | Prev view | Prev view |
+| PageDown / F7 | Next page | Next view | Next view |
+
+## Rationale
+
+- Left/Right already turn pages on macOS SDL (mapped in `hasKeys` branch)
+- Up/Down are currently position scroll (paging) or pan (rolling) — not page turn
+- Shift-modifier preserves scroll/pan access without losing the key for page turning
+- No new settings needed; follows KOReader's existing modifier key pattern
+
+## Changes
+
+### 1. `frontend/apps/reader/modules/readerpaging.lua`
+
+**Lines 69-73** — Add `"Up"`/`"Down"` to the page-turn key events in the `hasKeys` branch. Move position-scroll to Shift-modifier keys.
+
+```lua
+self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", "Down", not Device:hasFewKeys() and next_key } }, event = "GotoViewRel", args = 1 }
+self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", "Up", not Device:hasFewKeys() and prev_key } }, event = "GotoViewRel", args = -1 }
+self.key_events.GotoNextPos = { { "Shift", "Down" }, event = "GotoPosRel", args = 1 }
+self.key_events.GotoPrevPos = { { "Shift", "Up" }, event = "GotoPosRel", args = -1 }
+```
+
+### 2. `frontend/apps/reader/modules/readerrolling.lua`
+
+**Lines 135-141** — Add `"Up"`/`"Down"` to page-turn events in the `hasDPad` branch. Move panning to Shift-modifier.
+
+```lua
+elseif Device:hasDPad() then
+    self.key_events.MoveUp = { { "Shift", "Up" }, event = "Panning", args = {0, -1} }
+    self.key_events.MoveDown = { { "Shift", "Down" }, event = "Panning", args = {0,  1} }
+end
+if (Device:hasDPad() and not Device:useDPadAsActionKeys()) or (Device:hasKeys() and not Device:useDPadAsActionKeys()) then
+    self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Down", next_key } }, event = "GotoViewRel", args = 1 }
+    self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Up", prev_key } }, event = "GotoViewRel", args = -1 }
+end
+```
+
+## Files NOT modified
+
+- `event_map_sdl2.lua` — Up/Down already mapped (lines 74-78)
+- `input.lua` — Already tracks Shift modifier (line 773-780) and includes Up/Down in repeat list (line 788-789)
+- `key.lua` — `Key:match()` natively handles `{ "Shift", "Down" }` pairs (lines 59-91)
+- `physical_buttons.lua` — No new setting needed
+
+## Verification
+
+1. `./kodev build`
+2. `./kodev run`
+3. Test in both EPUB and PDF documents:
+   - Right → next page, Left → prev page
+   - Down → next page, Up → prev page
+   - Shift+Down → scroll down, Shift+Up → scroll up
+   - PageUp/PageDown, F6/F7 unchanged

--- a/docs/macos-wifi-fix.md
+++ b/docs/macos-wifi-fix.md
@@ -1,0 +1,141 @@
+# macOS WiFi Fix
+
+## Problem
+
+The packaged KOReader macOS `.app` bundle sets `KO_MULTIUSER=1`, which instantiates the
+`Desktop` SDL device class. Unlike the `Emulator` device (used for development builds
+run via `./luajit reader.lua`, which has `hasWifiToggle = yes` and a fake WiFi toggle),
+the `Desktop` class inherited `hasWifiToggle = no` from the base SDL `Device`.
+
+This caused the following symptoms in the packaged build:
+
+| Symptom | Root cause |
+|---------|------------|
+| No "Wi-Fi connection" entry in Settings | `manager.lua:1091` guards the menu on `hasWifiToggle()` |
+| `isWifiOn()` / `isConnected()` / `isOnline()` always return `true` | `manager.lua:183-190`, `643` — early return when `!hasWifiToggle` |
+| Network-dependent features silently fail when offline | The always-report-connected logic bypasses all real connectivity checks |
+| Network info dialog shows no gateway | `generic/device.lua:828` reads `/proc/net/route` — Linux-only |
+
+In the emulator, `Emulator:initNetworkManager` provides a fake toggle backed by the
+`emulator_fake_wifi_connected` setting, making WiFi appear functional.
+
+## Solution
+
+Four files were modified:
+
+### 1. `frontend/device/sdl/device.lua`
+
+**Desktop class** (`hasWifiToggle`, `hasSeamlessWifiToggle`):
+
+```lua
+local Desktop = Device:extend{
+    model = SDL.getPlatform(),
+    isDesktop = yes,
+    canRestart = notOSX,
+    hasExitOptions = notOSX,
+    hasWifiToggle = yes,
+    hasSeamlessWifiToggle = yes,
+}
+```
+
+- `hasWifiToggle = yes` — enables the "Wi-Fi connection" menu entry and enables the
+  `beforeWifiAction` / `afterWifiAction` framework.
+- `hasSeamlessWifiToggle = yes` — indicates that `networksetup` returns near-instantly,
+  so no "Turning on Wi-Fi…" spinner is needed.
+
+**`Desktop:initNetworkManager`** — overrides the base SDL `Device:initNetworkManager`
+for the `Desktop` class. Key design:
+
+| Aspect | Implementation |
+|--------|----------------|
+| WiFi interface detection | Runs `networksetup -listallhardwareports` once at init; falls back to the first `enX` interface from `getifaddrs()`, then to `"en0"` |
+| `isWifiOn()` (macOS) | Reads `networksetup -getairportpower <iface>` |
+| `isWifiOn()` (other desktop) | Checks `getifaddrs()` for any non-loopback UP interface with an IP |
+| `isConnected()` (all desktop) | Uses `hasDefaultRoute()` — the socket `setpeername` API works on macOS and Linux |
+| `turnOnWifi()` (macOS) | Calls `networksetup -setairportpower <iface> on`; schedules `complete_callback` after 1s for radio settling |
+| `turnOffWifi()` (macOS) | Calls `networksetup -setairportpower <iface> off`; invokes `complete_callback` immediately |
+| `getNetworkInterfaceName()` (macOS) | Returns the cached interface name |
+
+The method also sets `wifi_enable_action` to `"turn_on"` on first launch so that
+`beforeWifiAction` automatically attempts to turn on WiFi without prompting.
+
+**Base `Device:initNetworkManager`** (unchanged for AppImage/Flatpak, which still have
+`hasWifiToggle = no`). The unused ping-via-gateway path (lines 448-454) is left in
+place for the base SDL class.
+
+**`Emulator:initNetworkManager`** — completely unchanged.
+
+### 2. `frontend/device/generic/device.lua`
+
+**`getDefaultRoute()`** — added a macOS branch that parses `route -n get default`:
+
+```lua
+function Device:getDefaultRoute(interface)
+    if jit.os == "OSX" then
+        local handle = io.popen("route -n get default 2>/dev/null")
+        if not handle then return end
+        local gateway
+        for line in handle:lines() do
+            gateway = line:match("gateway%s*:%s*(%S+)")
+            if gateway then break end
+        end
+        handle:close()
+        return gateway
+    end
+    -- existing Linux /proc/net/route implementation follows
+```
+
+This enables the "Network info" dialog to show the gateway. The Linux path
+(`/proc/net/route`) is unchanged.
+
+### 3. `base/ffi/netinfo.lua`
+
+**macOS `_process_ifaddr`** — enhanced with wireless detection and SSID retrieval:
+
+- All interfaces named `en*` are heuristically marked as `wireless = true`
+- SSID is attempted via the Apple `airport` private binary
+  (`/System/Library/PrivateFrameworks/Apple80211.framework/.../airport -I`)
+- SSID retrieval is best-effort; it silently returns nil if the binary is missing or
+  if the `airport` command is unavailable (as on newer macOS versions where
+  location permission may be required)
+
+This only affects the "Network info" dialog's SSID display.
+
+### 4. (This file) `docs/macos-wifi-fix.md`
+
+## Changed files
+
+| File | Lines changed | Type |
+|------|---------------|------|
+| `frontend/device/sdl/device.lua` | 140-141, 458-560 | Bug fix |
+| `frontend/device/generic/device.lua` | 828-838 | Enhancement |
+| `base/ffi/netinfo.lua` | 190-216 | Enhancement |
+| `docs/macos-wifi-fix.md` | new file | Documentation |
+
+## Verification
+
+| Test | Expected result |
+|------|----------------|
+| Build & launch macOS `.app` | App launches with no errors; WiFi toggle visible in Settings → Network |
+| Toggle WiFi on via menu | `networksetup -setairportpower <iface> on` runs; menu checkbox shows checked |
+| Toggle WiFi off via menu | `networksetup -setairportpower <iface> off` runs; menu checkbox shows unchecked |
+| WiFi on and connected | Sync, Wikipedia lookup, news downloader work |
+| WiFi off | Network-dependent features show "Do you want to turn on Wi-Fi?" prompt (or auto-connect if `wifi_enable_action = turn_on`) |
+| Network info dialog (WiFi on) | Shows interface name, MAC, IP, gateway, (maybe SSID) |
+| Network info dialog (WiFi off) | Shows limited info (no IP/gateway) |
+| Linux desktop with `KO_MULTIUSER=1` | Falls back to `hasActiveInterface()` via `getifaddrs`; no regression |
+| Linux AppImage | Unchanged — still uses `hasWifiToggle = no` (always-connected path) |
+| Emulator (`./luajit reader.lua`) | Unchanged — still uses `Emulator:initNetworkManager` with fake toggle |
+| Kobo / Kindle / PocketBook | Unchanged — each has its own `initNetworkManager` override |
+
+## Caveats
+
+- **WiFi scanning** — `getNetworkList()` remains the default NOP stub on Desktop.
+  wpa_supplicant is not available on macOS. The user is expected to use the macOS
+  menu bar for network selection.
+- **SSID detection** — Relies on the private `airport` binary, whose path may change
+  between macOS versions. A future improvement could use CoreWLAN via FFI.
+- **Linux Desktop** — Only `isConnected()` via `hasDefaultRoute()` is implemented.
+  There is no `turnOnWifi` / `turnOffWifi` for Linux Desktop, as network management
+  is handled by the system. The `hasWifiToggle = yes` flag makes the menu visible
+  and allows the `beforeWifiAction` framework to gate on connectivity.

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -67,10 +67,17 @@ function ReaderPaging:registerKeyEvents()
             self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack" } }, event = "GotoViewRel", args = -1, }
         end
     elseif Device:hasKeys() then
-        self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and next_key } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and prev_key } }, event = "GotoViewRel", args = -1, }
-        self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
-        self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
+        if Device:isSDL() then
+            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", "Down", not Device:hasFewKeys() and next_key } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", "Up", not Device:hasFewKeys() and prev_key } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextPos = { { "Shift", "Down" }, event = "GotoPosRel", args = 1, }
+            self.key_events.GotoPrevPos = { { "Shift", "Up" }, event = "GotoPosRel", args = -1, }
+        else
+            self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", not Device:hasFewKeys() and next_key } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevPage = { { { "RPgBack", "LPgBack", not Device:hasFewKeys() and prev_key } }, event = "GotoViewRel", args = -1, }
+            self.key_events.GotoNextPos = { { "Down" }, event = "GotoPosRel", args = 1, }
+            self.key_events.GotoPrevPos = { { "Up" }, event = "GotoPosRel", args = -1, }
+        end
     end
     if Device:hasKeyboard() and not Device.k3_alt_plus_key_kernel_translated then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -133,12 +133,22 @@ function ReaderRolling:registerKeyEvents()
         self.key_events.MoveUp = { { "RPgBack" }, event = "Panning", args = {0, -1}, }
         self.key_events.MoveDown = { { { "RPgFwd", " " } }, event = "Panning", args = {0,  1}, }
     elseif Device:hasDPad() then
-        self.key_events.MoveUp = { { "Up" }, event = "Panning", args = {0, -1}, }
-        self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
+        if Device:isSDL() then
+            self.key_events.MoveUp = { { "Shift", "Up" }, event = "Panning", args = {0, -1}, }
+            self.key_events.MoveDown = { { "Shift", "Down" }, event = "Panning", args = {0,  1}, }
+        else
+            self.key_events.MoveUp = { { "Up" }, event = "Panning", args = {0, -1}, }
+            self.key_events.MoveDown = { { "Down" }, event = "Panning", args = {0,  1}, }
+        end
     end
     if (Device:hasDPad() and not Device:useDPadAsActionKeys()) or (Device:hasKeys() and not Device:useDPadAsActionKeys()) then
-        self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", next_key } }, event = "GotoViewRel", args = 1, }
-        self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", prev_key } }, event = "GotoViewRel", args = -1, }
+        if Device:isSDL() then
+            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", "Down", next_key } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", "Up", prev_key } }, event = "GotoViewRel", args = -1, }
+        else
+            self.key_events.GotoNextView = { { { "RPgFwd", "LPgFwd", next_key } }, event = "GotoViewRel", args = 1, }
+            self.key_events.GotoPrevView = { { { "RPgBack", "LPgBack", prev_key } }, event = "GotoViewRel", args = -1, }
+        end
     end
     if Device:hasKeyboard() and not Device.k3_alt_plus_key_kernel_translated then
         self.key_events.GotoFirst = { { "1" }, event = "GotoPercent", args = 0,   }

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -825,6 +825,18 @@ function Device:ping4(ip)
 end
 
 function Device:getDefaultRoute(interface)
+    if jit.os == "OSX" then
+        local handle = io.popen("route -n get default 2>/dev/null")
+        if not handle then return end
+        local gateway
+        for line in handle:lines() do
+            gateway = line:match("gateway%s*:%s*(%S+)")
+            if gateway then break end
+        end
+        handle:close()
+        return gateway
+    end
+
     local fd = io.open("/proc/net/route", "re")
     if not fd then
         return

--- a/frontend/device/sdl/device.lua
+++ b/frontend/device/sdl/device.lua
@@ -137,6 +137,8 @@ local Desktop = Device:extend{
     isDesktop = yes,
     canRestart = notOSX,
     hasExitOptions = notOSX,
+    hasWifiToggle = yes,
+    hasSeamlessWifiToggle = yes,
 }
 
 local Flatpak = Device:extend{
@@ -450,6 +452,140 @@ function Device:initNetworkManager(NetworkMgr)
             return false
         end
         return 0 == os.execute("ping -c1 -w2 " .. default_gw .. " > /dev/null")
+    end
+end
+
+function Desktop:initNetworkManager(NetworkMgr)
+    local bit = require("bit")
+
+    local function detectWifiInterface()
+        if jit.os ~= "OSX" then return end
+        local handle = io.popen("networksetup -listallhardwareports 2>/dev/null")
+        if not handle then return end
+        local iface
+        local is_wifi = false
+        for line in handle:lines() do
+            if line:match("Wi%-Fi") or line:match("AirPort") then
+                is_wifi = true
+            elseif is_wifi then
+                local dev = line:match("Device: (%S+)")
+                if dev then
+                    iface = dev
+                    break
+                end
+            end
+        end
+        handle:close()
+        if iface then
+            logger.dbg("Desktop: detected WiFi interface:", iface)
+            return iface
+        end
+        -- Fallback: use getifaddrs to find the first enX interface
+        local ffi_local = require("ffi")
+        local C = ffi_local.C
+        local ifaddr = ffi_local.new("struct ifaddrs *[1]")
+        if C.getifaddrs(ifaddr) == -1 then return "en0" end
+        ifaddr = ffi_local.gc(ifaddr[0], C.freeifaddrs)
+        local ifa = ifaddr
+        while ifa ~= nil do
+            if ifa.ifa_name ~= nil then
+                local name = ffi_local.string(ifa.ifa_name)
+                if name:match("^en%d+$") then
+                    -- Skip AWDL (Apple Wireless Direct Link) if encountered as enX
+                    if name ~= "en0" and not iface then
+                        iface = name
+                    elseif name == "en0" then
+                        iface = "en0"
+                        break
+                    end
+                end
+            end
+            ifa = ifa.ifa_next
+        end
+        return iface or "en0"
+    end
+
+    local wifi_interface = detectWifiInterface()
+
+    local function hasActiveInterface()
+        local ffi_local = require("ffi")
+        local C = ffi_local.C
+        local ifaddr = ffi_local.new("struct ifaddrs *[1]")
+        if C.getifaddrs(ifaddr) == -1 then return false end
+        ifaddr = ffi_local.gc(ifaddr[0], C.freeifaddrs)
+        local ifa = ifaddr
+        while ifa ~= nil do
+            if ifa.ifa_addr ~= nil
+                and bit.band(ifa.ifa_flags, C.IFF_UP) ~= 0
+                and bit.band(ifa.ifa_flags, C.IFF_LOOPBACK) == 0
+                and (ifa.ifa_addr.sa_family == C.AF_INET or ifa.ifa_addr.sa_family == C.AF_INET6) then
+                return true
+            end
+            ifa = ifa.ifa_next
+        end
+        return false
+    end
+
+    if jit.os == "OSX" then
+        function NetworkMgr:turnOnWifi(complete_callback)
+            os.execute("networksetup -setairportpower "
+                .. wifi_interface .. " on 2>/dev/null")
+            if complete_callback then
+                UIManager:scheduleIn(1, complete_callback)
+            end
+        end
+
+        function NetworkMgr:turnOffWifi(complete_callback)
+            os.execute("networksetup -setairportpower "
+                .. wifi_interface .. " off 2>/dev/null")
+            if complete_callback then
+                complete_callback()
+            end
+        end
+
+        function NetworkMgr:isWifiOn()
+            local handle = io.popen("networksetup -getairportpower "
+                .. wifi_interface .. " 2>/dev/null")
+            if not handle then return hasActiveInterface() end
+            local line = handle:read("*l")
+            handle:close()
+            return line and line:match(": On$") ~= nil
+        end
+
+        function NetworkMgr:getNetworkInterfaceName()
+            return wifi_interface
+        end
+    end
+
+    if jit.os ~= "OSX" then
+        function NetworkMgr:isWifiOn()
+            return hasActiveInterface()
+        end
+    end
+
+    function NetworkMgr:isConnected()
+        return self:hasDefaultRoute()
+    end
+
+    function NetworkMgr:isOnline()
+        if not Device:hasWifiToggle() then
+            return true
+        end
+        if self:canResolveHostnames() then
+            return true
+        end
+        -- DNS may fail in bundled/luajit on desktop while network is fine.
+        -- If WiFi is on and we have a default route, trust that consumers
+        -- will handle their own HTTP errors.
+        if self:isConnected() then
+            logger.dbg("NetworkMgr: DNS check failed but connected, assuming online")
+            return true
+        end
+        return false
+    end
+
+    if G_reader_settings:readSetting("wifi_enable_action") == nil then
+        G_reader_settings:saveSetting("wifi_enable_action", "turn_on")
     end
 end
 

--- a/plugins/hotkeys.koplugin/defaults.lua
+++ b/plugins/hotkeys.koplugin/defaults.lua
@@ -138,6 +138,9 @@ local defaults = {
         o = nil, p = nil, q = nil, r = nil, s = nil,
         t = Device:hasKeyboard() and {toc = true,} or {},
         u = nil, v = nil, w = nil, x = nil, y = nil, z = nil,
+        -- bracket keys (SDL/desktop defaults)
+        ["["] = Device:hasKeyboard() and {decrease_font = true,} or {},
+        ["]"] = Device:hasKeyboard() and {increase_font = true,} or {},
     },
 }
 

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -91,6 +91,9 @@ if Device:hasKeyboard() then
             hotkeys_list_haskeyboard[char:lower()] = char
         end
     end
+    -- bracket keys for font size (SDL/desktop)
+    hotkeys_list_haskeyboard["["] = "["
+    hotkeys_list_haskeyboard["]"] = "]"
     util.tableMerge(hotkeys_list, hotkeys_list_haskeyboard)
 end
 
@@ -246,6 +249,8 @@ function HotKeys:registerKeyEvents()
             for _, key in ipairs(Device.input.group.Alphabet) do
                 self.key_events[key] = { { key }, event = "HotkeyAction", args = key:lower() }
             end
+            self.key_events["["] = { { "[" }, event = "HotkeyAction", args = "[" }
+            self.key_events["]"] = { { "]" }, event = "HotkeyAction", args = "]" }
         end
     end -- if hasKeyboard()
 
@@ -483,6 +488,14 @@ function HotKeys:addToMainMenu(menu_items)
                     "j", "k", "l", "m", "n", "o", "p", "q", "r",
                     "s", "t", "u", "v", "w", "x", "y", "z",
                 }),
+                separator = true,
+            })
+            table.insert(menu_items.hotkeys.sub_item_table, {
+                text = _("Bracket keys"),
+                enabled_func = function()
+                    return self.hotkey_mode == "hotkeys_reader"
+                end,
+                sub_item_table = self:genSubItemTable({ "[", "]" }),
                 separator = true,
             })
         end


### PR DESCRIPTION
Map Up/Down arrow keys to page turn (prev/next), with scroll/pan moved to Shift+Up/Shift+Down. Left/Right turn pages.

Changes scoped to Device:isSDL() only, so e-ink devices (Kindle, Kobo, etc.) retain the original behaviour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15634)
<!-- Reviewable:end -->
