### PR TITLE
ReaderToc: expand/collapse the focused node with arrow keys on non-touch devices

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1012,10 +1012,8 @@ function ReaderToc:onShowToc()
     -- Tree-view idiom: right arrow key expands the focused node, left collapses
     -- it (swapped in mirrored UI layout). Replaces the horizontal focus moves,
     -- no-ops in this single-column menu; hasFewKeys devices use these keys otherwise.
-    local function applyTreeKeyMappings()
-        if not Device:hasDPad() or Device:hasFewKeys() then return end
-        toc_menu.key_events.FocusRight = nil
-        toc_menu.key_events.FocusLeft = nil
+    if Device:hasDPad() and not Device:hasFewKeys() then
+        toc_menu:releaseFocusKeys("FocusLeft", "FocusRight")
         local expand_key, collapse_key = "Right", "Left"
         if BD.mirroredUILayout() then
             expand_key, collapse_key = collapse_key, expand_key
@@ -1023,7 +1021,6 @@ function ReaderToc:onShowToc()
         toc_menu.key_events.ExpandCurrentNode = { { expand_key } }
         toc_menu.key_events.CollapseCurrentNode = { { collapse_key } }
     end
-    applyTreeKeyMappings()
 
     toc_menu.onExpandCurrentNode = function(menu)
         local focused_widget = menu:getFocusItem()
@@ -1041,13 +1038,6 @@ function ReaderToc:onShowToc()
             self:collapseToc(item.index, true)
         end
         return true
-    end
-
-    local base_onPhysicalKeyboardConnected = toc_menu.onPhysicalKeyboardConnected
-    toc_menu.onPhysicalKeyboardConnected = function(menu)
-        -- The generic handler re-merges the default key mappings — reapply ours.
-        base_onPhysicalKeyboardConnected(menu)
-        applyTreeKeyMappings()
     end
 
     toc_menu.close_callback = function()

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1009,12 +1009,9 @@ function ReaderToc:onShowToc()
         return true
     end
 
-    -- Keyboard tree-view idiom: expand the focused node with the right arrow
-    -- key, collapse it with the left one (swapped in mirrored UI layout, to
-    -- match the rotated expand icon). Both keys are otherwise no-ops in this
-    -- single-column menu, so unmap the horizontal focus moves to avoid
-    -- handling the same keys twice. Not for hasFewKeys devices, where Menu
-    -- already maps Left to close and Right to hold.
+    -- Tree-view idiom: right arrow key expands the focused node, left collapses
+    -- it (swapped in mirrored UI layout). Replaces the horizontal focus moves,
+    -- no-ops in this single-column menu; hasFewKeys devices use these keys otherwise.
     local function applyTreeKeyMappings()
         if not Device:hasDPad() or Device:hasFewKeys() then return end
         toc_menu.key_events.FocusRight = nil
@@ -1048,10 +1045,7 @@ function ReaderToc:onShowToc()
 
     local base_onPhysicalKeyboardConnected = toc_menu.onPhysicalKeyboardConnected
     toc_menu.onPhysicalKeyboardConnected = function(menu)
-        -- The FocusManager handler re-merges the generic key mappings, which
-        -- restores the horizontal focus moves we unmapped — reapply ours on
-        -- top. Also covers a keyboard hot-plugged while the ToC is open on a
-        -- touch-only device.
+        -- The generic handler re-merges the default key mappings — reapply ours.
         base_onPhysicalKeyboardConnected(menu)
         applyTreeKeyMappings()
     end
@@ -1156,8 +1150,7 @@ function ReaderToc:searchToc()
     input_dialog:onShowKeyboard()
 end
 
--- Keep the focus on the node that was just expanded or collapsed: without
--- this, the menu rebuild would reset the focus to the first item of the page.
+-- Keep the focus on the toggled node across the menu rebuild.
 function ReaderToc:refocusTocNode(node)
     if not Device:hasDPad() then return end
     for i, v in ipairs(self.collapsed_toc) do
