### PR TITLE
[InputText] Toggle on-screen keyboard with a lone Sym/ScreenKB tap

### DIFF
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -851,12 +851,40 @@ function Input:handleKeyBoardEv(ev)
         UIManager:nextTick(function() UIManager:quit() end) -- Ensure the program closes in case of some lingering dialog.
     end
 
+    -- A lone Sym key tap (pressed and released with no other key in between) is used
+    -- by InputText to toggle the on-screen keyboard, mirroring Shift/ScreenKB + Home.
+    -- Sym is otherwise only a modifier (the symbol layer) whose bare press/release is
+    -- swallowed just below, so we track the "tapped alone" state across both events.
+    -- It only counts as a lone tap if no other modifier is held at press time (Sym
+    -- itself is not marked in self.modifiers until the block below), so combinations
+    -- like Shift + Sym do not toggle the keyboard. A held Sym (auto-repeat) is not a
+    -- tap either, so clear the flag once repeats start coming in.
+    if ev.value == KEY_PRESS then
+        local solo = keycode == "Sym"
+        if solo then
+            for _, held in pairs(self.modifiers) do
+                if held then
+                    solo = false
+                    break
+                end
+            end
+        end
+        self.sym_tapped = solo
+    elseif ev.value == KEY_REPEAT and keycode == "Sym" then
+        self.sym_tapped = false
+    end
+
     -- handle modifier keys
     if self.modifiers[keycode] ~= nil then
         if ev.value == KEY_PRESS then
             self.modifiers[keycode] = true
         elseif ev.value == KEY_RELEASE then
             self.modifiers[keycode] = false
+            if keycode == "Sym" and self.sym_tapped then
+                self.sym_tapped = false
+                -- Surface the lone Sym tap as a dedicated key event; nothing else binds it.
+                return Event:new("KeyPress", Key:new("SymPress", self.modifiers))
+            end
         end
         return
     end

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -851,16 +851,17 @@ function Input:handleKeyBoardEv(ev)
         UIManager:nextTick(function() UIManager:quit() end) -- Ensure the program closes in case of some lingering dialog.
     end
 
-    -- A lone Sym key tap (pressed and released with no other key in between) is used
-    -- by InputText to toggle the on-screen keyboard, mirroring Shift/ScreenKB + Home.
-    -- Sym is otherwise only a modifier (the symbol layer) whose bare press/release is
-    -- swallowed just below, so we track the "tapped alone" state across both events.
-    -- It only counts as a lone tap if no other modifier is held at press time (Sym
-    -- itself is not marked in self.modifiers until the block below), so combinations
-    -- like Shift + Sym do not toggle the keyboard. A held Sym (auto-repeat) is not a
-    -- tap either, so clear the flag once repeats start coming in.
+    -- A lone Sym or ScreenKB key tap (pressed and released with no other key in
+    -- between) is used by InputText to toggle the on-screen keyboard, mirroring
+    -- Shift/ScreenKB + Home. Both are otherwise only modifiers whose bare
+    -- press/release is swallowed just below, so we track which one, if any, was
+    -- "tapped alone" across the press/release pair. It only counts as a lone tap
+    -- if no other modifier is held at press time (the key itself is not marked in
+    -- self.modifiers until the block below), so combinations like Shift + Sym do
+    -- not toggle the keyboard. Pressing any other key clears the flag, so the
+    -- symbol layer (Sym + key) never toggles.
     if ev.value == KEY_PRESS then
-        local solo = keycode == "Sym"
+        local solo = keycode == "Sym" or keycode == "ScreenKB"
         if solo then
             for _, held in pairs(self.modifiers) do
                 if held then
@@ -869,9 +870,7 @@ function Input:handleKeyBoardEv(ev)
                 end
             end
         end
-        self.sym_tapped = solo
-    elseif ev.value == KEY_REPEAT and keycode == "Sym" then
-        self.sym_tapped = false
+        self.keyboard_toggle_tapped = solo and keycode or nil
     end
 
     -- handle modifier keys
