### PR TITLE
Support tolino fw >=5.18

### DIFF
--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -12,7 +12,7 @@ local function probeDevice()
         return require("device/kindle/device")
     end
 
-    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/usr/bin/hwdetect.sh")
+    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/usr/bin/hwdetect.sh") or lfs.attributes("/usr/bin/hwdetect")
     if kobo_test_stat then
         return require("device/kobo/device")
     end

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -987,7 +987,7 @@ function Kobo:otaModel()
     local model = "kobo"
     -- Switch to the proper packages on FW 5.x
     -- NOTE: We don't distribute kobov4 binaries, the omission is on purpose.
-    if util.fileExists("/usr/bin/hwdetect.sh") then
+    if util.fileExists("/usr/bin/hwdetect.sh")  or util.fileExists("/usr/bin/hwdetect") then
         model = "kobov5"
     end
     return model, "ota"
@@ -1172,6 +1172,26 @@ local function getCodeName()
         if std_out then
             codename = std_out:read("*line")
             std_out:close()
+        end
+    end
+    if not codename then
+        local std_out_device = io.popen("/usr/bin/hwdetect device-name 2>/dev/null", "re")
+        local std_out_branding = io.popen("/usr/bin/hwdetect branding 2>/dev/null", "re")
+        local std_out_screen = io.popen("/usr/bin/hwdetect screen-variant 2>/dev/null", "re")
+        if std_out_device then
+            local device = std_out_device:read("*line")
+            local branding = std_out_branding:read("*line")
+            local screen = std_out_screen:read("*line")
+
+            local branding_first = string.sub(branding, 1, 1)
+            local branding_rest = string.sub(branding, 2)
+            branding = string.upper(branding_first) .. branding_rest
+
+            codename = device .. branding .. screen
+
+            std_out_device:close()
+            std_out_branding:close()
+            std_out_screen:close()
         end
     end
     return codename

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1175,18 +1175,17 @@ local function getCodeName()
         end
     end
     if not codename then
-        local std_out_device = io.popen("/usr/bin/hwdetect device-name 2>/dev/null", "re")
-        local std_out_branding = io.popen("/usr/bin/hwdetect branding 2>/dev/null", "re")
-        local std_out_screen = io.popen("/usr/bin/hwdetect screen-variant 2>/dev/null", "re")
-        if std_out_device then
+        local std_out_device = io.popen("/usr/bin/hwdetect device-name", "re")
+        local std_out_branding = io.popen("/usr/bin/hwdetect branding", "re")
+        local std_out_screen = io.popen("/usr/bin/hwdetect screen-variant", "re")
+        if std_out_device and std_out_branding and std_out_screen then
             local device = std_out_device:read("*line")
             local branding = std_out_branding:read("*line")
             local screen = std_out_screen:read("*line")
-
             local branding_first = string.sub(branding, 1, 1)
             local branding_rest = string.sub(branding, 2)
-            branding = string.upper(branding_first) .. branding_rest
 
+            branding = string.upper(branding_first) .. branding_rest
             codename = device .. branding .. screen
 
             std_out_device:close()

--- a/frontend/device/kobo/device.lua
+++ b/frontend/device/kobo/device.lua
@@ -1174,6 +1174,7 @@ local function getCodeName()
             std_out:close()
         end
     end
+    -- If that fails, try binary hwdetect (since firmware 5.18)
     if not codename then
         local std_out_device = io.popen("/usr/bin/hwdetect device-name", "re")
         local std_out_branding = io.popen("/usr/bin/hwdetect branding", "re")

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -253,6 +253,7 @@ if [ -z "${PRODUCT}" ]; then
     # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
     # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
+        # shellcheck disable=SC1091
         . /usr/libexec/platform/utils.sh
         PRODUCT="$(get_product_name)"
     else

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -250,7 +250,16 @@ if [ -z "${PRODUCT}" ]; then
 fi
 
 if [ -z "${PRODUCT}" ]; then
-    PRODUCT="$(/usr/bin/hwdetect.sh 2>/dev/null)"
+    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. So, use hwdetect, if available.
+    if [ -e "/usr/bin/hwdetect" ]; then
+        device=$(hwdetect device-name)
+        branding=$(hwdetect branding)
+        screen=$(hwdetect screen-variant)
+        PRODUCT=${device}${branding^}${screen}
+    else
+        PRODUCT="$(/usr/bin/hwdetect.sh 2>/dev/null)"
+    fi
+    
     export PRODUCT
 fi
 

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -250,16 +250,15 @@ if [ -z "${PRODUCT}" ]; then
 fi
 
 if [ -z "${PRODUCT}" ]; then
