### PR TITLE
device: get rid of probing code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ endef
 
 all: base mo
 	install -d $(INSTALL_DIR)/koreader
-	rm -f $(INSTALL_DIR)/koreader/git-rev; echo "$(VERSION)" > $(INSTALL_DIR)/koreader/git-rev
+	rm -f $(INSTALL_DIR)/koreader/git-rev; echo "$(VERSION)_$(DIST)" > $(INSTALL_DIR)/koreader/git-rev
 ifdef ANDROID
 	rm -f android-fdroid-version; echo -e "$(ANDROID_NAME)\n$(ANDROID_VERSION)" > koreader-android-fdroid-latest
 endif

--- a/frontend/device.lua
+++ b/frontend/device.lua
@@ -1,52 +1,26 @@
-local isAndroid, _ = pcall(require, "android")
-local lfs = require("libs/libkoreader-lfs")
 local util = require("ffi/util")
+local Version = require("version")
 
 local function probeDevice()
-    if isAndroid then
-        return require("device/android/device")
+    local platform = Version:getCurrentPlatform()
+    if platform then
+        if platform:sub(1, #"android") == "android" then
+            return require("device/android/device")
+        elseif platform:sub(1, #"cervantes") == "cervantes" then
+            return require("device/cervantes/device")
+        elseif platform:sub(1, #"kindle") == "kindle" then
+            return require("device/kindle/device")
+        elseif platform:sub(1, #"kobo") == "kobo" then
+            return require("device/kobo/device")
+        elseif platform:sub(1, #"pocketbook") == "pocketbook" then
+            return require("device/pocketbook/device")
+        elseif platform:sub(1, #"sony-prstux") == "sony-prstux" then
+            return require("device/sony-prstux/device")
+        end
     end
-
-    local kindle_test_stat = lfs.attributes("/proc/usid")
-    if kindle_test_stat then
-        return require("device/kindle/device")
-    end
-
-    local kobo_test_stat = lfs.attributes("/bin/kobo_config.sh") or lfs.attributes("/usr/bin/hwdetect.sh") or lfs.attributes("/usr/bin/hwdetect")
-    if kobo_test_stat then
-        return require("device/kobo/device")
-    end
-
-    local pbook_test_stat = lfs.attributes("/ebrmain")
-    if pbook_test_stat then
-        return require("device/pocketbook/device")
-    end
-
-    local remarkable_test_stat = lfs.attributes("/usr/bin/xochitl")
-    if remarkable_test_stat then
-        return require("device/remarkable/device")
-    end
-
-    local sony_prstux_test_stat = lfs.attributes("/etc/PRSTUX")
-    if sony_prstux_test_stat then
-        return require("device/sony-prstux/device")
-    end
-
-    local cervantes_test_stat = lfs.attributes("/usr/bin/ntxinfo")
-    if cervantes_test_stat then
-        return require("device/cervantes/device")
-    end
-
-    -- add new ports here:
-    --
-    -- if --[[ implement a proper test instead --]] false then
-    --     return require("device/newport/device")
-    -- end
-
     if util.loadSDL3() then
         return require("device/sdl/device")
     end
-
     error("Could not find hardware abstraction for this platform. If you are trying to run the emulator, please ensure SDL is installed.")
 end
 

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -70,24 +70,6 @@ function Version:getShortVersion()
     return self.short
 end
 
---- Returns the release date of the current version of KOReader, YYYYmmdd, in UTC.
---- Technically closer to the build date, but close enough where official builds are concerned ;).
--- @treturn int date
-function Version:getBuildDate()
-    if not self.date then
-        local lfs = require("libs/libkoreader-lfs")
-        local mtime = lfs.attributes("git-rev", "modification")
-        if mtime then
-            local ts = os.date("!%Y%m%d", mtime)
-            self.date = tonumber(ts) or 0
-        else
-            -- No git-rev file?
-            self.date = 0
-        end
-    end
-    return self.date
-end
-
 --- Get last line in `VERSION_LOG_FILE`.
 -- @treturn last line in `VERSION_LOG_FILE` or an empty string
 function Version:getLastLogLine()

--- a/frontend/version.lua
+++ b/frontend/version.lua
@@ -41,6 +41,11 @@ function Version:getNormalizedVersion(rev)
     return ((year or 0) * 100 + (month or 0)) * 1000000 + (point or 0) * 10000 + (revision or 0), commit
 end
 
+function Version:getCurrentPlatform()
+    local rev = self:getCurrentRevision()
+    return rev and rev:match("_([a-z][^_]*)")
+end
+
 --- Returns current version of KOReader.
 -- @treturn int version in the form of a 12 digit number such as `201511000982`
 -- @treturn string short git commit version hash such as `704d4238`


### PR DESCRIPTION
Append target platform to `git-rev` and use it in place of probing (cf. https://github.com/koreader/koreader/pull/15759#issuecomment-5152087823).

Tested on Kindle and with the emulator (with `hwdetect` installed).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15815)
<!-- Reviewable:end -->