@@ -880,10 +879,11 @@ function Input:handleKeyBoardEv(ev)
             self.modifiers[keycode] = true
         elseif ev.value == KEY_RELEASE then
             self.modifiers[keycode] = false
-            if keycode == "Sym" and self.sym_tapped then
-                self.sym_tapped = false
-                -- Surface the lone Sym tap as a dedicated key event; nothing else binds it.
-                return Event:new("KeyPress", Key:new("SymPress", self.modifiers))
+            if self.keyboard_toggle_tapped == keycode then
+                self.keyboard_toggle_tapped = nil
+                -- Surface the lone tap as a dedicated key event; nothing else binds it.
+                local tap_key = keycode == "Sym" and "SymPress" or "ScreenKBPress"
+                return Event:new("KeyPress", Key:new(tap_key, self.modifiers))
             end
         end
         return

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -859,7 +859,10 @@ function Input:handleKeyBoardEv(ev)
     -- if no other modifier is held at press time (the key itself is not marked in
     -- self.modifiers until the block below), so combinations like Shift + Sym do
     -- not toggle the keyboard. Pressing any other key clears the flag, so the
-    -- symbol layer (Sym + key) never toggles.
+    -- symbol layer (Sym + key) never toggles. A held key is not a tap either: the
+    -- keypad emits KEY_REPEAT for it (verified on a Kindle 3: mxckpd advertises
+    -- EV_REP, ~1s delay then ~5 Hz), so a repeat clears the flag and a long hold
+    -- does not toggle on release.
     if ev.value == KEY_PRESS then
         local solo = keycode == "Sym" or keycode == "ScreenKB"
         if solo then
@@ -871,6 +874,8 @@ function Input:handleKeyBoardEv(ev)
             end
         end
         self.keyboard_toggle_tapped = solo and keycode or nil
+    elseif ev.value == KEY_REPEAT and (keycode == "Sym" or keycode == "ScreenKB") then
+        self.keyboard_toggle_tapped = nil
     end
 
     -- handle modifier keys

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -861,8 +861,10 @@ function Input:handleKeyBoardEv(ev)
     -- not toggle the keyboard. Pressing any other key clears the flag, so the
     -- symbol layer (Sym + key) never toggles. A held key is not a tap either: the
     -- keypad emits KEY_REPEAT for it (verified on a Kindle 3: mxckpd advertises
-    -- EV_REP, ~1s delay then ~5 Hz), so a repeat clears the flag and a long hold
-    -- does not toggle on release.
+    -- EV_REP, ~1s delay then ~5 Hz), so any event for the key that is neither a
+    -- press nor a release clears the flag and a long hold does not toggle on
+    -- release. This also covers "Disable key repeat" (Kindle:toggleKeyRepeat),
+    -- which rewrites the repeat value to -1 rather than dropping the event.
     if ev.value == KEY_PRESS then
         local solo = keycode == "Sym" or keycode == "ScreenKB"
         if solo then
@@ -874,7 +876,7 @@ function Input:handleKeyBoardEv(ev)
             end
         end
         self.keyboard_toggle_tapped = solo and keycode or nil
-    elseif ev.value == KEY_REPEAT and (keycode == "Sym" or keycode == "ScreenKB") then
+    elseif ev.value ~= KEY_RELEASE and (keycode == "Sym" or keycode == "ScreenKB") then
         self.keyboard_toggle_tapped = nil
     end
 

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -859,12 +859,13 @@ function Input:handleKeyBoardEv(ev)
     -- if no other modifier is held at press time (the key itself is not marked in
     -- self.modifiers until the block below), so combinations like Shift + Sym do
     -- not toggle the keyboard. Pressing any other key clears the flag, so the
