### PR TITLE
Allow user to set custom Wikipedia and Translator URL

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -191,6 +191,84 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                     UIManager:show(wikilang_input)
                     wikilang_input:onShowKeyboard()
                 end,
+            },
+            {
+                text = _("Wikipedia server"),
+                keep_menu_open = true,
+                help_text = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://en.wikipedia.org)."),
+                callback = function(touchmenu_instance)
+                    local input
+                    input = InputDialog:new{
+                        title = _("Wikipedia server"),
+                        input = G_reader_settings:readSetting("wikipedia_server") or Wikipedia.wiki_server,
+                        input_hint = Wikipedia.wiki_server,
+                        input_type = "text",
+                        description = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://en.wikipedia.org)."),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function() UIManager:close(input) end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        local value = input:getInputText()
+                                        if value ~= "" then
+                                            G_reader_settings:saveSetting("wikipedia_server", value)
+                                        else
+                                            G_reader_settings:delSetting("wikipedia_server")
+                                        end
+                                        UIManager:close(input)
+                                        touchmenu_instance:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(input)
+                end,
+            },
+            {
+                text = _("Wikipedia path"),
+                keep_menu_open = true,
+                help_text = _("Request path of the Wikipedia API."),
+                callback = function(touchmenu_instance)
+                    local input
+                    input = InputDialog:new{
+                        title = _("Wikipedia API path"),
+                        input = G_reader_settings:readSetting("wikipedia_path") or Wikipedia.wiki_path,
+                        input_hint = Wikipedia.wiki_path,
+                        input_type = "text",
+                        description = _("Request path of the Wikipedia API."),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function() UIManager:close(input) end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        local value = input:getInputText()
+                                        if value ~= "" then
+                                            G_reader_settings:saveSetting("wikipedia_path", value)
+                                        else
+                                            G_reader_settings:delSetting("wikipedia_path")
+                                        end
+                                        UIManager:close(input)
+                                        touchmenu_instance:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(input)
+                end,
                 separator = true,
             },
             { -- setting used by dictquicklookup

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -195,7 +195,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
             {
                 text = _("Wikipedia server"),
                 keep_menu_open = true,
-                help_text = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://en.wikipedia.org)."),
+                help_text = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://%s.wikipedia.org)."),
                 callback = function(touchmenu_instance)
                     local input
                     input = InputDialog:new{
@@ -203,7 +203,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         input = G_reader_settings:readSetting("wikipedia_server") or Wikipedia.wiki_server,
                         input_hint = Wikipedia.wiki_server,
                         input_type = "text",
-                        description = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://en.wikipedia.org)."),
+                        description = _("Base URL of the Wikipedia API server, with the %s placeholder replaced by the language code (e.g. https://%s.wikipedia.org)."),
                         buttons = {
                             {
                                 {
@@ -229,6 +229,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         },
                     }
                     UIManager:show(input)
+                    input:onShowKeyboard()
                 end,
             },
             {
@@ -268,6 +269,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                         },
                     }
                     UIManager:show(input)
+                    input:onShowKeyboard()
                 end,
                 separator = true,
             },

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -467,6 +467,7 @@ This is useful:
                         },
                     }
                     UIManager:show(input)
+                    input:onShowKeyboard()
                 end,
             },
             {
@@ -506,6 +507,7 @@ This is useful:
                         },
                     }
                     UIManager:show(input)
+                    input:onShowKeyboard()
                 end,
             },
         },

--- a/frontend/ui/translator.lua
+++ b/frontend/ui/translator.lua
@@ -11,6 +11,7 @@ This module translates text using Google Translate.
 
 local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
 local TextViewer = require("ui/widget/textviewer")
 local UIManager = require("ui/uimanager")
 local JSON = require("json")
@@ -429,6 +430,84 @@ This is useful:
                 end,
                 sub_item_table = genLanguagesItems("translator_to_language", self:getTargetLanguage()),
             },
