### PR TITLE
ReaderToc: let the focused node draw its cursor

### DIFF
--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -884,6 +884,8 @@ function ReaderToc:onShowToc()
     -- *2/5 to account for Menu top title and bottom icons, and add some space between consecutive icons
     local icon_size = math.floor(Screen:getHeight() / items_per_page * 2/5)
     local button_width = icon_size * 2
+    -- no_focus: the button sits inside a menu item, and a Button that takes the Focus
+    -- event keeps the item itself from ever seeing it -- and from drawing its cursor.
     self.expand_button = Button:new{
         icon = "control.expand",
         icon_rotation_angle = BD.mirroredUILayout() and 180 or 0,
@@ -891,6 +893,7 @@ function ReaderToc:onShowToc()
         icon_width = icon_size,
         icon_height = icon_size,
         bordersize = 0,
+        no_focus = true,
         show_parent = self,
         callback = function(index) self:expandToc(index) end,
         onTapSelectButton = function() end, -- pass through taps to onMenuSelect
@@ -902,6 +905,7 @@ function ReaderToc:onShowToc()
         icon_width = icon_size,
         icon_height = icon_size,
         bordersize = 0,
+        no_focus = true,
         show_parent = self,
         callback = function(index) self:collapseToc(index) end,
         onTapSelectButton = function() end, -- pass through taps to onMenuSelect

--- a/frontend/apps/reader/modules/readertoc.lua
+++ b/frontend/apps/reader/modules/readertoc.lua
@@ -884,8 +884,7 @@ function ReaderToc:onShowToc()
     -- *2/5 to account for Menu top title and bottom icons, and add some space between consecutive icons
     local icon_size = math.floor(Screen:getHeight() / items_per_page * 2/5)
     local button_width = icon_size * 2
-    -- no_focus: the button sits inside a menu item, and a Button that takes the Focus
-    -- event keeps the item itself from ever seeing it -- and from drawing its cursor.
+    -- no_focus: expand/collapse is on the left/right keys, so the buttons don't need to take focus.
     self.expand_button = Button:new{
         icon = "control.expand",
         icon_rotation_angle = BD.mirroredUILayout() and 180 or 0,


### PR DESCRIPTION
In the ToC the focus cursor takes two shapes: ordinary rows get an underline, while a row with a subtree inverts its triangle instead. That still reads as "the selected one is marked", which is why this went unnoticed for so long.

A container hands an event to its children first and only handles it itself if none of them took it. Rows with a subtree have held a Button in `entry.state` since 7c9130744 (collapsable ToC, 2014), and `Button:onFocus` inverts its frame and returns true -- so `MenuItem:onFocus` never runs and the row never marks itself focused.

Those buttons are part of the row, not focus targets of their own: `no_focus` on both, and the cursor becomes one thing again.

Noticed while working on #15780, whose arrow keys make those rows a place one actually visits.

Verified on a Kindle 3, stock build apart from this change.

<img width="45%" alt="before" src="https://github.com/user-attachments/assets/0f915da4-9ebe-488e-9534-4b72c0cc6819" />
<img width="45%" alt="after" src="https://github.com/user-attachments/assets/37b4298a-3d16-49e0-a8fa-a29466fc7dbd" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15820)
<!-- Reviewable:end -->
