### PR TITLE
Reduce peak memory use on low-RAM devices

### DIFF
--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
+local Cache = require("cache")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
 local Event = require("ui/event")
@@ -13,6 +14,7 @@ local ffiutil = require("ffi/util")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local time = require("ui/time")
+local util = require("util")
 local _ = require("gettext")
 local Input = Device.input
 local Screen = Device.screen
@@ -1737,6 +1739,7 @@ function ReaderRolling:setupRerenderingAutomation()
 
     local next_step_not_before
     self._stepRerenderingAutomation = function(next_step)
+        Cache.checkAllMemoryPressure()
         -- Ensure transitions between partial rerendering steps
         logger.dbg("_stepRerenderingAutomation(", next_step, "), currently ", self.rendering_state)
         UIManager:unschedule(self._stepRerenderingAutomation)
@@ -1762,6 +1765,22 @@ function ReaderRolling:setupRerenderingAutomation()
                 logger.dbg("background rerendering not needed, current cache is usable")
                 self._current_rerendering_pid = nil -- have this mean no rerendering was needed
             else
+                local can_fork, memfree, needed = util.canForkSafely()
+                if not can_fork then
+                    -- Stay in this state and retry later: falling through would end up
+                    -- reloading and rerendering in the foreground, which is what gets
+                    -- big books killed by the OOM killer on low-memory devices.
+                    self._rerendering_deferrals = (self._rerendering_deferrals or 0) + 1
+                    logger.warn(string.format(
+                        "deferring background rerendering, low memory (%.1f MB free, %.1f MB needed), attempt %d",
+                        memfree / 1024 / 1024, needed / 1024 / 1024, self._rerendering_deferrals))
+                    if self.rendering_state ~= prev_state then
+                        UIManager:setDirty(self.view.dialog, "ui", self.view.flipping:getRefreshRegion())
+                    end
+                    UIManager:scheduleIn(self._rerendering_deferrals > 60 and 60 or 1, self._stepRerenderingAutomation)
+                    return
+                end
+                self._rerendering_deferrals = nil
                 self._current_rerendering_pid = self:_rerenderInBackground()
             end
 
@@ -1888,6 +1907,7 @@ function ReaderRolling:tearDownRerenderingAutomation()
         self._stepRerenderingAutomation = nil
         UIManager:allowStandby()
     end
+    self._rerendering_deferrals = nil
     if self._watchInputEvent then
         UIManager.event_hook:unregister("InputEvent", self._watchInputEvent)
         self._watchInputEvent = nil

--- a/frontend/apps/reader/modules/readerthumbnail.lua
+++ b/frontend/apps/reader/modules/readerthumbnail.lua
@@ -10,6 +10,7 @@ local UIManager = require("ui/uimanager")
 local Screen = Device.screen
 local ffiutil = require("ffi/util")
 local logger = require("logger")
+local time = require("ui/time")
 local util = require("util")
 local _ = require("gettext")
 
