### PR TITLE
mupdf: fix missing `fz_drop_archive` function export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 	@echo "[*] Install plugins"
 	$(SYMLINK) plugins $(INSTALL_DIR)/koreader/
 	@echo "[*] Install resources"
-	$(SYMLINK) resources/fonts/* $(INSTALL_DIR)/koreader/fonts/
+	$(SYMLINK) resources/fonts $(INSTALL_DIR)/koreader/fonts
 	install -d $(INSTALL_DIR)/koreader/{screenshots,fonts/host,ota}
 	# Note: the data dir is distinct from the one in base/build/…!
 	@echo "[*] Install data files"


### PR DESCRIPTION
Depend on koreader/koreader-base#2450, close #15691.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15695)
<!-- Reviewable:end -->
