### PR TITLE
NewsDownloader: say that emptying the download folder empties all of it

### DIFF
--- a/plugins/newsdownloader.koplugin/main.lua
+++ b/plugins/newsdownloader.koplugin/main.lua
@@ -1,4 +1,5 @@
 local BD = require("ui/bidi")
+local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local DocumentRegistry = require("document/documentregistry")
 local DownloadBackend = require("epubdownloadbackend")
@@ -225,13 +226,14 @@ function NewsDownloader:getSubMenuItems()
                     end,
                 },
                 {
-                    text = _("Delete all downloaded items"),
+                    text = _("Delete all items in download folder"),
                     keep_menu_open = true,
                     callback = function()
                         local Trapper = require("ui/trapper")
                         Trapper:wrap(function()
                                 local should_delete = Trapper:confirm(
-                                    _("Are you sure you want to delete all downloaded items?"),
+                                    T(_("Delete everything in the download folder?\n\n%1\n\nThis removes all of the folder's contents, not only the items downloaded by this plugin."),
+                                        BD.dirpath(self.download_dir)),
                                     _("Cancel"),
                                     _("Delete")
                                 )
@@ -925,18 +927,49 @@ function NewsDownloader:removeNewsButKeepFeedConfig()
     })
 end
 
+-- Whether a candidate download folder already holds something of the user's.
+-- The plugin's own feed configuration does not count: it is ours, and it is the
+-- one thing "Delete all items in download folder" keeps anyway.
+function NewsDownloader:folderHasOtherContent(path)
+    if lfs.attributes(path, "mode") ~= "directory" then
+        return false
+    end
+    for entry in lfs.dir(path) do
+        if entry ~= "." and entry ~= ".." and entry ~= self.feed_config_file then
+            return true
+        end
+    end
+    return false
+end
+
 function NewsDownloader:setCustomDownloadDirectory()
     require("ui/downloadmgr"):new{
         onConfirm = function(path)
-            logger.dbg("NewsDownloader: set download directory to: ", path)
-            self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
-            self.settings:flush()
+            local function apply()
+                logger.dbg("NewsDownloader: set download directory to: ", path)
+                self.settings:saveSetting(self.config_key_custom_dl_dir, ("%s/"):format(path))
+                self.settings:flush()
 
-            logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
-            FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
+                logger.dbg("NewsDownloader: Coping to new download folder previous self.feed_config_file from: ", self.feed_config_path)
+                FFIUtil.copyFile(self.feed_config_path, ("%s/%s"):format(path, self.feed_config_file))
 
-            self.initialized = false
-            self:lazyInitialization()
+                self.initialized = false
+                self:lazyInitialization()
+            end
+
+            -- Emptying the download folder removes everything in it, so say so
+            -- while the folder is being chosen. Afterwards the warning would come
+            -- too late to be of any use (#15508).
+            if self:folderHasOtherContent(path) then
+                UIManager:show(ConfirmBox:new{
+                    text = T(_("This folder is not empty:\n\n%1\n\nIt can still be used, but %2 will then delete everything in it, not only the items downloaded by this plugin."),
+                        BD.dirpath(path), _("Delete all items in download folder")),
+                    ok_text = _("Use folder"),
+                    ok_callback = apply,
+                })
+            else
+                apply()
+            end
         end,
     }:chooseDir()
 end

--- a/spec/unit/newsdownloader_spec.lua
+++ b/spec/unit/newsdownloader_spec.lua
@@ -378,4 +378,78 @@ describe("NewsDownloader module", function()
             assert.is_nil(getFeedItemTimestamp({ title = "x", link = "y" }))
         end)
     end)
