### PR TITLE
reMarkable: fix hall sensor setting being inverted on every start

### DIFF
--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -86,14 +86,14 @@ end
 function Remarkable_PowerD:onToggleHallSensor(toggle)
     if toggle == nil then
         -- Flip it
-        toggle = self:isHallSensorEnabled() and 1 or 0
-    else
-        -- Honor the requested state
-        toggle = toggle and 1 or 0
+        toggle = not self:isHallSensorEnabled()
     end
-    ffiUtil.writeToSysfs(toggle, self.hall_file)
 
-    G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", toggle == 0 and true or false)
+    -- true -> inhibited = 0
+    -- false -> inhibited = 1
+    ffiUtil.writeToSysfs(toggle and 0 or 1, self.hall_file)
+
+    G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", toggle)
 end
 
 function Remarkable_PowerD:beforeSuspend()


### PR DESCRIPTION
On reMarkable devices with a hall sensor, the "Disable cover events" state flips on every KOReader start: whatever the user chose, the next start applies the opposite and re-saves it.

**Root cause**

This code was adapted from the Kindle implementation, but the sysfs polarity is opposite: Kindle's `hall_enable` is 1 = enabled, while reMarkable's `/sys/class/input/input*/inhibited` is 1 = **disabled**. Three of the four polarity-sensitive spots were inverted during the port, but the "honor the requested state" branch was not.

Walking through `Remarkable_PowerD:onToggleHallSensor(true)` as an example:

- `toggle = toggle and 1 or 0` → `toggle = 1`
- `ffiUtil.writeToSysfs(toggle, self.hall_file)` writes 1 → **inhibits (disables) the sensor** which is the opposite of what was requested
- `G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", toggle == 0 and true or false)` → **re-saves the setting as `false`**

So applying "enabled" disables the sensor *and* rewrites the stored setting to disabled; the next start does the reverse.

**Fix**

A one-line fix would be `toggle = toggle and 0 or 1`, but the underlying confusion is that `toggle` switches meaning between "enabled as a boolean" and "raw sysfs value" mid-function. Instead, keep `toggle` a boolean throughout and confine the sysfs polarity to the single write.

Tested on a reMarkable Paper Pro Move.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15667)
<!-- Reviewable:end -->