+            {
+                text = _("Translation server"),
+                help_text = _("URL of the translation service, without the request path."),
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local input
+                    input = InputDialog:new{
+                        title = _("Translation server"),
+                        input = self:getTransServer(),
+                        input_hint = "https://translate.googleapis.com/",
+                        input_type = "text",
+                        description = _("URL of the translation service, without the request path."),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function() UIManager:close(input) end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        local value = input:getInputText()
+                                        if value ~= "" then
+                                            G_reader_settings:saveSetting("trans_server", value)
+                                        else
+                                            G_reader_settings:delSetting("trans_server")
+                                        end
+                                        UIManager:close(input)
+                                        touchmenu_instance:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(input)
+                end,
+            },
+            {
+                text = _("Translation path"),
+                help_text = _("Request path of the translation service."),
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local input
+                    input = InputDialog:new{
+                        title = _("Translation path"),
+                        input = G_reader_settings:readSetting("trans_path") or self.trans_path,
+                        input_hint = "/translate_a/single",
+                        input_type = "text",
+                        description = _("Request path of the translation service."),
+                        buttons = {
+                            {
+                                {
+                                    text = _("Cancel"),
+                                    id = "close",
+                                    callback = function() UIManager:close(input) end,
+                                },
+                                {
+                                    text = _("Save"),
+                                    is_enter_default = true,
+                                    callback = function()
+                                        local value = input:getInputText()
+                                        if value ~= "" then
+                                            G_reader_settings:saveSetting("trans_path", value)
+                                        else
+                                            G_reader_settings:delSetting("trans_path")
+                                        end
+                                        UIManager:close(input)
+                                        touchmenu_instance:updateItems()
+                                    end,
+                                },
+                            }
+                        },
+                    }
+                    UIManager:show(input)
+                end,
+            },
         },
     }
 end
@@ -523,7 +602,7 @@ function Translator:loadPage(text, target_lang, source_lang)
        query = query .. "dt=rm&"
     end
     local parsed = url.parse(self:getTransServer())
-    parsed.path = self.trans_path
+    parsed.path = G_reader_settings:readSetting("trans_path") or self.trans_path
     parsed.query = query .. "q=" .. url.escape(text)
 
     -- HTTP request

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -96,7 +96,8 @@ local Wikipedia = {
 }
 
 function Wikipedia:getWikiServer(lang)
-    return string.format(self.wiki_server, lang or self.default_lang)
+    local server = G_reader_settings:readSetting("wikipedia_server") or self.wiki_server
+    return string.format(server, lang or self.default_lang)
 end
 
 -- Search for the response header 'set-cookie', and extract the associated cookies
@@ -248,7 +249,7 @@ function Wikipedia:loadPage(text, lang, page_type, plain)
     local url = require("socket.url")
     local query = ""
     local parsed = url.parse(self:getWikiServer(lang))
-    parsed.path = self.wiki_path
+    parsed.path = G_reader_settings:readSetting("wikipedia_path") or self.wiki_path
     if page_type == WIKIPEDIA_INTRO then -- search query
         self.wiki_search_params.explaintext = plain and "" or nil
         for k,v in pairs(self.wiki_search_params) do


### PR DESCRIPTION
### Description

Currently Wikipedia and Google Translate API endpoints are hard-coded ([`koreader/frontend/ui/wikipedia.lua:24-25`](https://github.com/koreader/koreader/blob/2749cf89170b90b44fae2c6c624352dd178e63c9/frontend/ui/wikipedia.lua#L24) and [`koreader/frontend/ui/translator.lua:297,300`](https://github.com/koreader/koreader/blob/2749cf89170b90b44fae2c6c624352dd178e63c9/frontend/ui/translator.lua#L297). This PR allows user to set it in UI (in Search settings) so it's more convenient and persistent through updates.

This is especially useful for regions where Wikipedia or Google services are blocked or unstable. User can set up a reverse proxy (or a compatible API endpoint) and set it for lookup.

### Summary of changes

- Added 4 setting entry to set host and path for Wikipedia and Translator.
- Read settings on lookup, fallback to default value if not set.

Works well on Linux (Arch Linux, rolling), Kindle (Basic, 8th generation) and Android (vanilla, 14).

### AI usage disclosure

I'm not proficient in Lua, so to eliminate quirks, I used AI to review and improve my code, which results in the second commit.

Everything in this PR, AI-generated or not, is responsibly reviewed and tested by human.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15806)
<!-- Reviewable:end -->
