### PR TITLE
ReaderDictionary: in-process StarDict engine for exact lookups

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -19,6 +19,7 @@ local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local NetworkMgr = require("ui/network/manager")
 local Presets = require("ui/presets")
 local SortWidget = require("ui/widget/sortwidget")
+local StardictEngine = require("stardict/engine")
 local Trapper = require("ui/trapper")
 local UIManager = require("ui/uimanager")
 local Utf8Proc = require("ffi/utf8proc")
@@ -39,6 +40,30 @@ local android = Device:isAndroid() and require("android")
 -- so we only have to look for them on the first :init()
 local available_ifos = nil
 local lookup_history = nil
+
+-- In-process StarDict lookup engine (see frontend/stardict/engine.lua),
+-- shared as a module local: dictionary directories are global, not
+-- per-document. It answers exact lookups without spawning sdcv; anything
+-- it cannot serve with byte-identical results is deferred to sdcv.
+local inprocess_engine = nil
+local inprocess_session_disabled = false
+
+local function getInProcessEngine(data_dir)
+    if not inprocess_engine then
+        local dict_dirs = { data_dir }
+        local dict_ext = data_dir .. "_ext"
+        if lfs.attributes(dict_ext, "mode") == "directory" then
+            table.insert(dict_dirs, dict_ext)
+        end
+        local cache_dir = DataStorage:getDataDir() .. "/cache"
+        util.makePath(cache_dir)
+        inprocess_engine = StardictEngine.new{
+            dict_dirs = dict_dirs,
+            cache_dir = cache_dir,
+        }
+    end
+    return inprocess_engine
+end
 
 local function getIfosInDir(path)
     -- Get all the .ifo under directory path.
@@ -348,6 +373,42 @@ function ReaderDictionary:addToMainMenu(menu_items)
                 end,
                 hold_callback = function(touchmenu_instance)
                     self:toggleFuzzyDefault(touchmenu_instance)
+                end,
+            },
+            {
+                text = _("Enable in-process lookups"),
+                help_text = _("Answer exact-word lookups with the built-in StarDict engine instead of launching sdcv for every lookup. Much faster with large dictionaries. Fuzzy searches and unsupported dictionaries still use sdcv."),
+                checked_func = function()
+                    return G_reader_settings:nilOrTrue("dict_inprocess_lookup")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrTrue("dict_inprocess_lookup")
+                    inprocess_session_disabled = false
+                end,
+            },
+            {
+                text = _("Rebuild in-process lookup index"),
+                enabled_func = function()
+                    return G_reader_settings:nilOrTrue("dict_inprocess_lookup")
+                end,
+                keep_menu_open = true,
+                callback = function()
+                    local engine = getInProcessEngine(self.data_dir)
+                    local info = InfoMessage:new{ text = _("Rebuilding in-process lookup index…") }
+                    UIManager:show(info)
+                    UIManager:forceRePaint()
+                    UIManager:nextTick(function()
+                        local ok, success, err = pcall(engine.rebuild_all, engine)
+                        UIManager:close(info)
+                        if ok and success then
+                            UIManager:show(InfoMessage:new{ text = _("In-process lookup index rebuilt.") })
+                        else
+                            UIManager:show(InfoMessage:new{
+                                text = T(_("Index rebuild failed: %1"), tostring(ok and err or success)),
+                            })
+                        end
+                        inprocess_session_disabled = false
+                    end)
                 end,
                 separator = true,
             },