@@ -284,7 +285,24 @@ function ReaderThumbnail:getPageThumbnail(page, width, height, batch_id, when_ge
     return true -- delayed
 end
 
+-- This generation loop runs a few times a second, so don't poll /proc on every pass.
+function ReaderThumbnail:checkMemory()
+    local now = UIManager:getTime()
+    if self._mem_check_at and now < self._mem_check_at then
+        return self._mem_check_ok
+    end
+    self._mem_check_at = now + time.s(5)
+
+    Cache.checkAllMemoryPressure()
+    self._mem_check_ok = util.canForkSafely()
+    if not self._mem_check_ok then
+        logger.warn("deferring thumbnail generation, low memory")
+    end
+    return self._mem_check_ok
+end
+
 function ReaderThumbnail:ensureTileGeneration()
+    local can_generate = self:checkMemory()
     if not self._standby_prevented then
         self._standby_prevented = true
         UIManager:preventStandby()
@@ -315,6 +333,11 @@ function ReaderThumbnail:ensureTileGeneration()
                 local tile = self.tile_cache and self.tile_cache:check(req.hash)
                 if tile then
                     req.when_generated_callback(tile, req.batch_id, true)
+                elseif not can_generate then
+                    -- Requeue it as-is: we'll retry once memory frees up.
+                    table.insert(requests, 1, req)
+                    self.thumbnails_requests[req_id] = requests
+                    break
                 else
                     if self:startTileGeneration(req) then
                         self.req_in_progress = req

--- a/frontend/cache.lua
+++ b/frontend/cache.lua
@@ -10,6 +10,10 @@ local lru = require("ffi/lru")
 local md5 = require("ffi/sha2").md5
 local util = require("util")
 
+-- Every live instance, so a single pressure sweep can reach them all.
+-- Weak values: a cache that's been dropped shouldn't be pinned here.
+local instances = setmetatable({}, { __mode = "v" })
+
 local Cache = {
     -- Cache configuration:
     -- Max storage space, in bytes...
@@ -32,6 +36,7 @@ function Cache:new(o)
     setmetatable(o, self)
     self.__index = self
     if o.init then o:init() end
+    table.insert(instances, o)
     return o
 end
 
@@ -147,8 +152,22 @@ function Cache:clear()
     self.cache:clear()
 end
 
--- Terribly crappy workaround: evict half the cache if we appear to be redlining on free RAM...
-function Cache:memoryPressureCheck()
+-- Rebuild the LRU against a new storage budget. Cached entries are dropped.
+function Cache:resize(new_size)
+    if not self.size or not new_size or new_size == self.size then
+        return false
+    end
+
+    -- Clear first, so the eviction callback still gets a chance to free resources.
+    self.cache:clear()
+    self.size = new_size
+    self.slots = math.ceil(self.size / self.avg_itemsize)
+    self.cache = lru.new(self.slots, self.size, self.enable_eviction_cb)
+    return true
+end
+
+-- Returns free_fraction, memfree, memtotal when redlining on free RAM, nil otherwise.
+local function underPressure()
     local memfree, memtotal = util.calcFreeMem()
 
     -- Nonsensical values? (!Linux), skip this.
@@ -156,19 +175,51 @@ function Cache:memoryPressureCheck()
         return
     end
 
-    -- If less that 20% of the total RAM is free, drop half the Cache...
+    -- If less that 20% of the total RAM is free, we're under pressure.
     local free_fraction = memfree / memtotal
     if free_fraction < 0.20 then
-        logger.warn(string.format("Running low on memory (~%d%%, ~%.2f/%d MiB), evicting half of the cache...",
-                                  free_fraction * 100,
-                                  memfree / (1024 * 1024),
-                                  memtotal / (1024 * 1024)))
-        self.cache:chop()
-
-        -- And finish by forcing a GC sweep now...
-        collectgarbage()
-        collectgarbage()
+        return free_fraction, memfree, memtotal
     end
+end
+
+local function logPressure(free_fraction, memfree, memtotal)
+    logger.warn(string.format("Running low on memory (~%d%%, ~%.2f/%d MiB), evicting half of the cache...",
+                              free_fraction * 100,
+                              memfree / (1024 * 1024),
+                              memtotal / (1024 * 1024)))
+end
+
+-- Terribly crappy workaround: evict half the cache if we appear to be redlining on free RAM...
+function Cache:memoryPressureCheck()
+    local free_fraction, memfree, memtotal = underPressure()
+    if not free_fraction then
+        return false
+    end
+
+    logPressure(free_fraction, memfree, memtotal)
+    self.cache:chop()
+
+    -- And finish by forcing a GC sweep now...
+    collectgarbage()
+    collectgarbage()
+    return true
+end
+
+-- Same, but across every live cache, off a single free-RAM read.
+function Cache.checkAllMemoryPressure()
+    local free_fraction, memfree, memtotal = underPressure()
+    if not free_fraction then
+        return false
+    end
+
+    logPressure(free_fraction, memfree, memtotal)
+    for _, cache in pairs(instances) do
+        cache.cache:chop()
+    end
+
+    collectgarbage()
+    collectgarbage()
+    return true
 end
 
 -- Refresh the disk snapshot (mainly used by ui/data/onetime_migration)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -14,6 +14,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local lru = require("ffi/lru")
 local time = require("ui/time")
+local util = require("util")
 
 -- engine can be initialized only once, on first document opened
 local engine_initialized = false
@@ -77,6 +78,28 @@ local CreDocument = Document:extend{
     last_linear_page = nil,
 }
 
+-- crengine's various in-memory caches have rather small max-sizes
+-- (2.5 / 4.5 / 4.5 / 1 MB), and we avoid some bugs by increasing them.
+-- Each cache only grows when needed, depending on book characteristics, but the
+-- ceiling still has to fit the device: 40x of ~12.5 MB is most of a 512 MB Kindle.
+-- Users can always pin a value with the "cre_storage_size_factor" setting.
+function CreDocument.getDefaultStorageSizeFactor()
+    local _, memtotal = util.calcFreeMem()
+    if not memtotal then
+        return 40
+    end
+
+    local mb = memtotal / 1024 / 1024
+    if mb < 384 then
+        return 5
+    elseif mb < 768 then
+        return 10
+    elseif mb < 1536 then
+        return 20
+    end
+    return 40
+end
+
 function CreDocument.cacheInit()
     -- remove legacy cr3cache directory
     if lfs.attributes("./cr3cache", "mode") == "directory" then
@@ -85,18 +108,10 @@ function CreDocument.cacheInit()
     -- crengine saves caches on disk for faster re-openings, and cleans
     -- the less recently used ones when this limit is reached
     local default_cre_disk_cache_max_size = 64 -- in MB units
-    -- crengine various in-memory caches max-sizes are rather small
-    -- (2.5 / 4.5 / 4.5 / 1 MB), and we can avoid some bugs if we
-    -- increase them. Let's multiply them by 40 (each cache would
-    -- grow only when needed, depending on book characteristics).
-    -- People who would get out of memory crashes with big books on
-    -- older devices can decrease that with setting:
-    --   "cre_storage_size_factor"=1    (or 2, or 5)
-    local default_cre_storage_size_factor = 40
     cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache",
         (G_reader_settings:readSetting("cre_disk_cache_max_size") or default_cre_disk_cache_max_size)*1024*1024,
         G_reader_settings:nilOrTrue("cre_compress_cached_data"),
-        G_reader_settings:readSetting("cre_storage_size_factor") or default_cre_storage_size_factor)
+        G_reader_settings:readSetting("cre_storage_size_factor") or CreDocument.getDefaultStorageSizeFactor())
 end
 
 function CreDocument:engineInit()

