### PR TITLE
FocusManager: put the focus keys back when a keyboard goes away

### DIFF
--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -33,8 +33,6 @@ local FocusManager = InputContainer:extend{
     movement_allowed = { x = true, y = true },
     key_events_enabled = true,
     -- Widgets that bind keys the focus manager also uses set this; see releaseFocusKeys.
-    --- @fixme a callback that rebuilds a whole key_events set also brings back bindings
-    --- suppressed from the outside; it should only re-add what the rebuild dropped.
     focus_keys_callback = nil,
     released_focus_keys = nil,
 }

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -335,6 +335,9 @@ function FocusManager:onPhysicalKeyboardDisconnected()
                 self.key_events[k] = nil
             end
         end
+        -- And put back the ones we still want: a widget rebuilding its own bindings around
+        -- the hot-plug may well have dropped the whole set, ours included.
+        util.tableMerge(self.key_events, KEY_EVENTS)
     else
         -- If we longer have keys at all, that's easy ;).
         self.key_events = {}

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -130,6 +130,8 @@ end
 --- Releases focus keys a widget wants for itself, e.g. the horizontal moves in a
 --- single-column menu. They stay released when a keyboard hot-plug re-merges the
 --- default mappings.
+--- Only for keys FocusManager itself declares: a widget's own bindings are its
+--- registerKeyEvents' business, and that one runs again on hot-plug.
 function FocusManager:releaseFocusKeys(...)
     if not self.released_focus_keys then
         self.released_focus_keys = {}

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -130,8 +130,14 @@ end
 --- Releases focus keys a widget wants for itself, e.g. the horizontal moves in a
 --- single-column menu. They stay released when a keyboard hot-plug re-merges the
 --- default mappings.
---- Only for keys FocusManager itself declares: a widget's own bindings are its
---- registerKeyEvents' business, and that one runs again on hot-plug.
+--- SCOPE: this only guarantees FocusManager's own base key_events (built by
+--- populateEventMappings, e.g., FocusLeft/FocusRight/FocusHalfMove/...) stay
+--- released. It does NOT protect keys a subclass adds itself (e.g., Menu's
+--- ShowGotoDialog/FirstPage/LastPage): if that subclass's own key-rebuilding
+--- method (e.g. Menu:registerKeyEvents) reassigns such a key unconditionally on
+--- external-keyboard connect/disconnect, the release will silently be undone.
+--- A subclass that needs to release one of its own keys is responsible for
+--- checking self.released_focus_keys itself before rebinding it.
 function FocusManager:releaseFocusKeys(...)
     if not self.released_focus_keys then
         self.released_focus_keys = {}

--- a/spec/unit/focusmanager_spec.lua
+++ b/spec/unit/focusmanager_spec.lua
@@ -234,6 +234,21 @@ describe("FocusManager module", function()
         assert.are.equal(1, calls)
         assert.are.same({ { "Right" } }, focusmanager.key_events.ExpandCurrentNode)
     end)
+    it("should restore its own keys when a widget cleared them on disconnect", function()
+        local focusmanager = FocusManager:new{}
+        local focus_left = focusmanager.key_events.FocusLeft
+        -- What a widget rebuilding its bindings around the hot-plug does.
+        focusmanager.key_events = {}
+        focusmanager:onPhysicalKeyboardDisconnected()
+        assert.are.same(focus_left, focusmanager.key_events.FocusLeft)
+    end)
+    it("should keep released keys released across a disconnect", function()
+        local focusmanager = FocusManager:new{}
+        focusmanager:releaseFocusKeys("FocusLeft", "FocusRight")
+        focusmanager:onPhysicalKeyboardDisconnected()
+        assert.is_nil(focusmanager.key_events.FocusLeft)
+        assert.is_nil(focusmanager.key_events.FocusRight)
+    end)
     it("should not rebind anything once the device has no keys left", function()
         local Device = require("device")
         local focusmanager = FocusManager:new{}


### PR DESCRIPTION
The connect handler re-merges KEY_EVENTS, the disconnect one only drops what disappeared -- fine as long as key_events still holds what it held before. A widget that rebuilds its own bindings around the hot-plug may clear the whole table, and then nothing brings the focus moves back: an open menu is left with no way to move the cursor.

Merge on the way out too. Released keys are dropped again right after, by _refreshFocusKeys, so a widget that took a key for itself keeps it.

Came up in #15781, where Menu clears the set on disconnect at the reviewer's request.

Two specs: the restore after a widget cleared the table, and released keys staying released. I can't run the specs locally, no built base here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15819)
<!-- Reviewable:end -->

