### PR TITLE
bump base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ CR3GUI_DATADIR_FILES = $(filter-out $(CR3GUI_DATADIR_EXCLUDES),$(wildcard $(CR3G
 define DATADIR_FILES
 $(CR3GUI_DATADIR_FILES)
 $(OUTPUT_DIR_DATAFILES)
-$(THIRDPARTY_DIR)/kpvcrlib/cr3.css
 endef
 
 # files to link from main directory


### PR DESCRIPTION
- lunasvg: add pkg-config entry (koreader/koreader-base#2474)
- srell: install header to staging (koreader/koreader-base#2475)
- xxhash: add pkg-config entry (koreader/koreader-base#2476)
- bump crengine, ×4 (koreader/koreader-base#2479):
  * lvimg: fix `LVUnpackedImgSource` destructor (koreader/crengine#689)
  * lvrend: tables: fix padding calculation on min-width (koreader/crengine#692)
  * lvstsheet: update_style_content_property(): fix wrong content length (koreader/crengine#693)
  * lvtextfm: fix memory deallocation (koreader/crengine#694)
  * ci: bump actions (koreader/crengine#697)
  * lvxml: ReadRtfChar: fix charToHex buffer access (koreader/crengine#696)
  * lvtinydom: minor fixes (koreader/crengine#695)
  * hyphman: avoid using cri18n (koreader/crengine#698)
  * fix .gitignore (koreader/crengine#699)
  * miscellaneous cleanups (koreader/crengine#700)
  * chmlib: fix android compilation warning (koreader/crengine#701)
  * lvrefcache.h: initialize fields in LVIndexedRefCache constructor (koreader/crengine#690)
  * minor includes cleanups (koreader/crengine#702)
  * lvarray: fix `LVArray::set` (koreader/crengine#704)
  * lvref: fix `LVRefVec::set` (koreader/crengine#707)
  * hyphman: fix compiler warning [-Wunused-but-set-variable=] (koreader/crengine#705)
  * lvref:  suppress some "maybe-uninitialized" warnings (koreader/crengine#706)
  * CSS: fix font-variant-* handling (koreader/crengine#709)
  * CSS: fix attribute matching with id/name/href, add more length units, fix "rem", add "urem" and "urlh" - (koreader/crengine#710)
    Closes #15481.
    Closes #15339.
  * lvdocview: fix source page numbers with a page-list not in reading order (koreader/crengine#711)
  * proper build system - (koreader/crengine#703)
- einkfb: refresh the screen even when its content has not changed (koreader/koreader-base#2481)
- fix(blitbuffer): memory safety, soft-float overhead, and variable shadowing (koreader/koreader-base#2468)
- fix(wrap-mupdf): prevent integer overflow in allocator (koreader/koreader-base#2472)
- ffi/util: return available space from df, and fix its block maths (koreader/koreader-base#2478)
- fix(input): recompute nfds correctly in clearTimer (koreader/koreader-base#2467)
- fix(djvu): validate page bounds and check errors (koreader/koreader-base#2469)
- fix(nnsvg): prevent usage of freed NSVGimage (koreader/koreader-base#2471)
- fix(xtext): memory safety and input validation fixes (koreader/koreader-base#2473)
- kotasync: fix make reorder code (koreader/koreader-base#2483)
- ffi/downloader: fix range support check (koreader/koreader-base#2484)
- ffi/downloader: improve fetch implementation (koreader/koreader-base#2485)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15798)
<!-- Reviewable:end -->
