### PR TITLE
pdfdocument: rename deleteMarkupAnnotation call to deleteAnnotation

### DIFF
--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -272,7 +272,7 @@ function PdfDocument:deleteHighlight(pageno, item)
     local page = self._document:openPage(pageno)
     local annot = page:getMarkupAnnotation(quadpoints, n)
     if annot ~= nil then
-        page:deleteMarkupAnnotation(annot)
+        page:deleteAnnotation(annot)
         self:resetTileCacheValidity()
     end
     page:close()


### PR DESCRIPTION
### What

Renames the `page:deleteMarkupAnnotation(annot)` call in `frontend/document/pdfdocument.lua` to `page:deleteAnnotation(annot)`.

### Why

Companion to koreader/koreader-base#2444, which renames the underlying FFI helper. `pdf_delete_annot` is subtype-agnostic (ink annotations use the same delete path), so the helper was renamed from `deleteMarkupAnnotation` to `deleteAnnotation`. This updates the sole caller so the two land together on the next koreader-base submodule bump.

Depends on koreader/koreader-base#2444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15672)
<!-- Reviewable:end -->
