### PR TITLE
[Hotkeys]  hot-plug keyboard support

### DIFF
--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -27,28 +27,22 @@ local FileManagerMenu = InputContainer:extend{
     registered_widgets = nil, -- array
 }
 
-function FileManagerMenu:init()
-    self.menu_items = {
+local function getDefaultMenuButtons()
+    return {
         ["KOMenu:menu_buttons"] = {
             -- top menu
         },
         -- items in top menu
-        filemanager_settings = {
-            icon = "appbar.filebrowser",
-        },
-        setting = {
-            icon = "appbar.settings",
-        },
-        tools = {
-            icon = "appbar.tools",
-        },
-        search = {
-            icon = "appbar.search",
-        },
-        main = {
-            icon = "appbar.menu",
-        },
+        filemanager_settings = { icon = "appbar.filebrowser" },
+        setting = { icon = "appbar.settings" },
+        tools = { icon = "appbar.tools" },
+        search = { icon = "appbar.search" },
+        main = { icon = "appbar.menu" },
     }
+end
+
+function FileManagerMenu:init()
+    self.menu_items = getDefaultMenuButtons()
 
     self.registered_widgets = {}
 
@@ -67,7 +61,15 @@ function FileManagerMenu:registerKeyEvents()
     end
 end
 
-FileManagerMenu.onPhysicalKeyboardConnected = FileManagerMenu.registerKeyEvents
+function FileManagerMenu:onPhysicalKeyboardConnected()
+    self.key_events = {}
+    self:registerKeyEvents()
+    if self.menu_container then
+        self:onCloseFileManagerMenu()
+    end
+    self.tab_item_table = nil
+end
+FileManagerMenu.onPhysicalKeyboardDisconnected = FileManagerMenu.onPhysicalKeyboardConnected
 
 -- NOTE: FileManager emits a SetDimensions on init, it's our only caller
 function FileManagerMenu:initGesListener()
@@ -147,6 +149,9 @@ function FileManagerMenu:onOpenLastDoc()
 end
 
 function FileManagerMenu:setUpdateItemTable()
+    for k, v in pairs(getDefaultMenuButtons()) do
+        self.menu_items[k] = v
+    end
     local FileChooser = self.ui.file_chooser
 
     -- setting tab

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -1136,6 +1136,11 @@ function FileManagerMenu:onMenuSearch()
 end
 
 function FileManagerMenu:registerToMainMenu(widget)
+    for _, w in ipairs(self.registered_widgets) do
+        if w == widget then
+            return
+        end
+    end
     table.insert(self.registered_widgets, widget)
 end
 

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -20,40 +20,7 @@ local ReaderMenu = InputContainer:extend{
 }
 
 function ReaderMenu:init()
-    self.menu_items = {
-        ["KOMenu:menu_buttons"] = {
-            -- top menu
-        },
-        -- items in top menu
-        navi = {
-            icon = "appbar.navigation",
-        },
-        typeset = {
-            icon = "appbar.typeset",
-        },
-        setting = {
-            icon = "appbar.settings",
-        },
-        tools = {
-            icon = "appbar.tools",
-        },
-        search = {
-            icon = "appbar.search",
-        },
-        filemanager = {
-            icon = "appbar.filebrowser",
-            remember = false,
-            callback = function()
-                self:onTapCloseMenu()
-                local file = self.ui.document.file
-                self.ui:onClose()
-                self.ui:showFileManager(file)
-            end,
-        },
-        main = {
-            icon = "appbar.menu",
-        }
-    }
+    self.menu_items = self:getDefaultMenuButtons()
 
     self.registered_widgets = {}
 
@@ -84,7 +51,40 @@ function ReaderMenu:registerKeyEvents()
     end
 end
 
-ReaderMenu.onPhysicalKeyboardConnected = ReaderMenu.registerKeyEvents
+function ReaderMenu:getDefaultMenuButtons()
+    return {
+        ["KOMenu:menu_buttons"] = {
+            -- top menu
+        },
+        -- items in top menu
+        navi = { icon = "appbar.navigation" },
+        typeset = { icon = "appbar.typeset" },
+        setting = { icon = "appbar.settings" },
+        tools = { icon = "appbar.tools" },
+        search = { icon = "appbar.search" },
+        filemanager = {
+            icon = "appbar.filebrowser",
+            remember = false,
+            callback = function()
+                self:onTapCloseMenu()
+                local file = self.ui.document.file
+                self.ui:onClose()
+                self.ui:showFileManager(file)
+            end,
+        },
+        main = { icon = "appbar.menu" },
+    }
+end
+
+function ReaderMenu:onPhysicalKeyboardConnected()
+    self.key_events = {}
+    self:registerKeyEvents()
+    if self.menu_container then
+        self:onCloseReaderMenu()
+    end
+    self.tab_item_table = nil
+end
+ReaderMenu.onPhysicalKeyboardDisconnected = ReaderMenu.onPhysicalKeyboardConnected
 
 function ReaderMenu:getPreviousFile()
     return require("readhistory"):getPreviousFile(self.ui.document.file)
@@ -177,6 +177,9 @@ end
 ReaderMenu.onReaderReady = ReaderMenu.initGesListener
 
 function ReaderMenu:setUpdateItemTable()
+    for k, v in pairs(self:getDefaultMenuButtons()) do
+        self.menu_items[k] = v
+    end
     -- typeset tab
     self.menu_items.document_settings = {
         text = _("Document settings"),

--- a/frontend/apps/reader/modules/readermenu.lua
+++ b/frontend/apps/reader/modules/readermenu.lua
@@ -530,6 +530,11 @@ function ReaderMenu:onMenuSearch()
 end
 
 function ReaderMenu:registerToMainMenu(widget)
+    for _, w in ipairs(self.registered_widgets) do
+        if w == widget then
+            return
+        end
+    end
     table.insert(self.registered_widgets, widget)
 end
 

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -590,9 +590,11 @@ function HotKeys:onFlushSettings()
     end
 end
 
-function HotKeys:onDispatcherActionNameChanged(action)
+local function applyActionNameChange(data, action)
+    local changed = false
     for _, section in ipairs({ "hotkeys_fm", "hotkeys_reader" }) do
-        local hotkeys = self.settings_data.data[section]
+        local hotkeys = data[section]
+        if not hotkeys then return end
         for shortcut_name, shortcut in pairs(hotkeys) do
             if shortcut[action.old_name] ~= nil then
                 if shortcut.settings and shortcut.settings.order then
@@ -618,18 +620,21 @@ function HotKeys:onDispatcherActionNameChanged(action)
                     shortcut[action.new_name] = true
                 else
                     if next(shortcut) == nil then
-                        self.settings_data.data[section][shortcut_name] = nil
+                        data[section][shortcut_name] = nil
                     end
                 end
-                self.updated = true
+                changed = true
             end
         end
     end
+    return changed
 end
 
-function HotKeys:onDispatcherActionValueChanged(action)
+local function applyActionValueChange(data, action)
+    local changed = false
     for _, section in ipairs({ "hotkeys_fm", "hotkeys_reader" }) do
-        local hotkeys = self.settings_data.data[section]
+        local hotkeys = data[section]
+        if not hotkeys then return end
         for shortcut_name, shortcut in pairs(hotkeys) do
             if shortcut[action.name] == action.old_value then
                 shortcut[action.name] = action.new_value
@@ -649,13 +654,39 @@ function HotKeys:onDispatcherActionValueChanged(action)
                         end
                     end
                     if next(shortcut) == nil then
-                        self.settings_data.data[section][shortcut_name] = nil
+                        data[section][shortcut_name] = nil
                     end
                 end
-                self.updated = true
+                changed = true
             end
         end
     end
+    return changed
+end
+
+function HotKeys:withHotkeysSettings(apply_fn, action)
+    if self.settings_data then
+        if apply_fn(self.settings_data.data, action) then
+            self.updated = true
+        end
+        return
+    end
+
+    -- No live instance right now (no keyboard connected) — patch the
+    -- on-disk file directly so the change is already applied whenever
+    -- the plugin next initialises.
+    local settings = LuaSettings:open(hotkeys_path)
+    if apply_fn(settings.data, action) then
+        settings:flush()
+    end
+end
+
+function HotKeys:onDispatcherActionNameChanged(action)
+    self:withHotkeysSettings(applyActionNameChange, action)
+end
+
+function HotKeys:onDispatcherActionValueChanged(action)
+    self:withHotkeysSettings(applyActionValueChange, action)
 end
 
 return HotKeys

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -23,78 +23,89 @@ local HotKeys = InputContainer:extend{
     updated = false,
 }
 local hotkeys_path = ffiUtil.joinPath(DataStorage:getSettingsDir(), "hotkeys.lua")
+local hotkeys_list, base_keys, key_emitter_actions
 
--- Define hotkeys_list
-local hotkeys_list = {}
-local base_keys = {
-    up = "Up", down = "Down", left = "Left", right = "Right",
-    left_page_back = "LPgBack", left_page_forward = "LPgFwd",
-    right_page_back = "RPgBack", right_page_forward = "RPgFwd",
-    back = "Back", home = "Home", press = "Press"
-}
-local key_emitter_actions = {
-    key_up = { key = "Up", title = T(_("Send key: %1"), _("Up")) },
-    key_down = { key = "Down", title = T(_("Send key: %1"), _("Down")) },
-    key_left = { key = "Left", title = T(_("Send key: %1"), _("Left")) },
-    key_right = { key = "Right", title = T(_("Send key: %1"), _("Right")) },
-    key_left_page_back = { key = "LPgBack", title = T(_("Send key: %1"), _("Left page back")) },
-    key_left_page_forward = { key = "LPgFwd", title = T(_("Send key: %1"), _("Left page forward")) },
-    key_right_page_back = { key = "RPgBack", title = T(_("Send key: %1"), _("Right page back")) },
-    key_right_page_forward = { key = "RPgFwd", title = T(_("Send key: %1"), _("Right page forward")) },
-    key_back = { key = "Back", title = T(_("Send key: %1"), _("Back")) },
-    key_home = { key = "Home", title = T(_("Send key: %1"), _("Home")) },
-    key_press = { key = "Press", title = T(_("Send key: %1"), _("Press")) },
-    key_menu = { key = "Menu", title = T(_("Send key: %1"), _("Menu")) },
-    key_context_menu = { key = "ContextMenu", title = T(_("Send key: %1"), _("Context menu")) },
-}
--- modifier *here* refers to either screenkb or shift
-local modifier_one = Device:hasScreenKB() and _("ScreenKB + %1") or _("Shift + %1")
--- screenkb/shift + base_keys
-for key, label in pairs(base_keys) do
-    hotkeys_list["modifier_plus_" .. key] = T(modifier_one, label)
-    -- modifier_plus_menu (screenkb+menu) is already used globally for screenshots (on k4), don't add it here.
-end
-if LuaSettings:open(hotkeys_path).data["press_key_does_hotkeys"] then
-    util.tableMerge(hotkeys_list, { press = _("Press") })
-end
+local function buildHotkeysList()
+    -- Define hotkeys_list
+    hotkeys_list = {}
+    base_keys = {
+        up = "Up", down = "Down", left = "Left", right = "Right",
+        left_page_back = "LPgBack", left_page_forward = "LPgFwd",
+        right_page_back = "RPgBack", right_page_forward = "RPgFwd",
+        back = "Back", home = "Home", press = "Press"
+    }
+    key_emitter_actions = {
+        key_up = { key = "Up", title = T(_("Send key: %1"), _("Up")) },
+        key_down = { key = "Down", title = T(_("Send key: %1"), _("Down")) },
+        key_left = { key = "Left", title = T(_("Send key: %1"), _("Left")) },
+        key_right = { key = "Right", title = T(_("Send key: %1"), _("Right")) },
+        key_left_page_back = { key = "LPgBack", title = T(_("Send key: %1"), _("Left page back")) },
+        key_left_page_forward = { key = "LPgFwd", title = T(_("Send key: %1"), _("Left page forward")) },
+        key_right_page_back = { key = "RPgBack", title = T(_("Send key: %1"), _("Right page back")) },
+        key_right_page_forward = { key = "RPgFwd", title = T(_("Send key: %1"), _("Right page forward")) },
+        key_back = { key = "Back", title = T(_("Send key: %1"), _("Back")) },
+        key_home = { key = "Home", title = T(_("Send key: %1"), _("Home")) },
+        key_press = { key = "Press", title = T(_("Send key: %1"), _("Press")) },
+        key_menu = { key = "Menu", title = T(_("Send key: %1"), _("Menu")) },
+        key_context_menu = { key = "ContextMenu", title = T(_("Send key: %1"), _("Context menu")) },
+    }
 
-if Device:supportsGamepad() then
-    for i = 0, 15 do
-        local id = Gamepad.button_ids[i] or tostring(i)
-        local name = Gamepad.button_names[i] or T(_("Button %1"), i)
-        hotkeys_list["gamepad_button_" .. id] = T(_("Gamepad %1"), name)
-    end
-    for i = 0, 5 do
-        local id = Gamepad.axis_ids[i] or tostring(i)
-        local name = Gamepad.axis_names[i] or T(_("Axis %1"), i)
-        hotkeys_list["gamepad_axis_" .. id .. "_minus"] = T(_("Gamepad %1 –"), name)
-        hotkeys_list["gamepad_axis_" .. id .. "_plus"] = T(_("Gamepad %1 +"), name)
-    end
-end
-if Device:hasKeyboard() then
-    local hotkeys_list_haskeyboard = { modifier_plus_menu = _("Shift + Menu") }
-    -- now we can add the "menu" button to base_keys, so we can use it on haskeyboard devices
-    base_keys.menu = "Menu"
-    -- NOTE: we will use 'alt' for kindles and 'ctrl' for other devices with keyboards
-    --       but for simplicity we will use in code 'alt+keys' as the array's key for all.
-    local modifier_two = Device:hasSymKey() and _("Alt + %1") or _("Ctrl + %1")
-    -- Alt/Ctrl + base_keys
+    -- modifier *here* refers to either screenkb or shift
+    local modifier_one = Device:hasScreenKB() and _("ScreenKB + %1") or _("Shift + %1")
+    -- screenkb/shift + base_keys
     for key, label in pairs(base_keys) do
-        hotkeys_list_haskeyboard["alt_plus_" .. key] = T(modifier_two, label)
+        hotkeys_list["modifier_plus_" .. key] = T(modifier_one, label)
+        -- modifier_plus_menu (screenkb+menu) is already used globally for screenshots (on k4), don't add it here.
+    end
+    if LuaSettings:open(hotkeys_path).data["press_key_does_hotkeys"] then
+        util.tableMerge(hotkeys_list, { press = _("Press") })
     end
 
-    local type_to_search = LuaSettings:open(hotkeys_path).data["type_to_search"]
-    -- Alt/Ctrl + alphabet keys and (no modifier) + alphabet keys
-    for dummy, char in ipairs(Device.input.group.Alphabet) do
-        hotkeys_list_haskeyboard["alt_plus_" .. char:lower()] = T(modifier_two, char)
-        if not type_to_search then
-            hotkeys_list_haskeyboard[char:lower()] = char
+    if Device:supportsGamepad() then
+        for i = 0, 15 do
+            local id = Gamepad.button_ids[i] or tostring(i)
+            local name = Gamepad.button_names[i] or T(_("Button %1"), i)
+            hotkeys_list["gamepad_button_" .. id] = T(_("Gamepad %1"), name)
+        end
+        for i = 0, 5 do
+            local id = Gamepad.axis_ids[i] or tostring(i)
+            local name = Gamepad.axis_names[i] or T(_("Axis %1"), i)
+            hotkeys_list["gamepad_axis_" .. id .. "_minus"] = T(_("Gamepad %1 –"), name)
+            hotkeys_list["gamepad_axis_" .. id .. "_plus"] = T(_("Gamepad %1 +"), name)
         end
     end
-    util.tableMerge(hotkeys_list, hotkeys_list_haskeyboard)
+    if Device:hasKeyboard() then
+        local hotkeys_list_haskeyboard = { modifier_plus_menu = _("Shift + Menu") }
+        -- now we can add the "menu" button to base_keys, so we can use it on haskeyboard devices
+        base_keys.menu = "Menu"
+        -- NOTE: we will use 'alt' for kindles and 'ctrl' for other devices with keyboards
+        --       but for simplicity we will use in code 'alt+keys' as the array's key for all.
+        local modifier_two = Device:hasSymKey() and _("Alt + %1") or _("Ctrl + %1")
+        -- Alt/Ctrl + base_keys
+        for key, label in pairs(base_keys) do
+            hotkeys_list_haskeyboard["alt_plus_" .. key] = T(modifier_two, label)
+        end
+
+        local type_to_search = LuaSettings:open(hotkeys_path).data["type_to_search"]
+        -- Alt/Ctrl + alphabet keys and (no modifier) + alphabet keys
+        for dummy, char in ipairs(Device.input.group.Alphabet) do
+            hotkeys_list_haskeyboard["alt_plus_" .. char:lower()] = T(modifier_two, char)
+            if not type_to_search then
+                hotkeys_list_haskeyboard[char:lower()] = char
+            end
+        end
+        util.tableMerge(hotkeys_list, hotkeys_list_haskeyboard)
+    end
+end
+if Device:hasScreenKB() or Device:hasKeyboard() then
+    buildHotkeysList()
 end
 
 function HotKeys:init()
+    if not (Device:hasScreenKB() or Device:hasKeyboard()) then
+        self:disableHotkeys() -- clear all on keyboard disconnection
+        return
+    end
     local defaults_path = ffiUtil.joinPath(self.path, "defaults.lua")
     self.is_docless = self.ui == nil or self.ui.document == nil
     self.hotkey_mode = self.is_docless and "hotkeys_fm" or "hotkeys_reader"
@@ -253,7 +264,24 @@ function HotKeys:registerKeyEvents()
     logger.dbg("Total number of hotkey events registered successfully: ", key_event_count)
 end -- registerKeyEvents()
 
-HotKeys.onPhysicalKeyboardConnected = HotKeys.registerKeyEvents
+function HotKeys:onPhysicalKeyboardConnected()
+    buildHotkeysList()
+    self:init()
+    logger.dbg("HotKeys plugin reinit successfully after physical keyboard (dis)connection.")
+end
+HotKeys.onPhysicalKeyboardDisconnected = HotKeys.onPhysicalKeyboardConnected
+
+function HotKeys:disableHotkeys()
+    self.key_events = {}
+    self.hotkeys = nil
+    self.settings_data = nil
+    self.defaults = nil
+    self.hotkey_mode = nil
+    self.type_to_search = nil
+    self.is_docless = nil
+    hotkeys_list = nil
+    base_keys, key_emitter_actions = nil, nil
+end
 
 function HotKeys:shortcutTitleFunc(hotkey)
     local title = hotkeys_list[hotkey]
@@ -359,6 +387,11 @@ end
     and user settings. It supports different sets of keys for devices with and without keyboards.
 --]]
 function HotKeys:addToMainMenu(menu_items)
