### PR TITLE
screensaver: stop anti-ghosting redraws on wake

### DIFF
--- a/frontend/ui/screensaver.lua
+++ b/frontend/ui/screensaver.lua
@@ -747,6 +747,19 @@ function Screensaver:close()
 end
 
 function Screensaver:cleanup()
+    -- Cancel any pending anti-ghosting redraws.
+    UIManager:unschedule(Screensaver.flashBlack)
+    UIManager:unschedule(Screensaver.restoreCover)
+
+    if self.bb_copy then
+        self.bb_copy:free()
+        self.bb_copy = nil
+    end
+
+    -- Only meaningful while the suspend entry is being delayed for the flashing;
+    -- reset it so a later suspend (with no extra flashes) uses the normal timeout.
+    Device.screensaver_suspend_wait_timeout = nil
+
     self.show_message = nil
     self.screensaver_type = nil
     self.prefix = nil


### PR DESCRIPTION
Fixes https://github.com/koreader/koreader/issues/15777

When the device wakes during the anti-ghosting flash sequence, pending flash/restore tasks kept firing after resume, drawing over the actual content.

In Screensaver:cleanup():
- unschedule any pending flashBlack/restoreCover tasks so redraws stop on wake
- free the saved framebuffer copy (bb_copy) if still present
- reset Device.screensaver_suspend_wait_timeout so a later suspend without extra flashes uses the normal suspend timeout

The timeout reset might also address the power-off regression observed with rapid power presses during suspend entry, but I could not reproduce that myself, so I'm not sure: see https://github.com/koreader/koreader/pull/15752#issuecomment-5153110326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15797)
<!-- Reviewable:end -->
