### PR TITLE
NetworkMgr: Don't clear wifi_was_on on aborted connection attempts

### DIFF
--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -45,8 +45,11 @@ function NetworkMgr:_abortWifiConnection()
     -- Cancel any pending connectivity check, because it wouldn't achieve anything
     self:unscheduleConnectivityCheck()
 
-    self.wifi_was_on = false
-    G_reader_settings:makeFalse("wifi_was_on")
+    -- NOTE: We do *not* clear wifi_was_on here: it tracks the user's standing intent
+    --       ("Wi-Fi was enabled, and the user never explicitly disabled it"),
+    --       and an aborted/failed connection attempt is not direct user interaction (c.f., #15728).
+    --       Clearing it here would permanently disarm auto_restore_wifi after a single failed
+    --       background restore (e.g., waking up the device out of range of any known network).
     -- The connection never completed, so any DHCP lease we may have had is no longer valid.
     self.lease_ssid = nil
     -- Murder Wi-Fi and the async script (if any) first...


### PR DESCRIPTION
This addresses the main contract violation described in #15728.

---

`wifi_was_on` is documented as tracking the user's standing intent — the code comment in `getRestoreMenuTable` says *"everything flips wifi_was_on true, but only direct user interaction (i.e., Menu & Gestures) will flip it off"*, and the help text for "Restore Wi-Fi connection on resume" promises reconnection *"if Wi-Fi used to be enabled the last time you used KOReader, and you did not explicitly disable it."*

`_abortWifiConnection()` broke that contract: it cleared the flag on every failed/aborted connection attempt, none of which is direct user interaction. The practical consequence: waking the device once out of range of any known network (e.g., reading on a bus/train commute) permanently disarmed `auto_restore_wifi` — when the user got back home, resume would no longer reconnect until they manually toggled Wi-Fi in the menu.

### The fix

Stop touching `wifi_was_on` in `_abortWifiConnection()`. The rest of the abort path is unchanged: the pending connectivity check is still cancelled, and Wi-Fi is still torn down after a failed attempt. The flag is still cleared where the contract says it should be: an *interactive* `disableWifi()`. (This mirrors the existing "leave wifi_was_on as-is on purpose" approach the auto-disable path already takes in `networklistener.lua`.)

### Field test (Kindle PW, FW 5.18.3, KOReader v2025.08 + this patch)

One week of real commutes. Before the patch, every failed restore orphaned Wi-Fi for a day or more until a manual reconnect (log excerpts from `crash.log`):

```
07/28-08:32:46 INFO  Failed to restore Wi-Fi (after 45 seconds)!   <- commute, out of range
07/29-20:19:45 INFO  Wi-Fi successfully restored (after 0.25 seconds)!  <- only after manual re-enable, ~1.5 days later
07/30-08:33:41 INFO  Failed to restore Wi-Fi (after 45 seconds)!   <- commute again
07/31-11:08:00 INFO  Wi-Fi successfully restored (after 2.25 seconds)!  <- again manual, ~1 day later
```

After the patch, the same commute failure no longer disarms restore — the device reconnects silently at the next wake within range:

```
08/06-08:32:23 INFO  Failed to restore Wi-Fi (after 45 seconds)!   <- commute, out of range
08/07-01:06:12 INFO  Wi-Fi successfully restored (after 3 seconds)!    <- same day, automatic, at home
```

### Relation to #15792

Complementary, no overlap: #15792 gates the blocking `goOnlineToRun` path on `wifi_was_on` so a background finalizer can't resurrect Wi-Fi the user explicitly turned off. That gate trusts `wifi_was_on` to mean "the user turned Wi-Fi off" — but as long as a failed *attempt* also clears the flag, the gate can't distinguish the two, and would (post-#15792) also skip background syncs after a transient failure. This PR makes the flag mean what that check assumes it means.

### Tradeoff

With the flag no longer cleared, every wake out of range retries the restore and spends the full 45 s connectivity-check window with the radio on (successful restores complete in 0.25–3 s). In the field log above that's one 45 s window per out-of-range wake — roughly once per commute day. That seems like the right price for honoring an explicitly opted-in `auto_restore_wifi`; if it's a concern, a backoff could be layered on top in a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15835)
<!-- Reviewable:end -->
