### PR TITLE
ReaderSearch: 'all results' minor fixes

### DIFF
--- a/frontend/apps/reader/modules/readersearch.lua
+++ b/frontend/apps/reader/modules/readersearch.lua
@@ -756,7 +756,7 @@ function ReaderSearch:onShowFindAllResults(not_cached)
         title_bar_left_icon = "appbar.menu",
         onLeftButtonTap = function() self:showAllResultsMenuDialog() end,
         onMenuChoice = function(_menu_self, item)
-            self:gotoResultsItem(item.idx)
+            self:gotoResultsItem(item.idx, true) -- save current location
         end,
         onMenuHold = function(_menu_self, item)
             local text = T(_("Page: %1"), item.mandatory) .. "\n"
@@ -870,11 +870,13 @@ function ReaderSearch:showAllResultsMenuDialog()
     UIManager:show(button_dialog)
 end
 
-function ReaderSearch:gotoResultsItem(index)
+function ReaderSearch:gotoResultsItem(index, save_current_location)
     local item = self.result_menu.item_table[index]
     if self.ui.rolling then
-        self.ui.link:addCurrentLocationToStack()
-        self.ui.rolling:onGotoXPointer(item.start, item.start) -- show target line marker
+        if save_current_location then
+            self.ui.link:addCurrentLocationToStack()
+        end
+        self.ui.rolling:onGotoXPointer(item.start)
         self.ui.document:getTextFromXPointers(item.start, item["end"], true) -- highlight
     else
         if not self.skim_mode then
@@ -886,7 +888,7 @@ function ReaderSearch:gotoResultsItem(index)
         for i, box in ipairs(item.boxes) do
             boxes[i] = self.ui.document:nativeToPageRectTransform(page, box)
         end
-        self.ui.link:onGotoLink({ page = page - 1 })
+        self.ui.link:onGotoLink({ page = page - 1 }, not save_current_location)
         self.view.highlight.temp[page] = boxes
     end
 
@@ -904,6 +906,7 @@ function ReaderSearch:gotoResultsItem(index)
                     callback = function()
                         dialog:onClose()
                         self:onGoToStartPage()
+                        self.ui.link:popFromLocationStack()
                     end,
                 },
                 {


### PR DESCRIPTION
- Fixes https://github.com/koreader/koreader/issues/12900#issuecomment-5092054990

(1) Do not save locations to stack when jumping between results.
(2) Do not show the marker in epub (the result is highlighted and visible).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15784)
<!-- Reviewable:end -->
