### PR TITLE
OPDS 2.0 basic support

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -593,7 +593,7 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
             href = href,
              -- mimic OPDS 1.x
             ["thr:count"] = f_link.properties and f_link.properties.numberOfItems,
-            ["opds:activeFacet"] = ((f_rel and f_rel == "self") or (item_url == href)) and "true",
+            ["opds:activeFacet"] = (f_rel == "self" or item_url == href) and "true",
         }
     end
 
@@ -611,8 +611,7 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
     end
 
     local nav_nb = 0
-    local function add_navigation(navigation, metadata)
-        local top_title = metadata and metadata.title
+    local function add_navigation(navigation, top_title)
         for _, nav in ipairs(navigation) do
             local rel = get_value(nav.rel)
             if nav.title and nav.href and (not rel or rel ~= "self") then
@@ -639,15 +638,15 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
 
     if type(catalog.groups) == "table" then
         for _, group in ipairs(catalog.groups) do
+            local title = group.metadata and group.metadata.title
             if type(group.navigation) == "table" then -- navigation
-                add_navigation(group.navigation, group.metadata)
+                add_navigation(group.navigation, title)
             else -- collection
-                local text = group.metadata and group.metadata.title
                 local href = group.links and group.links[1] and group.links[1].href
-                if text and href then
-                    local numberOfItems = group.metadata and group.metadata.numberOfItems or 0
+                if title and href then
+                    local numberOfItems = group.metadata.numberOfItems or 0
                     table.insert(item_table, {
-                        text = text,
+                        text = title,
                         url = url.absolute(item_url, href),
                         mandatory = numberOfItems ~= 0 and numberOfItems or "-",
                     })
@@ -656,12 +655,9 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
         end
     end
 
-    if catalog.publications then
+    if type(catalog.publications) == "table" then
         for _, entry in ipairs(catalog.publications) do
-            local item = self:getItemFromPublication(entry, item_url)
-            if item then
-                table.insert(item_table, item)
-            end
+            table.insert(item_table, self:getItemFromPublication(entry, item_url))
         end
     end
 

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -586,11 +586,13 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
         end
     end
 
-    if type(catalog.navigation) == "table" then
-        for _, nav in ipairs(catalog.navigation) do
+    local nav_nb = 0
+    local function add_navigation(navigation)
+        for _, nav in ipairs(navigation) do
             local rel = get_value(nav.rel)
             if nav.title and nav.href and (not rel or rel ~= "self") then