-    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. So, use hwdetect, if available.
+    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
+    # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
-        device=$(hwdetect device-name)
-        branding=$(hwdetect branding)
-        screen=$(hwdetect screen-variant)
-        PRODUCT=${device}${branding^}${screen}
+        source /usr/libexec/platform/utils.sh
+        PRODUCT="$(get_product_name)"
     else
         PRODUCT="$(/usr/bin/hwdetect.sh 2>/dev/null)"
     fi
-    
+
     export PRODUCT
 fi
 

--- a/platform/kobo/koreader.sh
+++ b/platform/kobo/koreader.sh
@@ -253,7 +253,7 @@ if [ -z "${PRODUCT}" ]; then
     # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
     # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
-        source /usr/libexec/platform/utils.sh
+        . /usr/libexec/platform/utils.sh
         PRODUCT="$(get_product_name)"
     else
         PRODUCT="$(/usr/bin/hwdetect.sh 2>/dev/null)"

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -23,6 +23,7 @@ if [ -e "/etc/init.d/display-init.sh" ]; then
     # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
     # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
+        # shellcheck disable=SC1091
         . /usr/libexec/platform/utils.sh
         PRODUCT="$(get_product_name)"
     else

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -23,7 +23,7 @@ if [ -e "/etc/init.d/display-init.sh" ]; then
     # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
     # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
-        source /usr/libexec/platform/utils.sh
+        . /usr/libexec/platform/utils.sh
         PRODUCT="$(get_product_name)"
     else
         PRODUCT=$(hwdetect.sh)

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -20,7 +20,16 @@ unset FBINK_FORCE_ROTA
 
 # kobo v5 animation is originally done in display-init, we copy the neccessary parts here.
 if [ -e "/etc/init.d/display-init.sh" ]; then
-    PRODUCT=$(hwdetect.sh)
+    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. So, use hwdetect, if available.
+    if [ -e "/usr/bin/hwdetect" ]; then
+        device=$(hwdetect device-name)
+        branding=$(hwdetect branding)
+        screen=$(hwdetect screen-variant)
+        PRODUCT=${device}${branding^}${screen}
+    else
+        PRODUCT=$(hwdetect.sh)
+    fi
+   
     export PRODUCT
     echo "Starting boot animation..."
     animator.sh /etc/images/"${PRODUCT}"-on-*.raw.gz &

--- a/platform/kobo/nickel.sh
+++ b/platform/kobo/nickel.sh
@@ -20,16 +20,15 @@ unset FBINK_FORCE_ROTA
 
 # kobo v5 animation is originally done in display-init, we copy the neccessary parts here.
 if [ -e "/etc/init.d/display-init.sh" ]; then
-    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. So, use hwdetect, if available.
+    # FW >= 5.18 uses a binary hwdetect instead of the hwdetect.sh script. If hwdetect is available, we can use
+    # utils.sh for convenience.
     if [ -e "/usr/bin/hwdetect" ]; then
-        device=$(hwdetect device-name)
-        branding=$(hwdetect branding)
-        screen=$(hwdetect screen-variant)
-        PRODUCT=${device}${branding^}${screen}
+        source /usr/libexec/platform/utils.sh
+        PRODUCT="$(get_product_name)"
     else
         PRODUCT=$(hwdetect.sh)
     fi
-   
+
     export PRODUCT
     echo "Starting boot animation..."
     animator.sh /etc/images/"${PRODUCT}"-on-*.raw.gz &
@@ -153,6 +152,9 @@ if [ -e "/etc/init.d/z-nickel-hardware-status" ]; then
     # since sometime after 5.2, pulseaudio is started in rc.local. Detect and kill:
     if grep "pulseaudio" "/etc/rc.local"; then
         killall pulseaudio
+    fi
+    if grep "speech-dispatcher" "/etc/rc.local"; then
+        killall speech-dispatcher
     fi
     /etc/init.d/z-nickel-hardware-status
     sync


### PR DESCRIPTION
Kobo/Tolino firmware 5.18 uses a binary hwdetect. Also, we have to kill `speech-dispatcher` in order to restart nickel.

Fixes #15747

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15759)
<!-- Reviewable:end -->
