### PR TITLE
Screenshoter: fix screenshot folder shortcut crash

### DIFF
--- a/frontend/ui/widget/screenshoter.lua
+++ b/frontend/ui/widget/screenshoter.lua
@@ -138,7 +138,7 @@ function Screenshoter:chooseFolder()
     local default_path = self.default_dir
     local caller_callback = function(path)
         local ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
-        ui.folder_shortcuts:updateShortcut("screenshot", path)
+        ui.folder_shortcuts:updateShortcut("screenshot_dir", path)
         G_reader_settings:saveSetting("screenshot_dir", path)
     end
     filemanagerutil.showChooseDialog(title_header, caller_callback, current_path, default_path)


### PR DESCRIPTION
# Screenshoter: fix screenshot folder shortcut crash

Closes #15775.

`Screenshoter:chooseFolder()` passed `screenshot` to `FileManagerShortcuts:updateShortcut()`, but the registered provider key is `screenshot_dir`. Use the registered key so selecting a screenshot folder no longer indexes a missing provider and crashes.

Tests:

- `luac -p frontend/ui/widget/screenshoter.lua`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15776)
<!-- Reviewable:end -->
