### PR TITLE
Register an optional transform provider for epubs

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -299,7 +299,13 @@ function CreDocument:loadDocument(full_document)
     if not self._loaded then
         local only_metadata = full_document == false
         logger.dbg("CreDocument: loading document...")
-        if self._document:loadDocument(self.file, only_metadata) then
+        local loaded
+        if self.epub_entry_transform then
+            loaded = self._document:loadEpubWithEntryTransform(self.file, self.epub_entry_transform, only_metadata)
+        else
+            loaded = self._document:loadDocument(self.file, only_metadata)
+        end
+        if loaded then
             self._loaded = true
             logger.dbg("CreDocument: loading done.")
         else

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -109,6 +109,13 @@ function Document:close()
             self.is_open = false
             self._document:close()
             self._document = nil
+            -- Release resources held by an optional EPUB entry transform plugin.
+            if self.epub_entry_transform and self.epub_entry_transform.close then
+                local ok, err = pcall(self.epub_entry_transform.close, self.epub_entry_transform)
+                if not ok then
+                    logger.warn("Document: Failed to close EPUB entry transform for", self.file, err)
+                end
+            end
 
             -- NOTE: DocumentRegistry:openDocument will force a GC sweep the next time we open a Document.
             --       MµPDF will also do a bit of spring cleaning of its internal cache when opening a *different* document.

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -9,6 +9,7 @@ local util = require("util")
 local DocumentRegistry = {
     registry = {},
     providers = {},
+    epub_entry_transform_provider = nil,
     known_providers = {}, -- hash table of registered providers { provider_key = provider }
     filetype_provider = {},
     mimetype_ext = {},
@@ -54,6 +55,28 @@ end
 -- plugin in FileManager:openFile().
 function DocumentRegistry:addAuxProvider(provider)
     self.known_providers[provider.provider] = provider
+end
+
+-- Register an optional EPUB entry transform provider callback.
+-- It may return a transform object used while the EPUB is being loaded by CREngine:
+-- {
+--     transformEntry = function(self, path) end, -- required, returns bytes or nil
+--     close = function(self) end,                -- optional resource cleanup
+-- }
+function DocumentRegistry:setEpubEntryTransformProvider(provider)
+    self.epub_entry_transform_provider = provider
+end
+
+function DocumentRegistry:getEpubEntryTransform(file, provider)
+    local transform_provider = self.epub_entry_transform_provider
+    if not transform_provider then
+        return
+    end
+    local ok, transform = pcall(transform_provider, file, provider)
+    if ok then
+        return transform
+    end
+    logger.warn("EPUB entry transform provider failed for", file, transform)
 end
 
 --- Returns true if file has provider.
@@ -236,13 +259,23 @@ function DocumentRegistry:openDocument(file, provider)
         provider = provider or self:getProvider(file)
 
         if provider ~= nil then
-            local ok, doc = pcall(provider.new, provider, {file = file})
+            local epub_entry_transform
+            if provider.provider == "crengine" and (getSuffix(file) == "epub" or getSuffix(file) == "epub3") then
+                epub_entry_transform = self:getEpubEntryTransform(file, provider)
+            end
+            local ok, doc = pcall(provider.new, provider, {
+                file = file,
+                epub_entry_transform = epub_entry_transform,
+            })
             if ok then
                 self.registry[file] = {
                     doc = doc,
                     refs = 1,
                 }
             else
+                if epub_entry_transform and epub_entry_transform.close then
+                    pcall(epub_entry_transform.close, epub_entry_transform)
+                end
                 logger.warn("cannot open document", file, doc)
             end
         end


### PR DESCRIPTION
Related to https://github.com/koreader/koreader/issues/15649

Adds a `DocumentRegistry` hook that lets a plugin provide an entry transform when opening epub files with crengine.

The transform object is passed to `CreDocument`, which uses the new `loadEpubWithEntryTransform` base bridge when present. Otherwise the existing `loadDocument()` path is unchanged. This change is purely additive and doesn't affect any existing koreader paths.  

Relevant PRs in submodules: 
- https://github.com/koreader/crengine/pull/708
- https://github.com/koreader/koreader-base/pull/2477

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15739)
<!-- Reviewable:end -->
