### PR TITLE
Fix crash when opening KOReader with connected BT keyboard

### DIFF
--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -164,9 +164,17 @@ function ReaderKeySelection:init()
     self._edge_dy = nil
     self._last_move_was_quick_move = nil
     self.mirroredUI = BD.mirroredUILayout()
-    self.ui:registerPostInitCallback(function()
+    if self.ui.postInitCallback then
+        -- Register as part of ReaderUI:init().
+        self.ui:registerPostInitCallback(function()
+            self.ui.menu:registerToMainMenu(self)
+            self._registered_to_menu = true
+        end)
+    elseif not self._registered_to_menu then
+        -- A keyboard was connected after init. Register to the menu directly.
         self.ui.menu:registerToMainMenu(self)
-    end)
+        self._registered_to_menu = true
+    end
 end
 
 function ReaderKeySelection:onSetDimensions(dimen)

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -104,6 +104,7 @@ function ReaderUI:registerModule(name, ui_module, always_active)
 end
 
 function ReaderUI:registerPostInitCallback(callback)
+    self.postInitCallback = self.postInitCallback or {}
     table.insert(self.postInitCallback, callback)
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -104,7 +104,6 @@ function ReaderUI:registerModule(name, ui_module, always_active)
 end
 
 function ReaderUI:registerPostInitCallback(callback)
-    self.postInitCallback = self.postInitCallback or {}
     table.insert(self.postInitCallback, callback)
 end
 


### PR DESCRIPTION
Device: Kindle Scribe 1 (FW 5.17.2)
Installed https://github.com/zampierilucas/kindle-hid-passthrough/releases/tag/dev-9258cbd for enabling connecting BY keyboards (works well outside koreader, i.e. in Abiword https://www.mobileread.com/forums/showthread.php?t=374237)
I didn't install its KOReader plugin because it is being phased out.
BT Keyboard: A4 Tech FBX53C (ble).
KOReader version bug caught and fix tested on: 2026.03-255.

What happened:
1) With connected and working BT keyboard, opened KOReader.
2) KOReader opened the document as usual, but also showed a popup saying `Keyboard connected` then crashed:

```
./luajit: frontend/apps/reader/readerui.lua:107: bad argument #1 to 'insert' (table expected, got nil)
stack traceback:
	[C]: in function 'insert'
	frontend/apps/reader/readerui.lua:107: in function 'registerPostInitCallback'
	frontend/apps/reader/modules/readerkeyselection.lua:167: in function 'handleEvent'
	frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
	frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
	frontend/ui/uimanager.lua:974: in function 'broadcastEvent'
	plugins/externalkeyboard.koplugin/main.lua:442: in function 'action'
	frontend/ui/uimanager.lua:402: in function 'action'
	frontend/ui/uimanager.lua:1019: in function '_checkTasks'
	frontend/ui/uimanager.lua:1465: in function 'handleInput'
	frontend/ui/uimanager.lua:1585: in function 'run'
	./reader.lua:286: in main chunk
	[C]: at 0x00013ed5
```

3) I went to ask ChatGPT and added the suggestion to create and empty table right before it is attempting to add items to it.
4) Seems to fix the crash. I can also type with the BT keyboard in KOReader.


**Please comment on this if this is an appropriate approach!** I have no idea how external keyboards should be handled in KOReader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15681)
<!-- Reviewable:end -->