-                table.insert(item_table, {
+                nav_nb = nav_nb + 1
+                table.insert(item_table, nav_nb, {
                     text = nav.title,
                     url = url.absolute(item_url, nav.href),
                     mandatory = "\u{e602}", -- 'play arrow' sign
@@ -599,16 +601,24 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
         end
     end
 
+    if type(catalog.navigation) == "table" then
+        add_navigation(catalog.navigation)
+    end
+
     if type(catalog.groups) == "table" then
         for _, group in ipairs(catalog.groups) do
-            local text = group.metadata and group.metadata.title
-            local href = group.links and group.links[1] and group.links[1].href
-            if text and href then
-                table.insert(item_table, {
-                    text = text,
-                    url = url.absolute(item_url, href),
-                    mandatory = group.metadata and group.metadata.numberOfItems,
-                })
+            if type(group.navigation) == "table" then
+                add_navigation(group.navigation)
+            else
+                local text = group.metadata and group.metadata.title
+                local href = group.links and group.links[1] and group.links[1].href
+                if text and href then
+                    table.insert(item_table, {
+                        text = text,
+                        url = url.absolute(item_url, href),
+                        mandatory = group.metadata and group.metadata.numberOfItems,
+                    })
+                end
             end
         end
     end
@@ -619,16 +629,15 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
             local t = {}
             for i, link in ipairs(facet.links) do
                 local rel = get_value(link.rel)
-                local count = link.properties and link.properties.numberOfItems or 0
-                if link.href and count > 0 then
+                if link.href then
                     local href = url.absolute(item_url, link.href)
-                    t[i] = {
+                    table.insert(t, {
                         title = link.title,
                         href = href,
                          -- mimic OPDS 1.x
-                        ["thr:count"] = count,
+                        ["thr:count"] = link.properties and link.properties.numberOfItems,
                         ["opds:activeFacet"] = ((rel and rel == "self") or (item_url == href)) and "true",
-                    }
+                    })
                 end
             end
             self.facet_groups[facet.metadata.title] = t

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -626,6 +626,7 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
                         text = top_title and top_title .. " - " .. nav.title or nav.title,
                         url = url.absolute(item_url, nav.href),
                         mandatory = numberOfItems and numberOfItems .. " \u{e602}" or "\u{e602}", -- 'play arrow' sign
+                        acquisitions = {},
                     })
                 end
             end
@@ -649,6 +650,7 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
                         text = title,
                         url = url.absolute(item_url, href),
                         mandatory = numberOfItems ~= 0 and numberOfItems or "-",
+                        acquisitions = {},
                     })
                 end
             end

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -45,6 +45,12 @@ local OPDSBrowser = Menu:extend{
     borrow_rel           = "http://opds-spec.org/acquisition/borrow",
     stream_rel           = "http://vaemendis.net/opds-pse/stream",
     facet_rel            = "http://opds-spec.org/facet",
+    download_rel         = {
+        ["download"] = true,
+        ["publication"] = true,
+        ["http://opds-spec.org/acquisition"] = true,
+        ["http://opds-spec.org/acquisition/open-access"] = true,
+    },
     catalog_rel          = {
         ["subsection"] = true,
         ["http://opds-spec.org/subsection"] = true,
@@ -70,6 +76,13 @@ local OPDSBrowser = Menu:extend{
 
     title_shrink_font_to_fit = true,
 }
+
+local function get_value(value)
+    if type(value) == "table" then
+        return value[1]
+    end
+    return value
+end
 
 function OPDSBrowser:init()
     self.item_table = self:genItemTableFromRoot()
@@ -405,6 +418,7 @@ function OPDSBrowser:fetchFeed(item_url, headers_only)
         -- Some servers will still break RFC2616 14.3 and send crap instead.
         headers  = {
             ["Accept-Encoding"] = "identity",
+            ["Accept"] = self.opds20_feed, -- prefer OPDS 2.0
         },
         sink     = ltn12.sink.table(sink),
         user     = self.root_catalog_username,
@@ -550,66 +564,70 @@ function OPDSBrowser:genItemTableFromURL(item_url)
 end
 
 function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
-    local function build_href(href)
-        return url.absolute(item_url, href)
-    end
     self.catalog_title = catalog.metadata and catalog.metadata.title or self.catalog_title
     self.facet_groups = nil
     self.search_url = nil
     local item_table = { hrefs = {} }
 
-    if catalog.links then
+    if type(catalog.links) == "table" then
         for _, link in ipairs(catalog.links) do
-            if link.rel and link.href then
-                if link.rel == "search" then
-                    self.search_url = build_href(link.href:gsub("{query}", "%%s"))
+            local rel = get_value(link.rel)
+            if rel and link.href then
+                if rel == "search" then
+                    if link.href:gsub("{.*}", ""):find("query") then
+                        self.search_url = url.absolute(item_url, link.href:gsub("{.*}", "%%s"))
+                    else
+                        self.search_url = url.absolute(item_url, link.href:gsub("{.*}", "%?query=%%s"))
+                    end
                 else
-                    item_table.hrefs[link.rel] = build_href(link.href)
+                    item_table.hrefs[rel] = url.absolute(item_url, link.href)
                 end
             end
         end
     end
 
-    if catalog.navigation then
+    if type(catalog.navigation) == "table" then
         for _, nav in ipairs(catalog.navigation) do
-            if nav.title and nav.href and (not nav.rel or nav.rel ~= "self") then
+            local rel = get_value(nav.rel)
+            if nav.title and nav.href and (not rel or rel ~= "self") then
                 table.insert(item_table, {
                     text = nav.title,
-                    url = build_href(nav.href),
+                    url = url.absolute(item_url, nav.href),
                     mandatory = "\u{e602}", -- 'play arrow' sign
                 })
             end
         end
     end
 
-    if catalog.groups then
+    if type(catalog.groups) == "table" then
         for _, group in ipairs(catalog.groups) do
             local text = group.metadata and group.metadata.title
             local href = group.links and group.links[1] and group.links[1].href
             if text and href then
                 table.insert(item_table, {
                     text = text,
-                    url = build_href(href),
+                    url = url.absolute(item_url, href),
                     mandatory = group.metadata and group.metadata.numberOfItems,
                 })
             end
         end
     end
 
-    if catalog.facets then
+    if type(catalog.facets) == "table" then
         self.facet_groups = {}
         for _, facet in ipairs(catalog.facets) do
             local t = {}
             for i, link in ipairs(facet.links) do
+                local rel = get_value(link.rel)
                 local count = link.properties and link.properties.numberOfItems or 0
                 if link.href and count > 0 then
+                    local href = url.absolute(item_url, link.href)
                     t[i] = {
                         title = link.title,
-                        href = link.href,
+                        href = href,
                          -- mimic OPDS 1.x
                         ["thr:count"] = count,
-                        ["opds:activeFacet"] =
-                            ((link.rel and link.rel == "self") or util.stringEndsWith(item_url, link.href)) and "true",
+                        ["opds:activeFacet"] = ((rel and rel == "self") or (item_url == href)) and "true",
                     }
                 end
             end
@@ -630,35 +648,78 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
 end
 
 function OPDSBrowser:getItemFromPublication(entry, item_url)
-    local metadata = entry.metadata
-    local title = metadata.title or _("Unknown")
-    local author = metadata.author and metadata.author.name
-    if type(author) == "table" then
-        author = #author > 0 and table.concat(author, ", ")
+    local title, author, content
+    if type(entry.metadata) == "table" then
+        title = entry.metadata.title or _("Unknown")
+        author = entry.metadata.author
+        if type(author) == "table" then
+            author = author[1] and author[1].name or author.name
+            if type(author) == "table" then
+                author = #author > 0 and table.concat(author, ", ")
+            end
+        end
+        author = author or _("Unknown Author")
+        content = entry.metadata.description
     end
-    author = author or _("Unknown Author")
-    local image_href = util.tableGetValue(entry, "images", 1, "href")
+
+    local thumbnail, image
+    if type(entry.images) == "table" then
+        for _, link in ipairs(entry.images) do
+            local rel = get_value(link.rel)
+            if self.thumbnail_rel[rel] then
+                thumbnail = url.absolute(item_url, link.href)
+            elseif self.image_rel[rel] then
+                image = url.absolute(item_url, link.href)
+            end
+        end
+        thumbnail = thumbnail or url.absolute(item_url, entry.images[1].href)
+        image = image or thumbnail
+    end
+
     local acquisitions = {}
-    for _, link in ipairs(entry.links) do
-        if link.rel and link.rel ~= "self" then
-            if link.rel == self.borrow_rel then
-                table.insert(acquisitions, {
-                    type = "borrow",
-                })
-            elseif link.rel and link.rel:match(self.acquisition_rel) then
-                table.insert(acquisitions, {
-                    type = link.type,
-                    href = url.absolute(item_url, link.href),
-                })
+    if type(entry.links) == "table" then
+        for _, link in ipairs(entry.links) do
+            local rel = get_value(link.rel)
+            if rel and rel ~= "self" then
+                if rel == self.borrow_rel then
+                    table.insert(acquisitions, {
+                        type = "borrow",
+                    })
+                elseif rel:match(self.acquisition_rel) then
+                    if util.tableGetValue(link, "properties", "indirectAcquisition", 1, "type") then
+                        -- indirect acquisition
+                        local link_feed = self:parseFeed(url.absolute(item_url, link.href))
+                        if type(link_feed) == "table" and type(link_feed.links) == "table" then
+                            for _, in_link in ipairs(link_feed.links) do
+                                local in_rel = get_value(in_link.rel)
+                                if in_rel and self.download_rel[in_rel] then
+                                    table.insert(acquisitions, {
+                                        type = in_link.type,
+                                        title = in_link.title,
+                                        href = url.absolute(item_url, in_link.href),
+                                    })
+                                end
+                            end
+                        end
+                    else
+                        table.insert(acquisitions, {
+                            type = link.type,
+                            title = link.title,
+                            href = url.absolute(item_url, link.href),
+                        })
+                    end
+                end
             end
         end
     end
-    return {
+
+    return { -- book list item
         text = title .. " - " .. author,
         title = title,
         author = author,
-        image = image_href and url.absolute(item_url, image_href),
-        content = metadata.description,
+        content = content,
+        thumbnail = thumbnail,
+        image = image,
         acquisitions = acquisitions,
     }
 end

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -37,6 +37,7 @@ local CatalogCache = Cache:new{
 }
 
 local OPDSBrowser = Menu:extend{
+    opds20_feed          = "application/opds+json",
     catalog_type         = "application/atom%+xml",
     search_type          = "application/opensearchdescription%+xml",
     search_template_type = "application/atom%+xml",
@@ -146,64 +147,43 @@ function OPDSBrowser:showOPDSMenu()
     UIManager:show(dialog)
 end
 
--- Shows facet menu for OPDS catalogs with facets/search support
-function OPDSBrowser:showFacetMenu()
-    local buttons = {}
-    local dialog
+function OPDSBrowser:showCatalogMenu()
     local catalog_url = self.paths[#self.paths].url
-
-    -- Add sub-catalog to bookmarks option first
-    table.insert(buttons, {{
-        text = "\u{f067} " .. _("Add catalog"),
-        callback = function()
-            UIManager:close(dialog)
-            self:addSubCatalog(catalog_url)
-        end,
-        align = "left",
-    }})
-    table.insert(buttons, {}) -- separator
-
-    -- Add search option if available
+    local dialog
+    local buttons = {
+        {{
+            text = "\u{f067} " .. _("Add catalog"), -- 'plus' sign
+            callback = function()
+                UIManager:close(dialog)
+                self:addSubCatalog(catalog_url)
+            end,
+            align = "left",
+        }},
+    }
     if self.search_url then
+        table.insert(buttons, {}) -- separator
         table.insert(buttons, {{
-            text = "\u{f002} " .. _("Search"),
+            text = "\u{f002} " .. _("Search"), -- 'magnifying glass' sign
             callback = function()
                 UIManager:close(dialog)
                 self:searchCatalog(self.search_url)
             end,
             align = "left",
         }})
-        table.insert(buttons, {}) -- separator
     end
-
-    -- Add facet groups
     if self.facet_groups then
-        for group_name, facets in ffiUtil.orderedPairs(self.facet_groups) do
-            table.insert(buttons, {
-                { text = "\u{f0b0} " .. group_name, enabled = false, align = "left" }
-            })
-
-            for __, link in ipairs(facets) do
-                local facet_text = link.title
-                if link["thr:count"] then
-                    facet_text = T(_("%1 (%2)"), facet_text, link["thr:count"])
-                end
-                if link["opds:activeFacet"] == "true" then
-                    facet_text = "✓ " .. facet_text
-                end
-                table.insert(buttons, {{
-                    text = facet_text,
-                    callback = function()
-                        UIManager:close(dialog)
-                        self:updateCatalog(url.absolute(catalog_url, link.href))
-                    end,
-                    align = "left",
-                }})
-            end
-            table.insert(buttons, {}) -- separator between groups
+        table.insert(buttons, {}) -- separator
+        for group_name, links in ffiUtil.orderedPairs(self.facet_groups) do
+            local title = string.format("\u{f0b0} %s (%s)", group_name, #links) -- 'filter' sign
+            table.insert(buttons, {{
+                text = title,
+                callback = function()
+                    self:showFacetLinkList(title, links, catalog_url, dialog)
+                end,
+                menu_style = true,
+            }})
         end
     end
-
     dialog = ButtonDialog:new{
         buttons = buttons,
         shrink_unneeded_width = true,
@@ -214,6 +194,31 @@ function OPDSBrowser:showFacetMenu()
     UIManager:show(dialog)
 end
 
+function OPDSBrowser:showFacetLinkList(title, links, catalog_url, dialog)
+    local item_table = {}
+    for i, link in ipairs(links) do
+        item_table[i] = {
+            text = link.title,
+            mandatory = link["thr:count"],
+            bold = link["opds:activeFacet"] == "true" or nil,
+            href = link.href,
+        }
+    end
+    local link_list = Menu:new{
+        title = title,
+        item_table = item_table,
+        covers_fullscreen = true,
+        is_borderless = true,
+        is_popout = false,
+        title_bar_fm_style = true,
+        onMenuSelect = function(menu_self, item)
+            UIManager:close(menu_self)
+            UIManager:close(dialog)
+            self:updateCatalog(url.absolute(catalog_url, item.href))
+        end,
+    }
+    UIManager:show(link_list)
+end
 
 local function buildRootEntry(server)
     local icons = ""
@@ -463,8 +468,16 @@ function OPDSBrowser:parseFeed(item_url)
     else
         feed = self:fetchFeed(item_url)
     end
-    if feed then
+    local start = feed and feed:sub(1, 1)
+    if start == "<" then -- OPDS 1.x
         return OPDSParser:parse(feed)
+    elseif start == "{" then -- OPDS 2.0
+        local JSON = require("json")
+        local ret, result = pcall(JSON.decode, feed)
+        if ret then
+            result.is_opds2 = true
+            return result
+        end
     end
 end
 
@@ -529,7 +542,125 @@ function OPDSBrowser:genItemTableFromURL(item_url)
         })
         catalog = nil
     end
-    return self:genItemTableFromCatalog(catalog, item_url)
+    if catalog and catalog.is_opds2 then
+        return self:genItemTableFromCatalog2(catalog, item_url)
+    else
+        return self:genItemTableFromCatalog(catalog, item_url)
+    end
+end
+
+function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
+    local function build_href(href)
+        return url.absolute(item_url, href)
+    end
+    self.catalog_title = catalog.metadata and catalog.metadata.title or self.catalog_title
+    self.facet_groups = nil
+    self.search_url = nil
+    local item_table = { hrefs = {} }
+
+    if catalog.links then
+        for _, link in ipairs(catalog.links) do
+            if link.rel and link.href then
+                if link.rel == "search" then
+                    self.search_url = build_href(link.href:gsub("{query}", "%%s"))
+                else
+                    item_table.hrefs[link.rel] = build_href(link.href)
+                end
+            end
+        end
+    end
+
+    if catalog.navigation then
+        for _, nav in ipairs(catalog.navigation) do
+            if nav.title and nav.href and (not nav.rel or nav.rel ~= "self") then
+                table.insert(item_table, {
+                    text = nav.title,
+                    url = build_href(nav.href),
+                    mandatory = "\u{e602}", -- 'play arrow' sign
+                })
+            end
+        end
+    end
+
+    if catalog.groups then
+        for _, group in ipairs(catalog.groups) do
+            local text = group.metadata and group.metadata.title
+            local href = group.links and group.links[1] and group.links[1].href
+            if text and href then
+                table.insert(item_table, {
+                    text = text,
+                    url = build_href(href),
+                    mandatory = group.metadata and group.metadata.numberOfItems,
+                })
+            end
+        end
+    end
+
+    if catalog.facets then
+        self.facet_groups = {}
+        for _, facet in ipairs(catalog.facets) do
+            local t = {}
+            for i, link in ipairs(facet.links) do
+                local count = link.properties and link.properties.numberOfItems or 0
+                if link.href and count > 0 then
+                    t[i] = {
+                        title = link.title,
+                        href = link.href,
+                         -- mimic OPDS 1.x
+                        ["thr:count"] = count,
+                        ["opds:activeFacet"] =
+                            ((link.rel and link.rel == "self") or util.stringEndsWith(item_url, link.href)) and "true",
+                    }
+                end
+            end
+            self.facet_groups[facet.metadata.title] = t
+        end
+    end
+
+    if catalog.publications then
+        for _, entry in ipairs(catalog.publications) do
+            local item = self:getItemFromPublication(entry, item_url)
+            if item then
+                table.insert(item_table, item)
+            end
+        end
+    end
+
+    return item_table
+end
+
+function OPDSBrowser:getItemFromPublication(entry, item_url)
+    local metadata = entry.metadata
+    local title = metadata.title or _("Unknown")
+    local author = metadata.author and metadata.author.name
+    if type(author) == "table" then
+        author = #author > 0 and table.concat(author, ", ")
+    end
+    author = author or _("Unknown Author")
+    local image_href = util.tableGetValue(entry, "images", 1, "href")
+    local acquisitions = {}
+    for _, link in ipairs(entry.links) do
+        if link.rel and link.rel ~= "self" then
+            if link.rel == self.borrow_rel then
+                table.insert(acquisitions, {
+                    type = "borrow",
+                })
+            elseif link.rel and link.rel:match(self.acquisition_rel) then
+                table.insert(acquisitions, {
+                    type = link.type,
+                    href = url.absolute(item_url, link.href),
+                })
+            end
+        end
+    end
+    return {
+        text = title .. " - " .. author,
+        title = title,
+        author = author,
+        image = image_href and url.absolute(item_url, image_href),
+        content = metadata.description,
+        acquisitions = acquisitions,
+    }
 end
 
 -- Generates catalog item table and processes OPDS facets/search links
@@ -729,7 +860,7 @@ function OPDSBrowser:updateCatalog(item_url, paths_updated)
         if self.facet_groups or self.search_url then
             self:setTitleBarLeftIcon("appbar.menu")
             self.onLeftButtonTap = function()
-                self:showFacetMenu()
+                self:showCatalogMenu()
             end
         else
             self:setTitleBarLeftIcon("plus")

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -586,17 +586,49 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
         end
     end
 
+    local function get_facet(f_link, f_rel)
+        local href = url.absolute(item_url, f_link.href)
+        return {
+            title = f_link.title,
+            href = href,
+             -- mimic OPDS 1.x
+            ["thr:count"] = f_link.properties and f_link.properties.numberOfItems,
+            ["opds:activeFacet"] = ((f_rel and f_rel == "self") or (item_url == href)) and "true",
+        }
+    end
+
+    if type(catalog.facets) == "table" then
+        self.facet_groups = self.facet_groups or {}
+        for _, facet in ipairs(catalog.facets) do
+            self.facet_groups[facet.metadata.title] = {}
+            for i, link in ipairs(facet.links) do
+                if link.href then
+                    local rel = get_value(link.rel)
+                    table.insert(self.facet_groups[facet.metadata.title], get_facet(link, rel))
+                end
+            end
+        end
+    end
+
     local nav_nb = 0
-    local function add_navigation(navigation)
+    local function add_navigation(navigation, metadata)
+        local top_title = metadata and metadata.title
         for _, nav in ipairs(navigation) do
             local rel = get_value(nav.rel)
             if nav.title and nav.href and (not rel or rel ~= "self") then
-                nav_nb = nav_nb + 1
-                table.insert(item_table, nav_nb, {
-                    text = nav.title,
-                    url = url.absolute(item_url, nav.href),
-                    mandatory = "\u{e602}", -- 'play arrow' sign
-                })
+                if top_title and rel == self.facet_rel then -- facet
+                    self.facet_groups = self.facet_groups or {}
+                    self.facet_groups[top_title] = self.facet_groups[top_title] or {}
+                    table.insert(self.facet_groups[top_title], get_facet(nav, rel))
+                else -- navigation
+                    nav_nb = nav_nb + 1 -- navigations precede collections (groups) in the list
+                    local numberOfItems = nav.properties and nav.properties.numberOfItems
+                    table.insert(item_table, nav_nb, {
+                        text = top_title and top_title .. " - " .. nav.title or nav.title,
+                        url = url.absolute(item_url, nav.href),
+                        mandatory = numberOfItems and numberOfItems .. " \u{e602}" or "\u{e602}", -- 'play arrow' sign
+                    })
+                end
             end
         end
     end
@@ -607,40 +639,20 @@ function OPDSBrowser:genItemTableFromCatalog2(catalog, item_url)
 
     if type(catalog.groups) == "table" then
         for _, group in ipairs(catalog.groups) do
-            if type(group.navigation) == "table" then
-                add_navigation(group.navigation)
-            else
+            if type(group.navigation) == "table" then -- navigation
+                add_navigation(group.navigation, group.metadata)
+            else -- collection
                 local text = group.metadata and group.metadata.title
                 local href = group.links and group.links[1] and group.links[1].href
                 if text and href then
+                    local numberOfItems = group.metadata and group.metadata.numberOfItems or 0
                     table.insert(item_table, {
                         text = text,
                         url = url.absolute(item_url, href),
-                        mandatory = group.metadata and group.metadata.numberOfItems,
+                        mandatory = numberOfItems ~= 0 and numberOfItems or "-",
                     })
                 end
             end
-        end
-    end
-
-    if type(catalog.facets) == "table" then
-        self.facet_groups = {}
-        for _, facet in ipairs(catalog.facets) do
-            local t = {}
-            for i, link in ipairs(facet.links) do
-                local rel = get_value(link.rel)
-                if link.href then
-                    local href = url.absolute(item_url, link.href)
-                    table.insert(t, {
-                        title = link.title,
-                        href = href,
-                         -- mimic OPDS 1.x
-                        ["thr:count"] = link.properties and link.properties.numberOfItems,
-                        ["opds:activeFacet"] = ((rel and rel == "self") or (item_url == href)) and "true",
-                    })
-                end
-            end
-            self.facet_groups[facet.metadata.title] = t
         end
     end
 

--- a/plugins/opds.koplugin/opdspse.lua
+++ b/plugins/opds.koplugin/opdspse.lua
@@ -99,7 +99,7 @@ function OPDSPSE:streamPages(remote_url, count, continue, username, password, la
     -- will overwrite the book progress before we pull it, making it always 0.
     local ok, last_page = pcall(function() return self:getLastPage(remote_url, username, password) end)
     if not ok then
-        logger.warn("Couldn't pull progress, defaulting to Page 0.")
+        logger.dbg("Couldn't pull progress, defaulting to Page 0.")
         last_page = 0
     end
     local page_table = {image_disposable = true}


### PR DESCRIPTION
- Discussed in #14681

Spec: https://specs.opds.io/opds-2.0.html

The OPDS 2.0 code path is separated and doesn't affect OPDS 1.x handling.

Tested only on: https://lcps.zaki.com.hr/api/opds/homepage?id=102
I'd appreciate if anybody provides me with more links to OPDS 2.0 libraries.

Not tested:
-other formats but EPUB
-authentication
-syncing

-----

OPDS 2.0 provides navigation (subcatalogs) in two ways: `navigation` and `groups` properties of the feed.
`groups` may provide number of entries.

<img width="400" height="474" alt="1" src="https://github.com/user-attachments/assets/0365f178-401b-4f41-ad28-be71cd4026eb" />

-----

Chnages in the facets display.
Currently facet groups and facets themselves are shown as the upper left button menu (ButtonDialog widget).
When the number of facets is big, the menu is inconvenient.
So, the groups are displayed in the menu, the facets are displayed as a list (Menu widget).

<img width="400" height="474" alt="2" src="https://github.com/user-attachments/assets/a0a104e9-a4b5-4ba5-be2d-43891f9b8413" />

<img width="400" height="474" alt="3" src="https://github.com/user-attachments/assets/e1bbd259-fa83-42b9-8d5e-8275a3a9171a" />

-----

Download dialog unchanged.
<img width="400" height="474" alt="4" src="https://github.com/user-attachments/assets/c2242540-fa87-4467-a8a3-022cf1dbdb68" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15696)
<!-- Reviewable:end -->