@@ -1169,9 +1162,7 @@ function ReaderToc:refocusTocNode(node)
 end
 
 -- expand TOC node of index in raw toc table
--- refocus: keep the focus on the node even on touch-capable devices; set by the
--- key-driven callers, where the focus is part of the interaction. Toggles not
--- driven by keys preserve it only on non-touch devices, where it's always shown.
+-- refocus: keep the focus even on touch-capable devices (set by key-driven callers)
 function ReaderToc:expandToc(index, refocus)
     if self.expanded_nodes[index] == true then return end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1009,13 +1009,14 @@ function ReaderToc:onShowToc()
         return true
     end
 
-    if Device:hasDPad() and not Device:hasFewKeys() then
-        -- Keyboard tree-view idiom: expand the focused node with the right arrow
-        -- key, collapse it with the left one (swapped in mirrored UI layout, to
-        -- match the rotated expand icon). Both keys are otherwise no-ops in this
-        -- single-column menu, so unmap the horizontal focus moves to avoid
-        -- handling the same keys twice. Not for hasFewKeys devices, where Menu
-        -- already maps Left to close and Right to hold.
+    -- Keyboard tree-view idiom: expand the focused node with the right arrow
+    -- key, collapse it with the left one (swapped in mirrored UI layout, to
+    -- match the rotated expand icon). Both keys are otherwise no-ops in this
+    -- single-column menu, so unmap the horizontal focus moves to avoid
+    -- handling the same keys twice. Not for hasFewKeys devices, where Menu
+    -- already maps Left to close and Right to hold.
+    local function applyTreeKeyMappings()
+        if not Device:hasDPad() or Device:hasFewKeys() then return end
         toc_menu.key_events.FocusRight = nil
         toc_menu.key_events.FocusLeft = nil
         local expand_key, collapse_key = "Right", "Left"
@@ -1024,24 +1025,35 @@ function ReaderToc:onShowToc()
         end
         toc_menu.key_events.ExpandCurrentNode = { { expand_key } }
         toc_menu.key_events.CollapseCurrentNode = { { collapse_key } }
+    end
+    applyTreeKeyMappings()
 
-        toc_menu.onExpandCurrentNode = function(menu)
-            local focused_widget = menu:getFocusItem()
-            local item = focused_widget and focused_widget.entry
-            if item and item.state and item.state.icon == "control.expand" then
-                self:expandToc(item.index, true)
-            end
-            return true
+    toc_menu.onExpandCurrentNode = function(menu)
+        local focused_widget = menu:getFocusItem()
+        local item = focused_widget and focused_widget.entry
+        if item and item.state and item.state.icon == "control.expand" then
+            self:expandToc(item.index, true)
         end
+        return true
+    end
 
-        toc_menu.onCollapseCurrentNode = function(menu)
-            local focused_widget = menu:getFocusItem()
-            local item = focused_widget and focused_widget.entry
-            if item and item.state and item.state.icon == "control.collapse" then
-                self:collapseToc(item.index, true)
-            end
-            return true
+    toc_menu.onCollapseCurrentNode = function(menu)
+        local focused_widget = menu:getFocusItem()
+        local item = focused_widget and focused_widget.entry
+        if item and item.state and item.state.icon == "control.collapse" then
+            self:collapseToc(item.index, true)
         end
+        return true
+    end
+
+    local base_onPhysicalKeyboardConnected = toc_menu.onPhysicalKeyboardConnected
+    toc_menu.onPhysicalKeyboardConnected = function(menu)
+        -- The FocusManager handler re-merges the generic key mappings, which
+        -- restores the horizontal focus moves we unmapped — reapply ours on
+        -- top. Also covers a keyboard hot-plugged while the ToC is open on a
+        -- touch-only device.
+        base_onPhysicalKeyboardConnected(menu)
+        applyTreeKeyMappings()
     end
 
     toc_menu.close_callback = function()

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1072,6 +1072,10 @@ function ReaderToc:onShowToc()
         end
     end
 
