### PR TITLE
Highlight: custom colors

### DIFF
--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1642,16 +1642,15 @@ end
 function ReaderBookmark:filterByHighlightColor()
     UIManager:show(ButtonSelector:new{
         current_value = self.show_color_only,
-        values = self.ui.highlight.highlight_colors,
-        bg_colors = self.ui.highlight:getHighlightColorList(),
-        callback = function(value)
+        values = self.ui.highlight:getHighlightColorList(),
+        callback = function(selected_color_name)
             local item_table = self.bookmark_menu[1].item_table
             for i = #item_table, 1, -1 do
-                if item_table[i].color ~= value then
+                if item_table[i].color ~= selected_color_name then
                     table.remove(item_table, i)
                 end
             end
-            self.show_color_only = value
+            self.show_color_only = selected_color_name
             self:updateBookmarkList(item_table)
         end,
     })

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -37,9 +37,13 @@ local ReaderHighlight = InputContainer:extend{
         {_("Purple"), "purple"},
         {_("Gray"), "gray"},
     },
+    custom_colors = G_reader_settings:readSetting("highlight_custom_colors", {}),
 }
 
-function ReaderHighlight:getHighlightColorString(color_name)
+function ReaderHighlight:getHighlightColorString(color_name, force_orig)
+    if not force_orig and self.custom_colors[color_name] and self.custom_colors[color_name].name then
+        return self.custom_colors[color_name].name
+    end
     for _, color in ipairs(self.highlight_colors) do
         if color_name == color[2] then
             return color[1]
@@ -48,25 +52,38 @@ function ReaderHighlight:getHighlightColorString(color_name)
     return color_name -- unknown
 end
 
-function ReaderHighlight:getHighlightColorList()
-    local color_list = {}
-    for i, color in ipairs(self.highlight_colors) do
-        color_list[i] = self:getHighlightColor(color[2])
+function ReaderHighlight:getHighlightColorCode(color_name, force_orig, honor_night_mode)
+    local color_code = not force_orig
+        and self.custom_colors[color_name] and self.custom_colors[color_name].code
+        or Blitbuffer.HIGHLIGHT_COLORS[color_name]
+    if color_code and honor_night_mode and Screen.night_mode then -- invert
+        local r, g, b = color_code:match("#(..)(..)(..)")
+        return string.format("#%02x%02x%02x", 255 - tonumber(r, 16), 255 - tonumber(g, 16), 255 - tonumber(b, 16))
     end
-    return color_list
+    return color_code
 end
 
-function ReaderHighlight:getHighlightColor(color_name)
-    local color = Blitbuffer.colorFromName(color_name)
-    if color then
-        if Screen.night_mode then
-            local r, g, b = Blitbuffer.HIGHLIGHT_COLORS[color_name]:match("#(..)(..)(..)")
-            return Blitbuffer.colorFromString(string.format("#%02x%02x%02x",
-                255 - tonumber(r, 16), 255 - tonumber(g, 16), 255 - tonumber(b, 16)))
+function ReaderHighlight:getHighlightColor(color_name, force_orig, honor_night_mode)
+    if color_name ~= "gray" then
+        local color_code = self:getHighlightColorCode(color_name, force_orig, honor_night_mode)
+        if color_code then
+            return Blitbuffer.colorFromString(color_code)
         end
-        return color
     end
     return Blitbuffer.gray(G_reader_settings:readSetting("highlight_lighten_factor") or 0.2)
+end
+
+function ReaderHighlight:getHighlightColorList() -- for color ButtonSelector
+    local color_list = {}
+    for i, color in ipairs(self.highlight_colors) do
+        local color_name = color[2]
+        color_list[i] = {
+            self.custom_colors[color_name] and self.custom_colors[color_name].name or color[1],
+            color_name,
+            self:getHighlightColor(color_name, nil, true), -- honor night mode
+        }
+    end
+    return color_list
 end
 
 local function inside_box(pos, box)
