### PR TITLE
bump base. bump crengine: CSS font-face and text layout enhancements

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -178,6 +178,20 @@ function ReaderFont:onReadSettings(config)
     self.ui.document:setInterlineSpacePercent(self.configurable.line_spacing)
     self.ui.document:setGammaIndex(self.configurable.font_gamma)
 
+    -- We can get subpixel fractional positionning when with kerning
+    -- mode "best" (which is using Harfbuzz).
+    -- This setting accepts a strength from 0 to 3, with 0 disabling
+    -- the feature. Strength 1, 2 and 3 bound the positioning error
+    -- to 1/96, 1/192 and 1/384 em respectively.
+    -- The higher the strength or the smaller the font size, more
+    -- instances of the same glyph will be cached (with possibly
+    -- cache trashing when many glyphs from many fonts are used).
+    -- Default to a strength of 2 for good quality.
+    -- (No need to make this setting available through the UI. One
+    -- can manually set a different strength with this setting.)
+    local strength = G_reader_settings:readSetting("cre_font_fractional_positioning") or 2
+    self.ui.document:setFontFractionalPositioning(strength)
+
     self.font_family_fonts = config:readSetting("font_family_fonts") or {}
     self:updateFontFamilyFonts()
 
@@ -239,6 +253,14 @@ function ReaderFont:onSetFontKerning(mode)
     self.ui.document:setFontKerning(mode)
     self.ui:handleEvent(Event:new("UpdatePos"))
     Notification:notify(T(_("Font kerning set to: %1"), optionsutil:getOptionText("SetFontKerning", mode)))
+    return true
+end
+
+function ReaderFont:onSetFontFractionalPositioning(strength)
+    -- (Not exposed by the UI, but available via httpinspector for
+    -- scripting and comparing the effect of strength.)
+    self.ui.document:setFontFractionalPositioning(strength)
+    self.ui:handleEvent(Event:new("UpdatePos"))
     return true
 end
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -612,14 +612,16 @@ function ReaderLink:isXpointerCoherent(a_xpointer)
     -- Get screen coordinates of xpointer
     local screen_y, screen_x = self.document:getScreenPositionFromXPointer(a_xpointer)
     -- Get again link and a_xpointer from this position
-    local re_link_xpointer, re_a_xpointer = self.document:getLinkFromPosition({x = screen_x, y = screen_y}) -- luacheck: no unused
+    -- Providing forTextSelection=true may give more chances of success here
+    -- (eg. with negative text indent and the link rect being outside of its paragraph rect).
+    local re_link_xpointer, re_a_xpointer = self.document:getLinkFromPosition({x = screen_x, y = screen_y}, true) -- luacheck: no unused
     -- We should get the same a_xpointer. If not, crengine has messed up
     -- and we should not trust this xpointer to get back to this link.
     if re_a_xpointer ~= a_xpointer then
         -- Try it again with screen_x+1 (in the rare cases where screen_x
         -- fails, screen_x+1 usually works - probably something in crengine,
         -- but easier to workaround here that way)
-        re_link_xpointer, re_a_xpointer = self.document:getLinkFromPosition({x = screen_x+1, y = screen_y}) -- luacheck: no unused
+        re_link_xpointer, re_a_xpointer = self.document:getLinkFromPosition({x = screen_x+1, y = screen_y}, true) -- luacheck: no unused
         if re_a_xpointer ~= a_xpointer then
             logger.info("noncoherent a_xpointer:", a_xpointer)
             return false

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -949,8 +949,8 @@ function CreDocument:getPageLinks(internal_links_only)
     return self._document:getPageLinks(internal_links_only)
 end
 
-function CreDocument:getLinkFromPosition(pos)
-    return self._document:getLinkFromPosition(pos.x, pos.y)
+function CreDocument:getLinkFromPosition(pos, with_forTextSelection)
+    return self._document:getLinkFromPosition(pos.x, pos.y, with_forTextSelection)
 end
 
 function CreDocument:isLinkToFootnote(source_xpointer, target_xpointer, flags, max_text_size)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1303,6 +1303,11 @@ function CreDocument:setFontKerning(mode)
     self._document:setIntProperty("font.kerning.mode", mode)
 end
 
