### PR TITLE
Style tweaks: update 'rem' to 'urem'

### DIFF
--- a/frontend/apps/reader/modules/readerstyletweak.lua
+++ b/frontend/apps/reader/modules/readerstyletweak.lua
@@ -923,7 +923,7 @@ You can then paste it here with long-press in the text box.]]), true},
     }},
 
     { _("Common classic properties"), {
-        { "font-size: 1rem !important;", _("1rem will enforce your main font size.")},
+        { "font-size: 1urem !important;", _("1rem will enforce your main font size.")},
         { "font-weight: normal !important;", _("Remove bold. Use 'bold' to get bold.")},
         { "hyphens: none !important;", _("Disables hyphenation inside the targeted elements.")},
         { "text-indent: 1.2em !important;", _("1.2em is our default text indentation.")},

--- a/frontend/ui/data/css_tweaks.lua
+++ b/frontend/ui/data/css_tweaks.lua
@@ -452,7 +452,7 @@ listing, plaintext, xmp, samp, tt, kbd, pre, code { font-family: monospace !impo
                 title = _("Reset main text font size"),
                 description = _("Disable font-size set on the main text (keeping possibly larger headings untouched), so that KOReader's font size is used."),
                 priority = -1, -- so in-page footnotes smaller can override this
-                css = [[body, p, li, div, blockquote { font-size: 1rem !important; }]],
+                css = [[html, body, p, li, div, blockquote { font-size: 1urem !important; }]],
             },
         },
         {
@@ -868,7 +868,7 @@ body[name="notes"] section {
 }
 body[name="notes"] > section {
     -cr-only-if: fb2-document;
-        font-size: 0.75rem;
+        font-size: 0.75urem;
 }
 body[name="notes"] > title {
     -cr-only-if: fb2-document;
@@ -890,7 +890,7 @@ body[name="comments"] section {
 }
 body[name="comments"] > section {
     -cr-only-if: fb2-document;
-        font-size: 0.85rem;
+        font-size: 0.85urem;
 }
 body[name="comments"] > title {
     -cr-only-if: fb2-document;
@@ -910,7 +910,7 @@ body[name="notes"] > section,
 body[name="comments"] > section
 {
     -cr-only-if: fb2-document;
-        font-size: 1rem !important;
+        font-size: 1urem !important;
 }
                 ]],
             },
@@ -1051,7 +1051,7 @@ Decrease size of in-page footnotes. This may have no effect if it's overwritten 
 *, autoBoxing {
     -cr-hint: late;
     -cr-only-if: -fb2-document inpage-footnote;
-        font-size: 0.8rem !important;
+        font-size: 0.8urem !important;
 }
                     ]],
                     separator = true,
@@ -1067,7 +1067,7 @@ Decrease size of in-page footnotes. This may have no effect if it's overwritten 
 *, autoBoxing {
     -cr-hint: late;
     -cr-only-if: inside-inpage-footnote -inline;
-        font-size: %1rem !important;
+        font-size: %1urem !important;
 }
                     ]], rem),
                 })


### PR DESCRIPTION
With https://github.com/koreader/crengine/pull/710 (coming with https://github.com/koreader/koreader/pull/15798), crengine handling of 'rem' has been updated to reference the font-size set on the <html> element (per-specs).
'urem' (private unit) can be used to reference the user-set font size (as 'rem' used to do).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15799)
<!-- Reviewable:end -->
