### PR TITLE
Book opening info

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -1170,6 +1170,7 @@ function FileManager:deleteFile(file, is_file)
         local ok = os.remove(file)
         if ok then
             BookList.resetBookInfoCache(file)
+            FileManagerBookInfo.deleteOpeningInfo(file, true)
             DocSettings.updateLocation(file) -- delete sdr
             ReadHistory:fileDeleted(file)
             ReadCollection:removeItem(file)

--- a/frontend/apps/filemanager/filemanagerbookinfo.lua
+++ b/frontend/apps/filemanager/filemanagerbookinfo.lua
@@ -16,6 +16,7 @@ local InputDialog = require("ui/widget/inputdialog")
 local Math = require("optmath")
 local Notification = require("ui/widget/notification")
 local TextViewer = require("ui/widget/textviewer")
+local TileCacheItem = require("document/tilecacheitem")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local datetime = require("datetime")
@@ -924,6 +925,151 @@ function BookInfo:onShowNotebookFile()
     elseif lfs.attributes(notebook_file, "mode") == "file" then
         TextViewer.openFile(notebook_file)
     end
+end
+
+-- book opening info
+
+function BookInfo.getOpeningInfoFolder(file)
+    local DataStorage = require("datastorage")
+    return DataStorage:getDataDir() .. "/cache/opening_info/" .. file:gsub("[:/]", "_") .. "/"
+end
+
+function BookInfo.deleteOpeningInfo(file, all)
+    local folder = BookInfo.getOpeningInfoFolder(file)
+    if lfs.attributes(folder) then
+        if all then
+            ffiUtil.purgeDir(folder)
+        else
+            os.remove(folder .. "page0")
+            os.remove(folder .. "page1")
+            os.remove(folder .. "page2")
+            os.remove(folder .. "page3")
+        end
+    end
+end
+
+function BookInfo.getOpeningInfoCoverPath(file, for_save)
+    local folder = BookInfo.getOpeningInfoFolder(file)
+    if for_save then
+        util.makePath(folder)
+    end
+    return folder .. "cover"
+end
+
+function BookInfo.getOpeningInfoPagePath(file, for_save)
+    local folder = BookInfo.getOpeningInfoFolder(file)
+    local rota
+    if for_save then
+        util.makePath(folder)
+    elseif BookList.hasBookBeenOpened(file) then -- for show
+        local doc_settings = BookList.getDocSettings(file)
+        rota = doc_settings:readSetting("copt_rotation_mode") or doc_settings:readSetting("kopt_rotation_mode")
+    end
+    rota = rota or Screen:getRotationMode()
+    -- 4 types of saved page: portrait/landscape, day/night
+    local r = rota % 2 == 1 and 1 or 0
+    local n = Screen.night_mode and 2 or 0
+    return folder .. "page" .. (r + n), rota -- target orientation
+end
+
+function BookInfo:saveOpeningInfo(file)
+    local opening_info = G_reader_settings:readSetting("file_opening_info")
+    if opening_info == nil or opening_info == "none" then
+        return
+    elseif opening_info == "page" then
+        BookInfo.deleteOpeningInfo(file)
+        if self.ui.view.saved_page_bb then
+            local info_file = BookInfo.getOpeningInfoPagePath(file, true)
+            if Screen.night_mode then
+                self.ui.view.saved_page_bb:invert()
+            end
+            TileCacheItem:new{ bb = self.ui.view.saved_page_bb }:dump(info_file)
+            self.ui.view.saved_page_bb:free()
+            self.ui.view.saved_page_bb = nil
+        end
+    elseif opening_info == "cover" then
+        local info_file = BookInfo.getOpeningInfoCoverPath(file, true)
+        if not lfs.attributes(info_file) then
+            local cover_bb = self:getCoverImage(self.document)
+            if cover_bb then
+                TileCacheItem:new{ bb = cover_bb }:dump(info_file)
+            end
+        end
+    end
+end
+
+function BookInfo:showOpeningInfo(file, timeout)
+    -- timeout is passed by ReaderUI to show message or book cover after opening the book
+    local opening_info = G_reader_settings:readSetting("file_opening_info")
+    if opening_info == "none" then
+        return
+    elseif opening_info ~= nil then -- page or cover
+        local tile, x, y, w, h, rotation_angle, page_shown
+        if opening_info == "page" then
+            local info_file, rota = BookInfo.getOpeningInfoPagePath(file)
+            if lfs.attributes(info_file, "mode") == "file" then
+                tile = TileCacheItem:new{}
+                tile:load(info_file)
+                if tile.bb then
+                    local curr_rota = Screen:getRotationMode()
+                    if rota == curr_rota then
+                        rotation_angle = 0
+                    elseif rota % 2 == curr_rota % 2 then
+                        rotation_angle = 180
+                    else
+                        rotation_angle = 180 - 90 * (rota - curr_rota)
+                    end
+                    page_shown = true
+                end
+            end
+        else -- cover
+            local info_file = BookInfo.getOpeningInfoCoverPath(file)
+            if lfs.attributes(info_file, "mode") == "file" then
+                tile = TileCacheItem:new{}
+                tile:load(info_file)
+                if tile.bb then
+                    -- ImageWidget built-in scale_factor cannot be used
+                    -- because it inverts the screen outside of the image in night mode
+                    local scale_factor = (G_reader_settings:readSetting("file_opening_info_cover_scale") or 100) / 100
+                    local screen_w = Screen:getWidth()
+                    local screen_h = Screen:getHeight()
+                    w = math.floor(scale_factor * screen_w)
+                    h = math.floor(scale_factor * screen_h)
+                    local RenderImage = require("ui/renderimage")
+                    w, h = RenderImage.getScaledImageSize(tile.bb.w, tile.bb.h, w, h)
+                    x = math.floor((screen_w - w) / 2)
+                    y = math.floor((screen_h - h) / 2)
+                end
+            end
+        end
+        if tile and tile.bb then
+            local ImageWidget = require("ui/widget/imagewidget")
+            UIManager:show(ImageWidget:new{
+                image = tile.bb,
+                x = x,
+                y = y,
+                width = w,
+                height = h,
+                rotation_angle = rotation_angle,
+                alpha = true,
+                timeout = timeout or 0,
+            }, "full")
+            if not timeout then
+                UIManager:forceRePaint()
+            end
+            return page_shown, G_reader_settings:readSetting("file_opening_info_timeout")
+        end
+    end
+    local message = G_reader_settings:readSetting("file_opening_info_message")
+    UIManager:show(InfoMessage:new{
+        text = message and self:expandString(message, file)
+            or T(_("Opening file:\n%1"), BD.filepath(filemanagerutil.abbreviate(file))),
+        timeout = timeout or 0,
+    })
+    if not timeout then
+        UIManager:forceRePaint()
+    end
+    return nil, G_reader_settings:readSetting("file_opening_info_timeout")
 end
 
 -- book metadata (sdr)

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -19,6 +19,7 @@ local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local util  = require("util")
 local _ = require("gettext")