+    if self.collapsed_toc.current then
+        self:refocusTocNode(self.collapsed_toc[self.collapsed_toc.current])
+    end
+
     -- auto goto page of the current toc entry
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, self.collapsed_toc.current or -1)
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1025,20 +1025,20 @@ function ReaderToc:onShowToc()
         toc_menu.key_events.ExpandCurrentNode = { { expand_key } }
         toc_menu.key_events.CollapseCurrentNode = { { collapse_key } }
 
-        function toc_menu:onExpandCurrentNode()
-            local focused_widget = self:getFocusItem()
+        toc_menu.onExpandCurrentNode = function(menu)
+            local focused_widget = menu:getFocusItem()
             local item = focused_widget and focused_widget.entry
             if item and item.state and item.state.icon == "control.expand" then
-                item.state.callback(item.index)
+                self:expandToc(item.index, true)
             end
             return true
         end
 
-        function toc_menu:onCollapseCurrentNode()
-            local focused_widget = self:getFocusItem()
+        toc_menu.onCollapseCurrentNode = function(menu)
+            local focused_widget = menu:getFocusItem()
             local item = focused_widget and focused_widget.entry
             if item and item.state and item.state.icon == "control.collapse" then
-                item.state.callback(item.index)
+                self:collapseToc(item.index, true)
             end
             return true
         end
@@ -1146,9 +1146,8 @@ end
 
 -- Keep the focus on the node that was just expanded or collapsed: without
 -- this, the menu rebuild would reset the focus to the first item of the page.
--- Touch-only devices don't show the focus, nothing to preserve there.
 function ReaderToc:refocusTocNode(node)
-    if not Device:hasDPad() or Device:isTouchDevice() then return end
+    if not Device:hasDPad() then return end
     for i, v in ipairs(self.collapsed_toc) do
         if v == node then
             self.toc_menu.itemnumber = i
@@ -1158,7 +1157,10 @@ function ReaderToc:refocusTocNode(node)
 end
 
 -- expand TOC node of index in raw toc table
-function ReaderToc:expandToc(index)
+-- refocus: keep the focus on the node even on touch-capable devices; set by the
+-- key-driven callers, where the focus is part of the interaction. Toggles not
+-- driven by keys preserve it only on non-touch devices, where it's always shown.
+function ReaderToc:expandToc(index, refocus)
     if self.expanded_nodes[index] == true then return end
 
     self.expanded_nodes[index] = true
@@ -1188,12 +1190,15 @@ function ReaderToc:expandToc(index)
     if cur_node.state then cur_node.state:free() end
     cur_node.state = self.collapse_button:new{}
     self:updateCurrentNode()
-    self:refocusTocNode(cur_node)
+    if refocus or not Device:isTouchDevice() then
+        self:refocusTocNode(cur_node)
+    end
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, -1)
 end
 
 -- collapse TOC node of index in raw toc table
-function ReaderToc:collapseToc(index)
+-- refocus: see expandToc
+function ReaderToc:collapseToc(index, refocus)
     if self.expanded_nodes[index] == true then
         self.expanded_nodes[index] = nil
     end
@@ -1227,7 +1232,9 @@ function ReaderToc:collapseToc(index)
     cur_node.state:free()
     cur_node.state = self.expand_button:new{}
     self:updateCurrentNode()
-    self:refocusTocNode(cur_node)
+    if refocus or not Device:isTouchDevice() then
+        self:refocusTocNode(cur_node)
+    end
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, -1)
 end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1021,10 +1021,9 @@ function ReaderToc:onShowToc()
             return
         end
         menu:releaseFocusKeys("FocusLeft", "FocusRight")