+
+    -- "Delete all items in download folder" empties the folder wholesale, and the
+    -- folder is user-selectable, so pointing it at a library and using that entry
+    -- destroys the library (#15508). The folder chooser warns when the chosen
+    -- folder already holds something; this is the test for what "something" means.
+    describe("folderHasOtherContent", function()
+        local lfs, ffiutil, tmp_root
+
+        setup(function()
+            -- Required here, not in the describe body: describe bodies run at
+            -- collection time, before commonrequire has set the package path up.
+            lfs = require("libs/libkoreader-lfs")
+            ffiutil = require("ffi/util")
+            tmp_root = require("datastorage"):getDataDir() .. "/newsdownloader_folder_spec"
+            if lfs.attributes(tmp_root, "mode") == "directory" then
+                ffiutil.purgeDir(tmp_root)
+            end
+            lfs.mkdir(tmp_root)
+        end)
+
+        teardown(function()
+            if lfs.attributes(tmp_root, "mode") == "directory" then
+                ffiutil.purgeDir(tmp_root)
+            end
+        end)
+
+        local function makeDir(name)
+            local path = tmp_root .. "/" .. name
+            lfs.mkdir(path)
+            return path
+        end
+
+        local function touch(path, name)
+            local f = io.open(path .. "/" .. name, "w")
+            f:write("x")
+            f:close()
+        end
+
+        it("reports an empty folder as safe", function()
+            assert.is_false(NewsDownloader:folderHasOtherContent(makeDir("empty")))
+        end)
+
+        it("reports a folder holding a file of the user's", function()
+            local path = makeDir("with_book")
+            touch(path, "my_book.epub")
+            assert.is_true(NewsDownloader:folderHasOtherContent(path))
+        end)
+
+        it("reports a folder holding a subfolder of the user's", function()
+            local path = makeDir("with_subdir")
+            lfs.mkdir(path .. "/Anthologies")
+            assert.is_true(NewsDownloader:folderHasOtherContent(path))
+        end)
+
+        -- A folder this plugin has used before holds its feed configuration and
+        -- nothing else of the user's. Warning about our own file would teach
+        -- people to dismiss the warning.
+        it("does not count the plugin's own feed config", function()
+            local path = makeDir("only_feed_config")
+            touch(path, NewsDownloader.feed_config_file)
+            assert.is_false(NewsDownloader:folderHasOtherContent(path))
+        end)
+
+        it("still reports a used folder that also holds a file of the user's", function()
+            local path = makeDir("feed_config_and_book")
+            touch(path, NewsDownloader.feed_config_file)
+            touch(path, "my_book.epub")
+            assert.is_true(NewsDownloader:folderHasOtherContent(path))
+        end)
+
+        it("reports a path that is not a folder as safe", function()
+            assert.is_false(NewsDownloader:folderHasOtherContent(tmp_root .. "/does_not_exist"))
+        end)
+    end)
 end)


### PR DESCRIPTION
Fixes #15508.

`Delete all downloaded items` removes every file and folder in the download folder, sparing only `feed_config.lua`. The folder is user-selectable, so someone who points it at a library and later uses that entry loses the library, and the name gives them no reason to expect it.

This implements @Frenzie's suggestion from the issue rather than my earlier one: the delete behaviour is unchanged, and the naming stops being misleading.

- Renames the entry to **`Delete all items in download folder`**.
- The confirmation names the folder and says the sweep is not limited to downloaded news.
- Warns when a folder that already holds something is chosen as the download folder — a rename only helps at the moment of deletion, which is late; the folder chooser is where the choice is still cheap to change.

The plugin's own `feed_config.lua` deliberately does not count as content, since warning about our own file would teach people to dismiss the warning.

`folderHasOtherContent` has six specs covering empty, a user's file, a user's subfolder, feed config only, feed config plus a user's file, and a non-existent path. `luacheck` clean, 79/79 front specs pass.

One thing worth a second opinion: the warning interpolates the menu entry's translated name via `%2` so the two can't drift apart. Happy to inline the literal string instead if you'd rather translators saw it whole.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15762)
<!-- Reviewable:end -->
