### PR TITLE
make: fix `mo` rules

### DIFF
--- a/make/gettext.mk
+++ b/make/gettext.mk
@@ -14,10 +14,14 @@ MO_FILES = $(PO_FILES:%.po=%.mo)
 	@$(MSGFMT_BIN) --no-hash -o $@ $<
 
 mo:
+ifneq (,$(MO_FILES))
 	$(MAKE) $(if $(PARALLEL_JOBS),--jobs=$(PARALLEL_JOBS)) $(if $(PARALLEL_LOAD),--load-average=$(PARALLEL_LOAD)) --silent --file=$(SELF) $(MO_FILES)
+endif
 
 mo-clean:
+ifneq (,$(MO_FILES))
 	rm -f $(MO_FILES)
+endif
 
 pot: po
 	mkdir -p $(TEMPLATE_DIR)


### PR DESCRIPTION
Avoid an infinite recursive loop when using an empty sparse checkout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15813)
<!-- Reviewable:end -->
