### PR TITLE
document: fix crash when opening single images

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -392,7 +392,7 @@ end
 
 function Document:getFullPageHash(pageno, zoom, rotation, gamma, saturation)
     return "renderpg|"..self.file.."|"..self.mod_time.."|"..pageno.."|"
-                    ..zoom.."|"..rotation.."|"..gamma.."|"..self.configurable.background_cleanup.."|"
+                    ..zoom.."|"..rotation.."|"..gamma.."|"..(self.configurable.background_cleanup or 0).."|"
                     ..self.render_mode..(self.render_color and "|color" or "|bw")
                     ..(self.reflowable_font_size and "|"..self.reflowable_font_size or "")
                     .."|"..saturation
@@ -401,7 +401,7 @@ end
 function Document:getPagePartHash(pageno, zoom, rotation, gamma, saturation, rect)
     return "renderpgpart|"..self.file.."|"..self.mod_time.."|"..pageno.."|"
                     ..tostring(rect).."|"..zoom.."|"..tostring(rect.scaled_rect)
-                    .."|"..rotation.."|"..gamma.."|"..self.configurable.background_cleanup.."|"
+                    .."|"..rotation.."|"..gamma.."|"..(self.configurable.background_cleanup or 0).."|"
                     ..self.render_mode..(self.render_color and "|color" or "|bw")
                     ..(self.reflowable_font_size and "|"..self.reflowable_font_size or "")
                     .."|"..saturation


### PR DESCRIPTION
```
./luajit: frontend/document/document.lua:391: attempt to concatenate field 'background_cleanup' (a nil value)
stack traceback:
	frontend/document/document.lua:391: in function 'getFullPageHash'
	frontend/document/document.lua:413: in function 'renderPage'
	frontend/document/document.lua:534: in function 'drawPage'
	frontend/apps/reader/modules/readerview.lua:450: in function 'drawSinglePage'
	frontend/apps/reader/modules/readerview.lua:198: in function 'paintTo'
	frontend/ui/widget/container/inputcontainer.lua:91: in function 'paintTo'
	frontend/ui/uimanager.lua:1262: in function '_repaint'
	frontend/ui/uimanager.lua:1485: in function 'handleInput'
	frontend/ui/uimanager.lua:1585: in function 'run'
	reader.lua:251: in main chunk
	[C]: at 0x559b746b885b
```

Cf. #15401.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15644)
<!-- Reviewable:end -->