+function CreDocument:setFontFractionalPositioning(strength)
+    logger.dbg("CreDocument: set font fractionalbpositioning", strength)
+    self._document:setIntProperty("font.fractional.positioning", strength)
+end
+
 function CreDocument:setWordSpacing(values)
     -- values should be a table of 2 numbers (e.g.: { 90, 75 })
     -- - space width scale percent (hard scale the width of each space char in

--- a/spec/unit/readerrolling_spec.lua
+++ b/spec/unit/readerrolling_spec.lua
@@ -13,6 +13,9 @@ describe("Readerrolling module", function()
         Event = require("ui/event")
         Screen = require("device").screen
 
+        -- Expected values below established before the introduction of fractional positionning
+        G_reader_settings:saveSetting("cre_font_fractional_positioning", 0)
+
         local sample_epub = "spec/front/unit/data/juliet.epub"
         readerui = ReaderUI:new{
             dimen = Screen:getSize(),
@@ -22,6 +25,8 @@ describe("Readerrolling module", function()
     end)
 
     teardown(function()
+        G_reader_settings:delSetting("cre_font_fractional_positioning")
+        G_reader_settings:flush()
         readerui:onClose()
     end)
 

--- a/spec/unit/readertoc_spec.lua
+++ b/spec/unit/readertoc_spec.lua
@@ -10,6 +10,9 @@ describe("Readertoc module", function()
         Screen = require("device").screen
         DEBUG = require("dbg")
 
+        -- Expected values below established before the introduction of fractional positionning
+        G_reader_settings:saveSetting("cre_font_fractional_positioning", 0)
+
         local sample_epub = "spec/front/unit/data/juliet.epub"
         -- Clear settings from previous tests
         local DocSettings = require("docsettings")
@@ -24,6 +27,11 @@ describe("Readertoc module", function()
         -- reset book to first page
         readerui.rolling:onGotoPage(0)
         toc = readerui.toc
+    end)
+
+    teardown(function()
+        G_reader_settings:delSetting("cre_font_fractional_positioning")
+        G_reader_settings:flush()
     end)
 
     it("should get max toc depth", function()


### PR DESCRIPTION
Includes:
#### base:
- Android: let the system handle power key events https://github.com/koreader/koreader-base/pull/2482
- pocketbook: fix inkview version check https://github.com/koreader/koreader-base/pull/2499 (close #15824)
- thirdparty/giflib: add download mirrors https://github.com/koreader/koreader-base/pull/2493
- blifbuffer: refix rounded corners https://github.com/koreader/koreader-base/pull/2500
#### crengine:
- cmake: add setting for custom memory manager use https://github.com/koreader/crengine/pull/715
- fix `USE_ANSI_FILES` setting https://github.com/koreader/crengine/pull/716
- lvtextfm: word expansion: avoid involving space condensing https://github.com/koreader/crengine/pull/717 by @asz3
- lvfntman: subpixel/fractional HarfBuzz glyph positioning https://github.com/koreader/crengine/pull/685 by @hanspinckaers
- CSS/lvfntman: consolidate `@font-face` parsing and handling https://github.com/koreader/crengine/pull/713 by @spfenwick
  Closes #10040
  Closes #10604
  Closes #12525
  Closes #14287
  Closes #15557
- bump CACHE_FILE_FORMAT_VERSION https://github.com/koreader/crengine/pull/720
- cre.cpp: https://github.com/koreader/koreader-base/pull/2497
  - fix getLinkFromPosition()
  - add getLangTagForTextFromPosition()
    May help with https://github.com/koreader/koreader/issues/15785
  - tweak getLinkFromPosition() https://github.com/koreader/koreader-base/pull/2502
#### frontend:
- set font.fractional.positioning to strength 2
  (but keep unit tests using 0)
  To enable subpixel/fractional HarfBuzz glyph positioning
- ReaderLink:isXpointerCoherent(): fix check in some edge cases
  See https://github.com/koreader/koreader/pull/15613#issuecomment-4827147727

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15828)
<!-- Reviewable:end -->
