### PR TITLE
Add tools/expand-bump-prs.sh to help with release notes

### DIFF
--- a/tools/expand-bump-prs.sh
+++ b/tools/expand-bump-prs.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+USAGE:
+    expand-bump-prs.sh [OPTIONS] [FILE]
+
+Expand release-note bullets containing bump PR links with the descriptions
+from those PRs. Read FILE, or standard input when FILE is omitted or '-'.
+Output goes to standard output unless --in-place is used.
+
+OPTIONS:
+    -i, --in-place    replace FILE in place (requires FILE)
+    -q, --quiet       suppress progress messages
+    -h, --help        show this help
+EOF
+}
+
+in_place=''
+quiet=''
+file='-'
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -i | --in-place)
+            in_place=1
+            ;;
+        -q | --quiet)
+            quiet=1
+            ;;
+        --)
+            shift
+            [[ $# -le 1 ]] || { echo "ERROR: expected at most one FILE" >&2; exit 2; }
+            [[ $# -eq 1 ]] && file=$1
+            break
+            ;;
+        -* )
+            echo "ERROR: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            [[ "$file" = '-' ]] || { echo "ERROR: expected at most one FILE" >&2; exit 2; }
+            file=$1
+            ;;
+    esac
+    shift
+done
+
+if [[ -n "$in_place" && "$file" = '-' ]]; then
+    echo "ERROR: --in-place requires FILE" >&2
+    exit 2
+fi
+
+if ! command -v gh >/dev/null; then
+    echo "ERROR: gh command not found" >&2
+    exit 2
+fi
+
+input=$(mktemp)
+output=$(mktemp)
+trap 'rm -f "$input" "$output"' EXIT
+if [[ "$file" = '-' ]]; then
+    cat >"$input"
+else
+    cp -- "$file" "$input"
+fi
+
+declare -A body_cache
+fetched_body=''
+matched=0
+expanded=0
+
+log() {
+    [[ -n "$quiet" ]] || printf '%s\n' "$*" >&2
+}
+
+fetch_body() {
+    local repo=$1
+    local number=$2
+    local key="$repo#$number"
+
+    if [[ ${body_cache[$key]+yes} ]]; then
+        fetched_body="${body_cache[$key]}"
+        return
+    fi
+
+    local body
+    log "Fetching $key..."
+    if ! body=$(gh pr view "$number" --repo "$repo" --json body --template '{{.body}}'); then
+        echo "WARNING: unable to read $repo#$number; leaving bullet unchanged" >&2
+        fetched_body='__GH_ERROR__'
+        body_cache[$key]=$fetched_body
+        return
+    fi
+
+    # Reviewable adds a large, non-release-note footer to older PRs.
+    body=$(printf '%s\n' "$body" | awk '/<!--[[:space:]]*Reviewable:start[[:space:]]*-->/{exit} {print}')
+    fetched_body=$body
+    body_cache[$key]=$fetched_body
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^[[:space:]]*\*.*[Bb]ump.*https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        number="${BASH_REMATCH[3]}"
+        ((matched += 1))
+        fetch_body "$repo" "$number"
+        body=$fetched_body
+        if [[ "$body" != '__GH_ERROR__' && -n "${body//[[:space:]]/}" ]]; then
+            log "Expanding $repo#$number."
+            ((expanded += 1))
+            printf '%s\n' "$line" >>"$output"
+            while IFS= read -r body_line || [[ -n "$body_line" ]]; do
+                printf '  %s\n' "$body_line" >>"$output"
+            done <<<"$body"
+            continue
+        fi
+        [[ "$body" = '__GH_ERROR__' ]] || log "Skipping $repo#$number: no description."
+    fi
+    printf '%s\n' "$line" >>"$output"
+done <"$input"
+
+log "Done: expanded $expanded of $matched matching PRs."
+
+if [[ -n "$in_place" ]]; then
+    cp -- "$output" "$file"
+else
+    cat "$output"
+fi

--- a/tools/expand-bump-prs.sh
+++ b/tools/expand-bump-prs.sh
@@ -62,14 +62,18 @@ if ! command -v gh >/dev/null; then
     exit 2
 fi
 
-input=$(mktemp)
-output=$(mktemp)
-trap 'rm -f "$input" "$output"' EXIT
 if [[ "$file" = '-' ]]; then
-    cat >"$input"
+    input=/dev/stdin
+    output=$(mktemp)
 else
-    cp -- "$file" "$input"
+    input=$file
+    if [[ -n "$in_place" ]]; then
+        output=$(mktemp "$(dirname -- "$file")/.${file##*/}.XXXXXX")
+    else
+        output=$(mktemp)
+    fi
 fi
+trap 'rm -f "$output"' EXIT
 
 declare -A body_cache
 fetched_body=''
@@ -79,6 +83,12 @@ expanded=0
 log() {
     [[ -n "$quiet" ]] || printf '%s\n' "$*" >&2
 }
+
+if [[ "$file" = '-' ]]; then
+    log 'Reading standard input.'
+else
+    log "Reading $file."
+fi
 
 fetch_body() {
     local repo=$1
@@ -129,7 +139,8 @@ done <"$input"
 log "Done: expanded $expanded of $matched matching PRs."
 
 if [[ -n "$in_place" ]]; then
-    cp -- "$output" "$file"
+    chmod --reference="$file" "$output"
+    mv -- "$output" "$file"
 else
     cat "$output"
 fi

--- a/tools/expand-bump-prs.sh
+++ b/tools/expand-bump-prs.sh
@@ -23,37 +23,37 @@ quiet=''
 file='-'
 while [[ $# -gt 0 ]]; do
     case "$1" in
-    -h | --help)
-        usage
-        exit 0
-        ;;
-    -i | --in-place)
-        in_place=1
-        ;;
-    -q | --quiet)
-        quiet=1
-        ;;
-    --)
-        shift
-        [[ $# -le 1 ]] || {
-            echo "ERROR: expected at most one FILE" >&2
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -i | --in-place)
+            in_place=1
+            ;;
+        -q | --quiet)
+            quiet=1
+            ;;
+        --)
+            shift
+            [[ $# -le 1 ]] || {
+                echo "ERROR: expected at most one FILE" >&2
+                exit 2
+            }
+            [[ $# -eq 1 ]] && file=$1
+            break
+            ;;
+        -*)
+            echo "ERROR: unknown option: $1" >&2
+            usage >&2
             exit 2
-        }
-        [[ $# -eq 1 ]] && file=$1
-        break
-        ;;
-    -*)
-        echo "ERROR: unknown option: $1" >&2
-        usage >&2
-        exit 2
-        ;;
-    *)
-        [[ "$file" = '-' ]] || {
-            echo "ERROR: expected at most one FILE" >&2
-            exit 2
-        }
-        file=$1
-        ;;
+            ;;
+        *)
+            [[ "$file" = '-' ]] || {
+                echo "ERROR: expected at most one FILE" >&2
+                exit 2
+            }
+            file=$1
+            ;;
     esac
     shift
 done

--- a/tools/expand-bump-prs.sh
+++ b/tools/expand-bump-prs.sh
@@ -23,31 +23,37 @@ quiet=''
 file='-'
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        -i | --in-place)
-            in_place=1
-            ;;
-        -q | --quiet)
-            quiet=1
-            ;;
-        --)
-            shift
-            [[ $# -le 1 ]] || { echo "ERROR: expected at most one FILE" >&2; exit 2; }
-            [[ $# -eq 1 ]] && file=$1
-            break
-            ;;
-        -* )
-            echo "ERROR: unknown option: $1" >&2
-            usage >&2
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    -i | --in-place)
+        in_place=1
+        ;;
+    -q | --quiet)
+        quiet=1
+        ;;
+    --)
+        shift
+        [[ $# -le 1 ]] || {
+            echo "ERROR: expected at most one FILE" >&2
             exit 2
-            ;;
-        *)
-            [[ "$file" = '-' ]] || { echo "ERROR: expected at most one FILE" >&2; exit 2; }
-            file=$1
-            ;;
+        }
+        [[ $# -eq 1 ]] && file=$1
+        break
+        ;;
+    -*)
+        echo "ERROR: unknown option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    *)
+        [[ "$file" = '-' ]] || {
+            echo "ERROR: expected at most one FILE" >&2
+            exit 2
+        }
+        file=$1
+        ;;
     esac
     shift
 done

--- a/tools/expand-bump-prs.sh
+++ b/tools/expand-bump-prs.sh
@@ -48,7 +48,7 @@ while [[ $# -gt 0 ]]; do
             exit 2
             ;;
         *)
-            [[ "$file" = '-' ]] || {
+            [[ "${file}" = '-' ]] || {
                 echo "ERROR: expected at most one FILE" >&2
                 exit 2
             }
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-if [[ -n "$in_place" && "$file" = '-' ]]; then
+if [[ -n "${in_place}" && "${file}" = '-' ]]; then
     echo "ERROR: --in-place requires FILE" >&2
     exit 2
 fi
@@ -68,13 +68,13 @@ if ! command -v gh >/dev/null; then
     exit 2
 fi
 
-if [[ "$file" = '-' ]]; then
+if [[ "${file}" = '-' ]]; then
     input=/dev/stdin
     output=$(mktemp)
 else
-    input=$file
-    if [[ -n "$in_place" ]]; then
-        output=$(mktemp "$(dirname -- "$file")/.${file##*/}.XXXXXX")
+    input=${file}
+    if [[ -n "${in_place}" ]]; then
+        output=$(mktemp "$(dirname -- "${file}")/.${file##*/}.XXXXXX")
     else
         output=$(mktemp)
     fi
@@ -87,66 +87,66 @@ matched=0
 expanded=0
 
 log() {
-    [[ -n "$quiet" ]] || printf '%s\n' "$*" >&2
+    [[ -n "${quiet}" ]] || printf '%s\n' "$*" >&2
 }
 
-if [[ "$file" = '-' ]]; then
+if [[ "${file}" = '-' ]]; then
     log 'Reading standard input.'
 else
-    log "Reading $file."
+    log "Reading ${file}."
 fi
 
 fetch_body() {
     local repo=$1
     local number=$2
-    local key="$repo#$number"
+    local key="${repo}#${number}"
 
-    if [[ ${body_cache[$key]+yes} ]]; then
-        fetched_body="${body_cache[$key]}"
+    if [[ ${body_cache[${key}]+yes} ]]; then
+        fetched_body="${body_cache[${key}]}"
         return
     fi
 
     local body
-    log "Fetching $key..."
-    if ! body=$(gh pr view "$number" --repo "$repo" --json body --template '{{.body}}'); then
-        echo "WARNING: unable to read $repo#$number; leaving bullet unchanged" >&2
+    log "Fetching ${key}..."
+    if ! body=$(gh pr view "${number}" --repo "${repo}" --json body --template '{{.body}}'); then
+        echo "WARNING: unable to read ${repo}#${number}; leaving bullet unchanged" >&2
         fetched_body='__GH_ERROR__'
-        body_cache[$key]=$fetched_body
+        body_cache[${key}]=${fetched_body}
         return
     fi
 
     # Reviewable adds a large, non-release-note footer to older PRs.
-    body=$(printf '%s\n' "$body" | awk '/<!--[[:space:]]*Reviewable:start[[:space:]]*-->/{exit} {print}')
-    fetched_body=$body
-    body_cache[$key]=$fetched_body
+    body=$(printf '%s\n' "${body}" | awk '/<!--[[:space:]]*Reviewable:start[[:space:]]*-->/{exit} {print}')
+    fetched_body=${body}
+    body_cache[${key}]=${fetched_body}
 }
 
-while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$line" =~ ^[[:space:]]*\*.*[Bb]ump.*https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+while IFS= read -r line || [[ -n "${line}" ]]; do
+    if [[ "${line}" =~ ^[[:space:]]*\*.*[Bb]ump.*https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
         repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
         number="${BASH_REMATCH[3]}"
         ((matched += 1))
-        fetch_body "$repo" "$number"
-        body=$fetched_body
-        if [[ "$body" != '__GH_ERROR__' && -n "${body//[[:space:]]/}" ]]; then
-            log "Expanding $repo#$number."
+        fetch_body "${repo}" "${number}"
+        body=${fetched_body}
+        if [[ "${body}" != '__GH_ERROR__' && -n "${body//[[:space:]]/}" ]]; then
+            log "Expanding ${repo}#${number}."
             ((expanded += 1))
-            printf '%s\n' "$line" >>"$output"
-            while IFS= read -r body_line || [[ -n "$body_line" ]]; do
-                printf '  %s\n' "$body_line" >>"$output"
-            done <<<"$body"
+            printf '%s\n' "${line}" >>"${output}"
+            while IFS= read -r body_line || [[ -n "${body_line}" ]]; do
+                printf '  %s\n' "${body_line}" >>"${output}"
+            done <<<"${body}"
             continue
         fi
-        [[ "$body" = '__GH_ERROR__' ]] || log "Skipping $repo#$number: no description."
+        [[ "${body}" = '__GH_ERROR__' ]] || log "Skipping ${repo}#${number}: no description."
     fi
-    printf '%s\n' "$line" >>"$output"
-done <"$input"
+    printf '%s\n' "${line}" >>"${output}"
+done <"${input}"
 
-log "Done: expanded $expanded of $matched matching PRs."
+log "Done: expanded ${expanded} of ${matched} matching PRs."
 
-if [[ -n "$in_place" ]]; then
-    chmod --reference="$file" "$output"
-    mv -- "$output" "$file"
+if [[ -n "${in_place}" ]]; then
+    chmod --reference="${file}" "${output}"
+    mv -- "${output}" "${file}"
 else
-    cat "$output"
+    cat "${output}"
 fi


### PR DESCRIPTION
It's faster to remove or summarize the mostly irrelevant thirdparty bumps than to manually check whether to add more information. This is a "private" script expanded a bit into a tidier tool.

PS Minor private note dump:

I used to generate the starting changelog along these lines:

```
GIT_PAGER='' git log v2022.02..master --pretty=format:'* %s' --no-patch --reverse
```

Later expanded into something like this, but without authentication it rates limits. That's why for better or worse it's slightly easier to work with the `gh` command line client.
```
GIT_PAGER='' git log v2024.04..master --pretty=format:'* %s (%H)' --no-patch --reverse | \
while read line; do
  hash=$(echo $line | sed 's/.*(\(.*\))/\1/')
  gh_username=$(curl -s https://api.github.com/repos/koreader/koreader/commits/$hash | jq -r '.author.login')
  echo "$line" | sed "s/\(.*\)(\(.*\))/\1(@$gh_username)/"
done
```

I since switched to simply using "generate release notes" in the GH release interface, but I apply the following transformation to stick to my earlier format:

```
by\s+(@[\w-]+)\s+in\s+(.*)
($2) $1
```

So much of that is automated but mostly through copy-paste, which is completely fine for the frequency, but it's probably good to more some of this out of my mind into (script-based) documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15742)
<!-- Reviewable:end -->