--- a/frontend/document/doccache.lua
+++ b/frontend/document/doccache.lua
@@ -57,6 +57,20 @@ local DocCache = Cache:new{
     cache_path = DataStorage:getDataDir() .. "/cache/",
 }
 
+-- The budget computed at startup reflects post-boot free memory, which no longer
+-- holds mid-session. Recompute it, but only act on a substantial change so that
+-- routine openings don't throw away a warm cache.
+function DocCache:reevaluate()
+    local new_size = calcCacheMemSize()
+    if not self.size or math.abs(new_size - self.size) < self.size * 0.25 then
+        return false
+    end
+
+    logger.dbg(string.format("Resizing the global document cache: %.2f -> %.2f MB",
+                             self.size / 1024 / 1024, new_size / 1024 / 1024))
+    return self:resize(new_size)
+end
+
 function DocCache:serialize(doc_path)
     if not self.disk_cache then
         return

--- a/frontend/document/documentregistry.lua
+++ b/frontend/document/documentregistry.lua
@@ -2,6 +2,7 @@
 This is a registry for document providers
 ]]--
 
+local DocCache = require("document/doccache")
 local DocSettings = require("docsettings")
 local logger = require("logger")
 local util = require("util")
@@ -232,6 +233,7 @@ function DocumentRegistry:openDocument(file, provider)
     -- next regular gc. The second call may help reclaming more memory.
     collectgarbage()
     collectgarbage()
