### PR TITLE
fix(reMarkable): PowerD fixes for frontlight and HE sensor

### DIFF
--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -104,7 +104,7 @@ end
 
 function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
-    -- See the comment above in isFrontlightOnHW for these weird value choices
+    -- 0 is on, 4 is off on reMarkable devices
     if (value > 0) then
         ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     else

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -32,8 +32,7 @@ end
 
 function Remarkable_PowerD:isFrontlightOnHW()
     if not self.device:hasFrontlight() then return false end
-    -- 0 is on, 4 is off on reMarkable devices, how odd! I want to see the dev behind this decision...
-    -- As this is not documented, I tinkered with xochitl/csl to see which value it writes to sysfs paths
+    -- 0 is on, 4 is off as documented in Linux background.h
     return self:read_int_file(self.fl.frontlight_white .. "/bl_power") == 0
 end
 
@@ -104,7 +103,7 @@ end
 
 function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
-    -- 0 is on, 4 is off on reMarkable devices
+    -- 0 is on, 4 is off as documented in Linux background.h
     if (value > 0) then
         ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     else

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -8,61 +8,38 @@ local Remarkable_PowerD = BasePowerD:new{
     fl_min = 0, fl_max = 2047,
 }
 
-function Remarkable_PowerD:_syncLightOnStart()
-    local new_intensity = G_reader_settings:readSetting("frontlight_intensity") or nil
-    local is_frontlight_on = G_reader_settings:readSetting("is_frontlight_on") or nil
-
-    if new_intensity ~= nil then
-        self.hw_intensity = new_intensity
-    end
-
-    if is_frontlight_on ~= nil then
-        self.initial_is_fl_on = is_frontlight_on
-    end
-
-    if self.initial_is_fl_on == false and self.hw_intensity == 0 then
-        self.hw_intensity = 1
-    end
-end
-
-
 function Remarkable_PowerD:init()
-    self.hw_intensity = 20
-    self.initial_is_fl_on = true
-
     if self.device:hasFrontlight() then
         self.fl = SysfsLight:new(self.device.frontlight_settings)
-        self:_syncLightOnStart()
     end
 end
 
 function Remarkable_PowerD:saveSettings()
     if self.device:hasFrontlight() then
-        local cur_intensity = self.fl_intensity
-        local cur_is_fl_on = self.is_fl_on
-        G_reader_settings:saveSetting("frontlight_intensity", cur_intensity)
-        G_reader_settings:saveSetting("is_frontlight_on", cur_is_fl_on)
+        G_reader_settings:saveSetting("frontlight_intensity", self.fl_intensity)
+        G_reader_settings:saveSetting("is_frontlight_on", self.is_fl_on)
     end
 end
 
 function Remarkable_PowerD:frontlightIntensityHW()
     if not self.device:hasFrontlight() then return 0 end
-    return self.hw_intensity
+    local val = self:read_int_file(self.fl.frontlight_white .. "/brightness")
+    if val == 0 then
+        val = G_reader_settings:readSetting("frontlight_intensity") or 20
+    end
+    return val
 end
 
 function Remarkable_PowerD:isFrontlightOnHW()
-    if self.initial_is_fl_on ~= nil then
-        local ret = self.initial_is_fl_on
-        self.initial_is_fl_on = nil
-        return ret
-    end
-    return self.hw_intensity > 0
+    if not self.device:hasFrontlight() then return false end
+    -- 0 is on, 4 is off on reMarkable devices, how odd! I want to see the dev behind this decision...
+    -- As this is not documented, I tinkered with xochitl/csl to see which value it writes to sysfs paths
+    return self:read_int_file(self.fl.frontlight_white .. "/bl_power") == 0
 end
 
 function Remarkable_PowerD:setIntensityHW(intensity)
     if not self.device:hasFrontlight() then return end
     self:setBrightness(intensity)
-    self.hw_intensity = intensity
     self:_decideFrontlightState()
 end
 
@@ -84,16 +61,17 @@ function Remarkable_PowerD:isHallSensorEnabled()
 end
 
 function Remarkable_PowerD:onToggleHallSensor(toggle)
+    local inhibit_value
     if toggle == nil then
         -- Flip it
-        toggle = self:isHallSensorEnabled() and 1 or 0
+        inhibit_value = self:isHallSensorEnabled() and 1 or 0
     else
         -- Honor the requested state
-        toggle = toggle and 1 or 0
+        inhibit_value = toggle and 0 or 1
     end
-    ffiUtil.writeToSysfs(toggle, self.hall_file)
+    ffiUtil.writeToSysfs(inhibit_value, self.hall_file)
 
-    G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", toggle == 0 and true or false)
+    G_reader_settings:saveSetting("remarkable_hall_effect_sensor_enabled", inhibit_value == 0)
 end
 
 function Remarkable_PowerD:beforeSuspend()
@@ -107,7 +85,11 @@ end
 
 function Remarkable_PowerD:afterResume()
     if self.fl then
-        self:setBrightness(self.hw_intensity)
+        if self.fl_was_on then
+            self:setBrightness(self.fl_intensity)
+        else
+            self:setBrightness(0)
+        end
     end
 
     self:invalidateCapacityCache()
@@ -122,7 +104,7 @@ end
 
 function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
-    -- for rMPP '0' is on and '4' is off
+    -- See the comment above in isFrontlightOnHW for these weird value choices
     if (value > 0) then
         ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     else

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -32,7 +32,7 @@ end
 
 function Remarkable_PowerD:isFrontlightOnHW()
     if not self.device:hasFrontlight() then return false end
-    -- 0 is on, 4 is off as documented in Linux backlight.h
+    -- 0 is on, 4 is off as documented in https://github.com/torvalds/linux/blob/37e2f878a7a660a216cc7a60459995fefd150f25/include/linux/backlight.h#L185-L203
     return self:read_int_file(self.fl.frontlight_white .. "/bl_power") == 0
 end
 
@@ -103,7 +103,7 @@ end
 
 function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
-    -- 0 is on, 4 is off as documented in Linux backlight.h
+    -- 0 is on, 4 is off as documented in https://github.com/torvalds/linux/blob/37e2f878a7a660a216cc7a60459995fefd150f25/include/linux/backlight.h#L185-L203
     if (value > 0) then
         ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     else

--- a/frontend/device/remarkable/powerd.lua
+++ b/frontend/device/remarkable/powerd.lua
@@ -32,7 +32,7 @@ end
 
 function Remarkable_PowerD:isFrontlightOnHW()
     if not self.device:hasFrontlight() then return false end
-    -- 0 is on, 4 is off as documented in Linux background.h
+    -- 0 is on, 4 is off as documented in Linux backlight.h
     return self:read_int_file(self.fl.frontlight_white .. "/bl_power") == 0
 end
 
@@ -103,7 +103,7 @@ end
 
 function Remarkable_PowerD:_set_light_value(sysfs_directory, value)
     if not sysfs_directory then return end
-    -- 0 is on, 4 is off as documented in Linux background.h
+    -- 0 is on, 4 is off as documented in Linux backlight.h
     if (value > 0) then
         ffiUtil.writeToSysfs(0, sysfs_directory .. "/bl_power")
     else


### PR DESCRIPTION
Fixing some weird and non-properly-working frontlight and HE sensor code, with the help from Gemini 3.5 Flash! Now frontlight properly works, with no limbo state problem unlike the previous code!

This supersedes https://github.com/koreader/koreader/pull/15667 too!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15690)
<!-- Reviewable:end -->
