### PR TITLE
Maintain scroll offset for a kept open, multi-page QuickMenu

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -1416,10 +1416,12 @@ function Dispatcher._showAsMenu(settings, exec_props, rename_callback, rename_ho
                 if rename_callback then
                     rename_callback(v, quickmenu)
                 else
+                    local current_offset = quickmenu:getScrolledOffset()
                     UIManager:close(quickmenu)
                     Dispatcher:execute({[v.key] = settings[v.key]})
                     if keep_open_on_apply and not util.stringStartsWith(v.key, "touch_input") then
                         quickmenu:setTitle(title)
+                        quickmenu:setScrolledOffset(current_offset)
                         UIManager:show(quickmenu)
                     end
                 end


### PR DESCRIPTION
If "Keep QuickMenu open" is set, multi-page QuickMenus jump back to the first page every time an action is dispatched from them. This PR makes them maintain their scroll position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15756)
<!-- Reviewable:end -->