+    DocCache:reevaluate()
     if not self.registry[file] then
         provider = provider or self:getProvider(file)
 

--- a/frontend/util.lua
+++ b/frontend/util.lua
@@ -780,6 +780,35 @@ function util.calcFreeMem()
     end
 end
 
+--- Resident set size of the current process
+---- @treturn int bytes (or nil on unsupported platforms)
+function util.getRSS()
+    local statm = io.open("/proc/self/statm", "r")
+    if not statm then
+        return nil
+    end
+    local _, rss = statm:read("*number", "*number")
+    statm:close()
+    return rss and rss * 4096 or nil
+end
+
+--- Whether there's enough free memory to fork a worker that will grow alongside us.
+--- crengine estimates ~60 MB of extra RSS for a background rerendering against a
+--- ~120 MB parent, hence the default 0.6 ratio, with a floor for small parents.
+---- @number ratio (optional) fraction of our RSS the child is expected to need
+---- @treturn bool, int memfree, int needed
+function util.canForkSafely(ratio)
+    local memfree = util.calcFreeMem()
+    local rss = util.getRSS()
+    if not memfree or not rss then
+        -- Unsupported platform: don't change existing behaviour.
+        return true
+    end
+
+    local needed = math.max(rss * (ratio or 0.6), 40 * 1024 * 1024)
+    return memfree >= needed, memfree, needed
+end
+
 --- Recursively scan directory for files inside
 -- @string path
 -- @func callback(fullpath, name, attr)

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -427,14 +427,14 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
         -- We need to init engine (if no crengine book has yet been opened),
         -- so it does not reset our temporary cache dir when we first open
         -- a crengine book for extraction.
-        local cre = require("document/credocument"):engineInit()
+        local CreDocument = require("document/credocument")
+        local cre = CreDocument:engineInit()
         -- If we wanted to disallow caching completely:
         -- cre.initCache("", 1024*1024*32) -- empty path = no cache
         -- But it's best to use a cache for quicker and less memory
         -- usage when opening big books:
-        local default_cre_storage_size_factor = 20 -- note: keep in sync with the one in credocument.lua
         cre.initCache(self.tmpcr3cache, 0, -- 0 = previous book caches are removed when opening a book
-            true, G_reader_settings:readSetting("cre_storage_size_factor") or default_cre_storage_size_factor)
+            true, G_reader_settings:readSetting("cre_storage_size_factor") or CreDocument.getDefaultStorageSizeFactor())
         self.cre_cache_overriden = true
     end
 
@@ -689,6 +689,11 @@ end
 function BookInfoManager:extractInBackground(files)
     if #files == 0 then
         return
+    end
+
+    if not util.canForkSafely() then
+        logger.warn("Skipping background extraction, low memory")
+        return false -- let caller know it failed
     end
 
     -- Terminate any previous extraction background task that would be still running

--- a/spec/unit/cache_spec.lua
+++ b/spec/unit/cache_spec.lua
@@ -51,3 +51,101 @@ describe("Cache module", function()
         DocCache:clear()
     end)
 end)