-        local expand_key, collapse_key = "Right", "Left"
-        if BD.mirroredUILayout() then
-            expand_key, collapse_key = collapse_key, expand_key
-        end
+        local mirrored = BD.mirroredUILayout()
+        local expand_key = mirrored and "Left" or "Right"
+        local collapse_key = mirrored and "Right" or "Left"
         menu.key_events.ExpandCurrentNode = { { expand_key } }
         menu.key_events.CollapseCurrentNode = { { collapse_key } }
     end

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1012,11 +1012,8 @@ function ReaderToc:onShowToc()
     -- Tree-view idiom: right arrow key expands the focused node, left collapses
     -- it (swapped in mirrored UI layout). Replaces the horizontal focus moves,
     -- no-ops in this single-column menu; hasFewKeys devices use these keys otherwise.
-    -- A menu created with the few-keys bindings (Left close, Right hold) keeps them:
-    -- tree keys would clash with them when a keyboard hot-plug clears hasFewKeys.
-    local created_with_few_keys = Device:hasFewKeys()
     local function applyTreeKeyMappings()
-        if not Device:hasDPad() or Device:hasFewKeys() or created_with_few_keys then return end
+        if not Device:hasDPad() or Device:hasFewKeys() then return end
         toc_menu.key_events.FocusRight = nil
         toc_menu.key_events.FocusLeft = nil
         local expand_key, collapse_key = "Right", "Left"

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1144,6 +1144,19 @@ function ReaderToc:searchToc()
     input_dialog:onShowKeyboard()
 end
 
+-- Keep the focus on the node that was just expanded or collapsed: without
+-- this, the menu rebuild would reset the focus to the first item of the page.
+-- Touch-only devices don't show the focus, nothing to preserve there.
+function ReaderToc:refocusTocNode(node)
+    if not Device:hasDPad() or Device:isTouchDevice() then return end
+    for i, v in ipairs(self.collapsed_toc) do
+        if v == node then
+            self.toc_menu.itemnumber = i
+            break
+        end
+    end
+end
+
 -- expand TOC node of index in raw toc table
 function ReaderToc:expandToc(index)
     if self.expanded_nodes[index] == true then return end
@@ -1175,6 +1188,7 @@ function ReaderToc:expandToc(index)
     if cur_node.state then cur_node.state:free() end
     cur_node.state = self.collapse_button:new{}
     self:updateCurrentNode()
+    self:refocusTocNode(cur_node)
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, -1)
 end
 
@@ -1213,6 +1227,7 @@ function ReaderToc:collapseToc(index)
     cur_node.state:free()
     cur_node.state = self.expand_button:new{}
     self:updateCurrentNode()
+    self:refocusTocNode(cur_node)
     self.toc_menu:switchItemTable(nil, self.collapsed_toc, -1)
 end
 

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1012,8 +1012,11 @@ function ReaderToc:onShowToc()
     -- Tree-view idiom: right arrow key expands the focused node, left collapses
     -- it (swapped in mirrored UI layout). Replaces the horizontal focus moves,
     -- no-ops in this single-column menu; hasFewKeys devices use these keys otherwise.
+    -- A menu created with the few-keys bindings (Left close, Right hold) keeps them:
+    -- tree keys would clash with them when a keyboard hot-plug clears hasFewKeys.
+    local created_with_few_keys = Device:hasFewKeys()
     local function applyTreeKeyMappings()
-        if not Device:hasDPad() or Device:hasFewKeys() then return end
+        if not Device:hasDPad() or Device:hasFewKeys() or created_with_few_keys then return end
         toc_menu.key_events.FocusRight = nil
         toc_menu.key_events.FocusLeft = nil
         local expand_key, collapse_key = "Right", "Left"

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1009,6 +1009,41 @@ function ReaderToc:onShowToc()
         return true
     end
 
