### PR TITLE
InputDialog: close on Back when there is no Close button

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -573,7 +573,9 @@ function InputDialog:onTap(arg, ges)
         end
     else
         if ges.pos:notIntersectWith(self.dialog_frame.dimen) then
-            self:onCloseDialog()
+            -- Not onCloseDialog: a tap outside stays inert on dialogs that have no Close
+            -- button, as it has always been. Only the key falls back to closing.
+            self:_pressCloseButton()
         end
     end
 end
@@ -734,10 +736,17 @@ end
 
 InputDialog.onKeyboardHeightChanged = InputDialog.reinit
 
-function InputDialog:onCloseDialog()
+function InputDialog:_pressCloseButton()
     local close_button = self.button_table:getButtonById("close")
     if close_button and close_button.enabled then
         close_button.callback()
+        return true
+    end
+    return false
+end
+
+function InputDialog:onCloseDialog()
+    if self:_pressCloseButton() then
         return true
     end
     -- Nothing to defer to: a dialog that can lose work always has a Close button

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -740,7 +740,7 @@ function InputDialog:onCloseDialog()
         close_button.callback()
         return true
     end
-    -- Nothing to defer to: a dialog that can lose work always has a Close button
+    -- Nothing to defer to: a dialog that can lose work should add a Close button
     -- (see _addSaveCloseButtons), so the rest can just go away, as ButtonDialog does.
     UIManager:close(self)
     return true

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -740,7 +740,10 @@ function InputDialog:onCloseDialog()
         close_button.callback()
         return true
     end
-    return false
+    -- Nothing to defer to: a dialog that can lose work always has a Close button
+    -- (see _addSaveCloseButtons), so the rest can just go away, as ButtonDialog does.
+    UIManager:close(self)
+    return true
 end
 
 function InputDialog:onClose()

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -573,9 +573,7 @@ function InputDialog:onTap(arg, ges)
         end
     else
         if ges.pos:notIntersectWith(self.dialog_frame.dimen) then
-            -- Not onCloseDialog: a tap outside stays inert on dialogs that have no Close
-            -- button, as it has always been. Only the key falls back to closing.
-            self:_pressCloseButton()
+            self:onCloseDialog()
         end
     end
 end
@@ -736,17 +734,10 @@ end
 
 InputDialog.onKeyboardHeightChanged = InputDialog.reinit
 
-function InputDialog:_pressCloseButton()
+function InputDialog:onCloseDialog()
     local close_button = self.button_table:getButtonById("close")
     if close_button and close_button.enabled then
         close_button.callback()
-        return true
-    end
-    return false
-end
-
-function InputDialog:onCloseDialog()
-    if self:_pressCloseButton() then
         return true
     end
     -- Nothing to defer to: a dialog that can lose work always has a Close button

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -433,6 +433,8 @@ function Terminal:generateInputDialog()
             },
             {
             text = "✕", --cancel
+            -- Back goes through here, so it asks about the shell like the button does.
+            id = "close",
             callback = function()
                 UIManager:show(MultiConfirmBox:new{
                     text = _("You can close the terminal, but leave the shell open for further commands or quit it now."),


### PR DESCRIPTION
InputDialog binds the Back key group, but its handler only presses a button carrying
id "close" and does nothing when the dialog has none, so on a non-touch device those
dialogs cannot be dismissed with the key at all: the only way out is to aim the cursor
at Cancel.

Dialogs that can lose work always get that button (_addSaveCloseButtons adds it alongside
save_callback, and its callback is what asks about unsaved changes), so the rest can
simply close, as ButtonDialog does with the same key. In-tree that is the terminal
emulator: "Shell to use" (main.lua:631) and "Edit alias" (aliases.lua:85), both confirmed
inert on the device. Out of tree it is whatever a plugin builds without the id.

The second commit covers the terminal's main dialog, which does have a close button but
no id on it. That one closes through ✕, which asks whether to keep the shell running,
saves the input history and unschedules the refresh, so it must not be bypassed: tagging
the button keeps Back on the same path, where it previously did nothing at all.

The third commit keeps taps as they are. InputDialog:onTap routes a tap outside the frame
through onCloseDialog as well, so the fallback would have changed touch behaviour too;
the button press now lives in its own helper and only the key path falls back to closing.

Tested on a live Kindle 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15830)
<!-- Reviewable:end -->
