### PR TITLE
dictionaries: fix / update some dictionaries

### DIFF
--- a/frontend/ui/data/dictionaries.lua
+++ b/frontend/ui/data/dictionaries.lua
@@ -92,35 +92,11 @@ local dictionaries = {
     },
     {
         name = "GNU/FDL Anglicko/Český slovník",
-        lang_in = "eng",
-        lang_out = "ces",
-        entries = 178904, -- ~90000 each way
-        license = _("GNU/FDL"),
-        url = "http://http.debian.net/debian/pool/non-free/s/stardict-english-czech/stardict-english-czech_20161201.orig.tar.gz",
-    },
-    {
-        name = "GNU/FDL Anglicko/Český slovník",
         lang_in = "ces",
         lang_out = "eng",
         entries = 88994,
         license = _("GNU/FDL"),
         url = "https://github.com/Vuizur/czech-dictionary-extender/releases/download/1.0.0/czech-english-dict.tar.gz",
-    },
-    {
-        name = "GNU/FDL Německo/Český slovník",
-        lang_in = "deu",
-        lang_out = "ces",
-        entries = 2341, -- ~1200 each way
-        license = _("GNU/FDL"),
-        url = "http://http.debian.net/debian/pool/non-free/s/stardict-german-czech/stardict-german-czech_20161201.orig.tar.gz",
-    },
-    {
-        name = "GNU/FDL Německo/Český slovník",
-        lang_in = "ces",
-        lang_out = "deu",
-        entries = 2341, -- ~1200 each way
-        license = _("GNU/FDL"),
-        url = "http://http.debian.net/debian/pool/non-free/s/stardict-german-czech/stardict-german-czech_20161201.orig.tar.gz",
     },
     -- Dictionaries mirrored from Sourceforge, see https://github.com/koreader/koreader/pull/3176#issuecomment-447085441
     {
@@ -3345,7 +3321,7 @@ local dictionaries = {
         lang_out = "swe",
         entries = 14076,
         license = "GPLv3+ and CC BY-SA 4.0",
-        url = "https://github.com/xxyzz/wiktionary_stardict/releases/latest/download/nb-sv.tar.zst",
+        url = "https://github.com/xxyzz/wiktionary_stardict/releases/latest/download/no-sv.tar.zst",
     },
     {
         name = "Wiktionary Bulgarian-English",


### PR DESCRIPTION
- fix "Wiktionary Bokmål-Svenska" URL
- drop "GNU/FDL Anglicko/Český slovník" & "GNU/FDL Německo/Český slovník" dictionaries: URLs are not valid anymore, and the updated Debian package sources don't include the final StartDict dictionaries

Command used to check:
```
curl --head --no-show-headers -s -L --out-null \
-w '%{url} %{http_code} %header{content-length} %header{etag}\n' \
$(sed -n 's/^\s*url = "\(.*\)",\?/\1/p' 'frontend/ui/data/dictionaries.lua' | sort)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15641)
<!-- Reviewable:end -->