+    if Device:hasDPad() and not Device:hasFewKeys() then
+        -- Keyboard tree-view idiom: expand the focused node with the right arrow
+        -- key, collapse it with the left one (swapped in mirrored UI layout, to
+        -- match the rotated expand icon). Both keys are otherwise no-ops in this
+        -- single-column menu, so unmap the horizontal focus moves to avoid
+        -- handling the same keys twice. Not for hasFewKeys devices, where Menu
+        -- already maps Left to close and Right to hold.
+        toc_menu.key_events.FocusRight = nil
+        toc_menu.key_events.FocusLeft = nil
+        local expand_key, collapse_key = "Right", "Left"
+        if BD.mirroredUILayout() then
+            expand_key, collapse_key = collapse_key, expand_key
+        end
+        toc_menu.key_events.ExpandCurrentNode = { { expand_key } }
+        toc_menu.key_events.CollapseCurrentNode = { { collapse_key } }
+
+        function toc_menu:onExpandCurrentNode()
+            local focused_widget = self:getFocusItem()
+            local item = focused_widget and focused_widget.entry
+            if item and item.state and item.state.icon == "control.expand" then
+                item.state.callback(item.index)
+            end
+            return true
+        end
+
+        function toc_menu:onCollapseCurrentNode()
+            local focused_widget = self:getFocusItem()
+            local item = focused_widget and focused_widget.entry
+            if item and item.state and item.state.icon == "control.collapse" then
+                item.state.callback(item.index)
+            end
+            return true
+        end
+    end
+
     toc_menu.close_callback = function()
         UIManager:close(menu_container)
         BD.resetInvert()

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -1012,15 +1012,23 @@ function ReaderToc:onShowToc()
     -- Tree-view idiom: right arrow key expands the focused node, left collapses
     -- it (swapped in mirrored UI layout). Replaces the horizontal focus moves,
     -- no-ops in this single-column menu; hasFewKeys devices use these keys otherwise.
-    if Device:hasDPad() and not Device:hasFewKeys() then
-        toc_menu:releaseFocusKeys("FocusLeft", "FocusRight")
+    -- Runs again whenever the focus keys are rebuilt, e.g. when a hot-plugged
+    -- keyboard brings a D-Pad along.
+    toc_menu.focus_keys_callback = function(menu)
+        if not Device:hasDPad() or Device:hasFewKeys() then
+            menu.key_events.ExpandCurrentNode = nil
+            menu.key_events.CollapseCurrentNode = nil
+            return
+        end
+        menu:releaseFocusKeys("FocusLeft", "FocusRight")
         local expand_key, collapse_key = "Right", "Left"
         if BD.mirroredUILayout() then
             expand_key, collapse_key = collapse_key, expand_key
         end
-        toc_menu.key_events.ExpandCurrentNode = { { expand_key } }
-        toc_menu.key_events.CollapseCurrentNode = { { collapse_key } }
+        menu.key_events.ExpandCurrentNode = { { expand_key } }
+        menu.key_events.CollapseCurrentNode = { { collapse_key } }
     end
+    toc_menu:focus_keys_callback()
 
     toc_menu.onExpandCurrentNode = function(menu)
         local focused_widget = menu:getFocusItem()

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -140,6 +140,8 @@ end
 
 -- Re-drop the released keys after the defaults came back, and let the widget
 -- rebind its own keys: a hot-plug may just have brought a D-Pad along.
+-- The widget makes the first call itself, once it is fully built; we're not
+-- calling this from _init, where its own bindings aren't in place yet.
 function FocusManager:_refreshFocusKeys()
     for name in pairs(self.released_focus_keys or {}) do
         self.key_events[name] = nil
@@ -332,6 +334,7 @@ function FocusManager:onPhysicalKeyboardDisconnected()
         self:_refreshFocusKeys()
     else
         -- If we longer have keys at all, that's easy ;).
+        -- No point in asking the widget to rebind anything, either.
         self.key_events = {}
     end
     self.builtin_key_events = BUILTIN_KEY_EVENTS

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -122,6 +122,19 @@ function FocusManager:_init()
     self.extra_key_events = EXTRA_KEY_EVENTS
 end
 
