### PR TITLE
pocketbook: install into hidden ".koreader" directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -109,7 +109,7 @@ body:
         * Cervantes: `/mnt/private/koreader`
         * Kindle: `koreader/`
         * Kobo: `.adds/koreader/`
-        * Pocketbook: `applications/koreader/`
+        * Pocketbook: `applications/.koreader/` (a hidden directory)
         * Android: Go to [Menu] → Help → Bug Report to save logs to a file
         * AppImage: Run `koreader-20xx.AppImage 2>&1 | tee crash.log` from the terminal
         * Deb / Linux: Run `koreader-20xx 2>&1 | tee crash.log` from the terminal

--- a/make/pocketbook.mk
+++ b/make/pocketbook.mk
@@ -11,8 +11,9 @@ endef
 # library scanner ignores our fonts, help documents and crash.log instead of
 # indexing them as books (koreader/koreader#15462). The release tooling strips
 # dotfiles by default (-xr!.*), which would otherwise drop our own directory
-# back out of the package, so lift that blanket rule for this platform only.
-UPDATE_GLOBAL_EXCLUDES := $(filter-out .*,$(UPDATE_GLOBAL_EXCLUDES))
+# back out of the package. Swap that blanket rule for a VCS-cruft one on this
+# platform only, so ".koreader" is kept while .git/.gitignore/etc. are not.
+UPDATE_GLOBAL_EXCLUDES := $(filter-out .*,$(UPDATE_GLOBAL_EXCLUDES)) .git*
 
 update-prepare: all
 	# ensure that the binaries were built for ARM

--- a/make/pocketbook.mk
+++ b/make/pocketbook.mk
@@ -7,6 +7,13 @@ define UPDATE_PATH_EXCLUDES +=
 tools
 endef
 
+# We install into a hidden ".koreader" directory so PocketBook's built-in
+# library scanner ignores our fonts, help documents and crash.log instead of
+# indexing them as books (koreader/koreader#15462). The release tooling strips
+# dotfiles by default (-xr!.*), which would otherwise drop our own directory
+# back out of the package, so lift that blanket rule for this platform only.
+UPDATE_GLOBAL_EXCLUDES := $(filter-out .*,$(UPDATE_GLOBAL_EXCLUDES))
+
 update-prepare: all
 	# ensure that the binaries were built for ARM
 	file --dereference $(INSTALL_DIR)/koreader/luajit | grep ARM
