### PR TITLE
[DictQquickLookup] correct space bar call of LookupInputWord on kindle 3

### DIFF
--- a/frontend/ui/widget/dictquicklookup.lua
+++ b/frontend/ui/widget/dictquicklookup.lua
@@ -1813,8 +1813,12 @@ function DictQuickLookup:onLookupInputWord(hint, ev)
     if self.allow_key_text_selection and self.nt_text_selector_indicator then
         self:onStopTextSelectorIndicator(true)
     end
+    local key_pressed = ev and ev.key
+    if key_pressed and ev.key == " " then
+        return self:lookupInputWord()
+    end
     -- Key-event path: open dialog now, then inject key during next tick.
-    if Device:isSDL() and not hint and ev and ev.key then
+    if Device:isSDL() and not hint and key_pressed then
         if ev.key == " " then
             return self:lookupInputWord()
         end


### PR DESCRIPTION
### bug fix

* Using the space bar event to toggle the `lookupInputWord` widget on a kindle keyboard, allowed the event to propagate which in turn would introduce a whitespace to the `InputText` field, the new order returns for all space bar events, not just for those coming from SDL devices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15829)
<!-- Reviewable:end -->