-    -- symbol layer (Sym + key) never toggles. A held key is not a tap either: the
-    -- keypad emits KEY_REPEAT for it (verified on a Kindle 3: mxckpd advertises
-    -- EV_REP, ~1s delay then ~5 Hz), so any event for the key that is neither a
-    -- press nor a release clears the flag and a long hold does not toggle on
-    -- release. This also covers "Disable key repeat" (Kindle:toggleKeyRepeat),
-    -- which rewrites the repeat value to -1 rather than dropping the event.
+    -- symbol layer (Sym + key) never toggles. A held Sym is not a tap either: on
+    -- the Kindle 3 mxckpd advertises EV_REP (~1s delay then ~5 Hz), so a held Sym
+    -- repeats; any event for it that is neither a press nor a release clears the
+    -- flag and a long hold does not toggle on release. That guard also covers
+    -- "Disable key repeat" (Kindle:toggleKeyRepeat), which rewrites the repeat
+    -- value to -1 rather than dropping the event. The ScreenKB key (Kindle 4) does
+    -- not emit repeats, so it needs no such guard; a bare press/release is a tap.
     if ev.value == KEY_PRESS then
         local solo = keycode == "Sym" or keycode == "ScreenKB"
         if solo then
@@ -876,7 +877,7 @@ function Input:handleKeyBoardEv(ev)
             end
         end
         self.keyboard_toggle_tapped = solo and keycode or nil
-    elseif ev.value ~= KEY_RELEASE and (keycode == "Sym" or keycode == "ScreenKB") then
+    elseif ev.value ~= KEY_RELEASE and keycode == "Sym" then
         self.keyboard_toggle_tapped = nil
     end
 

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -233,15 +233,15 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
     -- lone Sym/ScreenKB press on devices that have such a key, otherwise Shift + Home.
     local vk_shortcut
     if Device:hasScreenKB() then
-        vk_shortcut = "'ScreenKB'"
+        vk_shortcut = _("'ScreenKB'")
     elseif Device:hasSymKey() then
-        vk_shortcut = "'Sym'"
+        vk_shortcut = _("'Sym'")
     else
-        vk_shortcut = "'Shift' + 'Home'"
+        vk_shortcut = _("'Shift' + 'Home'")
     end
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = FFIUtil.template(_("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing %1."), vk_shortcut),
+        help_text = T(_("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing %1."), vk_shortcut),
         checked_func = function()
             return G_reader_settings:isTrue("virtual_keyboard_enabled")
         end,
@@ -249,7 +249,7 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
             G_reader_settings:flipNilOrFalse("virtual_keyboard_enabled")
             if G_reader_settings:nilOrFalse("virtual_keyboard_enabled") then
                 UIManager:show(InfoMessage:new{
-                    text = FFIUtil.template(_("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing %1."), vk_shortcut),
+                    text = T(_("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing %1."), vk_shortcut),
                 })
             end
         end,

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -231,7 +231,7 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
     -- we use same pos. 4 as below so we are always above "keyboard appearance settings"
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home' — or, on devices with a physical 'Sym' key, by tapping 'Sym'."),
+        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home' — or by tapping a lone 'Sym' or 'ScreenKB' key."),
         checked_func = function()
             return G_reader_settings:isTrue("virtual_keyboard_enabled")
         end,
@@ -240,7 +240,7 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
             if G_reader_settings:nilOrFalse("virtual_keyboard_enabled") then
                 local keyboard_infomessage
                 if Device:hasScreenKB() then
-                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'ScreenKB' + 'Home'.")
+                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'ScreenKB' + 'Home', or by tapping 'ScreenKB'.")
                 elseif Device:hasSymKey() then
                     keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home', or by tapping 'Sym'.")
                 else

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -229,33 +229,27 @@ local sub_item_table = {
 }
 if Device:hasKeyboard() or Device:hasScreenKB() then
     -- we use same pos. 4 as below so we are always above "keyboard appearance settings"
-    local show_vk_help_text
+    -- The shortcut that temporarily toggles the keyboard while a field is focused: a
+    -- lone Sym/ScreenKB press on devices that have such a key, otherwise Shift + Home.
+    local vk_shortcut
     if Device:hasScreenKB() then
-        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'ScreenKB' + 'Home', or by tapping 'ScreenKB'.")
+        vk_shortcut = "'ScreenKB'"
     elseif Device:hasSymKey() then
-        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' + 'Home', or by tapping 'Sym'.")
+        vk_shortcut = "'Sym'"
     else
