### PR TITLE
android: set FONTDIR so MuPDF can find its fallback fonts

### DIFF
--- a/platform/android/llapp_main.lua
+++ b/platform/android/llapp_main.lua
@@ -18,6 +18,9 @@ end
 -- path to primary external storage partition
 local path = android.getExternalStoragePath()
 
+-- Set $FONTDIR to android.dir/fonts so MuPDF can find its fonts.
+C.setenv("FONTDIR", android.dir .. "/fonts", 1)
+
 -- create fake command-line arguments
 -- luacheck: ignore 121
 if android.isDebuggable() then


### PR DESCRIPTION
Companion fix for koreader/koreader#15736 / #15737. Originally proposed as koreader/android-luajit-launcher#601, moved here per review — it's a KOReader/MuPDF concern (see `base/thirdparty/mupdf/external_fonts.patch`), not a launcher one.

MuPDF resolves its fallback fonts via `$FONTDIR`, defaulting to `./fonts` (relative to cwd) when unset. Points it at `android.dir/fonts`, where the app's bundled fonts get extracted on install.

Tested on-device: previously-crashing HTML dictionary entries now render correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15738)
<!-- Reviewable:end -->
