### PR TITLE
Add hall_file support to KindleTouch and KindleBasic4

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1297,7 +1297,6 @@ function KindleTouch:init()
         device = self,
         batt_capacity_file = "/sys/devices/system/yoshi_battery/yoshi_battery0/battery_capacity",
         is_charging_file = "/sys/devices/platform/fsl-usb2-udc/charging",
-        -- Enable cover events toggle
         hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
     self.input = require("device/input"):new{
@@ -1800,7 +1799,6 @@ function KindleBasic4:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
-        -- Enable cover events toggle
         hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
 

--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -1297,6 +1297,8 @@ function KindleTouch:init()
         device = self,
         batt_capacity_file = "/sys/devices/system/yoshi_battery/yoshi_battery0/battery_capacity",
         is_charging_file = "/sys/devices/platform/fsl-usb2-udc/charging",
+        -- Enable cover events toggle
+        hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
     self.input = require("device/input"):new{
         device = self,
@@ -1798,6 +1800,8 @@ function KindleBasic4:init()
         batt_capacity_file = "/sys/class/power_supply/bd71827_bat/capacity",
         is_charging_file = "/sys/class/power_supply/bd71827_bat/charging",
         batt_status_file = "/sys/class/power_supply/bd71827_bat/status",
+        -- Enable cover events toggle
+        hall_file = "/sys/devices/platform/eink_hall/hall_enable",
     }
 
     -- Enable the so-called "fast" mode, so as to prevent the driver from silently promoting refreshes to REAGL.


### PR DESCRIPTION
Adding the `hall_file` mapping to KindleTouch and KindleBasic4 so that user can toggle cover events off via the KOReader device settings. Same as https://github.com/koreader/koreader/pull/13603 and https://github.com/koreader/koreader/pull/13615, tested on my devices with no issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15654)
<!-- Reviewable:end -->