-        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' + 'Home'.")
+        vk_shortcut = "'Shift' + 'Home'"
     end
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = show_vk_help_text,
+        help_text = FFIUtil.template(_("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing %1."), vk_shortcut),
         checked_func = function()
             return G_reader_settings:isTrue("virtual_keyboard_enabled")
         end,
         callback = function()
             G_reader_settings:flipNilOrFalse("virtual_keyboard_enabled")
             if G_reader_settings:nilOrFalse("virtual_keyboard_enabled") then
-                local keyboard_infomessage
-                if Device:hasScreenKB() then
-                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'ScreenKB' + 'Home', or by tapping 'ScreenKB'.")
-                elseif Device:hasSymKey() then
-                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home', or by tapping 'Sym'.")
-                else
-                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home'.")
-                end
                 UIManager:show(InfoMessage:new{
-                    text = keyboard_infomessage
+                    text = FFIUtil.template(_("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing %1."), vk_shortcut),
                 })
             end
         end,

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -231,7 +231,7 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
     -- we use same pos. 4 as below so we are always above "keyboard appearance settings"
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home'."),
+        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home' — or, on devices with a physical 'Sym' key, by tapping 'Sym'."),
         checked_func = function()
             return G_reader_settings:isTrue("virtual_keyboard_enabled")
         end,
@@ -241,6 +241,8 @@ if Device:hasKeyboard() or Device:hasScreenKB() then
                 local keyboard_infomessage
                 if Device:hasScreenKB() then
                     keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'ScreenKB' + 'Home'.")
+                elseif Device:hasSymKey() then
+                    keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home', or by tapping 'Sym'.")
                 else
                     keyboard_infomessage = _("When a text field is selected (in focus), you can temporarily bring up the virtual keyboard by pressing 'Shift' + 'Home'.")
                 end

--- a/frontend/ui/elements/menu_keyboard_layout.lua
+++ b/frontend/ui/elements/menu_keyboard_layout.lua
@@ -229,9 +229,17 @@ local sub_item_table = {
 }
 if Device:hasKeyboard() or Device:hasScreenKB() then
     -- we use same pos. 4 as below so we are always above "keyboard appearance settings"