+
+describe("Cache memory pressure", function()
+    local Cache, util
+    local orig_calcFreeMem
+    -- Strong ref: the instance registry holds weak values.
+    local probe, chopped
+
+    setup(function()
+        require("commonrequire")
+        Cache = require("cache")
+        util = require("util")
+        orig_calcFreeMem = util.calcFreeMem
+    end)
+    teardown(function()
+        util.calcFreeMem = orig_calcFreeMem
+    end)
+    before_each(function()
+        chopped = 0
+        probe = Cache:new{ slots = 4 }
+        probe.cache = { chop = function() chopped = chopped + 1 end }
+    end)
+
+    it("should do nothing when free memory is comfortable", function()
+        util.calcFreeMem = function() return 800 * 1024 * 1024, 1024 * 1024 * 1024 end
+        assert.is_false(Cache.checkAllMemoryPressure())
+        assert.are.equal(0, chopped)
+    end)
+
+    it("should do nothing on platforms without memory info", function()
+        util.calcFreeMem = function() return nil, nil end
+        assert.is_false(Cache.checkAllMemoryPressure())
+        assert.are.equal(0, chopped)
+    end)
+
+    it("should chop every registered cache when redlining", function()
+        util.calcFreeMem = function() return 64 * 1024 * 1024, 1024 * 1024 * 1024 end
+        assert.is_true(Cache.checkAllMemoryPressure())
+        assert.are.equal(1, chopped)
+    end)
+
+    it("should still support the single-cache check", function()
+        util.calcFreeMem = function() return 64 * 1024 * 1024, 1024 * 1024 * 1024 end
+        assert.is_true(probe:memoryPressureCheck())
+        assert.is_true(chopped >= 1)
+    end)
+end)
+
+describe("Cache resizing", function()
+    local Cache, DocCache, util
+    local orig_calcFreeMem
+
+    setup(function()
+        require("commonrequire")
+        Cache = require("cache")
+        DocCache = require("document/doccache")
+        util = require("util")
+        orig_calcFreeMem = util.calcFreeMem
+    end)
+    teardown(function()
+        util.calcFreeMem = orig_calcFreeMem
+    end)
+
+    it("should rebuild the LRU against a new budget", function()
+        local cache = Cache:new{ size = 8 * 1024 * 1024, avg_itemsize = 1024 * 1024 }
+        assert.are.equal(8, cache.slots)
+        assert.is_true(cache:resize(4 * 1024 * 1024))
+        assert.are.equal(4 * 1024 * 1024, cache.size)
+        assert.are.equal(4, cache.slots)
+    end)
+
+    it("should ignore a no-op resize", function()
+        local cache = Cache:new{ size = 8 * 1024 * 1024, avg_itemsize = 1024 * 1024 }
+        assert.is_false(cache:resize(8 * 1024 * 1024))
+        assert.is_false(cache:resize(nil))
+    end)
+
+    it("should re-evaluate the document cache budget on a substantial change", function()
+        if not DocCache.size then return end -- cache was disabled at load time
+        util.calcFreeMem = function() return 1000 * 1024 * 1024, 2048 * 1024 * 1024 end
+        DocCache:reevaluate()
+        local before = DocCache.size
+
+        util.calcFreeMem = function() return 400 * 1024 * 1024, 2048 * 1024 * 1024 end
+        assert.is_true(DocCache:reevaluate())
+        assert.is_true(DocCache.size < before)
+    end)
+
+    it("should leave the document cache alone on a small change", function()
+        if not DocCache.size then return end
+        util.calcFreeMem = function() return 400 * 1024 * 1024, 2048 * 1024 * 1024 end
+        DocCache:reevaluate()
+        local before = DocCache.size
+
+        util.calcFreeMem = function() return 440 * 1024 * 1024, 2048 * 1024 * 1024 end
+        assert.is_false(DocCache:reevaluate())
+        assert.are.equal(before, DocCache.size)
+    end)
+end)

--- a/spec/unit/document_spec.lua
+++ b/spec/unit/document_spec.lua
@@ -80,3 +80,38 @@ describe("EPUB document module", function()
         doc:close()
     end)
 end)
