### PR TITLE
timesync: bound the NTP client's runtime

### DIFF
--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -51,6 +51,29 @@ local function currentTime()
     return _("Time synchronized.")
 end
 
+-- busybox ntpd and ntpdate both time out via alarm()/SIGALRM, so neither can give up if SIGALRM
+-- is blocked in the mask we inherited -- and a mask survives execve(). sleep and SIGTERM still
+-- work, hence an external watchdog, as in the ping CLI fall-back in Device:ping4.
+local NTP_TIMEOUT = 30 -- seconds
+
+local function runNTPClient()
+    -- One-second steps so the watchdog exits with the client; `exit` carries the client's status.
+    return os.execute(string.format([[%s &
+                                      pid=$!
+                                      (i=%d
+                                       while [ $i -gt 0 ] && kill -0 $pid 2>/dev/null; do
+                                           sleep 1
+                                           i=$((i-1))
+                                       done
+                                       [ $i -eq 0 ] && kill $pid 2>/dev/null) &
+                                      watchdog=$!
+                                      wait $pid 2>/dev/null
+                                      rc=$?
+                                      kill $watchdog 2>/dev/null
+                                      exit $rc
+                                      ]], ntp_cmd, NTP_TIMEOUT))
+end
+
 local function syncNTP()
     local info = InfoMessage:new{
         text = _("Synchronizing time. This may take several seconds.")
@@ -58,7 +81,7 @@ local function syncNTP()
     UIManager:show(info)
     UIManager:forceRePaint()
     local txt
-    if os.execute(ntp_cmd) ~= 0 then
+    if runNTPClient() ~= 0 then
         txt = _("Failed to retrieve time from server. Please check your network configuration.")
     else
         txt = currentTime()

--- a/plugins/timesync.koplugin/main.lua
+++ b/plugins/timesync.koplugin/main.lua
@@ -58,20 +58,21 @@ local NTP_TIMEOUT = 30 -- seconds
 
 local function runNTPClient()
     -- One-second steps so the watchdog exits with the client; `exit` carries the client's status.
-    return os.execute(string.format([[%s &
-                                      pid=$!
-                                      (i=%d
-                                       while [ $i -gt 0 ] && kill -0 $pid 2>/dev/null; do
-                                           sleep 1
-                                           i=$((i-1))
-                                       done
-                                       [ $i -eq 0 ] && kill $pid 2>/dev/null) &
-                                      watchdog=$!
-                                      wait $pid 2>/dev/null
-                                      rc=$?
-                                      kill $watchdog 2>/dev/null
-                                      exit $rc
-                                      ]], ntp_cmd, NTP_TIMEOUT))
+    return os.execute(string.format([[
+        %s &
+        pid=$!
+        (i=%d
+            while [ $i -gt 0 ] && kill -0 $pid 2>/dev/null; do
+                sleep 1
+                i=$((i-1))
+            done
+            [ $i -eq 0 ] && kill $pid 2>/dev/null) &
+        watchdog=$!
+        wait $pid 2>/dev/null
+        rc=$?
+        kill $watchdog 2>/dev/null
+        exit $rc
+    ]], ntp_cmd, NTP_TIMEOUT))
 end
 
 local function syncNTP()


### PR DESCRIPTION
### Problem

**Synchronize time** can wedge KOReader for good. `syncNTP()` shows its "Synchronizing time…"
message and then calls `os.execute(ntp_cmd)` synchronously, with nothing bounding it. If the NTP
client never returns, `os.execute()` never returns either and the UI is stuck — on a non-touch
device the only way out is a power cycle.

### Why the client may never return

Both busybox's `ntpd` and `ntpdate` implement their timeouts with `alarm()`/`SIGALRM`. If
`SIGALRM` is blocked in the signal mask they inherit from us, the alarm is raised but never
delivered — it just sits pending. The client cannot detect this and cannot undo it: a signal mask
is inherited across `fork()` and preserved across `execve()`. Passing an explicit timeout
(`ntpdate -t`) does not help either, because that option is implemented with the same signal.

This is reachable in practice, not theoretical: third-party Kindle hotkey launchers exist that run
the launched program from inside their own `SIGALRM` handler. The kernel keeps the signal blocked
for the duration of the handler, so the mask reaches KOReader and, in turn, every helper KOReader
spawns.

### Fix

Bound the client's runtime with an external watchdog, mirroring the `ping` CLI fall-back in
`Device:ping4` (#15663). `sleep` goes through `nanosleep` and `SIGTERM` is not blocked, so the
watchdog still works when alarms cannot be delivered.

The watchdog counts in one-second steps and re-checks the client each time, rather than sleeping
through the whole timeout. That way it exits on its own as soon as the client has been reaped, so
a late kill can never land on a recycled pid, and cancelling it leaks at most a one-second `sleep`
— the saved pid is the subshell, and killing that does not reach a `sleep` child of it. `exit`
carries the client's own status past the cleanup, since `wait` is no longer the last command.

The 30s bound is deliberately generous; a real sync takes a few seconds.

### Testing

Done on two live Kindle 3 devices (busybox 1.7.2, glibc 2.5, kernel 2.6.26).

**Root cause confirmed.** While frozen, the reader sits in `do_wait` and `ntpdate` in
`do_sys_poll`, with bit 14 set in both `SigBlk` and `ShdPnd` of `/proc/<pid>/status`. `tcpdump` on
the router shows zero NTP packets leaving the device, and `ping -c 3` emits only `seq 0` — the
same signature, from the same cause.

**Behaviour matrix, measured on-device** (real server is the LAN gateway; the black hole is
`192.0.2.1`, and `SIGALRM` was blocked with `sigprocmask` to reproduce the pathological case):

| `SIGALRM` | target | result | elapsed |
| --- | --- | --- | --- |
| unblocked | real server | success | 1s |
| unblocked | black hole | client gives up by itself | 3s |
| blocked | real server | bounded, non-zero | at the bound |
| blocked | black hole | bounded, non-zero | at the bound |

Note the third row: with alarms undeliverable the client cannot finish even against a working
server, because it never gets to collect its samples. Bounding is the only thing that ends it.

**Shell portability.** The snippet was exercised under `dash` and `busybox ash`, and on the
device's own busybox 1.7.2, which does support `kill -0` and `$((...))`: success returns `0`
immediately without waiting out the timeout, a failing client's exit status is preserved, a
hanging client is killed exactly at the bound, and no `sleep` process is left behind.

**Happy path** with the patched plugin running in KOReader on-device: *Synchronize time* completes
in about a second and reports the new time, unchanged from before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15740)
<!-- Reviewable:end -->
