### PR TITLE
screensaver: add default values to anti-ghosting redraws spinner

### DIFF
--- a/frontend/ui/elements/screen_eink_opt_menu_table.lua
+++ b/frontend/ui/elements/screen_eink_opt_menu_table.lua
@@ -52,6 +52,9 @@ local eink_settings_table = {
                     right_text = _("Delay (ms)"),
                     title_text = _("Sleep screen flashes"),
                     ok_text = _("Set anti-ghosting redraws"),
+                    left_default = 2,
+                    right_default = 1000,
+                    default_text = _("Recommended (2×, 1000 ms)"),
                     callback = function(left_value, right_value)
                         G_reader_settings:saveSetting("screensaver_extra_flash_count", left_value)
                         G_reader_settings:saveSetting("screensaver_extra_flash_delay", right_value)


### PR DESCRIPTION
Add a "Recommended (2×, 1000 ms)" reset button to the anti-ghosting redraws spinner in E-ink settings.

These values work well as a starting point on affected devices (e.g. Kobo Libra 2), but users may need to adjust depending on their device.

Suggested by @Frenzie in #15703.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15710)
<!-- Reviewable:end -->