+--- Releases focus keys a widget wants for itself, e.g. the horizontal moves in a
+--- single-column menu. They stay released when a keyboard hot-plug re-merges the
+--- default mappings.
+function FocusManager:releaseFocusKeys(...)
+    if not self.released_focus_keys then
+        self.released_focus_keys = {}
+    end
+    for _, name in ipairs({...}) do
+        self.released_focus_keys[name] = true
+        self.key_events[name] = nil
+    end
+end
+
 function FocusManager:isAlternativeKey(key)
     for _, seq in pairs(self.extra_key_events) do
         for _, oneseq in ipairs(seq) do
@@ -284,6 +297,9 @@ function FocusManager:onPhysicalKeyboardConnected()
     -- and it'll call InputContainer._init, which *also* resets the touch zones.
     -- Instead, we'll just do a merge ourselves.
     util.tableMerge(self.key_events, KEY_EVENTS)
+    for name in pairs(self.released_focus_keys or {}) do
+        self.key_events[name] = nil
+    end
     -- populateEventMappings replaces these, so, update our refs
     self.builtin_key_events = BUILTIN_KEY_EVENTS
     self.extra_key_events = EXTRA_KEY_EVENTS

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -32,6 +32,9 @@ local FocusManager = InputContainer:extend{
     layout = nil, -- mandatory
     movement_allowed = { x = true, y = true },
     key_events_enabled = true,
+    -- Widgets that bind keys the focus manager also uses set this; see releaseFocusKeys.
+    focus_keys_callback = nil,
+    released_focus_keys = nil,
 }
 
 -- Only build the default mappings once on initialization, or when an external keyboard is (dis-)/connected.
@@ -132,6 +135,17 @@ function FocusManager:releaseFocusKeys(...)
     for _, name in ipairs({...}) do
         self.released_focus_keys[name] = true
         self.key_events[name] = nil
+    end
+end
+
+-- Re-drop the released keys after the defaults came back, and let the widget
+-- rebind its own keys: a hot-plug may just have brought a D-Pad along.
+function FocusManager:_refreshFocusKeys()
+    for name in pairs(self.released_focus_keys or {}) do
+        self.key_events[name] = nil
+    end
+    if self.focus_keys_callback then
+        self:focus_keys_callback()
     end
 end
 
@@ -297,9 +311,7 @@ function FocusManager:onPhysicalKeyboardConnected()
     -- and it'll call InputContainer._init, which *also* resets the touch zones.
     -- Instead, we'll just do a merge ourselves.
     util.tableMerge(self.key_events, KEY_EVENTS)
-    for name in pairs(self.released_focus_keys or {}) do
-        self.key_events[name] = nil
-    end
+    self:_refreshFocusKeys()
     -- populateEventMappings replaces these, so, update our refs
     self.builtin_key_events = BUILTIN_KEY_EVENTS
     self.extra_key_events = EXTRA_KEY_EVENTS
@@ -317,6 +329,7 @@ function FocusManager:onPhysicalKeyboardDisconnected()
                 self.key_events[k] = nil
             end
         end
+        self:_refreshFocusKeys()
     else
         -- If we longer have keys at all, that's easy ;).
         self.key_events = {}

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -313,10 +313,11 @@ function FocusManager:onPhysicalKeyboardConnected()
     -- and it'll call InputContainer._init, which *also* resets the touch zones.
     -- Instead, we'll just do a merge ourselves.
     util.tableMerge(self.key_events, KEY_EVENTS)
-    self:_refreshFocusKeys()
     -- populateEventMappings replaces these, so, update our refs
     self.builtin_key_events = BUILTIN_KEY_EVENTS
     self.extra_key_events = EXTRA_KEY_EVENTS
+    -- Last, so the widget's callback sees the new refs too.
+    self:_refreshFocusKeys()
 end
 
 function FocusManager:onPhysicalKeyboardDisconnected()
