### PR TITLE
Kindle: decide the frontlight state when the resume callback runs

### DIFF
--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -334,16 +334,20 @@ function KindlePowerD:afterResume()
     if not self.device:hasFrontlight() then
         return
     end
-    if self:isFrontlightOn() then
-        -- The Kindle framework should turn the front light back on automatically.
-        -- The following statement ensures consistency of intensity, but should basically always be redundant,
-        -- since we set intensity via lipc and not sysfs ;).
-        -- NOTE: This is race-y, and we want to *lose* the race, hence the use of the scheduler (c.f., #4392)
-        UIManager:tickAfterNext(function() self:turnOnFrontlightHW() end)
-    else
-        -- But in the off case, we *do* use sysfs, so this one actually matters.
-        UIManager:tickAfterNext(function() self:turnOffFrontlightHW() end)
-    end
+    -- NOTE: This is race-y, and we want to *lose* the race, hence the use of the scheduler (c.f., #4392)
+    --       Decide once we actually run: plugins reacting to the Resume event we just broadcast may
+    --       have adjusted the frontlight in between, and we don't want to clobber that.
+    UIManager:tickAfterNext(function()
+        if self:isFrontlightOn() then
+            -- The Kindle framework should turn the front light back on automatically.
+            -- The following statement ensures consistency of intensity, but should basically always be redundant,
+            -- since we set intensity via lipc and not sysfs ;).
+            self:turnOnFrontlightHW()
+        else
+            -- But in the off case, we *do* use sysfs, so this one actually matters.
+            self:turnOffFrontlightHW()
+        end
+    end)
 end
 
 function KindlePowerD:UIManagerReadyHW(uimgr)


### PR DESCRIPTION
## Problem

`KindlePowerD:afterResume()` broadcasts the `Resume` event, then schedules the frontlight re-apply two ticks later so it loses the race against the framework (#4392). But it picks `turnOn` vs `turnOff` **immediately**, from the pre-suspend `is_fl_on`:

```lua
self.device:_afterResume()          -- broadcasts Resume

if self:isFrontlightOn() then                                     -- decided here
    UIManager:tickAfterNext(function() self:turnOnFrontlightHW() end)
else
    UIManager:tickAfterNext(function() self:turnOffFrontlightHW() end)
end
```

By the time the callback runs, the choice is already baked in. Anything that adjusts the frontlight while handling `Resume` lands on the tick in between and is then clobbered:

| Tick | |
|---|---|
| N | `Resume` broadcast → a plugin schedules its frontlight work on `nextTick` |
| N | powerd picks `turnOffFrontlightHW` from the stale `is_fl_on` for `tickAfterNext` |
| N+1 | the plugin sets the intensity → light comes on |
| N+2 | the already-decided `turnOffFrontlightHW()` fires → writes 0 to lipc **and** every `fl_intensity_files` node → light off again |

I hit this on a Paperwhite with a magnetic cover and a plugin that applies a scheduled brightness on resume: opening the cover left the light off even though the schedule had just turned it on. Because `fl_intensity` survives the toggle, a manual change in the menu brings it straight back — which is what made it look like a plugin bug rather than an ordering one.

Anything that touches the frontlight during resume is affected, including a `profiles.koplugin` profile bound to `Resume` or `OutOfScreenSaver` (the latter is broadcast from `Screensaver:close()`, i.e. even earlier in `Kindle:outofScreenSaver`), and `autodim.koplugin`'s `restoreFrontlight`.

## Change

Move the on/off decision inside the callback so it reflects the state at the moment it actually runs. Still deferred via `tickAfterNext`, so the `#4392` behaviour of losing the race against the framework is preserved.

When nothing touches the frontlight during resume, `is_fl_on` is unchanged between the two points and the behaviour is identical to before.

## Testing

Tested on a Kindle Paperwhite 5 SE (`KindlePaperWhite5SE`) with the magnetic cover: with the frontlight off, closing and reopening the cover now brings it up at the scheduled level instead of staying dark. Suspend/resume with no frontlight activity in between behaves as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15764)
<!-- Reviewable:end -->
