### PR TITLE
kindle: only translate gyro events coming from the accelerometer

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -577,10 +577,14 @@ function Kindle:openInputDevices()
         --       And let's add that isn't also a touchscreen to the mix, because while not true at time of writing, that's an event touchscreens sure can support...
         devices = FBInkInput.fbink_input_scan(C.INPUT_ROTATION_EVENT, bit.bor(C.INPUT_TABLET, C.INPUT_TOUCHSCREEN), C.NO_RECAP, dev_count)
         if devices ~= nil then
+            self.input.rotation_fds = {}
             for i = 0, tonumber(dev_count[0]) - 1 do
                 local dev = devices[i]
                 if dev.matched then
-                    self.input:fdopen(tonumber(dev.fd), ffi.string(dev.path), ffi.string(dev.name))
+                    local fd = tonumber(dev.fd)
+                    self.input:fdopen(fd, ffi.string(dev.path), ffi.string(dev.name))
+                    -- Remember the fd, so the gyro translation hooks can skip lookalike events from other devices
+                    self.input.rotation_fds[fd] = true
                 end
             end
             C.free(devices)
@@ -1428,7 +1432,9 @@ local function OasisGyroTranslation(this, ev)
     local DEVICE_ORIENTATION_LANDSCAPE              = 21
     local DEVICE_ORIENTATION_LANDSCAPE_ROTATED      = 22
 
-    if ev.type == C.EV_ABS and ev.code == C.ABS_PRESSURE then
+    -- Only trust the accelerometer, other devices may report ABS_PRESSURE, too (e.g., hotplugged keyboards w/ a digitizer collection)
+    if ev.type == C.EV_ABS and ev.code == C.ABS_PRESSURE
+        and (not ev.fd or not this.rotation_fds or this.rotation_fds[ev.fd]) then
         if ev.value == DEVICE_ORIENTATION_PORTRAIT
             or ev.value == DEVICE_ORIENTATION_PORTRAIT_LEFT
             or ev.value == DEVICE_ORIENTATION_PORTRAIT_RIGHT then
@@ -1536,7 +1542,9 @@ local function KindleGyroTransform(this, ev)
     local UPWARD_LANDSCAPE_LEFT_INTERRUPT_HAPPENED  = 17
     local UPWARD_LANDSCAPE_RIGHT_INTERRUPT_HAPPENED = 18
 
-    if ev.type == C.EV_ABS and ev.code == C.ABS_PRESSURE then
+    -- Only trust the accelerometer, other devices may report ABS_PRESSURE, too (e.g., hotplugged keyboards w/ a digitizer collection)
+    if ev.type == C.EV_ABS and ev.code == C.ABS_PRESSURE
+        and (not ev.fd or not this.rotation_fds or this.rotation_fds[ev.fd]) then
         if ev.value == UPWARD_PORTRAIT_UP_INTERRUPT_HAPPENED then
             -- i.e., UR
             ev.type = C.EV_MSC


### PR DESCRIPTION
The gyro translation hooks run on events from every open input fd. Now that ExternalKeyboard can attach keyboards on Kindle (#15248), a hotplugged device that reports `EV_ABS:ABS_PRESSURE` (e.g. a keyboard with a digitizer collection in its HID descriptor) can flip the screen into the opposite landscape, bypassing both rotation locks (the gsensor lock only checks the orientation axis, which both landscape modes share).

Remember the fds opened by the rotation device scan and have the hooks ignore `ABS_PRESSURE` from any other fd. Depends on koreader/koreader-base#2429 for `ev.fd`, until the base bump this is a no-op.

Spotted while chasing zampierilucas/kindle-hid-passthrough#83.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15635)
<!-- Reviewable:end -->
