### PR TITLE
Wallabag: skip archive dir in recursive scan

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -1421,15 +1421,11 @@ function Wallabag:archiveLocalArticle(path)
     if lfs.attributes(path, "mode") == "file" then
         local _, file = util.splitFilePathName(path)
         local new_path = ffiUtil.joinPath(self.archive_directory, file)
-        if path == new_path then -- Already archived
+        if FileManager:moveFile(path, new_path) then
             result = true
-        else
-            if FileManager:moveFile(path, new_path) then
-                result = true
-            end
-            DocSettings.updateLocation(path, new_path, false) -- move sdr
-            --- @todo Why is sdr copied instead of moved?
         end
+        DocSettings.updateLocation(path, new_path, false) -- move sdr
+        --- @todo Why is sdr copied instead of moved?
     end
 
     return result
@@ -1487,6 +1483,10 @@ function Wallabag:getLocalArticles(dir, map)
 
     if map == nil then
         map = {}
+    end
+
+    if dir == self.archive_directory then
+        return map
     end
 
     for entry in lfs.dir(dir) do


### PR DESCRIPTION
Including the archive dir in the result of Wallabag:getLocalArticles causes all archived articles' statuses to be synced with Wallabag every time. That leads to an increase in sync times from seconds to minutes (or even more if one's archive is larger than hundreds…).

The fix is simple: skip the archive dir when scanning.

(As a side effect, this allows one to organise their archive dir using subdirs, which is similar to the motivation of the PR that broke this…)

Fixes: 896646bf8bb0 ("Reworked the Wallabag plugin to recursively scan the download directory (#15558)")
Fixes: https://github.com/koreader/koreader/pull/15558#issuecomment-5136923551

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15767)
<!-- Reviewable:end -->