+    if not self.settings_data then
+        menu_items.hotkeys = nil
+        menu_items.a_type_to_search = nil
+        return
+    end
     -- 1. Defines sets of cursor keys, page-turn buttons, and function keys.
     local cursor_keys = {
         "modifier_plus_up",


### PR DESCRIPTION
This pull request refactors how menu buttons and hotkey lists are initialised and updated in both the file manager, reader menu, and hotkeys plugin. The changes improve code modularity, ensure proper handling of keyboard connection events, and make hotkey settings updates more robust—especially when no keyboard is connected.

### what's new

* Extracted menu button definitions into reusable functions (`getDefaultMenuButtons` for `FileManagerMenu` and `ReaderMenu`), allowing touch menu to rebuild itself. 
Note that `menuSorter` murders `menu_items`, thus our need to reintroduce them for future rebuilds.
```
07/22/26-13:53:30 WARN  menu id not found: tools 
07/22/26-13:53:30 WARN  menu id not found: main 
07/22/26-13:53:30 WARN  menu id not found: setting 
07/22/26-13:53:30 WARN  menu id not found: filemanager_settings 
07/22/26-13:53:30 WARN  menu id not found: search 
07/22/26-13:53:30 WARN  menu id not found: KOMenu:menu_buttons 
./luajit: frontend/ui/menusorter.lua:139: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
        [C]: in function 'ipairs'
        frontend/ui/menusorter.lua:139: in function <frontend/ui/menusorter.lua:48>
        frontend/apps/filemanager/filemanagermenu.lua:889: in function 'old_method'
        frontend/dbg.lua:48: in function 'setUpdateItemTable'
        frontend/apps/filemanager/filemanagermenu.lua:1032: in function 'handleEvent'
        frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
        frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
        frontend/ui/uimanager.lua:910: in function 'sendEvent'
        frontend/ui/uimanager.lua:53: in function '__default__'
        frontend/ui/uimanager.lua:1441: in function 'handleInputEvent'
        frontend/ui/uimanager.lua:1541: in function 'handleInput'
        frontend/ui/uimanager.lua:1585: in function 'run'
        reader.lua:286: in main chunk
        [C]: at 0x0107bb2890
make: *** [make/emulator.mk:20: run] Error 1
```

* Refactored keyboard connection/disconnection event handlers (`onPhysicalKeyboardConnected`/`onPhysicalKeyboardDisconnected`) in both menus and the hotkeys plugin to properly reset state, reinitialize key events, and close menus if open. This ensures the UI and hotkey logic stay in sync with hardware changes.

* Moved hotkey list construction into a function (`buildHotkeysList`) and ensured it is only built when a keyboard is present. Added logic to clear hotkey state when keyboards are disconnected. 

* Refactored how hotkey action name/value changes are applied: changes are now applied to in-memory settings if available, or directly to the on-disk settings file if not (e.g., when no keyboard is connected). 

**Note:** The main gate remains unchanged. We still need a centralised mechanism for determining which devices to run on.
https://github.com/koreader/koreader/blob/ef1b4e20e3934bd50295f27d8120ce95e9026bd3/plugins/hotkeys.koplugin/main.lua#L14-L16

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15731)
<!-- Reviewable:end -->
