### PR TITLE
Device:ping4: keep the native ICMP path on kernels < 2.6.27 (fix legacy Kindle UI freeze)

### DIFF
--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -704,13 +704,16 @@ function Device:ping4(ip)
     -- NOTE: This is disabled by default, barring custom distro setup during init, c.f., sysctl net.ipv4.ping_group_range
     --       It also requires Linux 3.0+ (https://github.com/torvalds/linux/commit/c319b4d76b9e583a5d88d6bf190e079c4e43213d)
     local socket, socket_type
-    socket = C.socket(C.AF_INET, bit.bor(C.SOCK_DGRAM, C.SOCK_NONBLOCK, C.SOCK_CLOEXEC), C.IPPROTO_ICMP)
+    -- NOTE: We deliberately do NOT call socket() with SOCK_NONBLOCK/SOCK_CLOEXEC:
+    --       that form requires Linux 2.6.27+ and fails with EINVAL on older versions.
+    --       We set both flags via fcntl() below instead, which works on every kernel.
+    socket = C.socket(C.AF_INET, C.SOCK_DGRAM, C.IPPROTO_ICMP)
     if socket == -1 then
         local errno = ffi.errno()
         logger.dbg("Device:ping4: unprivileged ICMP socket:", ffi.string(C.strerror(errno)))
 
         -- Try a raw socket
-        socket = C.socket(C.AF_INET, bit.bor(C.SOCK_RAW, C.SOCK_NONBLOCK, C.SOCK_CLOEXEC), C.IPPROTO_ICMP)
+        socket = C.socket(C.AF_INET, C.SOCK_RAW, C.IPPROTO_ICMP)
         if socket == -1 then
             errno = ffi.errno()
             if errno == C.EPERM then
@@ -731,6 +734,10 @@ function Device:ping4(ip)
     else
         socket_type = C.SOCK_DGRAM
     end
+
+    -- Apply FD_CLOEXEC + O_NONBLOCK now (see the socket() note above).
+    C.fcntl(socket, C.F_SETFD, C.FD_CLOEXEC)
+    C.fcntl(socket, C.F_SETFL, bit.bor(C.fcntl(socket, C.F_GETFL, 0), C.O_NONBLOCK))
 
     -- c.f., busybox's networking/ping.c
     local DEFDATALEN = 56 -- 64 - 8

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -726,13 +726,9 @@ function Device:ping4(ip)
             --       used on Legacy Kindles (K4 included). Bound the runtime ourselves by
             --       killing the ping after a timeout, which works with any ping implementation.
             return os.execute(string.format([[ping -q -c1 %s >/dev/null &
-                                              ping_pid=$!
-                                              (sleep 2; kill $ping_pid) &
-                                              timeout_pid=$!
-                                              wait $ping_pid
-                                              code=$?
-                                              kill $timeout_pid 2>/dev/null
-                                              exit $code
+                                              pid=$!
+                                              (sleep 2; kill $pid 2>/dev/null) &
+                                              wait $pid 2>/dev/null
                                               ]], ip)) == 0
         else
             socket_type = C.SOCK_RAW

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -722,12 +722,18 @@ function Device:ping4(ip)
                 logger.dbg("Device:ping4: raw ICMP socket:", ffi.string(C.strerror(errno)))
             end
             --- Fall-back to the ping CLI tool, in the hope that it's setuid...
-            if self:isKindle() and self:hasDPad() then
-                -- NOTE: No -w flag available in the old busybox build used on Legacy Kindles (K4 included)...
-                return os.execute("ping -q -c1 " .. ip .. " > /dev/null") == 0
-            else
-                return os.execute("ping -q -c1 -w2 " .. ip .. " > /dev/null") == 0
-            end
+            -- NOTE: We can't rely on `ping -w`: it's not available in the old busybox build
+            --       used on Legacy Kindles (K4 included). Bound the runtime ourselves by
+            --       killing the ping after a timeout, which works with any ping implementation.
+            return os.execute(string.format([[ping -q -c1 %s >/dev/null &
+                                              ping_pid=$!
+                                              (sleep 2; kill $ping_pid) &
+                                              timeout_pid=$!
+                                              wait $ping_pid
+                                              code=$?
+                                              kill $timeout_pid 2>/dev/null
+                                              exit $code
+                                              ]], ip)) == 0
         else
             socket_type = C.SOCK_RAW
         end


### PR DESCRIPTION
## Problem

Opening **Settings → Network → Show network info** can hard-freeze the entire KOReader UI on legacy Kindles (K2/K3/K4/DX) — unrecoverable except by pulling the power.

`Device:ping4` (called synchronously on the UI loop by `retrieveNetworkInfo`) opens an ICMP socket with `SOCK_NONBLOCK|SOCK_CLOEXEC` in the `socket()` **type** argument. Those type-flags require Linux ≥ 2.6.27; on the 2.6.26 kernel of legacy Kindles `socket()` returns `EINVAL`, so both the unprivileged and the raw attempt fail and the code falls back to a synchronous busybox `ping -q -c1 <gw>` **without `-w`** (busybox 1.7.2 has no timeout flag and no `timeout` applet). Against a silent/unreachable gateway that CLI ping **blocks forever** — measured >190 s on a live K3 — freezing the UI thread until a hard power-off.

## Fix

Create the ICMP sockets **without** `SOCK_NONBLOCK|SOCK_CLOEXEC` in the `socket()` type argument, and set `FD_CLOEXEC` + `O_NONBLOCK` via `fcntl` once the socket is open. One code path for every kernel; the existing native, poll-timeout-bounded ICMP path is kept, so the blocking CLI fallback is no longer reached on these devices.

The `F_*`/`FD_CLOEXEC` constants come from `ffi/posix_h` (koreader-base) — see @benoit-pierre's base PR.

## Verification (live K3, kernel 2.6.26-rt-lab126, KOReader v2026.03)

Plain `SOCK_RAW` opens; `fcntl(F_SETFD, FD_CLOEXEC)` and `fcntl(F_SETFL, |O_NONBLOCK)` succeed (confirmed via `F_GETFD`/`F_GETFL` read-back); ICMP RTT to the gateway works; a silent gateway now times out via `poll` (~2 s) instead of hanging. Unprivileged ICMP `SOCK_DGRAM` is unsupported on this kernel → falls through to `SOCK_RAW` as designed. Modern-kernel path checked separately by @benoit-pierre (3.0.35).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15663)
<!-- Reviewable:end -->