+
+describe("CreDocument storage size factor", function()
+    local CreDocument, util
+    local orig_calcFreeMem
+
+    setup(function()
+        require("commonrequire")
+        CreDocument = require("document/credocument")
+        util = require("util")
+        orig_calcFreeMem = util.calcFreeMem
+    end)
+    teardown(function()
+        util.calcFreeMem = orig_calcFreeMem
+    end)
+
+    local function withTotalMem(mb)
+        util.calcFreeMem = function() return mb * 1024 * 1024 / 2, mb * 1024 * 1024 end
+    end
+
+    it("should scale with total memory", function()
+        withTotalMem(256)
+        assert.is_equal(5, CreDocument.getDefaultStorageSizeFactor())
+        withTotalMem(512)
+        assert.is_equal(10, CreDocument.getDefaultStorageSizeFactor())
+        withTotalMem(1024)
+        assert.is_equal(20, CreDocument.getDefaultStorageSizeFactor())
+        withTotalMem(4096)
+        assert.is_equal(40, CreDocument.getDefaultStorageSizeFactor())
+    end)
+
+    it("should keep the previous default when memory is unknown", function()
+        util.calcFreeMem = function() return nil, nil end
+        assert.is_equal(40, CreDocument.getDefaultStorageSizeFactor())
+    end)
+end)

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -496,4 +496,55 @@ describe("util module", function()
                 util.urlDecode(util.urlEncode("~^-_%!*'();:@&=+$,/?#[]")))
         end)
     end)
+
+    describe("canForkSafely", function()
+        local orig_calcFreeMem, orig_getRSS
+        setup(function()
+            orig_calcFreeMem = util.calcFreeMem
+            orig_getRSS = util.getRSS
+        end)
+        teardown(function()
+            util.calcFreeMem = orig_calcFreeMem
+            util.getRSS = orig_getRSS
+        end)
+
+        it("should allow forking when free memory covers the estimate", function()
+            util.getRSS = function() return 120 * 1024 * 1024 end
+            util.calcFreeMem = function() return 200 * 1024 * 1024, 512 * 1024 * 1024 end
+            assert.is_true((util.canForkSafely()))
+        end)
+
+        it("should refuse forking when free memory is short", function()
+            util.getRSS = function() return 120 * 1024 * 1024 end
+            util.calcFreeMem = function() return 40 * 1024 * 1024, 512 * 1024 * 1024 end
+            local ok, memfree, needed = util.canForkSafely()
+            assert.is_false(ok)
+            assert.is_equal(40 * 1024 * 1024, memfree)
+            assert.is_equal(72 * 1024 * 1024, needed)
+        end)
+
+        it("should apply a floor for small parents", function()
+            util.getRSS = function() return 10 * 1024 * 1024 end
+            util.calcFreeMem = function() return 30 * 1024 * 1024, 512 * 1024 * 1024 end
+            local ok, _, needed = util.canForkSafely()
+            assert.is_false(ok)
+            assert.is_equal(40 * 1024 * 1024, needed)
+        end)
+
+        it("should honour a custom ratio", function()
+            util.getRSS = function() return 400 * 1024 * 1024 end
+            util.calcFreeMem = function() return 100 * 1024 * 1024, 1024 * 1024 * 1024 end
+            assert.is_true((util.canForkSafely(0.2)))
+        end)
+
+        it("should not change behaviour on unsupported platforms", function()
+            util.getRSS = function() return nil end
+            util.calcFreeMem = function() return 1, 1 end
+            assert.is_true((util.canForkSafely()))
+
+            util.getRSS = function() return 120 * 1024 * 1024 end
+            util.calcFreeMem = function() return nil, nil end
+            assert.is_true((util.canForkSafely()))
+        end)
+    end)
 end)


### PR DESCRIPTION
## Problem

On a 512 MB Kindle PW5 SE, a large EPUB (金庸作品全集, 16.7 MB / 12,790 pages) reliably got KOReader OOM-killed:

```
Book open completed ... elapsed_ms= 2255          <- partial rerendering, fast open
... user changes a text setting ...
CRE WARNING: cached rendering is invalid (style hash mismatch): doing full rendering
Killed
```

The partial-rerendering automation forked a full render, reloaded the document, the crengine cache was rejected on a style hash mismatch, and the resulting *foreground* full rendering was killed by the OOM killer.

Looking into it turned up four separate places where memory is claimed or spent without regard for what's actually available.

## Changes

### 1. `Cache.checkAllMemoryPressure()` — the existing sweep never ran on the CRE path

