### PR TITLE
BookList: safeguard series index for sorting

### DIFF
--- a/frontend/ui/widget/booklist.lua
+++ b/frontend/ui/widget/booklist.lua
@@ -213,6 +213,7 @@ BookList.collates = {
         item_func = function(item, ui)
             local doc_props = ui.bookinfo:getDocProps(item.path or item.file)
             doc_props.series = doc_props.series or "\u{FFFF}"
+            doc_props.series_index = tonumber(doc_props.series_index)
             item.doc_props = doc_props
         end,
         init_sort_func = function()


### PR DESCRIPTION
- Closes #15697

We do this initially:
https://github.com/koreader/koreader/blob/cde23b992fd590b0ed11496ba91aad0053b199d1/frontend/document/document.lua#L183
But a user may set inproper custom series index despite forcing the numeric keyboard:
https://github.com/koreader/koreader/blob/cde23b992fd590b0ed11496ba91aad0053b199d1/frontend/apps/filemanager/filemanagerbookinfo.lua#L599

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15705)
<!-- Reviewable:end -->