@@ -17,15 +24,15 @@ update-prepare: all
 	$(SYMLINK) $(POCKETBOOK_DIR)/koreader.app $(INSTALL_DIR)/applications/
 	$(SYMLINK) $(POCKETBOOK_DIR)/system_koreader.app $(INSTALL_DIR)/system/bin/koreader.app
 	$(SYMLINK) $(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader/
-	$(SYMLINK) $(INSTALL_DIR)/koreader $(INSTALL_DIR)/applications/
+	$(SYMLINK) $(INSTALL_DIR)/koreader $(INSTALL_DIR)/applications/.koreader
 
 update-zip: update-prepare
-	$(strip $(call mkupdate,--manifest-transform=/^system\//d $(PB_PACKAGE),applications/koreader)) applications system
+	$(strip $(call mkupdate,--manifest-transform=/^system\//d $(PB_PACKAGE),applications/.koreader)) applications system
 
 update-txz: update-prepare
-	$(strip $(call mkupdate,--manifest-transform=/^system\//d $(PB_PACKAGE_OTA),applications/koreader)) applications system
+	$(strip $(call mkupdate,--manifest-transform=/^system\//d $(PB_PACKAGE_OTA),applications/.koreader)) applications system
 
 update-tgz: update-prepare
-	$(strip $(call mkupdate,--manifest-transform=s/^/..\// $(PB_PACKAGE_OLD_OTA),applications/koreader)) applications
+	$(strip $(call mkupdate,--manifest-transform=s/^/..\// $(PB_PACKAGE_OLD_OTA),applications/.koreader)) applications
 
 update: update-zip update-txz update-tgz

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -96,13 +96,17 @@ ko_update_check() {
 # One-time migration for installs created before #15462, when our payload lived
 # in the non-hidden applications/koreader directory (which PocketBook's library
 # scanner indexed as books). This build already unpacked a fresh payload into
-# .koreader, so pull across only the files the old tree has and we don't (the
+# .koreader, so bring across only the files the old tree has and we don't (the
 # user's settings, history, statistics, custom fonts / patches / plugins, ...)
-# without clobbering the new payload, then drop the old directory.
+# without clobbering the new payload. Only drop the old directory if the copy
+# succeeded, so a failed or partial copy can never destroy user data.
 OLD_KOREADER_DIR="${UNPACK_DIR}/applications/koreader"
 if [ -d "${OLD_KOREADER_DIR}" ] && [ "${OLD_KOREADER_DIR}" != "${KOREADER_DIR}" ]; then
-    cp -rn "${OLD_KOREADER_DIR}/." "${KOREADER_DIR}/" 2>/dev/null
-    rm -rf "${OLD_KOREADER_DIR}"
+    if cp -rn "${OLD_KOREADER_DIR}/." "${KOREADER_DIR}/"; then
+        # Drop any stale zsync base so the next OTA rebuilds it from the merged tree.
+        rm -f "${KOREADER_DIR}/ota/koreader.installed.tar"
+        rm -rf "${OLD_KOREADER_DIR}"
+    fi
 fi
 
 # we're always starting from our working directory

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -4,7 +4,9 @@ export LC_ALL="en_US.UTF-8"
 
 UNPACK_DIR='/mnt/ext1'
 # KOReader's working directory.
-KOREADER_DIR="${UNPACK_DIR}/applications/koreader"
+# Note: the leading dot keeps the PocketBook library scanner from indexing our
+# own files (fonts, help documents, crash.log) as books (koreader/koreader#15462).
+KOREADER_DIR="${UNPACK_DIR}/applications/.koreader"
 
 # Relocalize ourselves to /tmp: this is used by KOReader to detect if the
 # original script has changed after an update (requiring a complete restart

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -93,6 +93,18 @@ ko_update_check() {
     fi
 }
 
+# One-time migration for installs created before #15462, when our payload lived
+# in the non-hidden applications/koreader directory (which PocketBook's library
+# scanner indexed as books). This build already unpacked a fresh payload into
+# .koreader, so pull across only the files the old tree has and we don't (the
+# user's settings, history, statistics, custom fonts / patches / plugins, ...)
+# without clobbering the new payload, then drop the old directory.
+OLD_KOREADER_DIR="${UNPACK_DIR}/applications/koreader"
+if [ -d "${OLD_KOREADER_DIR}" ] && [ "${OLD_KOREADER_DIR}" != "${KOREADER_DIR}" ]; then
+    cp -rn "${OLD_KOREADER_DIR}/." "${KOREADER_DIR}/" 2>/dev/null
+    rm -rf "${OLD_KOREADER_DIR}"
+fi
+
 # we're always starting from our working directory
 cd ${KOREADER_DIR} || exit
 


### PR DESCRIPTION
## Problem

On PocketBook, the firmware's built-in library scanner indexes everything under `applications/`. Because KOReader installs its payload at `applications/koreader/`, the scanner picks up KOReader's own files (fonts, help documents, and the `crash.log` that is written on every shutdown) and lists them as books. Users see dozens of bogus "books" appear in their PocketBook library shortly after installing.

Fixes #15462.

## Fix

Install the payload into a hidden `applications/.koreader/` directory instead. PocketBook's scanner skips dot-prefixed directories, so it leaves our files alone. This matches the manual workaround the reporter confirmed in the issue (renaming the install dir to `.koreader` and repointing the `.app` launcher).

The launcher (`applications/koreader.app`) stays visible so the app still shows up on the device; only the payload directory it points at is hidden.

Changes, all scoped to the PocketBook target:

- `make/pocketbook.mk`: symlink the payload in as `.koreader` and point the three OTA package bases at `applications/.koreader`.
- `make/pocketbook.mk`: the release tooling excludes dotfiles by default (`-xr!.*` in `mkrelease.sh`), which would otherwise strip our own hidden directory back out of the package. For this platform only, swap that blanket rule for a VCS-cruft one: `UPDATE_GLOBAL_EXCLUDES := $(filter-out .*,$(UPDATE_GLOBAL_EXCLUDES)) .git*`, so `.koreader` is kept while `.git`/`.gitignore`/etc. are still excluded.
- `platform/pocketbook/koreader.app`: `KOREADER_DIR` now points at `applications/.koreader`, plus a one-time migration for existing installs (see below). Everything else in the script is relative to `KOREADER_DIR` / uses the `../koreader.app` launcher.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: update the "where is crash.log" hint for PocketBook.

No shared/cross-platform build code is touched.

## OTA migration

Fresh installs land directly in `.koreader/`. For existing installs updating over OTA, the new payload is unpacked into `applications/.koreader/` while the old `applications/koreader/` (holding the user's settings, history, statistics, custom fonts, patches, ...) is left in place. To avoid orphaning that directory (still scanned by the library) and losing the user's data, the launcher performs a one-time migration on first run of the new version:

```sh
OLD_KOREADER_DIR="${UNPACK_DIR}/applications/koreader"
if [ -d "${OLD_KOREADER_DIR}" ] && [ "${OLD_KOREADER_DIR}" != "${KOREADER_DIR}" ]; then
    cp -rn "${OLD_KOREADER_DIR}/." "${KOREADER_DIR}/" 2>/dev/null
    rm -rf "${OLD_KOREADER_DIR}"
fi
```

The no-clobber copy keeps the freshly unpacked payload (it never overwrites the new binaries/Lua) and brings across only the files unique to the old tree, i.e. the user's data, then removes the old directory. It self-terminates once the old directory is gone, and is a no-op for fresh installs and for users who already applied the issue's manual workaround.

## Testing

- Reproduced the release manifest step (`7z -ba -l h applications system ...`) on a build tree with the payload symlinked in as `.koreader` and stray `.gitignore` / `.git/` planted inside it: with `-xr!.*` the entire `.koreader` subtree is excluded (the package ships empty); with `$(filter-out .*,...) .git*` the payload is kept while `.gitignore` / `.git/` are still dropped.
- Verified the migration on a mock old/new layout: the new `reader.lua` is preserved (no-clobber) while the user's settings, history and custom font are carried across and the old directory is removed.
- Verified no other code path references the old payload path (`otamanager.lua`, `device.lua`, and `system_koreader.app` all use relative paths or the `.app` launcher).
- I verified this fix by manually renaming the dir as in the issue first for feasibility.
- Not yet exercised on real hardware; an on-device fresh install plus an OTA update pass is still wanted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15674)
<!-- Reviewable:end -->