+    local show_vk_help_text
+    if Device:hasScreenKB() then
+        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'ScreenKB' + 'Home', or by tapping 'ScreenKB'.")
+    elseif Device:hasSymKey() then
+        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' + 'Home', or by tapping 'Sym'.")
+    else
+        show_vk_help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' + 'Home'.")
+    end
     table.insert(sub_item_table, 4, {
         text = _("Show virtual keyboard"),
-        help_text = _("Enable this setting to always display the virtual keyboard within a text input field. When a field is selected (in focus), you can temporarily toggle the keyboard on/off by pressing 'Shift' (or 'ScreenKB') + 'Home' — or by tapping a lone 'Sym' or 'ScreenKB' key."),
+        help_text = show_vk_help_text,
         checked_func = function()
             return G_reader_settings:isTrue("virtual_keyboard_enabled")
         end,

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -797,8 +797,8 @@ function InputText:onKeyPress(key)
         return false
     end
 
-    -- A lone Sym key tap toggles the on-screen keyboard, same as Shift/ScreenKB + Home.
-    if key["SymPress"] then
+    -- A lone Sym or ScreenKB key tap toggles the on-screen keyboard, same as Shift/ScreenKB + Home.
+    if key["SymPress"] or key["ScreenKBPress"] then
         if self:isKeyboardVisible() then
             self:onCloseKeyboard()
         else

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -796,6 +796,17 @@ function InputText:onKeyPress(key)
     if not self.focused then
         return false
     end
+
+    -- A lone Sym key tap toggles the on-screen keyboard, same as Shift/ScreenKB + Home.
+    if key["SymPress"] then
+        if self:isKeyboardVisible() then
+            self:onCloseKeyboard()
+        else
+            self:onShowKeyboard()
+        end
+        return self.keyboard ~= nil -- readonly fields have no keyboard: let the event bubble
+    end
+
     local handled = true
 
     if not key["Ctrl"] and not key["Shift"] and not key["Alt"] and not key["ScreenKB"] then

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -797,13 +797,9 @@ function InputText:onKeyPress(key)
         return false
     end
 
-    -- A lone Sym or ScreenKB key tap toggles the on-screen keyboard, same as Shift/ScreenKB + Home.
+    -- A lone Sym or ScreenKB key press toggles the on-screen keyboard, same as Shift/ScreenKB + Home.
     if key["SymPress"] or key["ScreenKBPress"] then
-        if self:isKeyboardVisible() then
-            self:onCloseKeyboard()
-        else
-            self:onShowKeyboard()
-        end
+        self:toggleKeyboard()
         return self.keyboard ~= nil -- readonly fields have no keyboard: let the event bubble
     end
 
@@ -891,11 +887,7 @@ function InputText:onKeyPress(key)
         elseif key["Press"] then
             self:holdTextBox()
         elseif key["Home"] then
-            if self.keyboard:isVisible() then
-                self:onCloseKeyboard()
-            else
-                self:onShowKeyboard()
-            end
+            self:toggleKeyboard()
         elseif key["."] and Device:hasSymKey() then
             -- Kindle does not have a dedicated button for commas
             self:addChars(",")
@@ -986,6 +978,15 @@ function InputText:isKeyboardVisible()
     end
     -- NOTE: Never return `nil`, to avoid inheritance issues in (Multi)InputDialog's keyboard_visible flag.
     return false
+end
+
+-- Temporarily show/hide the on-screen keyboard, e.g. via Shift/ScreenKB + Home or a lone Sym/ScreenKB press.
+function InputText:toggleKeyboard()
+    if self:isKeyboardVisible() then
+        self:onCloseKeyboard()
+    else
+        self:onShowKeyboard()
+    end
 end
 
 function InputText:lockKeyboard(toggle)


### PR DESCRIPTION
## What
On devices with a physical keyboard (Kindle) or a dedicated `ScreenKB` key, the on-screen keyboard can already be toggled while a text field is focused via `Shift`/`ScreenKB` + `Home`. This adds a **lone tap of the physical `Sym` key** (and, symmetrically, a lone tap of the `ScreenKB` key) as an additional, more natural trigger — it matches how the `Sym` key behaves in the stock Kindle firmware.

## Why
On a keyboard Kindle the `Sym` key is only ever a *held* modifier for the symbol layer (`Sym`+`Q` → `!`, `Sym`+`B` → `1`, …). A bare `Sym` press does nothing in a text field, and the existing toggle lives on the `Shift`+`Home` chord, which is not discoverable. Users reasonably expect `Sym` alone to summon/dismiss the keyboard. The same reasoning applies even more directly to the dedicated `ScreenKB` key, which is otherwise only used as a modifier for the `ScreenKB`+`Home` chord.

## How
`Input:handleKeyBoardEv` swallows a bare modifier press/release before it becomes a key event, so a lone `Sym`/`ScreenKB` never reaches a widget. This tracks whether one of them was *tapped alone* (pressed and released with no other key in between) and, on release, surfaces it as a dedicated `SymPress`/`ScreenKBPress` key event. `InputText:onKeyPress` handles those exactly like the existing `Shift`/`ScreenKB` + `Home` toggle.

The symbol layer is unaffected: any intervening key press clears the lone-tap state, so `Sym`+`<key>` still types symbols and only a true solo tap fires the toggle. `SymPress`/`ScreenKBPress` are fresh event names that nothing else binds, so there is no collision with menu shortcut keys or `FocusManager`.

## Testing
Tested on a physical Kindle 3 (Keyboard, `kindle-legacy`/armv6): a lone `Sym` tap shows/hides the on-screen keyboard in a focused input field; `Sym`+letter symbol input and `Shift`+`Home` continue to work unchanged. The `ScreenKB` path shares the same code, but my hardware has no `ScreenKB` key, so it has not been verified on-device — a check by someone with a `ScreenKB` device would be welcome. Help text updated for `hasSymKey` and `hasScreenKB` devices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15669)
<!-- Reviewable:end -->
