### PR TITLE
Menu, TouchMenu, ListMenu: thicken the focus underline

### DIFF
--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -64,8 +64,8 @@ local Size = {
         thin = Screen:scaleBySize(0.5),
         medium = Screen:scaleBySize(1),
         thick = Screen:scaleBySize(1.5),
-        -- 5 px reads at a glance where scaleBySize maps one to one; denser screens
-        -- get the same weight out of 3.
+        -- 5 px reads at a glance where scaleBySize maps one to one;
+        -- denser screens get a similar relative weight out of 3.
         focus_indicator = Screen:scaleBySize(Screen:getDPI() < 200 and 5 or 3),
         progress = Screen:scaleBySize(7),
     },

--- a/frontend/ui/size.lua
+++ b/frontend/ui/size.lua
@@ -64,7 +64,9 @@ local Size = {
         thin = Screen:scaleBySize(0.5),
         medium = Screen:scaleBySize(1),
         thick = Screen:scaleBySize(1.5),
-        focus_indicator = Screen:scaleBySize(5),
+        -- 5 px reads at a glance where scaleBySize maps one to one; denser screens
+        -- get the same weight out of 3.
+        focus_indicator = Screen:scaleBySize(Screen:getDPI() < 200 and 5 or 3),
         progress = Screen:scaleBySize(7),
     },
     item = {

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -12,6 +12,10 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local UnderlineContainer = WidgetContainer:extend{
     linesize = Size.line.thick,
+    -- Painted while focused. It grows upwards, into the room linesize already reserves,
+    -- so switching focus repaints the line and nothing else.
+    focus_linesize = nil,
+    focused = false,
     padding = Size.padding.tiny,
     -- We default to white to be invisible by default for FocusManager use-cases (only switching to black @ onFocus)
     color = Blitbuffer.COLOR_WHITE,
@@ -54,8 +58,9 @@ function UnderlineContainer:paintTo(bb, x, y)
         p_y = (container_size.h - content_size.h) + y
     end
     self[1]:paintTo(bb, x, p_y)
-    bb:paintRect(line_x, y + container_size.h - self.linesize,
-        line_width, self.linesize, self.color)
+    local linesize = self.focused and self.focus_linesize or self.linesize
+    bb:paintRect(line_x, y + container_size.h - linesize,
+        line_width, linesize, self.color)
 end
 
 return UnderlineContainer

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -425,6 +425,7 @@ function MenuItem:init()
     self._underline_container = UnderlineContainer:new{
         color = self.line_color,
         linesize = self.linesize,
+        focus_linesize = Size.line.focus_indicator,
         vertical_align = "center",
         padding = 0,
         dimen = Geom:new{
@@ -488,17 +489,13 @@ end
 
 function MenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK
-    -- NOTE: Medium is really, really, really thin; so we'd ideally swap to something thicker...
-    --       Unfortunately, this affects vertical text positioning,
-    --       leading to an unsightly refresh of the item :/.
-    --self._underline_container.linesize = Size.line.thick
+    self._underline_container.focused = true
     return true
 end
 
 function MenuItem:onUnfocus()
     self._underline_container.color = self.line_color
-    -- See above for reasoning.
-    --self._underline_container.linesize = self.linesize
+    self._underline_container.focused = false
     return true
 end
 

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -147,6 +147,7 @@ function TouchMenuItem:init()
 
     self._underline_container = UnderlineContainer:new{
         vertical_align = "center",
+        focus_linesize = Size.line.focus_indicator,
         dimen = self.dimen:copy(),
         line_width = self.item_frame:getSize().w, -- we'll draw a shorter line
         self.item_frame,
@@ -160,11 +161,13 @@ end
 
 function TouchMenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK
+    self._underline_container.focused = true
     return true
 end
 
 function TouchMenuItem:onUnfocus()
     self._underline_container.color = Blitbuffer.COLOR_WHITE
+    self._underline_container.focused = false
     return true
 end
 

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -115,6 +115,7 @@ function ListMenuItem:init()
             h = self.height
         },
         linesize = self.underline_h,
+        focus_linesize = Size.line.focus_indicator,
         -- widget : will be filled in self:update()
     }
     self[1] = self._underline_container
@@ -793,11 +794,13 @@ end
 -- As done in MenuItem
 function ListMenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK
+    self._underline_container.focused = true
     return true
 end
 
 function ListMenuItem:onUnfocus()
     self._underline_container.color = Blitbuffer.COLOR_WHITE
+    self._underline_container.focused = false
     return true
 end
 


### PR DESCRIPTION
At 167 dpi the underline marking the row a d-pad is standing on is 1 px in `Menu` and 1.5 px elsewhere. On an eInk Pearl screen it takes a close look to tell it apart from the separator above it.

This was already wanted — `MenuItem:onFocus` carries a commented-out attempt:

```lua
-- NOTE: Medium is really, really, really thin; so we'd ideally swap to something thicker...
--       Unfortunately, this affects vertical text positioning,
--       leading to an unsightly refresh of the item :/.
--self._underline_container.linesize = Size.line.thick
```

The focused row and the separators are the same widget, `UnderlineContainer`, painted in `line_color` normally and black while focused. So raising `linesize` fattens the separators too, and swapping it on focus changes the reserved height and reflows the item. `ListMenuItem` hit the same wall from the other side and pinned its own line to 1 px "to not shift our vertical alignment".

This adds `focus_linesize`: the thickness painted while the item is focused, growing upwards into the room the reserved height already leaves. The reserved height never changes, so switching focus repaints the line and only the line, and unfocused rows keep the stock separator. It is the shape @poire-z sketched in #12132 — "make it bigger on XYZ devices, without affecting our sizing" — generalised so each widget can opt in.

Focused rows use `Size.line.focus_indicator`, the thickness the mosaic view has drawn with since #12189. Nothing is gated on `hasDPad`: `focus_linesize` only applies once a widget has been sent a `Focus` event, which is also what makes it correct when a d-pad arrives with a hot-plugged keyboard.

Covers `Menu`, `TouchMenuItem` and CoverBrowser's `ListMenuItem`. `ConfigDialog` is deliberately left alone: there the underline doubles as the selected-value marker and the two already fight over it (#15800).

This finishes the non-touch half of #12132, which was closed when #12189 fixed the mosaic view only.

**Testing.** Verified on a Kindle 3 (167 dpi, non-touch, d-pad): file browser in CoverBrowser detailed-list mode, the main menu, and the last row of a page. Covers, title wrapping and row heights are pixel-identical to stock; only the focused row's line differs.

## Screenshots

Kindle 3, 167 dpi. Each pair is the same screen on the same device, pixel-identical except the focus line, whose bottom edge stays put.

File browser, `ListMenuItem` — 1 px → 5 px:

<img  alt="1-list-before-1px" src="https://github.com/user-attachments/assets/6359e2be-4d22-41b9-8fcf-e8f54797b0eb" width=45% /> 
<img  alt="2-list-after-5px" src="https://github.com/user-attachments/assets/79555998-9e0b-4956-83aa-000028593b88" width=45% />



Main menu, `TouchMenuItem` — 2 px → 5 px:

<img alt="3-menu-before-2px" width=45% src="https://github.com/user-attachments/assets/e69e4170-6c4c-49df-a846-17ac270ea19e" /> 
<img  alt="4-menu-after-5px" width=45% src="https://github.com/user-attachments/assets/4c3a4bd2-ae55-4a1d-a53a-ea07f8868b46" />



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15801)
<!-- Reviewable:end -->
