### PR TITLE
WebDAV sync: fix infinite 412 loop on weak ETags

### DIFF
--- a/frontend/apps/cloudstorage/syncservice.lua
+++ b/frontend/apps/cloudstorage/syncservice.lua
@@ -151,12 +151,17 @@ function SyncService.sync(server, file_path, sync_cb, is_silent)
     end
     local code_response = 412 -- If-Match header failed
     local etag
+    -- Bound the If-Match retry loop so a persistently failing 412 (e.g. a server
+    -- that only ever returns a weak ETag which can't satisfy If-Match) can't hang
+    -- the app indefinitely; give up after a few tries and report failure.
+    local max_tries, tries = 5, 0
     local api = server.type == "dropbox" and require("apps/cloudstorage/dropboxapi") or require("apps/cloudstorage/webdavapi")
     local token = server.password
     if server.type == "dropbox" and not (server.address == nil or server.address == "") then
         token = api:getAccessToken(server.password, server.address)
     end
-    while code_response == 412 do
+    while code_response == 412 and tries < max_tries do
+        tries = tries + 1
         os.remove(income_file_path)
         if server.type == "dropbox" then
             local url_base = server.url:sub(-1) == "/" and server.url or server.url.."/"

--- a/frontend/apps/cloudstorage/webdavapi.lua
+++ b/frontend/apps/cloudstorage/webdavapi.lua
@@ -175,6 +175,12 @@ end
 
 function WebDavApi:uploadFile(file_url, user, pass, local_path, etag)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+    -- If-Match uses strong comparison (RFC 7232 §3.1), so a weak validator
+    -- (W/"…", returned e.g. for gzip-compressed responses) can never match and
+    -- would 412 forever. Strip the weak prefix; proxies keep the same value.
+    if type(etag) == "string" then
+        etag = etag:gsub("^%s*[Ww]/", "")
+    end
     local code, _, status = socket.skip(1, http.request{
         url      = file_url,
         method   = "PUT",

--- a/plugins/cloudstorage.koplugin/providers/webdav.lua
+++ b/plugins/cloudstorage.koplugin/providers/webdav.lua
@@ -163,6 +163,12 @@ end
 
 function WebDavApi.uploadFile(file_url, user, pass, local_path, etag)
     socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+    -- If-Match uses strong comparison (RFC 7232 §3.1), so a weak validator
+    -- (W/"…", returned e.g. for gzip-compressed responses) can never match and
+    -- would 412 forever. Strip the weak prefix; proxies keep the same value.
+    if type(etag) == "string" then
+        etag = etag:gsub("^%s*[Ww]/", "")
+    end
     local code, _, status = socket.skip(1, http.request{
         url      = file_url,
         method   = "PUT",


### PR DESCRIPTION
## Summary

Fixes #15707.

WebDAV cloud sync (`SyncService` / the `AnnotationSync` plugin that uses it) gets stuck in an **infinite `412 Precondition Failed` loop** — the UI hangs on the sync message and the app has to be killed — whenever the WebDAV server returns a **weak ETag** (`W/"…"`). Servers legitimately return a weak validator whenever the response body is **gzip-compressed**, which is very common (nginx `gzip on`, Cloudflare, Traefik `compress`, PHP `zlib.output_compression`, …).

## Root cause

`SyncService.sync()` loops on `while code_response == 412`:

1. `GET` the remote file and capture `headers.etag`,
2. run the merge callback,
3. `PUT` the merged file back with `If-Match: <that etag>`.

When the `GET` response is gzip-compressed the server returns a **weak** validator (`W/"…"`, correct per RFC 7232 — a compressed body is a different representation). But **`If-Match` requires *strong* comparison** (RFC 7232 §3.1), so a weak ETag can *never* satisfy it → the server correctly returns **412** → KOReader re-fetches (same weak ETag) → retries → loops forever and hangs. New files sync fine (create → no `If-Match`); only **updates to existing files** trigger it.

## Changes

- **Strip the weak `W/` prefix** from the ETag before using it in `If-Match`, in both `WebDavApi.uploadFile` implementations (`frontend/apps/cloudstorage/webdavapi.lua` and `plugins/cloudstorage.koplugin/providers/webdav.lua`). Proxies keep the same opaque value and only add the prefix, so the strong form matches in practice. The `nil` case (new files, no `If-Match`) is unaffected.
- **Bound the `If-Match` retry loop** in `SyncService.sync()` (`max_tries = 5`) so any persistent `412` gives up and reports failure instead of hanging the app indefinitely.

## Evidence

The underlying HTTP behaviour is confirmed with plain `curl` (no KOReader involved) in #15707: a `PUT` with `If-Match: W/"…"` returns `412`, and the exact same value with the `W/` stripped returns `204`. The original hang was reproduced against Nextcloud behind a gzip-weakening reverse proxy (details in the issue).

Note: I have not been able to run a full patched KOReader build to exercise these code paths end-to-end. Review of the sync-side behaviour (and confirmation that the stripped ETag still round-trips on setups other than mine) is welcome.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15715)
<!-- Reviewable:end -->