@@ -324,21 +325,24 @@ function FocusManager:onPhysicalKeyboardDisconnected()
     populateEventMappings()
 
     -- If we still have keys, remove what disappeared from KEY_EVENTS from self.key_events (if any).
-    if Device:hasKeys() then
+    local has_keys = Device:hasKeys()
+    if has_keys then
         -- NOTE: This is slightly overkill, we could very well live with a few unreachable mappings for the rest of this widget's life ;).
         for k, _ in pairs(prev_key_events) do
             if not KEY_EVENTS[k] then
                 self.key_events[k] = nil
             end
         end
-        self:_refreshFocusKeys()
     else
         -- If we longer have keys at all, that's easy ;).
-        -- No point in asking the widget to rebind anything, either.
         self.key_events = {}
     end
     self.builtin_key_events = BUILTIN_KEY_EVENTS
     self.extra_key_events = EXTRA_KEY_EVENTS
+    -- Nothing left to bind when the keys are gone, so don't ask the widget to.
+    if has_keys then
+        self:_refreshFocusKeys()
+    end
 end
 
 -- constant, used to reset focus widget after layout recreation

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -234,6 +234,18 @@ describe("FocusManager module", function()
         assert.are.equal(1, calls)
         assert.are.same({ { "Right" } }, focusmanager.key_events.ExpandCurrentNode)
     end)
+    it("should not rebind anything once the device has no keys left", function()
+        local Device = require("device")
+        local focusmanager = FocusManager:new{}
+        local called = false
+        focusmanager.focus_keys_callback = function() called = true end
+        stub(Device, "hasKeys")
+        Device.hasKeys.returns(false)
+        focusmanager:onPhysicalKeyboardDisconnected()
+        Device.hasKeys:revert()
+        assert.is_false(called)
+        assert.are.same({}, focusmanager.key_events)
+    end)
     it("alternative key", function()
         local focusmanager = FocusManager:new{}
         focusmanager.extra_key_events = {

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -213,6 +213,27 @@ describe("FocusManager module", function()
         }
         assert.are.same(expected, fm1.layout)
     end)
+    it("should keep released keys released when a keyboard is hot-plugged", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager:releaseFocusKeys("FocusLeft", "FocusRight")
+        assert.is_nil(focusmanager.key_events.FocusLeft)
+        assert.is_nil(focusmanager.key_events.FocusRight)
+        -- The handler re-merges the default mappings, which would bring them back.
+        focusmanager:onPhysicalKeyboardConnected()
+        assert.is_nil(focusmanager.key_events.FocusLeft)
+        assert.is_nil(focusmanager.key_events.FocusRight)
+    end)
+    it("should let the widget rebind its own keys when the mappings are rebuilt", function()
+        local focusmanager = FocusManager:new{}
+        local calls = 0
+        focusmanager.focus_keys_callback = function(self)
+            calls = calls + 1
+            self.key_events.ExpandCurrentNode = { { "Right" } }
+        end
+        focusmanager:onPhysicalKeyboardConnected()
+        assert.are.equal(1, calls)
+        assert.are.same({ { "Right" } }, focusmanager.key_events.ExpandCurrentNode)
+    end)
     it("alternative key", function()
         local focusmanager = FocusManager:new{}
         focusmanager.extra_key_events = {


### PR DESCRIPTION
On d-pad devices the left/right arrow keys were no-ops in the single-column ToC
menu. Map them to the tree-view idiom: right expands the focused node, left
collapses it (swapped in mirrored UI layout, matching the rotated expand icon).
The focus stays on the toggled node — this also fixes the focus reset to the top
of the page in the existing non-touch path (Hold on a node).

hasFewKeys devices keep their Left-close/Right-hold bindings, including across
external-keyboard hot-plug. Tested on a Kindle 3.

Edit: Fix https://github.com/koreader/koreader/issues/14741

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15780)
<!-- Reviewable:end -->
