### PR TITLE
NetworkMgr: don't resurrect user-disabled Wi-Fi in goOnlineToRun

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -756,6 +756,19 @@ function NetworkMgr:goOnlineToRun(callback)
         return true
     end
 
+    -- Don't resurrect Wi-Fi the user explicitly turned off.
+    -- goOnlineToRun is the *blocking* path used by finalizers (e.g. an automatic
+    -- push on document close), so it never represents a direct user request.
+    -- A manual turnOffWifi clears wifi_was_on (an auto_disable_wifi power-save
+    -- toggle does not), so if it's false the user deliberately disabled Wi-Fi:
+    -- honoring turn_on here would go behind their back, and -- since we're
+    -- offline -- block the UI waiting for a connection that isn't coming.
+    -- Mirror auto_restore_wifi, which is likewise gated on wifi_was_on.
+    if not self.wifi_was_on then
+        logger.dbg("NetworkMgr:goOnlineToRun: Wi-Fi was disabled by the user, not going online")
+        return false
+    end
+
     -- If beforeWifiAction isn't turn_on, we're done.
     -- We don't want to go behind the user's back by enforcing "turn_on" behavior,
     -- and we *cannot* use prompt, as we'll block before handling the popup input...


### PR DESCRIPTION
### Problem

On a non-touch / legacy device, closing a book triggers a plugin's automatic progress push via `NetworkMgr:goOnlineToRun`. With *Action when Wi-Fi is off → turn on*, it turns Wi-Fi back on and blocks — even though the user had just explicitly turned Wi-Fi off. Being offline, the connection never completes, so the UI is frozen until the ~30s timeout (120 × 250 ms) or a tap aborts it.

### Root cause

`goOnlineToRun` only gated on `wifi_enable_action == "turn_on"`, not on *why* Wi-Fi was off. `wifi_was_on` already distinguishes the two: a manual `turnOffWifi` clears it, while an `auto_disable_wifi` power-save toggle keeps it set.

### Fix

Skip (`return false`, i.e. defer) when `wifi_was_on` is false, mirroring `auto_restore_wifi`, which is likewise gated on it. `goOnlineToRun` is the blocking finalizer path, so this never affects a direct user request — those go through the non-blocking `beforeWifiAction` / `willRerunWhenOnline` prompt path. No behaviour change when Wi-Fi is on, or was turned off automatically for power saving. +13 lines.

This does not fix the underlying problem, which is described in #15728: `wifi_was_on` fuses user intent, an in-progress attempt and the achieved connection into one boolean. Until intent gets a signal of its own, this gate at least stops a background finalizer from resurrecting Wi-Fi behind the user's back and freezing the UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15792)
<!-- Reviewable:end -->