+local C_ = _.pgettext
 local T = ffiUtil.template
 
 local FileManagerMenu = InputContainer:extend{
@@ -390,6 +391,14 @@ To:
                 end,
                 callback = function()
                     G_reader_settings:flipNilOrFalse("file_ask_to_open")
+                end,
+            },
+            {
+                text_func = function()
+                    return T(_("Show on opening: %1"), self:genOpeningInfoMenu(true))
+                end,
+                sub_item_table_func = function()
+                    return self:genOpeningInfoMenu()
                 end,
             },
             {
@@ -1014,6 +1023,146 @@ function FileManagerMenu:getStartWithMenuTable()
             end
         end,
         sub_item_table = sub_item_table,
+    }
+end
+
+function FileManagerMenu:genOpeningInfoMenu(get_text, opening_info)
+    local strings = {
+        none       = _("none"),
+        message    = _("message"),
+        page       = _("book current page"),
+        cover      = _("book cover (%1 %)"),
+    }
+    if get_text then
+        opening_info = opening_info or G_reader_settings:readSetting("file_opening_info") or "message"
+        local text = strings[opening_info]
+        if opening_info == "message" then
+            if G_reader_settings:has("file_opening_info_message") then
+                return text .. " \u{F040}" -- pen
+            end
+        elseif opening_info == "cover" then
+            return T(text, G_reader_settings:readSetting("file_opening_info_cover_scale") or 100)
+        end
+        return text
+    end
+
+    local function genOpeningInfoMenuItems(value, hold_callback, separator)
+        return {
+            text_func = function()
+                return self:genOpeningInfoMenu(true, value)
+            end,
+            checked_func = function()
+                return (G_reader_settings:readSetting("file_opening_info") or "message") == value
+            end,
+            radio = true,
+            callback = function()
+                G_reader_settings:saveSetting("file_opening_info", value ~= "message" and value or nil)
+            end,
+            hold_callback = hold_callback and function(touchmenu_instance)
+                hold_callback(touchmenu_instance)
+            end,
+            separator = separator,
+        }
+    end
+
+    local function message_hold_callback(touchmenu_instance)
+        local default_text = _("Opening file:\n%F") 
+        local input_dialog
+        local InputDialog = require("ui/widget/inputdialog")
+        input_dialog = InputDialog:new{
+            title = _("Book opening message"),
+            input = G_reader_settings:readSetting("file_opening_info_message") or default_text,
+            input_hint = default_text,
+            allow_newline = true,
+            buttons = {
+                {
+                    {
+                        text = _("Info"),
+                        callback = self.ui.bookinfo.expandString,
+                    },
+                    {
+                        text = _("Default"),
+                        callback = function()
+                            input_dialog._input_widget:setText(default_text)
+                            input_dialog._input_widget:goToEnd()
+                        end,
+                    },
+                },
+                {
+                    {
+                        text = _("Cancel"),
+                        id = "close",
+                        callback = function()
+                            UIManager:close(input_dialog)
+                        end,
+                    },
+                    {
+                        text = _("Set"),
+                        callback = function()
+                            local text = input_dialog:getInputText()
+                            text = (text ~= "" and text ~= default_text) and text or nil
+                            G_reader_settings:saveSetting("file_opening_info_message", text)
+                            UIManager:close(input_dialog)
+                            touchmenu_instance:updateItems()
+                        end,
+                    },
+                },
+            },
+        }
+        UIManager:show(input_dialog)
+        input_dialog:onShowKeyboard()
+    end
+
+    local function cover_hold_callback(touchmenu_instance)
+        UIManager:show(SpinWidget:new{
+            title_text = _("Cover scale factor"),
+            width_factor = 0.5,
+            value = G_reader_settings:readSetting("file_opening_info_cover_scale") or 100,
+            value_min = 20,
+            value_max = 100,
+            value_step = 10,
+            value_hold_step = 1,
+            unit = "%",
+            default_value = 100,
+            callback = function(spin)
+                G_reader_settings:saveSetting("file_opening_info_cover_scale", spin.value ~= 100 and spin.value or nil)
+                touchmenu_instance:updateItems()
+            end,
+        })
+    end
+
+    return {
+        genOpeningInfoMenuItems("none"),
+        genOpeningInfoMenuItems("message", message_hold_callback),
+        genOpeningInfoMenuItems("page"),
+        genOpeningInfoMenuItems("cover", cover_hold_callback, true),
+        {
+            text_func = function()
+                return T(_("Show after opening: %1 s"), G_reader_settings:readSetting("file_opening_info_timeout") or 0)
+            end,
+            enabled_func = function()
+                local value = G_reader_settings:readSetting("file_opening_info")
+                return value ~= "none" and value ~= "page"
+            end,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                UIManager:show(SpinWidget:new{
+                    title_text = _("Show time interval"),
+                    width_factor = 0.5,
+                    value = G_reader_settings:readSetting("file_opening_info_timeout") or 0,
+                    value_min = 0,
+                    value_max = 30,
+                    value_step = 1,
+                    value_hold_step = 2,
+                    unit = C_("Time", "s"),
+                    default_value = 0,
+                    callback = function(spin)
+                        G_reader_settings:saveSetting("file_opening_info_timeout", spin.value ~= 0 and spin.value or nil)
+                        touchmenu_instance:updateItems()
+                    end,
+                })
+            end,
+        },
     }
 end
 

