### PR TITLE
add `pocketbookhf` target

### DIFF
--- a/frontend/device/pocketbook/device.lua
+++ b/frontend/device/pocketbook/device.lua
@@ -902,6 +902,13 @@ local PocketBook970 = PocketBook:extend{
     hasNaturalLight = yes,
 }
 
+-- PocketBook InkPad One (1030)
+local PocketBook1030 = PocketBook:extend{
+    model = "PB1030",
+    display_dpi = 226,
+    hasNaturalLight = yes,
+}
+
 -- PocketBook InkPad X (1040)
 local PocketBook1040 = PocketBook:extend{
     model = "PB1040",
@@ -998,6 +1005,8 @@ elseif codename == "840" or codename == "Reader InkPad" then
     return PocketBook840
 elseif codename == "970" then
     return PocketBook970
+elseif codename == "1030" then
+    return PocketBook1030
 elseif codename == "1040" then
     return PocketBook1040
 elseif codename == "Color Lux" then

--- a/kodev
+++ b/kodev
@@ -142,6 +142,7 @@ TARGET:
     linux
     macos                     MacOS app bundle
     pocketbook
+    pocketbookhf
     remarkable
     remarkable-aarch64
     sony-prstux
@@ -170,7 +171,7 @@ function setup_target() {
         cervantes) ;;
         kindle | kindlehf | kindlepw2 | kindle-legacy) ;;
         kobo | kobov4 | kobov5) ;;
-        pocketbook) ;;
+        pocketbook | pocketbookhf) ;;
         remarkable) ;;
         remarkable-aarch64) ;;
         sony-prstux) ;;

--- a/make/pocketbookhf.mk
+++ b/make/pocketbookhf.mk
@@ -1,0 +1,1 @@
+include make/pocketbook.mk


### PR DESCRIPTION
For models like the InkPad One.

Nightly-builds patch: [0001-add-pocketbookhf-build.patch](https://github.com/user-attachments/files/30754569/0001-add-pocketbookhf-build.patch)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15812)
<!-- Reviewable:end -->