@@ -1245,6 +1306,29 @@ function ReaderDictionary:rawSdcv(words, dict_names, fuzzy_search, lookup_progre
     -- early exit if no dictionaries
     if dictDirsEmpty(dict_dirs) then
         return false, nil
+    end
+    -- Try the in-process StarDict engine first: it answers exact lookups
+    -- without spawning a sdcv process per lookup (sdcv re-scans whole .syn
+    -- files on every launch, which costs seconds per tap with large
+    -- inflection dictionaries). Fuzzy searches, special query syntax,
+    -- dictionaries the engine cannot serve with byte-identical results,
+    -- and any engine error fall through to sdcv below.
+    if G_reader_settings:nilOrTrue("dict_inprocess_lookup")
+            and not fuzzy_search and not inprocess_session_disabled then
+        local start_time = time.now()
+        local ok, results_or_err, reason = pcall(function()
+            return getInProcessEngine(self.data_dir):lookup_words(words, dict_names)
+        end)
+        if ok then
+            if results_or_err then
+                logger.dbg("in-process dict lookup done in", time.to_ms(time.since(start_time)), "ms")
+                return false, results_or_err
+            end
+            logger.dbg("in-process dict lookup deferred to sdcv:", reason)
+        else
+            logger.warn("in-process dict lookup failed, disabled for this session:", results_or_err)
+            inprocess_session_disabled = true
+        end
     end
     local all_results = {}
     local lookup_cancelled = false

--- a/frontend/stardict/dictzip.lua
+++ b/frontend/stardict/dictzip.lua
@@ -1,0 +1,194 @@
+--[[--
+FastDict: random-access reader for dictzip (.dz) files.
+
+A .dz file is a gzip member whose FEXTRA header carries an 'RA' subfield
+listing the compressed size of each fixed-length (chlen) chunk. Chunks are
+separated with Z_FULL_FLUSH, so each one can be inflated independently with
+a raw-deflate inflater.
+
+Pure LuaJIT + FFI; no KOReader dependencies.
+]]
+
+local bit = require("bit")
+local ffi = require("ffi")
+
+pcall(ffi.cdef, [[
+typedef struct fastdict_z_stream {
+    const uint8_t *next_in;
+    unsigned avail_in;
+    unsigned long total_in;
+    uint8_t *next_out;
+    unsigned avail_out;
+    unsigned long total_out;
+    const char *msg;
+    void *state;
+    void *zalloc;
+    void *zfree;
+    void *opaque;
+    int data_type;
+    unsigned long adler;
+    unsigned long reserved;
+} fastdict_z_stream;
+int inflateInit2_(fastdict_z_stream *strm, int windowBits, const char *version, int stream_size);
+int inflate(fastdict_z_stream *strm, int flush);
+int inflateEnd(fastdict_z_stream *strm);
+const char *zlibVersion(void);
+]])
+
+local libz
+do
+    -- ffi.loadlib is a KOReader extension; plain ffi.load for desktop luajit.
+    local ok, lib = pcall(function() return ffi.loadlib("z", 1) end)
+    if ok then libz = lib else libz = ffi.load("z") end
+end
+
+-- Flush-when-full cache size: once cache_count reaches this, the whole
+-- chunk cache is cleared (not an LRU eviction of individual entries).
+local MAX_CACHED_CHUNKS = 8
+
+local function inflate_raw(cdata, max_out)
+    local strm = ffi.new("fastdict_z_stream")
+    local ret = libz.inflateInit2_(strm, -15, libz.zlibVersion(), ffi.sizeof("fastdict_z_stream"))
+    if ret ~= 0 then
+        error("inflateInit2 failed: " .. ret)
+    end
+    local inbuf = ffi.new("uint8_t[?]", #cdata)
+    ffi.copy(inbuf, cdata, #cdata)
+    local outbuf = ffi.new("uint8_t[?]", max_out)
+    strm.next_in, strm.avail_in = inbuf, #cdata
+    strm.next_out, strm.avail_out = outbuf, max_out
+    ret = libz.inflate(strm, 0) -- Z_NO_FLUSH
+    local produced = max_out - strm.avail_out
+    libz.inflateEnd(strm)
+    -- Z_OK (0) mid-stream chunk, Z_STREAM_END (1) final chunk,
+    -- Z_BUF_ERROR (-5) all input consumed with output space left.
+    if ret ~= 0 and ret ~= 1 and ret ~= -5 then
+        error("inflate failed: " .. ret)
+    end
+    return ffi.string(outbuf, produced)
+end
+
+local function u16le(s, pos)
+    local a, b = s:byte(pos, pos + 1)
+    return a + b * 256
+end
+
+local DictZip = {}
+DictZip.__index = DictZip
+
+local M = {}
+
+function M.open(path)
+    local f = io.open(path, "rb")
+    if not f then
+        return nil, "cannot open " .. path
+    end
+    local head = f:read(12)
+    if not head or #head < 12 or head:byte(1) ~= 0x1f or head:byte(2) ~= 0x8b then
+        f:close()
+        return nil, "not a gzip file: " .. path
+    end
+    local flg = head:byte(4)
+    if bit.band(flg, 0x04) == 0 then
+        f:close()
+        return nil, "no FEXTRA field (not dictzip): " .. path
+    end
+    local xlen = u16le(head, 11)
+    local extra = f:read(xlen)
+    if not extra or #extra < xlen then
+        f:close()
+        return nil, "truncated FEXTRA: " .. path
+    end
+    local chlen, sizes
+    local pos = 1
+    while pos + 3 <= xlen do
+        local si1, si2 = extra:byte(pos, pos + 1)
+        local len = u16le(extra, pos + 2)
+        if si1 == 82 and si2 == 65 then -- 'R','A'
+            chlen = u16le(extra, pos + 6)
+            local chcnt = u16le(extra, pos + 8)
+            sizes = {}
+            local p = pos + 10
+            for i = 1, chcnt do
+                sizes[i] = u16le(extra, p)
+                p = p + 2
+            end
+        end
+        pos = pos + 4 + len
+    end
+    if not chlen or not sizes then
+        f:close()
+        return nil, "no RA subfield (not dictzip): " .. path
+    end
+    -- skip optional FNAME / FCOMMENT / FHCRC to find the data start
+    for _, flag in ipairs({ 0x08, 0x10 }) do
+        if bit.band(flg, flag) ~= 0 then
+            repeat
+                local c = f:read(1)
+                if not c then f:close() return nil, "truncated gzip header" end
+            until c == "\0"
+        end
+    end
+    if bit.band(flg, 0x02) ~= 0 then
+        f:read(2)
+    end
+    local data_start = f:seek()
+    local offs = {}
+    local o = data_start
+    for i = 1, #sizes do
+        offs[i] = o
+        o = o + sizes[i]
+    end
+    return setmetatable({
+        f = f,
+        chlen = chlen,
+        sizes = sizes,
+        offs = offs,
+        cache = {},
+        cache_count = 0,
+    }, DictZip)
+end
+
+function DictZip:_chunk(i) -- 0-based chunk number
+    local cached = self.cache[i]
+    if cached then
+        return cached
+    end
+    if i < 0 or i >= #self.sizes then
+        error("chunk out of range: " .. i)
+    end
+    self.f:seek("set", self.offs[i + 1])
+    local cdata = self.f:read(self.sizes[i + 1])
+    local out = inflate_raw(cdata, self.chlen)
+    -- flush-when-full: the whole cache is cleared once it reaches
+    -- MAX_CACHED_CHUNKS, rather than evicting a single least-recently-used
+    -- entry like a true LRU would.
+    if self.cache_count >= MAX_CACHED_CHUNKS then
+        self.cache = {}
+        self.cache_count = 0
+    end
+    self.cache[i] = out
+    self.cache_count = self.cache_count + 1
+    return out
+end
+
+function DictZip:read(offset, size)
+    if size <= 0 then
+        return ""
+    end
+    local first = math.floor(offset / self.chlen)
+    local last = math.floor((offset + size - 1) / self.chlen)
+    local parts = {}
+    for i = first, last do
+        parts[#parts + 1] = self:_chunk(i)
+    end
+    local blob = table.concat(parts)
+    local rel = offset - first * self.chlen
+    return blob:sub(rel + 1, rel + size)
+end
+
+function DictZip:close()
+    self.f:close()
+end
+
+return M

--- a/frontend/stardict/engine.lua
+++ b/frontend/stardict/engine.lua
@@ -1,0 +1,200 @@
+--[[--
+FastDict: multi-dictionary lookup orchestration.
+
+Scans dictionary directories for .ifo files, opens them with stardict.lua,
+and answers batched exact lookups with the same dictionary filtering and
+ordering semantics as KOReader's sdcv invocation (-u bookname options).
+
+Pure LuaJIT; no unconditional KOReader dependencies.
+]]
+
+local stardict = require("stardict/stardict")
+
+local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+if not ok_lfs then
+    ok_lfs, lfs = pcall(require, "lfs")
+end
+
+local M = {}
+
+local Engine = {}
+Engine.__index = Engine
+
+function M.new(opts)
+    return setmetatable({
+        dict_dirs = assert(opts.dict_dirs),
+        cache_dir = opts.cache_dir or "/tmp",
+        dicts = nil,
+    }, Engine)
+end
+
+local function find_ifos(dir, out)
+    if ok_lfs then
+        local mode = lfs.attributes(dir, "mode")
+        if mode ~= "directory" then return end
+        for name in lfs.dir(dir) do
+            if name ~= "." and name ~= ".." and not name:match("^%.") then
+                local path = dir .. "/" .. name
+                local m = lfs.attributes(path, "mode")
+                if m == "directory" then
+                    find_ifos(path, out)
+                elseif m == "file" and name:match("%.ifo$") then
+                    out[#out + 1] = path
+                end
+            end
+        end
+    else
+        -- desktop test fallback without lfs. %q is Lua quoting (adequate
+        -- here for test-only use); -not -path '*/.*' also excludes a root
+        -- dir that itself lives under a dot-directory.
+        local p = io.popen(string.format("find %q -name '*.ifo' -not -path '*/.*' 2>/dev/null", dir))
+        if p then
+            for line in p:lines() do out[#out + 1] = line end
+            p:close()
+        end
+    end
+end
+
+function Engine:load()
+    self.dicts = {}
+    self.by_name = {}
+    for _, dir in ipairs(self.dict_dirs) do
+        local ifos = {}
+        find_ifos(dir, ifos)
+        -- sdcv uses readdir order; sorted order is a deliberate deterministic
+        -- choice (only observable when no dict_names filter is passed).
+        table.sort(ifos)
+        for _, ifo in ipairs(ifos) do
+            local d = stardict.open(ifo, self.cache_dir)
+            if d then
+                self.dicts[#self.dicts + 1] = d
+                if d.bookname and not self.by_name[d.bookname] then
+                    self.by_name[d.bookname] = d
+                end
+            end
+        end
+    end
+end
+
+-- Words sdcv would route to regex/fuzzy/data lookup instead of simple lookup
+-- (analyze_query): leading '/' or '|', any '*', '?' or '\'.
+local function is_special(word)
+    return word:sub(1, 1) == "/" or word:sub(1, 1) == "|"
+        or word:find("[*?\\]") ~= nil
+end
+
+--- Batched exact lookup.
+-- @param words array of query strings
+-- @param dict_names optional array of booknames (KOReader's enabled dicts, in
+--   priority order); nil or empty = all dictionaries, like sdcv without -u.
+-- @return results[i] = array of {dict, word, definition} for words[i],
+--   or nil, reason when this call must be answered by sdcv instead.
+function Engine:lookup_words(words, dict_names)
+    for _, w in ipairs(words) do
+        if is_special(w) then
+            return nil, "special query syntax: " .. w
+        end
+    end
+    if not self.dicts then
+        self:load()
+    end
+    if #self.dicts == 0 then
+        return nil, "no dictionaries found"
+    end
+    local order = {}
+    if dict_names and #dict_names > 0 then
+        for _, name in ipairs(dict_names) do
+            local d = self.by_name[name]
+            if d then -- unknown names are skipped, like sdcv's unknown -u
+                if not d.supported then
+                    return nil, "unsupported dictionary enabled: " .. name
+                end
+                order[#order + 1] = d
+            end
+        end
+    else
+        -- Deliberate deviation from sdcv: sdcv is invoked once per dict dir
+        -- (all data/dict results precede data/dict_ext per word) and queries
+        -- same-bookname duplicates in both dirs, while the engine merges
+        -- dirs, orders strictly by dict_names priority, and first-wins on
+        -- duplicate booknames.
+        for _, d in ipairs(self.dicts) do
+            if not d.supported then
+                return nil, "unsupported dictionary present: " .. (d.bookname or d.ifo_path)
+            end
+            order[#order + 1] = d
+        end
+    end
+    local all = {}
+    for wi, word in ipairs(words) do
+        local per = {}
+        for _, d in ipairs(order) do
+            local ok, entries = pcall(d.lookup, d, word)
+            if not ok then
+                -- quarantine this dictionary and let sdcv answer the call
+                d.supported = false
+                d.unsupported_reason = "lookup error: " .. tostring(entries)
+                return nil, "dictionary failed, deferring to sdcv: " .. tostring(entries)
+            end
+            for _, r in ipairs(entries) do
+                per[#per + 1] = { dict = d.bookname, word = r.word, definition = r.definition }
+            end
+        end
+        all[wi] = per
+    end
+    return all
+end
+
+--- Build (or load) sidecar caches for every supported dictionary.
+function Engine:build_all()
+    if not self.dicts then
+        self:load()
+    end
+    local first_err
+    for _, d in ipairs(self.dicts) do
+        if d.supported then
+            local ok, err = d:ensure_index()
+            if not ok then
+                first_err = first_err or err
+            end
+        end
+    end
+    if first_err then
+        return nil, first_err
+    end
+    return true
+end
+
+--- Delete sidecar caches and rebuild from scratch, re-scanning dictionaries
+-- (this also clears any quarantine from transient lookup failures).
+function Engine:rebuild_all()
+    if not self.dicts then
+        self:load()
+    end
+    for _, d in ipairs(self.dicts) do
+        d:close()
+        d.ready = false
+        os.remove(d:cache_path())
+    end
+    self.dicts = nil
+    self.by_name = nil
+    return self:build_all()
+end
+
+function Engine:status()
+    if not self.dicts then
+        self:load()
+    end
+    local st = {}
+    for _, d in ipairs(self.dicts) do
+        st[#st + 1] = {
+            bookname = d.bookname or d.ifo_path,
+            supported = d.supported,
+            ready = d.ready or false,
+            reason = d.unsupported_reason,
+        }
+    end
+    return st
+end
+
+return M

--- a/frontend/stardict/stardict.lua
+++ b/frontend/stardict/stardict.lua
@@ -1,0 +1,501 @@
+--[[--
+FastDict: StarDict dictionary reader with sidecar offset caches.
+
+Replicates the exact-search behavior of sdcv 0.5.5 (Dict::Lookup +
+libwrapper parse_data): binary search over .syn and .idx with
+stardict_strcmp, definitions formatted per sametypesequence.
+
+Pure LuaJIT + FFI; no unconditional KOReader dependencies.
+]]
+
+local ffi = require("ffi")
+local dictzip = require("stardict/dictzip")
+
+local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+if not ok_lfs then
+    ok_lfs, lfs = pcall(require, "lfs")
+end
+
+local M = {}
+
+-- @return size, mtime (mtime is 0 when lfs is unavailable: desktop tests)
+local function file_stat(path)
+    if ok_lfs then
+        local a = lfs.attributes(path)
+        if not a then return nil end
+        return a.size, a.modification
+    end
+    local f = io.open(path, "rb")
+    if not f then return nil end
+    local size = f:seek("end")
+    f:close()
+    return size, 0
+end
+M._file_stat = file_stat -- exposed for tests
+
+local byte = string.byte
+
+--- stardict_strcmp: g_ascii_strcasecmp (sign only), strcmp tiebreak.
+function M.cmp(a, b)
+    local la, lb = #a, #b
+    local n = la < lb and la or lb
+    for i = 1, n do
+        local ca, cb = byte(a, i), byte(b, i)
+        if ca >= 65 and ca <= 90 then ca = ca + 32 end
+        if cb >= 65 and cb <= 90 then cb = cb + 32 end
+        if ca ~= cb then
+            return ca < cb and -1 or 1
+        end
+    end
+    if la ~= lb then
+        -- caseless prefix: shorter first
+        return la < lb and -1 or 1
+    end
+    -- caseless equal: bytewise strcmp tiebreak. LuaJIT's string `<`/`>` is a
+    -- raw byte comparison (not locale-collation like PUC Lua): this bytewise
+    -- behavior is load-bearing for sdcv sort-order parity, do not "fix" it
+    -- to locale-aware comparison.
+    if a == b then return 0 end
+    return a < b and -1 or 1
+end
+
+function M.parse_ifo(path)
+    local f = io.open(path, "rb")
+    if not f then
+        return nil, "cannot open " .. path
+    end
+    local content = f:read("*a") or ""
+    f:close()
+    if not content:find("StarDict's dict ifo file", 1, true) then
+        return nil, "not a StarDict ifo: " .. path
+    end
+    local info = {}
+    for line in content:gmatch("[^\r\n]+") do
+        local k, v = line:match("^([%w_]+)=(.*)$")
+        if k then info[k] = v end
+    end
+    return info
+end
+
+local Dict = {}
+Dict.__index = Dict
+
+local SUPPORTED_TYPES = { h = true, m = true, w = true, l = true,
+                          g = true, x = true, t = true, k = true, y = true }
+
+function M.open(ifo_path, fallback_cache_dir)
+    local info, err = M.parse_ifo(ifo_path)
+    if not info then
+        return nil, err
+    end
+    local d = setmetatable({
+        ifo_path = ifo_path,
+        base = (ifo_path:gsub("%.ifo$", "")),
+        info = info,
+        bookname = info.bookname,
+        wordcount = tonumber(info.wordcount) or 0,
+        synwordcount = tonumber(info.synwordcount) or 0,
+        sametypesequence = info.sametypesequence,
+        fallback_cache_dir = fallback_cache_dir,
+        supported = true,
+    }, Dict)
+    if not d.bookname or d.bookname == "" then
+        d.supported, d.unsupported_reason = false, "missing bookname"
+    elseif info.idxoffsetbits == "64" then
+        d.supported, d.unsupported_reason = false, "64-bit idx offsets"
+    elseif not d.sametypesequence or not SUPPORTED_TYPES[d.sametypesequence] then
+        d.supported, d.unsupported_reason = false,
+            "unsupported sametypesequence: " .. tostring(d.sametypesequence)
+    elseif not file_stat(d.base .. ".idx") then
+        d.supported, d.unsupported_reason = false, "no plain .idx file"
+    end
+    return d
+end
+
+--- Scan a .idx/.syn file once, recording the offset of every entry.
+-- stride = fixed bytes after each NUL (8 for .idx with 32-bit offsets, 4 for .syn).
+-- Returns a uint32 FFI array with expected_count+1 slots (last = file size).
+function M.scan_offsets(path, stride, expected_count)
+    local f = io.open(path, "rb")
+    if not f then
+        return nil, "cannot open " .. path
+    end
+    local offs = ffi.new("uint32_t[?]", expected_count + 1)
+    local count = 0
+    local base, buf, pos = 0, "", 1
+    offs[0] = 0
+    while true do
+        local z = buf:find("\0", pos, true)
+        if z then
+            if count >= expected_count then
+                f:close()
+                return nil, string.format("scan mismatch in %s: more than %d entries", path, expected_count)
+            end
+            count = count + 1
+            pos = z + stride + 1
+            offs[count] = base + pos - 1
+        else
+            local chunk = f:read(1048576)
+            if not chunk then break end
+            -- keep unscanned tail; `pos` may point past the buffer end when an
+            -- entry's fixed-width tail straddles the refill boundary
+            local blen = #buf
+            local keep = pos <= blen and buf:sub(pos) or ""
+            local skip = pos > blen and (pos - blen - 1) or 0
+            buf = keep .. chunk
+            base = base + (blen - #keep)
+            pos = 1 + skip
+        end
+    end
+    local fsize = f:seek("end")
+    f:close()
+    if count ~= expected_count or offs[count] ~= fsize then
+        return nil, string.format("scan mismatch in %s: %d entries / sentinel %d (expected %d / %d)",
+            path, count, count > 0 and tonumber(offs[count]) or -1, expected_count, fsize)
+    end
+    return offs
+end
+
+local CACHE_MAGIC = "FDX1"
+local CACHE_VERSION = 1
+local HEADER_BYTES = 32 -- 4 magic + 7 * u32
+
+local function pack_u32(...)
+    local n = select("#", ...)
+    local arr = ffi.new("uint32_t[?]", n, ...)
+    return ffi.string(arr, n * 4)
+end
+
+function Dict:cache_path()
+    if self._cache_path then
+        return self._cache_path
+    end
+    local next_to_dict = self.base .. ".fdx"
+    local probe = io.open(next_to_dict, "a+b")
+    if probe then
+        probe:close()
+        self._cache_path = next_to_dict
+    else
+        local name = self.base:gsub("[^%w%-_.]", "#") .. ".fdx"
+        self._cache_path = self.fallback_cache_dir .. "/" .. name
+    end
+    return self._cache_path
+end
+
+function Dict:_build_cache()
+    local idx_path = self.base .. ".idx"
+    local idx_size, idx_mtime = file_stat(idx_path)
+    if not idx_size then
+        return nil, "missing " .. idx_path
+    end
+    local idx_off, err = M.scan_offsets(idx_path, 8, self.wordcount)
+    if not idx_off then
+        return nil, err
+    end
+    local syn_off, syn_size, syn_mtime
+    if self.synwordcount > 0 then
+        local syn_path = self.base .. ".syn"
+        syn_size, syn_mtime = file_stat(syn_path)
+        if not syn_size then
+            return nil, "missing " .. syn_path
+        end
+        syn_off, err = M.scan_offsets(syn_path, 4, self.synwordcount)
+        if not syn_off then
+            return nil, err
+        end
+    end
+    local cp = self:cache_path()
+    local tmp = cp .. ".tmp"
+    local f = io.open(tmp, "wb")
+    if not f then
+        return nil, "cannot write " .. tmp
+    end
+    f:write(CACHE_MAGIC)
+    f:write(pack_u32(CACHE_VERSION, idx_size, idx_mtime,
+        syn_size or 0, syn_mtime or 0,
+        self.wordcount + 1, syn_off and (self.synwordcount + 1) or 0))
+    f:write(ffi.string(idx_off, (self.wordcount + 1) * 4))
+    if syn_off then
+        f:write(ffi.string(syn_off, (self.synwordcount + 1) * 4))
+    end
+    f:close()
+    -- required on FAT/vfat filesystems (Kindle user storage), where rename
+    -- won't overwrite an existing file.
+    os.remove(cp)
+    local ok = os.rename(tmp, cp)
+    if not ok then
+        return nil, "cannot rename " .. tmp
+    end
+    return true
+end
+
+function Dict:_load_cache()
+    local cp = self:cache_path()
+    local f = io.open(cp, "rb")
+    if not f then
+        return nil
+    end
+    local blob = f:read("*a")
+    f:close()
+    if not blob or #blob < HEADER_BYTES or blob:sub(1, 4) ~= CACHE_MAGIC then
+        return nil
+    end
+    local hdr = ffi.cast("const uint32_t *", ffi.cast("const char *", blob) + 4)
+    local version, idx_size, idx_mtime = hdr[0], hdr[1], hdr[2]
+    local syn_size, syn_mtime, n_idx, n_syn = hdr[3], hdr[4], hdr[5], hdr[6]
+    if version ~= CACHE_VERSION then
+        return nil
+    end
+    if #blob ~= HEADER_BYTES + (tonumber(n_idx) + tonumber(n_syn)) * 4 then
+        return nil
+    end
+    local cur_idx_size, cur_idx_mtime = file_stat(self.base .. ".idx")
+    if cur_idx_size ~= tonumber(idx_size) or cur_idx_mtime ~= tonumber(idx_mtime) then
+        return nil
+    end
+    if self.synwordcount > 0 then
+        local cur_syn_size, cur_syn_mtime = file_stat(self.base .. ".syn")
+        if cur_syn_size ~= tonumber(syn_size) or cur_syn_mtime ~= tonumber(syn_mtime) then
+            return nil
+        end
+        if tonumber(n_syn) ~= self.synwordcount + 1 then
+            return nil
+        end
+    end
+    if tonumber(n_idx) ~= self.wordcount + 1 then
+        return nil
+    end
+    self._cache_blob = blob -- anchor: FFI pointers below point into this string
+    local p = ffi.cast("const uint8_t *", blob)
+    self.idx_off = ffi.cast("const uint32_t *", p + HEADER_BYTES)
+    self.n_idx = self.wordcount
+    if self.synwordcount > 0 then
+        self.syn_off = ffi.cast("const uint32_t *", p + HEADER_BYTES + tonumber(n_idx) * 4)
+        self.n_syn = self.synwordcount
+    else
+        self.syn_off, self.n_syn = nil, 0
+    end
+    return true
+end
+
+local function plain_reader(path)
+    local f = io.open(path, "rb")
+    if not f then
+        return nil, "cannot open " .. path
+    end
+    return {
+        read = function(_, off, size)
+            f:seek("set", off)
+            return f:read(size) or ""
+        end,
+        close = function() f:close() end,
+    }
+end
+
+function Dict:ensure_index()
+    if self.ready then
+        return true
+    end
+    if not self.supported then
+        return nil, "unsupported dictionary: " .. tostring(self.unsupported_reason)
+    end
+    if not self.dict_f then
+        local dz = self.base .. ".dict.dz"
+        local r, err
+        if file_stat(dz) then
+            r, err = dictzip.open(dz)
+        else
+            r, err = plain_reader(self.base .. ".dict")
+        end
+        if not r then
+            return nil, err
+        end
+        self.dict_f = r
+    end
+    self.idx_f = self.idx_f or io.open(self.base .. ".idx", "rb")
+    if not self.idx_f then
+        return nil, "cannot open " .. self.base .. ".idx"
+    end
+    if self.synwordcount > 0 then
+        self.syn_f = self.syn_f or io.open(self.base .. ".syn", "rb")
+        if not self.syn_f then
+            return nil, "cannot open " .. self.base .. ".syn"
+        end
+    end
+    if not self:_load_cache() then
+        local ok, err = self:_build_cache()
+        if not ok then
+            return nil, err
+        end
+        if not self:_load_cache() then
+            return nil, "sidecar cache unreadable after build: " .. self:cache_path()
+        end
+    end
+    self.ready = true
+    return true
+end
+
+function Dict:close()
+    if self.dict_f then self.dict_f:close() self.dict_f = nil end
+    if self.idx_f then self.idx_f:close() self.idx_f = nil end
+    if self.syn_f then self.syn_f:close() self.syn_f = nil end
+    self.ready = false
+end
+
+--- Port of sdcv's xdxf2text with colorize=false.
+local function xdxf2text(p)
+    local res = {}
+    local i, n = 1, #p
+    while i <= n do
+        local c = p:sub(i, i)
+        if c ~= "<" then
+            if p:sub(i, i + 3) == "&gt;" then
+                res[#res + 1] = ">" ; i = i + 4
+            elseif p:sub(i, i + 3) == "&lt;" then
+                res[#res + 1] = "<" ; i = i + 4
+            elseif p:sub(i, i + 4) == "&amp;" then
+                res[#res + 1] = "&" ; i = i + 5
+            elseif p:sub(i, i + 5) == "&quot;" then
+                res[#res + 1] = "\"" ; i = i + 6
+            elseif p:sub(i, i + 5) == "&apos;" then
+                res[#res + 1] = "'" ; i = i + 6
+            else
+                res[#res + 1] = c ; i = i + 1
+            end
+        else
+            local gt = p:find(">", i, true)
+            if not gt then
+                i = i + 1 -- sdcv skips a lone '<'
+            else
+                local name = p:sub(i + 1, gt - 1)
+                local nexti = gt + 1
+                if name == "k" then
+                    local close = p:find("</k>", gt, true)
+                    if close then nexti = close + 4 end
+                elseif name == "tr" then
+                    res[#res + 1] = "["
+                elseif name == "/tr" then
+                    res[#res + 1] = "]"
+                end
+                -- every other tag renders as nothing without colorize
+                i = nexti
+            end
+        end
+    end
+    return table.concat(res)
+end
+M._xdxf2text = xdxf2text -- exposed for tests
+
+--- Format a raw .dict payload the way sdcv's parse_data renders it in JSON mode.
+function Dict:_format(payload)
+    local t = self.sametypesequence
+    local seg = payload:match("^[^%z]*") -- sdcv reads with strlen()
+    if #seg == 0 then
+        return ""
+    end
+    if t == "x" or t == "g" then
+        return "\n" .. xdxf2text(seg)
+    elseif t == "t" then
+        return "\n[" .. seg .. "]"
+    elseif t == "k" or t == "y" then
+        return seg
+    else -- h, m, w, l
+        return "\n" .. seg
+    end
+end
+
+function Dict:_read_range(f, from, to)
+    f:seek("set", from)
+    return f:read(to - from) or ""
+end
+
+function Dict:_idx_entry(i) -- 0-based; returns word, offset, size
+    local raw = self:_read_range(self.idx_f, tonumber(self.idx_off[i]), tonumber(self.idx_off[i + 1]))
+    local z = raw:find("\0", 1, true)
+    local o1, o2, o3, o4, s1, s2, s3, s4 = raw:byte(z + 1, z + 8)
+    return raw:sub(1, z - 1),
+        ((o1 * 256 + o2) * 256 + o3) * 256 + o4,
+        ((s1 * 256 + s2) * 256 + s3) * 256 + s4
+end
+
+function Dict:_idx_word(i)
+    local raw = self:_read_range(self.idx_f, tonumber(self.idx_off[i]), tonumber(self.idx_off[i + 1]))
+    return raw:sub(1, raw:find("\0", 1, true) - 1)
+end
+
+function Dict:_syn_entry(i) -- 0-based; returns word, target idx entry number
+    local raw = self:_read_range(self.syn_f, tonumber(self.syn_off[i]), tonumber(self.syn_off[i + 1]))
+    local z = raw:find("\0", 1, true)
+    local n1, n2, n3, n4 = raw:byte(z + 1, z + 4)
+    return raw:sub(1, z - 1), ((n1 * 256 + n2) * 256 + n3) * 256 + n4
+end
+
+-- Binary search over entries 0..n-1 using M.cmp; returns the inclusive
+-- range [first, last] of entries equal to word, or nil.
+local function bsearch(n, getword, word)
+    local lo, hi = 0, n - 1
+    while lo <= hi do
+        local mid = math.floor((lo + hi) / 2)
+        local c = M.cmp(word, getword(mid))
+        if c > 0 then
+            lo = mid + 1
+        elseif c < 0 then
+            hi = mid - 1
+        else
+            local first, last = mid, mid
+            while first > 0 and M.cmp(word, getword(first - 1)) == 0 do
+                first = first - 1
+            end
+            while last < n - 1 and M.cmp(word, getword(last + 1)) == 0 do
+                last = last + 1
+            end
+            return first, last
+        end
+    end
+    return nil
+end
+
+--- Exact lookup, replicating sdcv's Dict::Lookup + SimpleLookup rendering.
+-- @return array of { word = idx headword, definition = formatted text }
+function Dict:lookup(word)
+    local ok, err = self:ensure_index()
+    if not ok then
+        error(err)
+    end
+    local hits, seen = {}, {}
+    if self.n_syn and self.n_syn > 0 then
+        local first, last = bsearch(self.n_syn,
+            function(i) return (self:_syn_entry(i)) end, word)
+        if first then
+            for i = first, last do
+                local _, target = self:_syn_entry(i)
+                if target < self.n_idx and not seen[target] then
+                    seen[target] = true
+                    hits[#hits + 1] = target
+                end
+            end
+        end
+    end
+    local first, last = bsearch(self.n_idx,
+        function(i) return (self:_idx_word(i)) end, word)
+    if first then
+        for i = first, last do
+            if not seen[i] then
+                seen[i] = true
+                hits[#hits + 1] = i
+            end
+        end
+    end
+    table.sort(hits)
+    local results = {}
+    for _, i in ipairs(hits) do
+        local w, off, size = self:_idx_entry(i)
+        results[#results + 1] = {
+            word = w,
+            definition = self:_format(self.dict_f:read(off, size)),
+        }
+    end
+    return results
+end
+
+return M

--- a/tools/merge_syn.py
+++ b/tools/merge_syn.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Fold a StarDict .syn file into the .idx.
+
+sdcv linearly re-scans the whole .syn on every process launch (no offset
+cache), which makes lookups against large inflection dictionaries very slow
+on e-readers. Folding every synonym into the .idx as a real entry removes
+the .syn entirely; sdcv then uses its lazy, .oft-cached index access.
+
+Usage: merge_syn.py <src_dict_dir> <out_dir>
+
+The source directory must contain one dictionary (.ifo/.idx[/.syn] and
+.dict or .dict.dz). The output directory receives the merged dictionary;
+the source is never modified.
+"""
+import struct
+import shutil
+import sys
+from pathlib import Path
+
+LOWER = bytes(c + 32 if 65 <= c <= 90 else c for c in range(256))
+
+
+def sd_key(word: bytes):
+    """stardict_strcmp sort key: ascii-casefolded bytes, then raw bytes."""
+    return (word.translate(LOWER), word)
+
+
+def read_ifo(path: Path):
+    pairs = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            pairs.append((k, v))
+    return pairs
+
+
+def read_idx(path: Path):
+    data = path.read_bytes()
+    entries, i = [], 0
+    while i < len(data):
+        z = data.index(0, i)
+        off, size = struct.unpack(">II", data[z + 1:z + 9])
+        entries.append((data[i:z], off, size))
+        i = z + 9
+    return entries
+
+
+def read_syn(path: Path):
+    data = path.read_bytes()
+    entries, i = [], 0
+    while i < len(data):
+        z = data.index(0, i)
+        (n,) = struct.unpack(">I", data[z + 1:z + 5])
+        entries.append((data[i:z], n))
+        i = z + 5
+    return entries
+
+
+def main(src_dir: str, out_dir: str):
+    src, dst = Path(src_dir), Path(out_dir)
+    try:
+        ifo_path = next(src.glob("*.ifo"))
+    except StopIteration:
+        sys.exit(f"no .ifo file found in {src}")
+    base = ifo_path.stem
+    ifo = read_ifo(ifo_path)
+    ifo_map = dict(ifo)
+    if ifo_map.get("idxoffsetbits") == "64":
+        sys.exit("64-bit idx offsets are not supported")
+
+    idx = read_idx(src / f"{base}.idx")
+    n_syn = 0
+    entries = list(idx)
+    syn_path = src / f"{base}.syn"
+    if syn_path.exists():
+        for word, n in read_syn(syn_path):
+            if n < len(idx):
+                _, off, size = idx[n]
+                entries.append((word, off, size))
+                n_syn += 1
+    entries.sort(key=lambda e: sd_key(e[0]))
+
+    merged, seen = [], set()
+    for e in entries:
+        if e not in seen:
+            seen.add(e)
+            merged.append(e)
+
+    buf = bytearray()
+    for word, off, size in merged:
+        buf += word + b"\0" + struct.pack(">II", off, size)
+
+    dst.mkdir(parents=True, exist_ok=True)
+    (dst / f"{base}.idx").write_bytes(buf)
+
+    out_lines = ["StarDict's dict ifo file"]
+    for k, v in ifo:
+        if k == "synwordcount":
+            continue
+        if k == "wordcount":
+            v = str(len(merged))
+        elif k == "idxfilesize":
+            v = str(len(buf))
+        out_lines.append(f"{k}={v}")
+    (dst / f"{base}.ifo").write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+
+    for suffix in (".dict.dz", ".dict"):
+        p = src / f"{base}{suffix}"
+        if p.exists():
+            shutil.copy2(p, dst / p.name)
+
+    print(f"{base}: {len(idx)} idx entries + {n_syn} syn entries "
+          f"-> {len(merged)} merged (idx {len(buf)} bytes)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## What this does

Answers **exact (tap-on-word) dictionary lookups in-process** with a pure-Lua StarDict engine instead of spawning `sdcv` per lookup.

This addresses the slowness described in #5437: sdcv's `SynFile::load` does a full linear walk over the entire `.syn` file **on every process launch** to build its pointer list (0.5.4 only made the *search* binary). With a large inflection dictionary (my Ukrainian dict: 46 MB `.syn`, 1,725,572 entries) that scan plus process spawn costs seconds per tap on device — the Polish dictionary in #5437 (2.4M synonyms) reported 15+ s on a Kindle.

## How

- `frontend/stardict/` — self-contained engine (no changes to existing modules' behavior): `stardict.lua` builds a small sidecar offset cache per dictionary once (like sdcv's `.oft`, but covering `.syn` too), binary-searches `.idx`/`.syn` with exact `stardict_strcmp` ordering, and renders definitions exactly like sdcv's `parse_data`/`xdxf2text` (ported, GPL). `dictzip.lua` inflates only the 1–2 chunks covering an entry via zlib FFI. `engine.lua` mirrors sdcv's `-u` filtering/ordering semantics.
- `readerdictionary.lua` — `rawSdcv()` tries the engine first when fuzzy search is off; fuzzy searches, wildcard/regex/data queries, unsupported dictionary features (multi-type `sametypesequence`, 64-bit offsets, `.idx.gz`), empty dict dirs, and **any engine error** fall through to the existing sdcv code unchanged. Worst case is always "as slow as before", never different results. Toggle + cache rebuild under Dictionary settings (default on; happy to flip the default if preferred).
- `tools/merge_syn.py` (optional, desktop) folds a `.syn` into the `.idx` so the sdcv fallback path gets fast too.

## Parity and testing

Output is byte-identical to `sdcv --utf8-input --utf8-output --json-output --non-interactive --exact-search`: a parity harness samples headwords + syn forms from real dictionaries and compares full `(dict, word, definition)` multisets — 600/600 identical on my two dictionaries (202k headwords / 1.7M syn entries; `sametypesequence` `h` and `x`). The harness plus 24 standalone LuaJIT unit tests live at https://github.com/asxelot/fastdict.koplugin — happy to port them to `spec/unit`.

Measured on desktop: ~0.06 ms per lookup vs ~34 ms per sdcv spawn; the gap is much larger on e-ink where the `.syn` scan dominates.

---

This pull request was written by a human with AI assistance (implementation developed and reviewed with Claude).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15645)
<!-- Reviewable:end -->