--- a/frontend/apps/filemanager/filemanagermenu.lua
+++ b/frontend/apps/filemanager/filemanagermenu.lua
@@ -400,6 +400,7 @@ To:
                 sub_item_table_func = function()
                     return self:genOpeningInfoMenu()
                 end,
+                separator = true,
             },
             {
                 text = _("Show parent folder"),
@@ -1066,7 +1067,7 @@ function FileManagerMenu:genOpeningInfoMenu(get_text, opening_info)
     end
 
     local function message_hold_callback(touchmenu_instance)
-        local default_text = _("Opening file:\n%F") 
+        local default_text = _("Opening file:\n%F")
         local input_dialog
         local InputDialog = require("ui/widget/inputdialog")
         input_dialog = InputDialog:new{

--- a/frontend/apps/filemanager/filemanagerutil.lua
+++ b/frontend/apps/filemanager/filemanagerutil.lua
@@ -214,6 +214,8 @@ function filemanagerutil.genResetSettingsButton(doc_settings_or_file, caller_cal
                         BookList.setBookInfoCacheProperty(file, "been_opened", false)
                         require("readhistory"):fileSettingsPurged(file)
                     end
+                    local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+                    FileManagerBookInfo.deleteOpeningInfo(file)
                     caller_callback()
                 end,
             }
@@ -253,12 +255,14 @@ function filemanagerutil.genMultipleResetSettingsButton(files, caller_callback, 
                        _("Information will be permanently lost."),
                 ok_text = _("Reset"),
                 ok_callback = function()
+                    local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
                     for file in pairs(files) do
                         if BookList.hasBookBeenOpened(file) then
                             DocSettings:open(file):purge()
                             UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
                             BookList.setBookInfoCacheProperty(file, "been_opened", false)
                             require("readhistory"):fileSettingsPurged(file)
+                            FileManagerBookInfo.deleteOpeningInfo(file)
                         end
                     end
                     caller_callback()

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -78,6 +78,7 @@ local ReaderView = OverlapGroup:extend{
 }
 
 function ReaderView:init()
+    self.do_save_page_bb = G_reader_settings:readSetting("file_opening_info") == "page"
     self.view_modules = {}
 
     self.state = {
@@ -287,6 +288,10 @@ function ReaderView:paintTo(bb, x, y)
             end
         end
         self.state.drawn = true
+    end
+
+    if self.do_save_page_bb and not self.ui.highlight.selected_text and not self.ui.highlight.select_mode then
+        self.saved_page_bb = Screen.bb:copy()
     end
 end
 

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -709,13 +709,12 @@ function ReaderUI:extendProvider(file, provider, is_provider_forced)
 end
 
 function ReaderUI:showReaderCoroutine(file, provider, seamless)
-    UIManager:show(InfoMessage:new{
-        text = T(_("Opening file '%1'."), BD.filepath(filemanagerutil.abbreviate(file))),
-        timeout = 0.0,
-        invisible = seamless,
-    })
-    -- doShowReader might block for a long time, so force repaint here
-    UIManager:forceRePaint()
+    if seamless then
+        -- dummy invisible widget to keep KOReader open after rerendering
+        UIManager:show(InfoMessage:new{ invisible = true, timeout = 0 })
+    else
+        self.opening_page_shown, self.opening_page_timeout = FileManagerBookInfo:showOpeningInfo(file)
+    end
     UIManager:nextTick(function()
         logger.dbg("creating coroutine for showing reader")
         local co = coroutine.create(function()
@@ -788,7 +787,13 @@ function ReaderUI:doShowReader(file, provider, seamless)
         FileManager.instance:onClose()
     end
 
+    seamless = seamless or self.opening_page_shown
     UIManager:show(reader, seamless and "ui" or "full")
+
+    if self.opening_page_timeout and not seamless then
+        reader.bookinfo:showOpeningInfo(file, self.opening_page_timeout)
+    end
+    self.opening_page_shown = nil
 end
 
 function ReaderUI:unlockDocumentWithPassword(document, try_again)
@@ -873,6 +878,7 @@ function ReaderUI:onClose(full_refresh)
     local file
     if self.document ~= nil then
         file = self.document.file
+        self.bookinfo:saveOpeningInfo(file)
         require("readhistory"):updateLastBookTime(self.tearing_down)
         require("readcollection"):updateLastBookTime(file)
         -- Serialize the most recently displayed page for later launch

--- a/frontend/ui/renderimage.lua
+++ b/frontend/ui/renderimage.lua
@@ -470,4 +470,18 @@ function RenderImage:renderCheckerboard(width, height, bb_type)
     return bb
 end
 
+function RenderImage.getScaledImageSize(img_w, img_h, max_img_w, max_img_h)
+    -- img_w, img_h - image size; max_img_w, max_img_h - container size; sides ratio is kept
+    local scale_factor
+    local width = math.floor(max_img_h * img_w / img_h + 0.5)
+    if max_img_w >= width then
+        max_img_w = width
+        scale_factor = max_img_w / img_w
+    else
+        max_img_h = math.floor(max_img_w * img_h / img_w + 0.5)
+        scale_factor = max_img_h / img_h
+    end
+    return max_img_w, max_img_h, scale_factor
+end
+
 return RenderImage

--- a/frontend/ui/widget/imagewidget.lua
+++ b/frontend/ui/widget/imagewidget.lua
@@ -61,6 +61,10 @@ local ImageWidget = Widget:extend{
     -- normally true unless our caller wants to reuse its provided image
     image_disposable = true,
 
+    -- upper left corner of container
+    x = nil,
+    y = nil,
+
     -- Width and height of container, to limit rendering to this area
     -- (if provided, and scale_factor is nil, image will be resized to
     -- these width and height without regards to original aspect ratio)
@@ -68,6 +72,7 @@ local ImageWidget = Widget:extend{
     height = nil,
 
     hide = nil, -- to not be painted
+    timeout = nil, -- in seconds
 
     -- Settings that apply at paintTo() time
     invert = nil,
@@ -517,6 +522,8 @@ end
 
 function ImageWidget:paintTo(bb, x, y)
     if self.hide then return end
+    x = self.x or x
+    y = self.y or y
     -- self:_render is called in getSize method
     local size = self:getSize()
     if not self.dimen then
@@ -590,6 +597,10 @@ function ImageWidget:paintTo(bb, x, y)
     ---        Currently, this is *only* the KOReader icon in Help, AFAIK.
     if Screen.night_mode and self.original_in_nightmode and not self.is_icon then
         bb:invertRect(x, y, size.w, size.h)
+    end
+
+    if self.timeout then
+        UIManager:scheduleIn(self.timeout, function() UIManager:close(self) end)
     end
 end
 

--- a/plugins/coverbrowser.koplugin/bookinfomanager.lua
+++ b/plugins/coverbrowser.koplugin/bookinfomanager.lua
@@ -997,18 +997,7 @@ Do you want to prune the cache of removed books?]]
     UIManager:show(info)
 end
 
-function BookInfoManager.getCachedCoverSize(img_w, img_h, max_img_w, max_img_h)
-    local scale_factor
-    local width = math.floor(max_img_h * img_w / img_h + 0.5)
-    if max_img_w >= width then
-        max_img_w = width
-        scale_factor = max_img_w / img_w
-    else
-        max_img_h = math.floor(max_img_w * img_h / img_w + 0.5)
-        scale_factor = max_img_h / img_h
-    end
-    return max_img_w, max_img_h, scale_factor
-end
+BookInfoManager.getCachedCoverSize = RenderImage.getScaledImageSize
 
 function BookInfoManager.isCachedCoverInvalid(bookinfo, cover_specs)
     if not bookinfo.cover_w or not bookinfo.cover_h then -- no thumbnail yet


### PR DESCRIPTION
A frequent request to hide the opening message or to show the book cover instead.
Another option that works for previously opened books: show current book page immediately, while the book is being rendered/opened.
Adjustable period of time to keep the message/cover on screen after the book has been opened.

-----

<img width="400" height="406" alt="1" src="https://github.com/user-attachments/assets/89ea804f-51a3-4e62-98b8-c2f6e11dce59" />

-----

<img width="400" height="237" alt="2" src="https://github.com/user-attachments/assets/f812f46f-2e30-4075-983f-cbb4bb94e570" />

-----

The opening message is editable, with patterns support.
<img width="400" height="536" alt="3" src="https://github.com/user-attachments/assets/9cfe4e1c-e304-423b-9ade-e58d58080bef" />

-----

The cover can be scaled (percentage of the screen size).
<img width="400" height="536" alt="4" src="https://github.com/user-attachments/assets/2190aca8-9b12-4100-8aeb-d0d707f49d4b" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15783)
<!-- Reviewable:end -->
