### PR TITLE
DictQuickLookup: guard against setContent() errors in update()

### DIFF
--- a/frontend/ui/widget/htmlboxwidget.lua
+++ b/frontend/ui/widget/htmlboxwidget.lua
@@ -13,6 +13,7 @@ local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local time = require("ui/time")
 local util  = require("util")
+local _ = require("gettext")
 
 -- -1: right to left, 0: mixed, +1: left to right
 local function getLineTextDirection(line)
@@ -260,7 +261,13 @@ function HtmlBoxWidget:setContent(body, css, default_font_size, is_xhtml, no_css
 
         ok, self.document = pcall(Mupdf.openDocumentFromText, html, "html", html_resource_directory)
         if not ok then
-            error(self.document)
+            logger.warn("HTML plain-text fallback loading also failed:", self.document)
+            -- This shouldn't fail
+            html = string.format("<html><body>%s</body></html>", _("Failed to render this content."))
+            ok, self.document = pcall(Mupdf.openDocumentFromText, html, "html", html_resource_directory)
+            if not ok then
+                error(self.document)
+            end
         end
     end
 


### PR DESCRIPTION
Fixes koreader/koreader#15736 (one of two companion fixes — see also the android-luajit-launcher PR for the FONTDIR fix).

# PR (koreader/koreader) — DictQuickLookup: guard against setContent() errors in update()

**Branch:** `fix/dict-crash-mupdf-font-resolution` (base: `master`)
**Commit:** `351180411a29effc4e6fecbd0b6276a13c803b1a`

## Title

DictQuickLookup: guard against setContent() errors in update()

## Summary

- `DictQuickLookup:update()` calls `HtmlBoxWidget:setContent()` to refresh
  the dictionary popup's content when switching between dictionary results
  or looking up a new word while the popup stays open. Unlike the initial
  lookup path (`ReaderDictionary:stardictLookup` → `Trapper`, which runs
  under `xpcall`), this refresh path had no error protection at all.
- `setContent()` can raise (e.g. MuPDF failing to render both the HTML body
  and its plain-text fallback — see companion PR in
  `koreader/android-luajit-launcher` for one concrete trigger on Android).
  An uncaught error here propagates past the `NativeThread` script runner on
  Android, which `exit()`s the whole process instead of just failing to
  refresh the popup.
- Wraps the `setContent()` call in `pcall`; on failure, logs a warning and
  leaves the previous content in place instead of crashing.

## Test plan

- [x] Reproduced the crash on-device (Android 14, bigme hibreak) before the
      fix: opening a dictionary popup then tapping "next dictionary result"
      onto an HTML-rendered entry (Wiktionary) crashed the app.
- [x] Confirmed the fix (combined with the companion FONTDIR fix) resolves
      it: navigated through all 4 dictionary sources for a word (including
      the HTML Wiktionary entry, which now renders correctly with proper
      formatting) and back, with zero crashes and the same process pid
      throughout.
- [ ] No automated test added — this is a defensive guard around a
      third-party rendering call; happy to add a busted test if maintainers
      want one, but wasn't obvious how to unit-test the MuPDF failure mode
      without device-specific font-path conditions.

## Notes for reviewers

This is a **defense-in-depth** fix: even without the Android font-path bug,
`setContent()` can fail for other reasons (e.g. malformed HTML from a
third-party dictionary), and `DictQuickLookup:update()` should not be able
to take the whole app down either way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15737)
<!-- Reviewable:end -->