`Cache:memoryPressureCheck()` already exists and does the right thing (evict half, force a GC when free RAM < 20%), but its only caller is `KoptInterface:hintPage`, i.e. the k2pdfopt/reflow path. Reading an EPUB never triggers it.

This adds a weak-valued registry of live `Cache` instances and a class-level sweep driven by a single free-RAM read, then calls it from the rerendering-automation tick and from thumbnail generation. `memoryPressureCheck` keeps its signature and behaviour, so the koptinterface call site is untouched.

### 2. `DocCache:reevaluate()` — the budget was frozen at startup

`doccache_size` is computed once, at `require` time. On Kindle that's immediately after `koreader.sh` kills the framework, when free RAM is at its daily peak; a book opened hours later still gets a boot-time budget.

Adds `Cache:resize()` and `DocCache:reevaluate()`, called from `DocumentRegistry:openDocument` where a GC is already forced and the cache is about to turn over anyway. Gated on a 25% change so routine opens don't discard a warm cache.

### 3. `util.canForkSafely()` — no admission control on any of the three fork sites

`ReaderRolling:_rerenderInBackground` carries this comment:

> Ie. with a big book and KOReader taking 120 MB, the subprocess would additionally use:
> - 60 MB when doing a simple rerendering
> - 130 MB when doing a full load+render

…but nothing checks whether that's available. Same for `ReaderThumbnail` and coverbrowser's metadata extractor.

Adds `util.getRSS()` and `util.canForkSafely()` (60% of current RSS, 40 MB floor, derived from the estimate above) and consults them before forking. Critically, when the rerendering automation can't fork it **stays in `FULL_RENDERING_IN_BACKGROUND` and retries** (1 s, backing off to 60 s) rather than advancing to `FULL_RENDERING_READY` → reload → foreground rerender. Deferring leaves the book in its documented degraded partial-render state, which beats being killed.

Thumbnail requests are requeued rather than dropped; the memory poll there is throttled to 5 s since that loop runs several times a second. Coverbrowser returns `false`, which callers already handle as a fork failure.

`util.canForkSafely()` returns `true` when `/proc` isn't available, so non-Linux builds are unaffected.

### 4. `cre_storage_size_factor` now scales with total RAM

The default was a flat `40`, multiplying crengine's ~12.5 MB of base in-memory caches toward a ~500 MB ceiling — on a device that has 512 MB in total. The existing comment already tells users to fix this by hand:

> People who would get out of memory crashes with big books on older devices can decrease that with setting: `"cre_storage_size_factor"=1` (or 2, or 5)

`util.calcFreeMem()` already returns `memtotal` as its second value, so the default is now derived from it: `<384 MB → 5`, `<768 MB → 10`, `<1.5 GB → 20`, else `40` (unchanged). An explicit `cre_storage_size_factor` setting still takes precedence, and devices with ≥1.5 GB see no change.

This also gives `bookinfomanager.lua` a shared definition. It had its own copy hardcoded to `20` under a `-- note: keep in sync with the one in credocument.lua` comment, which had drifted.

## Tests

Added to `spec/unit/cache_spec.lua`, `spec/unit/util_spec.lua` and `spec/unit/document_spec.lua`. They stub `util.calcFreeMem`/`util.getRSS` rather than depending on the host's real memory:

- registry population, sweep no-op vs. chop, unsupported-platform no-op
- `Cache:resize` rebuilds the LRU; no-op resize returns false
- `DocCache:reevaluate` acts on a large change, ignores a small one
- `canForkSafely` boundaries incl. the 40 MB floor, custom ratio, and nil `getRSS`
- storage-factor tiering and the `memtotal == nil` fallback

## Notes

- No settings migration; no changes to `DGLOBAL_CACHE_*` in `defaults.lua`.
- Nothing in `base/`/crengine is touched.
- Verified on the device that triggered this: the same book that produced `Killed` now logs `deferring background rerendering, low memory (...)` and survives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15763)
<!-- Reviewable:end -->
