### PR TITLE
Quickstart: teach about menu search

### DIFF
--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -367,6 +367,10 @@ To use the dictionary lookup function, first you need to install one or more dic
 -- More information
 table.insert(quickstart_guide, T(_([[## More info <a id="more"></a>
 
+- You can find any option within the top menu using:
+
+> **Menu ➔ ![Menu](resources/icons/mdlight/appbar.menu.svg) ➔ Help ➔ Menu search
+
 You can find more information on our GitHub page
 
 [https://github.com/koreader/koreader](https://github.com/koreader/koreader)

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -367,9 +367,9 @@ To use the dictionary lookup function, first you need to install one or more dic
 -- More information
 table.insert(quickstart_guide, T(_([[## More info <a id="more"></a>
 
-- You can find any option within the top menu using:
+You can find any option within the top menu using:
 
-> **Menu ➔ ![Menu](resources/icons/mdlight/appbar.menu.svg) ➔ Help ➔ Menu search
+**Menu ➔ ![Menu](resources/icons/mdlight/appbar.menu.svg) ➔ Help ➔ Menu search
 
 You can find more information on our GitHub page
 


### PR DESCRIPTION
I just think this is important for user discovery, as the option is already a little hidden, with its usefulness outpacing user awareness.

I hope I put it in the right place

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15712)
<!-- Reviewable:end -->
