### PR TITLE
screensaver: fix anti-ghosting flash breaking transparency when using no fill option on sleep screen

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -672,14 +672,20 @@ function Screensaver:show()
             local screen_w2, screen_h2 = Screen:getWidth(), Screen:getHeight()
             local delay_ms = G_reader_settings:readSetting("screensaver_extra_flash_delay", 1000)
             Device.screensaver_suspend_wait_timeout = Device:getScreensaverSuspendWaitTimeout(extra_flash_count, delay_ms)
+            -- Save the framebuffer once before any flashes. Each flash restores this copy
+            -- so that transparent areas always composite over the original content.
+            local bb_copy = Screen.bb:copy()
             for i = 1, extra_flash_count do
                 local t = 0.5 + (i - 1) * (delay_ms / 1000)
                 local is_last = (i == extra_flash_count)
                 UIManager:scheduleIn(t, function()
-                    -- Paint black directly to the framebuffer and refresh, then force a full widget redraw.
                     Screen.bb:fill(Blitbuffer.COLOR_BLACK)
                     Screen:refreshFull(0, 0, screen_w2, screen_h2)
                     UIManager:scheduleIn(0.5, function()
+                        Screen.bb:blitFrom(bb_copy)
+                        if is_last then
+                            bb_copy:free()
+                        end
                         UIManager:setDirty(self.screensaver_widget, "full")
                         UIManager:forceRePaint()
                         if is_last then

--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -669,31 +669,15 @@ function Screensaver:show()
         UIManager:show(self.screensaver_widget, "full")
         local extra_flash_count = G_reader_settings:readSetting("screensaver_extra_flash_count", 0)
         if extra_flash_count > 0 then
-            local screen_w2, screen_h2 = Screen:getWidth(), Screen:getHeight()
             local delay_ms = G_reader_settings:readSetting("screensaver_extra_flash_delay", 1000)
             Device.screensaver_suspend_wait_timeout = Device:getScreensaverSuspendWaitTimeout(extra_flash_count, delay_ms)
             -- Save the framebuffer once before any flashes. Each flash restores this copy
             -- so that transparent areas always composite over the original content.
-            local bb_copy = Screen.bb:copy()
+            self.bb_copy = Screen.bb:copy()
             for i = 1, extra_flash_count do
                 local t = 0.5 + (i - 1) * (delay_ms / 1000)
                 local is_last = (i == extra_flash_count)
-                UIManager:scheduleIn(t, function()
-                    Screen.bb:fill(Blitbuffer.COLOR_BLACK)
-                    Screen:refreshFull(0, 0, screen_w2, screen_h2)
-                    UIManager:scheduleIn(0.5, function()
-                        Screen.bb:blitFrom(bb_copy)
-                        if is_last then
-                            bb_copy:free()
-                        end
-                        UIManager:setDirty(self.screensaver_widget, "full")
-                        UIManager:forceRePaint()
-                        if is_last then
-                            -- It's flagged as modal, so it'll stay on top
-                            UIManager:show(self.screensaver_lock_widget)
-                        end
-                    end)
-                end)
+                UIManager:scheduleIn(t, self.flashBlack, self, is_last)
             end
         else
             -- It's flagged as modal, so it'll stay on top
@@ -704,6 +688,30 @@ function Screensaver:show()
         if self.screensaver_lock_widget then
             UIManager:show(self.screensaver_lock_widget)
         end
+    end
+end
+
+function Screensaver:flashBlack(is_last)
+    local screen_w, screen_h = Screen:getWidth(), Screen:getHeight()
+    Screen.bb:fill(Blitbuffer.COLOR_BLACK)
+    Screen:refreshFull(0, 0, screen_w, screen_h)
+
+    UIManager:scheduleIn(0.5, self.restoreCover, self, is_last)
+end
+
+function Screensaver:restoreCover(is_last)
+    if self.bb_copy then
+        Screen.bb:blitFrom(self.bb_copy)
+        if is_last then
+            self.bb_copy:free()
+            self.bb_copy = nil
+        end
+    end
+    UIManager:setDirty(self.screensaver_widget, "full")
+    UIManager:forceRePaint()
+    if is_last then
+        -- It's flagged as modal, so it'll stay on top
+        UIManager:show(self.screensaver_lock_widget)
     end
 end
 


### PR DESCRIPTION
When "no fill" is set as the sleep screen background, the anti-ghosting black flash was permanently overwriting the framebuffer, causing transparent areas to appear black after the redraw.

Fix is by saving a copy of the framebuffer before the black fill, then restoring it before the widget redraws. This preserves the original content beneath transparent areas.

Fixes #15750

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15752)
<!-- Reviewable:end -->
