### PR TITLE
Flash when displaying covers to reduce ghosting

### DIFF
--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -93,7 +93,10 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        local refreshtype = self.show_parent.dithered and "flashui" or "ui"
+        local refreshtype = "ui"
+        if self.show_parent.dithered and BookInfoManager:getSetting("flash_ui_cover_images") then
+            refreshtype = "flashui"
+        end
         return refreshtype, refresh_dimen, self.show_parent.dithered
     end)
 
@@ -131,8 +134,6 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
         self.items_update_action = function()
             logger.dbg("Scheduled items update:", #self.items_to_update, "waiting")
             local is_still_extracting = BookInfoManager:isExtractingInBackground()
-            -- Flash UI for cover images to reduce ghosting
-            local refreshtype = self.show_parent.dithered and "flashui" or "ui"
             local i = 1
             while i <= #self.items_to_update do -- process and clean in-place
                 local item = self.items_to_update[i]
@@ -140,6 +141,10 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
                 if item.bookinfo_found then
                     logger.dbg("  found", item.text)
                     self.show_parent.dithered = item._has_cover_image
+                    local refreshtype = "ui"
+                    if self.show_parent.dithered and BookInfoManager:getSetting("flash_ui_cover_images") then
+                        refreshtype = "flashui"
+                    end
                     local refreshfunc = function()
                         if item.refresh_dimen then
                             -- MosaicMenuItem may exceed its own dimen in its paintTo

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -94,7 +94,7 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
         local refreshtype = "ui"
-        if self.show_parent.dithered and BookInfoManager:getSetting("flash_ui_cover_images") then
+        if self._has_cover_images and BookInfoManager:getSetting("flash_ui_cover_images") then
             refreshtype = "flashui"
         end
         return refreshtype, refresh_dimen, self.show_parent.dithered
@@ -142,7 +142,7 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
                     logger.dbg("  found", item.text)
                     self.show_parent.dithered = item._has_cover_image
                     local refreshtype = "ui"
-                    if self.show_parent.dithered and BookInfoManager:getSetting("flash_ui_cover_images") then
+                    if item._has_cover_image and BookInfoManager:getSetting("flash_ui_cover_images") then
                         refreshtype = "flashui"
                     end
                     local refreshfunc = function()

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -93,7 +93,8 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
         local refresh_dimen =
             old_dimen and old_dimen:combine(self.dimen)
             or self.dimen
-        return "ui", refresh_dimen, self.show_parent.dithered
+        local refreshtype = self.show_parent.dithered and "flashui" or "ui"
+        return refreshtype, refresh_dimen, self.show_parent.dithered
     end)
 
     -- As additionally done in FileChooser:updateItems()

--- a/plugins/coverbrowser.koplugin/covermenu.lua
+++ b/plugins/coverbrowser.koplugin/covermenu.lua
@@ -130,6 +130,8 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
         self.items_update_action = function()
             logger.dbg("Scheduled items update:", #self.items_to_update, "waiting")
             local is_still_extracting = BookInfoManager:isExtractingInBackground()
+            -- Flash UI for cover images to reduce ghosting
+            local refreshtype = self.show_parent.dithered and "flashui" or "ui"
             local i = 1
             while i <= #self.items_to_update do -- process and clean in-place
                 local item = self.items_to_update[i]
@@ -141,9 +143,9 @@ function CoverMenu:updateItems(select_number, no_recalculate_dimen)
                         if item.refresh_dimen then
                             -- MosaicMenuItem may exceed its own dimen in its paintTo
                             -- with its "description" hint
-                            return "ui", item.refresh_dimen, self.show_parent.dithered
+                            return refreshtype, item.refresh_dimen, self.show_parent.dithered
                         else
-                            return "ui", item[1].dimen, self.show_parent.dithered
+                            return refreshtype, item[1].dimen, self.show_parent.dithered
                         end
                     end
                     UIManager:setDirty(self.show_parent, refreshfunc)

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -351,7 +351,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Flash UI for cover images"),
+                text = _("Use full refresh for covers"),
                 checked_func = function()
                     return BookInfoManager:getSetting("flash_ui_cover_images")
                 end,

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -349,6 +349,15 @@ function CoverBrowser:addToMainMenu(menu_items)
                     BookInfoManager:toggleSetting("hide_file_info")
                     fc:updateItems(1, true)
                 end,
+            },
+            {
+                text = _("Flash UI for cover images"),
+                checked_func = function()
+                    return BookInfoManager:getSetting("flash_ui_cover_images")
+                end,
+                callback = function()
+                    BookInfoManager:toggleSetting("flash_ui_cover_images")
+                end,
                 separator = true,
             },
             {

--- a/plugins/coverbrowser.koplugin/main.lua
+++ b/plugins/coverbrowser.koplugin/main.lua
@@ -351,7 +351,7 @@ function CoverBrowser:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Use full refresh for covers"),
+                text = _("Flash when displaying covers"),
                 checked_func = function()
                     return BookInfoManager:getSetting("flash_ui_cover_images")
                 end,


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/11602 again (my fix was overwritten).
Fixes https://github.com/koreader/koreader/issues/14805 as well.

Tested on Pocketbook Inkpad Color 3 and Pocketbook Era Lite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15724)
<!-- Reviewable:end -->
