### PR TITLE
Add tappable candidates to the Pinyin keyboard

### DIFF
--- a/frontend/ui/data/keyboardlayouts/generic_ime.lua
+++ b/frontend/ui/data/keyboardlayouts/generic_ime.lua
@@ -55,6 +55,7 @@ local IME = {
     iter_map = nil, -- next code when using wildcard
     iter_map_last_key = nil,
     show_candi_callback = function() end,
+    candidate_callback = function() end,
     switch_char = "SWITCH",
     separator = "SEPARATOR",
     partial_separators = { " " }, -- when in state act as separator, otherwise input itself
@@ -235,6 +236,24 @@ function IME:delOnStageAndHintChars(inputbox)
     end
 end
 
+function IME:notifyCandidates(inputbox)
+    local imex = _stack[#_stack]
+    self.candidate_callback(inputbox, imex.candi, imex.index)
+end
+
+function IME:selectCandidate(inputbox, index)
+    local imex = _stack[#_stack]
+    local candidate = imex.candi[index]
+    if not candidate then
+        return
+    end
+    self:delOnStageAndHintChars(inputbox)
+    inputbox.addChars:raw_method_call(candidate)
+    self:clear_stack()
+    self:notifyCandidates(inputbox)
+    return true
+end
+
 function IME:getHintChars()
     self.hint_char_count = 0
     self.on_stage_char_count = 0
@@ -285,6 +304,7 @@ end
 function IME:refreshHintChars(inpuxbox)
     self:delOnStageAndHintChars(inpuxbox)
     inpuxbox.addChars:raw_method_call(self:getHintChars())
+    self:notifyCandidates(inpuxbox)
 end
 
 function IME:separate(inputbox)
@@ -292,6 +312,7 @@ function IME:separate(inputbox)
         self:delHintChars(inputbox)
     end
     self:clear_stack()
+    self:notifyCandidates(inputbox)
 end
 
 function IME:tweak_case(new_candi, old_imex, new_stroke_upper)
@@ -342,6 +363,7 @@ function IME:wrappedDelChar(inputbox)
         -- one char with one stroke
         self:delOnStageAndHintChars(inputbox)
         self:clear_stack()
+        self:notifyCandidates(inputbox)
     else
         inputbox.delChar:raw_method_call()
     end

--- a/frontend/ui/data/keyboardlayouts/zh_CN_keyboard.lua
+++ b/frontend/ui/data/keyboardlayouts/zh_CN_keyboard.lua
@@ -8,11 +8,29 @@ local SETTING_NAME = "keyboard_chinese_pinyin_settings"
 
 local code_map = dofile("frontend/ui/data/keyboardlayouts/zh_pinyin_data.lua")
 local settings = G_reader_settings:readSetting(SETTING_NAME, {show_candi=true})
+local active_inputbox
 local ime = IME:new {
     code_map = code_map,
     partial_separators = {" "},
     show_candi_callback = function()
-        return settings.show_candi
+        local keyboard = active_inputbox and active_inputbox.keyboard
+        return settings.show_candi and not (keyboard and keyboard.candidate_row)
+    end,
+    candidate_callback = function(inputbox, candidates, index)
+        local keyboard = inputbox and inputbox.keyboard
+        if keyboard and keyboard.setCandidates then
+            local selected_index
+            if #candidates > 0 then
+                selected_index = ((index or 1) - 1) % #candidates + 1
+            end
+            local page = inputbox._pinyin_candidate_page or 1
+            if not inputbox._pinyin_manual_page and selected_index then
+                page = math.ceil(selected_index / keyboard.candidate_page_size)
+                inputbox._pinyin_candidate_page = page
+            end
+            inputbox._pinyin_manual_page = false
+            keyboard:setCandidates(settings.show_candi and candidates or {}, page, selected_index)
+        end
     end,
     switch_char = "→",
     switch_char_prev = "←",
@@ -75,12 +93,35 @@ local genMenuItems = function(self)
             callback = function()
                 settings.show_candi = not settings.show_candi
                 G_reader_settings:saveSetting(SETTING_NAME, settings)
+                if active_inputbox then
+                    ime:notifyCandidates(active_inputbox)
+                end
             end
         }
     }
 end
 
 local wrappedAddChars = function(inputbox, char)
+    if char == "\1candidate_prev" then
+        inputbox._pinyin_candidate_page = math.max(1, (inputbox._pinyin_candidate_page or 1) - 1)
+        inputbox._pinyin_manual_page = true
+        ime:notifyCandidates(inputbox)
+        return
+    elseif char == "\1candidate_next" then
+        inputbox._pinyin_candidate_page = (inputbox._pinyin_candidate_page or 1) + 1
+        inputbox._pinyin_manual_page = true
+        ime:notifyCandidates(inputbox)
+        return
+    end
+    local candidate_index = type(char) == "string" and tonumber(char:match("^\1candidate_(%d+)$"))
+    if candidate_index then
+        if ime:selectCandidate(inputbox, candidate_index) then
+            inputbox._pinyin_candidate_page = 1
+        end
+        return
+    end
+    inputbox._pinyin_candidate_page = 1
+    inputbox._pinyin_manual_page = false
     ime:wrappedAddChars(inputbox, char)
 end
 
@@ -107,16 +148,26 @@ local function separate(inputbox)
 end
 
 local function wrappedDelChar(inputbox)
+    inputbox._pinyin_candidate_page = 1
+    inputbox._pinyin_manual_page = false
     ime:wrappedDelChar(inputbox)
 end
 
 local function clear_stack()
     ime:clear_stack()
+    if active_inputbox then
+        active_inputbox._pinyin_candidate_page = 1
+        active_inputbox._pinyin_manual_page = false
+        ime:notifyCandidates(active_inputbox)
+    end
 end
 
 local wrapInputBox = function(inputbox)
     if inputbox._py_wrapped == nil then
         inputbox._py_wrapped = true
+        inputbox._pinyin_candidate_page = 1
+        inputbox._pinyin_manual_page = false
+        active_inputbox = inputbox
         local wrappers = {}
 
         -- Wrap all of the navigation and non-single-character-input keys with
@@ -148,6 +199,11 @@ local wrapInputBox = function(inputbox)
                     wrapper:revert()
                 end
                 inputbox._py_wrapped = nil
+                inputbox._pinyin_candidate_page = nil
+                inputbox._pinyin_manual_page = nil
+                if active_inputbox == inputbox then
+                    active_inputbox = nil
+                end
             end
         end
     end
@@ -155,5 +211,7 @@ end
 
 py_keyboard.wrapInputBox = wrapInputBox
 py_keyboard.genMenuItems = genMenuItems
+py_keyboard.candidate_row = true
+py_keyboard.candidate_page_size = 6
 py_keyboard.keys[5][4].label = "空格"
 return py_keyboard

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -36,6 +36,7 @@ local VirtualKey = InputContainer:extend{
     icon = nil,
     label = nil,
     bold = nil,
+    background = nil,
 
     keyboard = nil,
     callback = nil,
@@ -260,7 +261,7 @@ function VirtualKey:init()
     self[1] = FrameContainer:new{
         margin = 0,
         bordersize = self.bordersize,
-        background = Blitbuffer.COLOR_WHITE,
+        background = self.background or Blitbuffer.COLOR_WHITE,
         radius = 0,
         padding = 0,
         allow_mirroring = false,
@@ -797,6 +798,8 @@ local VirtualKeyboard = FocusManager:extend{
     symbolmode = false,
     umlautmode = false,
     layout = nil, -- array
+    candidate_row = false,
+    candidate_page_size = 6,
 
     height = nil,
     default_label_size = DEFAULT_LABEL_SIZE,
@@ -853,7 +856,17 @@ function VirtualKeyboard:init()
     local lang = self:getKeyboardLayout()
     local keyboard_layout = self.lang_to_keyboard_layout[lang] or self.lang_to_keyboard_layout["en"]
     local keyboard = require("ui/data/keyboardlayouts/" .. keyboard_layout)
-    self.KEYS = keyboard.keys or {}
+    self.min_layer = keyboard.min_layer
+    self.max_layer = keyboard.max_layer
+    self.candidate_row = keyboard.candidate_row or false
+    self.candidate_page_size = keyboard.candidate_page_size or 6
+    self.KEYS = {}
+    if self.candidate_row then
+        table.insert(self.KEYS, self:_buildCandidateRow({}, 1))
+    end
+    for _, row in ipairs(keyboard.keys or {}) do
+        table.insert(self.KEYS, row)
+    end
     self.shiftmode_keys = keyboard.shiftmode_keys or {}
     self.symbolmode_keys = keyboard.symbolmode_keys or {}
     self.utf8mode_keys = keyboard.utf8mode_keys or {}
@@ -861,8 +874,6 @@ function VirtualKeyboard:init()
     self.width = Screen:getWidth()
     local keys_height = G_reader_settings:isTrue("keyboard_key_compact") and 48 or 64
     self.height = Screen:scaleBySize(keys_height * #self.KEYS)
-    self.min_layer = keyboard.min_layer
-    self.max_layer = keyboard.max_layer
     self:initLayer(self.keyboard_layer)
     self.tap_interval_override = time.ms(G_reader_settings:readSetting("ges_tap_interval_on_keyboard_ms", 0))
     if Device:hasKeys() then
@@ -881,6 +892,59 @@ function VirtualKeyboard:init()
             end
         end
     end
+end
+
+function VirtualKeyboard:_candidateKey(label, key, selected)
+    local candidate_key = {
+        bold = selected or false,
+        background = selected and Blitbuffer.COLOR_LIGHT_GRAY or nil,
+    }
+    for layer = self.min_layer, self.max_layer do
+        candidate_key[layer] = { label = label, key }
+    end
+    return candidate_key
+end
+
+function VirtualKeyboard:_buildCandidateRow(candidates, page, selected_index)
+    local page_size = self.candidate_page_size
+    local page_count = math.max(1, math.ceil(#candidates / page_size))
+    page = math.max(1, math.min(page or 1, page_count))
+    local row = {
+        self:_candidateKey(page > 1 and "‹" or "", "\1candidate_prev"),
+    }
+    local start_index = (page - 1) * page_size + 1
+    for offset = 0, page_size - 1 do
+        local index = start_index + offset
+        table.insert(row, self:_candidateKey(
+            candidates[index] or "", "\1candidate_" .. index, index == selected_index
+        ))
+    end
+    table.insert(row, self:_candidateKey(page < page_count and "›" or "", "\1candidate_next"))
+    return row
+end
+
+function VirtualKeyboard:setCandidates(candidates, page, selected_index)
+    if not self.candidate_row then
+        return
+    end
+    self._pending_candidates = candidates or {}
+    self._pending_candidate_page = page or 1
+    self._pending_candidate_index = selected_index
+    if self._candidate_update_scheduled then
+        return
+    end
+    self._candidate_update_scheduled = true
+    UIManager:nextTick(function()
+        self._candidate_update_scheduled = false
+        if not self.candidate_row or not self.KEYS then
+            return
+        end
+        self.KEYS[1] = self:_buildCandidateRow(
+            self._pending_candidates, self._pending_candidate_page, self._pending_candidate_index
+        )
+        self:addKeys()
+        self:_refresh(false)
+    end)
 end
 
 function VirtualKeyboard:_isTextKeyWithoutModifier(seq)
@@ -1010,7 +1074,8 @@ end
 function VirtualKeyboard:addKeys()
     self:free() -- free previous keys' TextWidgets
     self.layout = {}
-    local base_key_width = math.floor((self.width - (#self.KEYS[1] + 1)*self.key_padding - 2*self.padding)/#self.KEYS[1])
+    local base_row = self.candidate_row and self.KEYS[2] or self.KEYS[1]
+    local base_key_width = math.floor((self.width - (#base_row + 1)*self.key_padding - 2*self.padding)/#base_row)
     local base_key_height = math.floor((self.height - (#self.KEYS + 1)*self.key_padding - 2*self.padding)/#self.KEYS)
     local h_key_padding = HorizontalSpan:new{width = self.key_padding}
     local v_key_padding = VerticalSpan:new{width = self.key_padding}
@@ -1049,6 +1114,7 @@ function VirtualKeyboard:addKeys()
                 label = label,
                 alt_label = alt_label,
                 bold = self.KEYS[i][j].bold,
+                background = self.KEYS[i][j].background,
                 keyboard = self,
                 width = key_width,
                 height = key_height,

--- a/spec/unit/generic_ime_spec.lua
+++ b/spec/unit/generic_ime_spec.lua
@@ -1,0 +1,52 @@
+local IME = require("ui/data/keyboardlayouts/generic_ime")
+local util = require("util")
+
+describe("Generic IME", function()
+    local function newInputBox()
+        local chars = {}
+        return {
+            addChars = {
+                raw_method_call = function(_, value)
+                    util.arrayAppend(chars, util.splitToChars(value))
+                end,
+            },
+            delChar = {
+                raw_method_call = function()
+                    table.remove(chars)
+                end,
+            },
+            getText = function()
+                return table.concat(chars)
+            end,
+        }
+    end
+
+    it("reports and selects candidates", function()
+        local reported_candidates = {}
+        local reported_index
+        local ime = IME:new{
+            code_map = {
+                n = { "你", "拟" },
+                ni = { "你", "拟", "尼" },
+            },
+            show_candi_callback = function() return false end,
+            candidate_callback = function(_, candidates, index)
+                reported_candidates = candidates
+                reported_index = index
+            end,
+        }
+        local inputbox = newInputBox()
+
+        ime:wrappedAddChars(inputbox, "n")
+        ime:wrappedAddChars(inputbox, "i")
+
+        assert.are.equal("你", inputbox.getText())
+        assert.are.same({ "你", "拟", "尼" }, reported_candidates)
+        ime:wrappedAddChars(inputbox, "SWITCH")
+        assert.are.equal("拟", inputbox.getText())
+        assert.are.equal(2, reported_index)
+        assert.is_true(ime:selectCandidate(inputbox, 3))
+        assert.are.equal("尼", inputbox.getText())
+        assert.are.same({}, reported_candidates)
+    end)
+end)


### PR DESCRIPTION
## Summary

- add an optional candidate row to the virtual keyboard
- show six tappable candidates with previous/next page controls for Simplified Chinese Pinyin
- keep the highlighted candidate and candidate page synchronized with the existing left/right arrow selection
- add a generic IME callback and direct candidate-selection API
- add a focused unit test for reporting and selecting candidates

## Why

The existing Pinyin IME renders candidate hints inline inside the input field and requires cycling with the cursor arrows. On touch devices this makes candidates difficult to discover and impossible to select directly. In dialogs where the input field has limited visible space, the inline hints may also be obscured.

This change provides a touch-friendly candidate row while preserving arrow-key operation for non-touch and keyboard-driven use.

## User impact

Typing Pinyin now displays tappable candidates above the Simplified Chinese virtual keyboard. Candidates can be selected directly, browsed six at a time, or selected with the existing arrow keys. Arrow selection automatically changes candidate pages and highlights the active candidate.

Other keyboard layouts are unchanged unless they opt into the candidate-row capability.

## Validation

- tested on a Kindle Oasis running KOReader 2026.03
- verified candidate tapping, candidate paging, highlighted arrow selection, and automatic page changes beyond six candidates
- parsed all changed Lua files successfully with `luaparse`
- added `generic_ime_spec.lua` coverage for candidate reporting, arrow selection, and direct candidate selection

The full KOReader test suite was not run locally because the available macOS Bash is 3.2, while `kodev` requires Bash 4 or newer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15679)
<!-- Reviewable:end -->
