### PR TITLE
util: read disk usage with statvfs instead of df

### DIFF
--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -3,12 +3,15 @@ This module contains miscellaneous helper functions for the KOReader frontend.
 ]]
 
 local Utf8Proc = require("ffi/utf8proc")
+local ffi = require("ffi")
 local ffiUtil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local md5 = require("ffi/sha2").md5
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = ffiUtil.template
+require("ffi/posix_h")
+local C = ffi.C
 
 local lshift = bit.lshift
 local rshift = bit.rshift
@@ -923,31 +926,19 @@ end
 -- @string path of the directory
 -- @treturn table with total, used and available bytes
 function util.diskUsage(dir)
-    -- safe way of testing df & awk
-    local function doCommand(d)
-        local handle = io.popen("df -kP " .. util.shell_escape({d}) .. " 2>/dev/null | awk '$3 ~ /[0-9]+/ { print $2,$3,$4 }' 2>/dev/null || echo ::ERROR::")
-        if not handle then return end
-        local output = handle:read("*all")
-        handle:close()
-        if not output:find "::ERROR::" then
-            return output
-        end
-    end
     local err = { total = nil, used = nil, available = nil }
     if not dir or lfs.attributes(dir, "mode") ~= "directory" then return err end
-    local usage = doCommand(dir)
-    if not usage then return err end
-    local stage, result = {}, {}
-    for size in usage:gmatch("%w+") do
-        table.insert(stage, size)
-    end
-    for k, v in pairs({"total", "used", "available"}) do
-        if stage[k] ~= nil then
-            -- sizes are in kb, return bytes here
-            result[v] = stage[k] * 1024
-        end
-    end
-    return result
+    local statvfs = ffi.new("struct statvfs")
+    if C.statvfs(dir, statvfs) ~= 0 then return err end
+    -- The block counts are in f_frsize units, which is not always f_bsize.
+    local frsize = tonumber(statvfs.f_frsize)
+    local blocks = tonumber(statvfs.f_blocks)
+    return {
+        total = blocks * frsize,
+        used = (blocks - tonumber(statvfs.f_bfree)) * frsize,
+        -- What df calls available: free blocks less those held back for root.
+        available = tonumber(statvfs.f_bavail) * frsize,
+    }
 end
 
 

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -924,7 +924,6 @@ end
 -- @treturn table with total, used and available bytes
 function util.diskUsage(dir)
     local err = { total = nil, used = nil, available = nil }
-    if not dir or lfs.attributes(dir, "mode") ~= "directory" then return err end
     local total, free, available = ffiUtil.df(dir)
     if not total then return err end
     return {

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -919,12 +919,12 @@ function util.removeFile(file)
     end
 end
 
--- Gets total, used and available bytes for the mountpoint that holds a given directory.
--- @string path of the directory
+-- Gets total, used and available bytes for the mountpoint that holds a given path.
+-- @string path of a file or a directory
 -- @treturn table with total, used and available bytes
-function util.diskUsage(dir)
+function util.diskUsage(path)
     local err = { total = nil, used = nil, available = nil }
-    local total, free, available = ffiUtil.df(dir)
+    local total, free, available = ffiUtil.df(path)
     if not total then return err end
     return {
         total = total,

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -3,15 +3,12 @@ This module contains miscellaneous helper functions for the KOReader frontend.
 ]]
 
 local Utf8Proc = require("ffi/utf8proc")
-local ffi = require("ffi")
 local ffiUtil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local md5 = require("ffi/sha2").md5
 local _ = require("gettext")
 local C_ = _.pgettext
 local T = ffiUtil.template
-require("ffi/posix_h")
-local C = ffi.C
 
 local lshift = bit.lshift
 local rshift = bit.rshift
@@ -928,16 +925,12 @@ end
 function util.diskUsage(dir)
     local err = { total = nil, used = nil, available = nil }
     if not dir or lfs.attributes(dir, "mode") ~= "directory" then return err end
-    local statvfs = ffi.new("struct statvfs")
-    if C.statvfs(dir, statvfs) ~= 0 then return err end
-    -- The block counts are in f_frsize units, which is not always f_bsize.
-    local frsize = tonumber(statvfs.f_frsize)
-    local blocks = tonumber(statvfs.f_blocks)
+    local total, free, available = ffiUtil.df(dir)
+    if not total then return err end
     return {
-        total = blocks * frsize,
-        used = (blocks - tonumber(statvfs.f_bfree)) * frsize,
-        -- What df calls available: free blocks less those held back for root.
-        available = tonumber(statvfs.f_bavail) * frsize,
+        total = total,
+        used = total - free,
+        available = available,
     }
 end
 


### PR DESCRIPTION
`util.diskUsage` shelled out to `df` and parsed its columns with `awk`. busybox
before 1.13.0 has no `-P` and prints nothing at all when given it, so on legacy
Kindles (busybox 1.7.2) the function silently returned an empty table.
`calibre.koplugin/wireless.lua:96` substitutes a fallback for that and tells
Calibre there is a fictional 1 GB free, so a sync runs into a full device
instead of a clean refusal.

The function now calls `statvfs(3)`, using the binding already present in
koreader-base: `struct statvfs` in `ffi/posix_types_*.lua`, the prototype in
`ffi/posix_h.lua`.

`available` comes from `f_bavail` rather than `f_bfree`: that is what `df`
prints in its Available column, and the two differ on a filesystem with blocks
reserved for root.

This also drops a fork+exec per call and the parser's exposure to long device
names wrapping onto their own line, to mount points containing spaces, and to
format differences between `df` implementations.

Verified on a Kindle 3 (kernel 2.6.26, busybox 1.7.2): the figures match `df` to
the byte on the VFAT user store (3279044608 / 788029440 / 2491015168) and on the
ext3 root, where available sits 26 MB below free. Edge cases are unchanged: a
missing directory, a file instead of a directory, and `nil` all yield a table
with empty fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15755)
<!-- Reviewable:end -->