@@ -422,17 +439,9 @@ function ReaderHighlight:addToMainMenu(menu_items)
     hl_sub_item_table[#highlight_style].separator = true
     table.insert(hl_sub_item_table, {
         text_func = function()
-            local saved_color = self.view.highlight.saved_color
-            local text
-            for _, v in ipairs(self.highlight_colors) do
-                if v[2] == saved_color then
-                    text = v[1]:lower()
-                    break
-                end
-            end
-            text = text or saved_color -- nonstandard color
             local default_color = G_reader_settings:readSetting("highlight_color") or self._fallback_color
-            if saved_color == default_color then
+            local text = self:getHighlightColorString(self.view.highlight.saved_color)
+            if self.view.highlight.saved_color == default_color then
                 text = text .. star
             end
             return T(_("Highlight color: %1"), text)
@@ -442,16 +451,7 @@ function ReaderHighlight:addToMainMenu(menu_items)
         end,
         keep_menu_open = true,
         callback = function(touchmenu_instance) -- set color for new highlights in this book
-            UIManager:show(ButtonSelector:new{
-                current_value = self.view.highlight.saved_color,
-                values = self.highlight_colors,
-                bg_colors = self:getHighlightColorList(),
-                callback = function(value)
-                    self.view.highlight.saved_color = value
-                    self:setSelectionColor()
-                    touchmenu_instance:updateItems()
-                end,
-            })
+            self:setHighlightColor(touchmenu_instance)
         end,
         hold_callback = function(touchmenu_instance) -- set color for new highlights in new books
             G_reader_settings:saveSetting("highlight_color", self.view.highlight.saved_color)
@@ -2257,7 +2257,7 @@ function ReaderHighlight:writePdfAnnotation(action, item, content)
     logger.dbg("write to pdf document", action, item)
     local function doAction(action_, page_, item_, content_)
         if action_ == "save" then
-            self.document:saveHighlight(page_, item_)
+            self.document:saveHighlight(page_, item_, self:getHighlightColor(item_.color))
         elseif action_ == "delete" then
             self.document:deleteHighlight(page_, item_)
         elseif action_ == "content" then
@@ -2369,11 +2369,10 @@ function ReaderHighlight:editHighlightColor(index)
     local color_selector
     color_selector = ButtonSelector:new{
         current_value = item.color,
-        values = self.highlight_colors,
-        bg_colors = self:getHighlightColorList(),
-        callback = function(value)
+        values = self:getHighlightColorList(),
+        callback = function(selected_color_name)
             self:writePdfAnnotation("delete", item)
-            item.color = value
+            item.color = selected_color_name
             if self.ui.paging then
                 self:writePdfAnnotation("save", item)
                 if item.note then
@@ -2388,6 +2387,103 @@ function ReaderHighlight:editHighlightColor(index)
         end,
     }
     UIManager:show(color_selector)
+end
+
+function ReaderHighlight:setHighlightColor(touchmenu_instance)
+    local highlight_color_selector
+    highlight_color_selector = ButtonSelector:new{
+        current_value = self.view.highlight.saved_color,
+        values = self:getHighlightColorList(),
+        callback = function(selected_color_name)
+            self.view.highlight.saved_color = selected_color_name
+            self:setSelectionColor()
+            touchmenu_instance:updateItems()
+        end,
+        hold_callback = function(selected_color_name, selected_color_string)
+            if selected_color_name ~= "gray" then
+                self:editCustomColor(selected_color_name, selected_color_string, touchmenu_instance, highlight_color_selector)
+            end
+        end,
+    }
+    UIManager:show(highlight_color_selector)
+end
+
+function ReaderHighlight:editCustomColor(color_name, color_string, touchmenu_instance, highlight_color_selector)
+    local MultiInputDialog = require("ui/widget/multiinputdialog")
+    local orig_color_string = self:getHighlightColorString(color_name, true)
+    local orig_color_code = self:getHighlightColorCode(color_name, true)
+    local color_code = self:getHighlightColorCode(color_name)
+    local edit_color_dialog
+
+    local function save_color(old_color_string, old_color_code, new_color_string, new_color_code)
+        if new_color_string == old_color_string and new_color_code == old_color_code then return end
+        if new_color_string then
+            if new_color_string == orig_color_string then
+                new_color_string = nil
+            end
+        end
+        if new_color_code then
+            if new_color_code == orig_color_code then
+                new_color_code = nil
+            elseif not new_color_code:match("^#%x%x%x%x%x%x$") then
+                UIManager:show(Notification:new{ text = _("Incorrect color code") })
+                return
+            end
+        end
+        self.custom_colors[color_name] = (new_color_string or new_color_code)
+            and { name = new_color_string, code = new_color_code } or nil
+        UIManager:close(edit_color_dialog)
+        UIManager:close(highlight_color_selector)
+        if new_color_code ~= old_color_code then
+            self.view:resetHighlightBoxesCache()
+            UIManager:setDirty(self.dialog, "ui")
+        end
+        touchmenu_instance:updateItems()
+        self:setHighlightColor(touchmenu_instance)
+    end
+
+    edit_color_dialog = MultiInputDialog:new{
+        title = T(_("Highlight color: %1"), orig_color_string),
+        fields = {
+            {
+                text = color_string,
+                hint = orig_color_string,
+            },
+            {
+                text = color_code,
+                hint = orig_color_code,
+            },
+        },
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(edit_color_dialog)
+                    end,
+                },
+                {
+                    text = _("Reset"),
+                    enabled = color_string ~= orig_color_string or color_code ~= orig_color_code,
+                    callback = function()
+                        save_color(color_string, color_code)
+                    end,
+                },
+                {
+                    text = _("Save"),
+                    callback = function()
+                        local fields = edit_color_dialog:getFields()
+                        save_color(color_string, color_code,
+                            fields[1] ~= "" and fields[1] or orig_color_string,
+                            fields[2] ~= "" and fields[2] or orig_color_code)
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(edit_color_dialog)
+    edit_color_dialog:onShowKeyboard(true)
 end
 
 function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
@@ -2418,11 +2514,10 @@ function ReaderHighlight:showHighlightPrompt(caller_callback, prompt)
             local color_selector
             color_selector = ButtonSelector:new{
                 current_value = self.view.highlight.saved_color,
-                values = self.highlight_colors,
-                bg_colors = self:getHighlightColorList(),
+                values = self:getHighlightColorList(),
                 apply_current_value = true,
-                callback = function(value)
-                    self.selected_text.color = value
+                callback = function(selected_color_name)
+                    self.selected_text.color = selected_color_name
                     do_highlight()
                 end,
                 tap_close_callback = function()
@@ -2759,13 +2854,8 @@ function ReaderHighlight:setSelectionColor()
     if self.ui.paging then return end
     local color = self.view.highlight.saved_drawer ~= "invert"
         and G_reader_settings:isTrue("highlight_selection_use_highlight_color")
-        and Blitbuffer.HIGHLIGHT_COLORS[self.view.highlight.saved_color]
-    if color then
-        if Screen.night_mode then
-            local r, g, b = color:match("#(..)(..)(..)")
-            color = string.format("#%02x%02x%02x", 255 - tonumber(r, 16), 255 - tonumber(g, 16), 255 - tonumber(b, 16))
-        end
-    else -- gray
+        and self:getHighlightColorCode(self.view.highlight.saved_color, nil, true) -- honor night mode
+    if not color then -- gray
         local lighten_factor = G_reader_settings:readSetting("highlight_selection_lighten_factor") or 0.2
         if lighten_factor == 0 then
             color = "#FFFFFF"

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -505,7 +505,7 @@ end
 function ReaderView:drawTempHighlight(bb, x, y)
     local color = self.highlight.saved_drawer ~= "invert"
         and G_reader_settings:isTrue("highlight_selection_use_highlight_color")
-        and Blitbuffer.colorFromName(self.highlight.saved_color) or nil
+        and self.ui.highlight:getHighlightColor(self.highlight.saved_color) or nil
     for page, boxes in pairs(self.highlight.temp) do
         for i = 1, #boxes do
             local rect = self:pageToScreenTransform(page, boxes[i])
@@ -552,7 +552,7 @@ function ReaderView:drawPageSavedHighlight(bb, x, y)
                 local boxes = self.document:getPageBoxesFromPositions(page, item.pos0, item.pos1)
                 if boxes then
                     local drawer = item.drawer
-                    local color = item.color and Blitbuffer.colorFromName(item.color)
+                    local color = self.ui.highlight:getHighlightColor(item.color)
                     if not colorful and color and not Blitbuffer.isColor8(color) then
                         colorful = true
                     end
@@ -625,7 +625,7 @@ function ReaderView:drawXPointerSavedHighlight(bb, x, y)
                     local boxes = self.document:getScreenBoxesFromPositions(item.pos0, item.pos1, true) -- get_segments=true
                     if boxes then
                         local drawer = item.drawer
-                        local color = item.color and Blitbuffer.colorFromName(item.color)
+                        local color = self.ui.highlight:getHighlightColor(item.color)
                         if not colorful and color and not Blitbuffer.isColor8(color) then
                             colorful = true
                         end

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -1,4 +1,3 @@
-local BlitBuffer = require("ffi/blitbuffer")
 local CacheItem = require("cacheitem")
 local CanvasContext = require("document/canvascontext")
 local DocCache = require("document/doccache")
@@ -237,7 +236,7 @@ local function _quadpointsToPboxes(quadpoints, n)
     return pboxes
 end
 
-function PdfDocument:saveHighlight(pageno, item)
+function PdfDocument:saveHighlight(pageno, item, annot_color)
     local can_write = self:_checkIfWritable()
     if can_write ~= true then return can_write end
 
@@ -245,7 +244,6 @@ function PdfDocument:saveHighlight(pageno, item)
     local quadpoints, n = _quadpointsFromPboxes(item.pboxes)
     local page = self._document:openPage(pageno)
     local annot_type = C.PDF_ANNOT_HIGHLIGHT
-    local annot_color = item.color and BlitBuffer.colorFromName(item.color)
     if item.drawer == "lighten" then
         annot_type = C.PDF_ANNOT_HIGHLIGHT
     elseif item.drawer == "underscore" then

--- a/frontend/ui/widget/bookmarkbrowser.lua
+++ b/frontend/ui/widget/bookmarkbrowser.lua
@@ -693,10 +693,9 @@ function BookmarkBrowser:showBookmarkListMenu()
                     UIManager:close(bm_list_menu)
                     UIManager:show(ButtonSelector:new{
                         current_value = self.filter_table.color,
-                        values = ReaderHighlight.highlight_colors,
-                        bg_colors = ReaderHighlight:getHighlightColorList(),
-                        callback = function(value)
-                            self.filter_table.color = value
+                        values = ReaderHighlight:getHighlightColorList(),
+                        callback = function(selected_color_name)
+                            self.filter_table.color = selected_color_name
                             self:updateBookmarkList()
                         end,
                     })

--- a/frontend/ui/widget/buttonselector.lua
+++ b/frontend/ui/widget/buttonselector.lua
@@ -6,8 +6,7 @@ local _ = require("gettext")
 local ButtonSelector = ButtonDialog:extend{
     multi_choice = nil,
     current_value = nil, -- value; or for multi_choice: hash table { value_key = true }
-    values = nil, -- array { { value_text, value_key } } - buttons in order
-    bg_colors = nil, -- array { color }, corresponding to values
+    values = nil, -- array { { value_text, value_key, value_color } } - buttons in order
     apply_current_value = nil, -- set to true to apply the callback when value == current_value
     keep_open_on_apply = nil,
     width_factor = 0.4,
@@ -19,7 +18,11 @@ function ButtonSelector:init()
 
     self.buttons = {}
     for i, v in ipairs(self.values) do
-        local value_text, value_key = unpack(v)
+        local value_text, value_key, value_color = unpack(v)
+        if value_color and not self.colorful then
+            self.colorful = true
+            self.dithered = true
+        end
         if self.multi_choice then
             -- no current_value means no filter, i.e. all selected
             curr_values[value_key] = not self.current_value or self.current_value[value_key]
@@ -28,7 +31,7 @@ function ButtonSelector:init()
             id = value_key,
             text = value_text,
             menu_style = true,
-            background = self.bg_colors and self.bg_colors[i],
+            background = value_color,
             checked_func = function()
                 if self.multi_choice then
                     return curr_values[value_key]
@@ -50,6 +53,11 @@ function ButtonSelector:init()
                         self:init()
                         UIManager:show(self)
                     end
+                end
+            end,
+            hold_callback = function()
+                if self.hold_callback then
+                    self.hold_callback(value_key, value_text)
                 end
             end,
         }}
@@ -92,11 +100,6 @@ function ButtonSelector:init()
                 end,
             },
         })
-    end
-
-    if self.bg_color then
-        self.colorful = true
-        self.dithered = true
     end
 
     ButtonDialog.init(self)

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -368,12 +368,11 @@ function Exporter:addToMainMenu(menu_items)
                 callback = function(touchmenu_instance)
                     UIManager:show(ButtonSelector:new{
                         current_value = util.tableGetValue(settings, "filter", "color"),
-                        values = ReaderHighlight.highlight_colors,
-                        bg_colors = ReaderHighlight:getHighlightColorList(),
+                        values = ReaderHighlight:getHighlightColorList(),
                         multi_choice = true,
-                        callback = function(value)
-                            if value then
-                                util.tableSetValue(settings, value, "filter", "color")
+                        callback = function(selected_color_names)
+                            if selected_color_names then
+                                util.tableSetValue(settings, selected_color_names, "filter", "color")
                             else
                                 util.tableRemoveValue(settings, "filter", "color")
                             end


### PR DESCRIPTION
(After the release)

Total number of colors unchanged: 8 + gray.
Color displayed name and color code can be customized.
- Closes #14243

-----

<img width="400" height="500" alt="0" src="https://github.com/user-attachments/assets/94fe1ca7-2fc8-40c0-8f06-15c0a542df31" />

-----

<img width="400" height="500" alt="1" src="https://github.com/user-attachments/assets/8f7be146-05ab-4a8b-81e6-fe05d2111bbe" />

-----

<img width="400" height="500" alt="2" src="https://github.com/user-attachments/assets/a82b03b7-6829-44b1-b5d9-2be3653a8e34" />

-----

<img width="400" height="500" alt="3" src="https://github.com/user-attachments/assets/84fb9e98-c294-4796-afd8-3144bf82be0f" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15676)
<!-- Reviewable:end -->
