### PR TITLE
pocketbook: fix startup crash after 6.11.1480 firmware update

### DIFF
--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+# Work around PocketBook firmware 6.11.1480 rejecting executable-stack system libraries.
 export GLIBC_TUNABLES=glibc.rtld.execstack=2
+
 export LC_ALL="en_US.UTF-8"
 
 UNPACK_DIR='/mnt/ext1'

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Work around PocketBook firmware 6.11.1480 rejecting executable-stack system libraries.
-export GLIBC_TUNABLES=glibc.rtld.execstack=2
+export GLIBC_TUNABLES="${GLIBC_TUNABLES}${GLIBC_TUNABLES:+:}glibc.rtld.execstack=2"
 
 export LC_ALL="en_US.UTF-8"
 

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+export GLIBC_TUNABLES=glibc.rtld.execstack=2
 export LC_ALL="en_US.UTF-8"
 
 UNPACK_DIR='/mnt/ext1'

--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Work around PocketBook firmware 6.11.1480 rejecting executable-stack system libraries.
+# See https://github.com/koreader/koreader/issues/15720#issuecomment-5059698020
 export GLIBC_TUNABLES="${GLIBC_TUNABLES}${GLIBC_TUNABLES:+:}glibc.rtld.execstack=2"
 
 export LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
New PocketBook firmware blocks third-party apps from loading some system libraries that request an executable stack (GNU_STACK RWE).

Set `GLIBC_TUNABLES=glibc.rtld.execstack=2` in the PocketBook launcher to restore compatibility with new firmware version.

Fixes https://github.com/koreader/koreader/issues/15720

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15730)
<!-- Reviewable:end -->
