### PR TITLE
Add Kazakh language support plugin

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1368,24 +1368,19 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     -- and one of them being non-CJK is what keeps fuzzy search on for a mixed
     -- selection (Japanese deinflection can strip a selection down to its
     -- non-CJK prefix, e.g. imperative negative "な" -> "").
-    local shouldnt_fuzzy_search = true
-    for _, w in ipairs(words) do
-        if not util.hasCJKChar(w) then
-            shouldnt_fuzzy_search = false
-            break
-        end
-    end
-    if shouldnt_fuzzy_search and candidates then
-        for _, w in ipairs(candidates) do
-            if not util.hasCJKChar(w) then
-                shouldnt_fuzzy_search = false
-                break
+    if fuzzy_search then
+        local function allCJK(list)
+            for _, w in ipairs(list) do
+                if not util.hasCJKChar(w) then
+                    return false
+                end
             end
+            return true
         end
-    end
-    if shouldnt_fuzzy_search then
-        logger.dbg("disabling fuzzy searching for all-CJK word search:", words)
-        fuzzy_search = false
+        if allCJK(words) and (candidates == nil or allCJK(candidates)) then
+            logger.dbg("disabling fuzzy searching for all-CJK word search:", words)
+            fuzzy_search = false
+        end
     end
 
     -- Language plugin candidates are dictionary forms, and are always looked up
@@ -1412,6 +1407,10 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             }
         }
     else -- flatten any possible results
+        -- Only reached when the lookup above was fuzzy: --exact-search is an
+        -- sdcv command-line flag, so one invocation cannot search the user's
+        -- own word loosely and these strictly. When fuzzy search is off they
+        -- were appended to `words` above and no second call happens.
         if exact_candidates and not lookup_cancelled then
             local candidates_cancelled, candidate_results =
                 self:rawSdcv(exact_candidates, dict_names, false, self.lookup_progress_msg or false)

--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1348,13 +1348,14 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
         end
     end
 
+    -- Get any other candidates from any language-specific plugins we have.
+    -- We prefer the originally selected word first (in case there is a
+    -- dictionary entry for whatever text the user selected).
+    local candidates
     if self.ui.languagesupport and self.ui.languagesupport:hasActiveLanguagePlugins() then
-        -- Get any other candidates from any language-specific plugins we have.
-        -- We prefer the originally selected word first (in case there is a
-        -- dictionary entry for whatever text the user selected).
-        local candidates = self.ui.languagesupport:extraDictionaryFormCandidates(word)
-        if candidates then
-            util.arrayAppend(words, candidates)
+        candidates = self.ui.languagesupport:extraDictionaryFormCandidates(word)
+        if candidates and #candidates == 0 then
+            candidates = nil
         end
     end
 
@@ -1362,6 +1363,11 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
     -- (probably) a CJK word. We don't want fuzzy searching in this case
     -- because sdcv cannot handle CJK text properly when fuzzy searching (with
     -- Japanese, it returns hundreds of useless results).
+    -- The plugin candidates take part in this decision even though they are
+    -- looked up separately below, because they used to be part of `words` here
+    -- and one of them being non-CJK is what keeps fuzzy search on for a mixed
+    -- selection (Japanese deinflection can strip a selection down to its
+    -- non-CJK prefix, e.g. imperative negative "な" -> "").
     local shouldnt_fuzzy_search = true
     for _, w in ipairs(words) do
         if not util.hasCJKChar(w) then
@@ -1369,9 +1375,31 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             break
         end
     end
+    if shouldnt_fuzzy_search and candidates then
+        for _, w in ipairs(candidates) do
+            if not util.hasCJKChar(w) then
+                shouldnt_fuzzy_search = false
+                break
+            end
+        end
+    end
     if shouldnt_fuzzy_search then
         logger.dbg("disabling fuzzy searching for all-CJK word search:", words)
         fuzzy_search = false
+    end
+
+    -- Language plugin candidates are dictionary forms, and are always looked up
+    -- with exact search: an intermediate form that is not actually a headword
+    -- would otherwise contribute near-spelling matches that sort above the
+    -- entry the user asked for. sdcv's --exact-search is per invocation, so
+    -- they can share the lookup below only when it is exact anyway.
+    local exact_candidates
+    if candidates then
+        if fuzzy_search then
+            exact_candidates = candidates
+        else
+            util.arrayAppend(words, candidates)
+        end
     end
 
     local lookup_cancelled, results = self:rawSdcv(words, dict_names, fuzzy_search, self.lookup_progress_msg or false)
@@ -1384,6 +1412,16 @@ function ReaderDictionary:startSdcv(word, dict_names, fuzzy_search)
             }
         }
     else -- flatten any possible results
+        if exact_candidates and not lookup_cancelled then
+            local candidates_cancelled, candidate_results =
+                self:rawSdcv(exact_candidates, dict_names, false, self.lookup_progress_msg or false)
+            lookup_cancelled = candidates_cancelled
+            if candidate_results then
+                -- Appended, so the tapped word's own results keep the lead.
+                util.arrayAppend(results, candidate_results)
+            end
+        end
+
         local flat_results = {}
         local seen_results = {}
         -- Flatten the array, removing any duplicates we may have gotten (sdcv

--- a/frontend/languagesupport.lua
+++ b/frontend/languagesupport.lua
@@ -85,6 +85,13 @@ corresponding onHandler method):
    all be displayed to the user. It is not necessary to include the original
    word in the candidate list -- it will always be given highest priority.
 
+   Candidates are always resolved with exact search, even when the user has
+   fuzzy search enabled. A candidate is a dictionary form, and an analysis that
+   is not actually a headword would otherwise contribute near-spelling matches
+   that sort above the entry the user asked for. A candidate that is not a
+   headword simply returns nothing, so plugins can offer every analysis they
+   consider legal and let the dictionary decide which ones exist.
+
 @param Plugin to register (plugin.name is used as the internal name and must not be nil or "").
 @treturn bool Whether the plugin was successfully registered.
 ]]
@@ -119,6 +126,13 @@ local function callPlugin(plugin, handler_name, ...)
     local ok = table.remove(ret, 1)
     if not ok then
         logger.err("language plugin", plugin, "crashed during", handler_name, "handler:", unpack(ret))
+        return
+    end
+    -- A handler returning nil is declining to handle this text, and the caller
+    -- must go on to the next plugin. Without this the pcall wrapper would turn
+    -- that into an empty (but non-nil) table and the search would stop here.
+    if ret[1] == nil then
+        logger.dbg("language plugin", plugin, "declined to handle", handler_name)
         return
     end
     logger.dbg("language plugin", handler_name, "returned", ret)

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -44,6 +44,7 @@ local BUILTIN_PLUGINS = {
     ["hotkeys"] = true,
     ["httpinspector"] = true,
     ["japanese"] = true,
+    ["kazakh"] = true,
     ["keepalive"] = true,
     ["kosync"] = true,
     ["movetoarchive"] = true,

--- a/plugins/kazakh.koplugin/README.md
+++ b/plugins/kazakh.koplugin/README.md
@@ -1,0 +1,76 @@
+# Kazakh support
+
+Makes dictionary lookup work on inflected Kazakh words.
+
+Kazakh is agglutinative. `мектептерімізде` is `мектеп` ("school") plus plural,
+first-person-plural possessive and locative. Dictionaries are keyed on the
+lemma, so tapping that word in a book finds nothing, and fuzzy search does not
+rescue it: it measures *spelling* distance, not morphology.
+
+The plugin hooks the same `LanguageSupport` WordLookup mechanism the Japanese
+plugin uses for deinflection, and supplies extra dictionary-form candidates:
+
+```
+мектептерімізде  →  мектептеріміз, мектептері, мектептер, мектеп
+кітабы           →  кітаб, кітап          (undoes б→п devoicing)
+орны             →  орын                  (restores the elided vowel)
+```
+
+It offers every morphologically legal analysis rather than picking one stem,
+and lets the dictionary decide which exist. A useful consequence: **no lexicon
+is shipped or loaded.**
+
+## Ranking
+
+KOReader queries the tapped word first, then the plugin's candidates in the
+order returned, concatenating results in that order — so an exact hit on the
+tapped word always leads.
+
+Intermediate rungs are usually not words, and KOReader resolves candidates with
+fuzzy search on, so each would return near-spelling matches that sort above the
+real article. The plugin therefore resolves its own candidates first with exact
+search and passes on only those that exist, in ladder order, so the shallowest
+analysis comes first. If that check cannot run, the unfiltered list is
+returned.
+
+The one source of noise it cannot remove is the tapped word's **own** fuzzy
+matches, since KOReader queries it before the plugin is consulted. Unchecking
+**Search → Settings → Dictionary settings → Enable fuzzy search** removes them.
+With a book open that is a per-book setting, so it need not affect anything else
+you read; long-press the item to change the default for new books.
+
+## Requirements
+
+At least one Kazakh StarDict dictionary in `koreader/data/dict/`. The book's
+language must be detected as `kk`/`kaz`, or set it via
+*Book information → Language*.
+
+## Settings
+
+*Menu → Search → Language support → Kazakh → Maximum candidates* (default 8).
+
+## Implementation
+
+| file | |
+|---|---|
+| `main.lua` | registers the plugin, implements `onWordLookup` |
+| `stemmer.lua` | the ladder walk — suffix layers, vowel harmony, sound-change repair |
+| `rules.lua` | **generated** suffix inventory; do not edit by hand |
+
+Everything indexes by character, never by byte: Cyrillic is two bytes per
+character in UTF-8, so byte offsets would put every length check and suffix
+boundary in the wrong place.
+
+The algorithm is a Lua port of
+[kazsearch-py](https://github.com/iDynbek/kazsearch-py), itself a port of the
+Rust core of [pg-kazsearch](https://github.com/darkhanakh/pg-kazsearch).
+`rules.lua` is generated there by `tools/gen_lua_rules.py`, so the suffix
+inventory cannot drift, and `tools/parity_lua.py` diffs the hand-ported walk
+against the reference: 20,006 of 20,020 golden words identical, the remaining
+14 single characters that this port drops by policy.
+
+## Licence
+
+Derived from pg-kazsearch by darkhanakh, licensed **LGPL-3.0-or-later**, and
+distributed here under KOReader's **AGPL-3.0-or-later** — permitted by
+LGPL-3.0 §2 and AGPL-3.0 §13.

--- a/plugins/kazakh.koplugin/README.md
+++ b/plugins/kazakh.koplugin/README.md
@@ -24,14 +24,12 @@ is shipped or loaded.**
 
 KOReader queries the tapped word first, then the plugin's candidates in the
 order returned, concatenating results in that order — so an exact hit on the
-tapped word always leads.
+tapped word always leads, and the shallowest analysis leads the rest.
 
-Intermediate rungs are usually not words, and KOReader resolves candidates with
-fuzzy search on, so each would return near-spelling matches that sort above the
-real article. The plugin therefore resolves its own candidates first with exact
-search and passes on only those that exist, in ladder order, so the shallowest
-analysis comes first. If that check cannot run, the unfiltered list is
-returned.
+Intermediate rungs are usually not words. Language support resolves candidates
+with exact search, so a rung that is not a headword returns nothing rather than
+near-spelling matches that would sort above the real article, and the plugin can
+offer every legal analysis without filtering them itself.
 
 The one source of noise it cannot remove is the tapped word's **own** fuzzy
 matches, since KOReader queries it before the plugin is consulted. Unchecking

--- a/plugins/kazakh.koplugin/_meta.lua
+++ b/plugins/kazakh.koplugin/_meta.lua
@@ -1,0 +1,10 @@
+local _ = require("gettext")
+return {
+    fullname = _("Kazakh support"),
+    description = _([[
+Kazakh language support for KOReader.
+
+This plugin analyses the tapped word and offers every morphological form to the dictionary, which then returns whichever ones actually exist.
+
+You must have at least one Kazakh dictionary installed for this plugin to be useful.]]),
+}

--- a/plugins/kazakh.koplugin/main.lua
+++ b/plugins/kazakh.koplugin/main.lua
@@ -1,0 +1,155 @@
+--- Kazakh language support for KOReader.
+-- Kazakh is agglutinative, so `мектептерімізде` carries plural, possessive and
+-- locative on top of the lemma `мектеп` a dictionary is keyed on. This plugin
+-- extends KOReader's dictionary lookup with the morphological forms of the
+-- tapped word, in the same way the Japanese plugin does with deinflection.
+--
+-- It offers every legal analysis rather than picking one stem, and lets the
+-- dictionary decide which exist, so no lexicon is shipped or held in memory.
+--
+-- @module koplugin.kazakh
+-- @alias Kazakh
+
+-- Licensed under the AGPLv3 or later.
+--
+-- The stemmer is ported from kazsearch-py
+-- <https://github.com/iDynbek/kazsearch-py>, itself a port of the Rust core of
+-- pg-kazsearch <https://github.com/darkhanakh/pg-kazsearch>, LGPLv3 or later.
+
+local LanguageSupport = require("languagesupport")
+local ReaderDictionary = require("apps/reader/modules/readerdictionary")
+local Stemmer = require("stemmer")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local logger = require("logger")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+-- Offering every rung of a very long word costs a wider sdcv call for
+-- diminishing returns; deep rungs are short and rarely the intended lemma.
+local DEFAULT_MAX_CANDIDATES = 8
+
+local Kazakh = WidgetContainer:extend{
+    name = "kazakh",
+    pretty_name = "Kazakh",
+}
+
+-- U+0400–U+04FF (Cyrillic, including the Kazakh-specific ә ғ қ ң ө ұ ү һ і)
+-- is exactly the two-byte UTF-8 sequences with a lead byte of 0xD0–0xD3.
+local function hasCyrillic(text)
+    return text:find("[\208-\211]") ~= nil
+end
+
+function Kazakh:init()
+    self.max_candidates = G_reader_settings:readSetting("language_kazakh_max_candidates")
+        or DEFAULT_MAX_CANDIDATES
+    self.dictionary = (self.ui and self.ui.dictionary) or ReaderDictionary:new()
+    LanguageSupport:registerPlugin(self)
+end
+
+function Kazakh:supportsLanguage(language_code)
+    return language_code == "kk" or language_code == "kaz" or language_code == "kk-KZ"
+end
+
+--- Called from @{languagesupport.extraDictionaryFormCandidates} for Kazakh
+-- text. Returns every morphologically legal analysis of the tapped word.
+-- @param args arguments from language support ({ text = [string] })
+-- @treturn {string,...} extra dictionary form candidates (or nil)
+-- @see languagesupport.extraDictionaryFormCandidates
+function Kazakh:onWordLookup(args)
+    local text = args.text
+    if not text or text == "" then return end
+    if not hasCyrillic(text) then return end
+
+    local lower = text:lower()
+    local rungs = Stemmer.ladder(lower)
+    if #rungs == 0 then return end
+
+    local candidates = {}
+    for i = 1, math.min(#rungs, self.max_candidates) do
+        -- KOReader already looks the tapped word up itself; offering it again
+        -- would only duplicate a result.
+        if rungs[i] ~= text and rungs[i] ~= lower then
+            candidates[#candidates + 1] = rungs[i]
+        end
+    end
+    if #candidates == 0 then return end
+
+    candidates = self:_keepRealHeadwords(candidates)
+    logger.dbg("kazakh.koplugin: candidates for", text, "->", candidates)
+    if #candidates == 0 then return end
+    return candidates
+end
+
+--- Drop candidates that are not actually headwords.
+--
+-- Intermediate rungs are usually not words, and KOReader resolves candidates
+-- with fuzzy search on, so each one returns near-spelling matches that sort
+-- above the real article. Resolving them here with exact search first keeps
+-- only those that exist, in ladder order, so the shallowest analysis leads.
+--
+-- On any failure the unfiltered list is returned: this can only add precision,
+-- never lose a result.
+function Kazakh:_keepRealHeadwords(candidates)
+    if not self.dictionary or not self.dictionary.rawSdcv then
+        return candidates
+    end
+    -- fuzzy_search = false, and no progress message: this must be invisible.
+    local ok, cancelled, results =
+        pcall(self.dictionary.rawSdcv, self.dictionary, candidates, nil, false, false)
+    if not ok then
+        logger.dbg("kazakh.koplugin: candidate check failed:", cancelled)
+        return candidates
+    end
+    if cancelled or type(results) ~= "table" or #results == 0 then
+        return candidates
+    end
+
+    local kept = {}
+    for i, cand in ipairs(candidates) do
+        local r = results[i]
+        if type(r) == "table" and #r > 0 then
+            kept[#kept + 1] = cand
+        end
+    end
+    return kept
+end
+
+function Kazakh:genMenuItem()
+    return {
+        -- @translators The Kazakh language, shown under Language support.
+        text = _("Kazakh"),
+        help_text = _("Offers every morphological form of the tapped word to the dictionary, which then returns whichever ones actually exist."),
+        sub_item_table = {
+            {
+                text_func = function()
+                    -- @translators %1 is the number of dictionary forms offered per lookup.
+                    return T(_("Maximum candidates: %1"), self.max_candidates)
+                end,
+                help_text = _("How many dictionary-form candidates to offer per lookup. Lowering this makes lookups faster."),
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    local Screen = require("device").screen
+                    UIManager:show(SpinWidget:new{
+                        title_text = _("Maximum candidates"),
+                        width = math.floor(Screen:getWidth() * 0.75),
+                        value = self.max_candidates,
+                        value_min = 1,
+                        value_max = 16,
+                        value_step = 1,
+                        default_value = DEFAULT_MAX_CANDIDATES,
+                        callback = function(spin)
+                            self.max_candidates = spin.value
+                            G_reader_settings:saveSetting(
+                                "language_kazakh_max_candidates", spin.value)
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    })
+                end,
+            },
+        },
+    }
+end
+
+return Kazakh

--- a/plugins/kazakh.koplugin/main.lua
+++ b/plugins/kazakh.koplugin/main.lua
@@ -17,9 +17,9 @@
 -- pg-kazsearch <https://github.com/darkhanakh/pg-kazsearch>, LGPLv3 or later.
 
 local LanguageSupport = require("languagesupport")
-local ReaderDictionary = require("apps/reader/modules/readerdictionary")
 local Stemmer = require("stemmer")
 local UIManager = require("ui/uimanager")
+local Utf8Proc = require("ffi/utf8proc")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local logger = require("logger")
 local _ = require("gettext")
@@ -34,21 +34,50 @@ local Kazakh = WidgetContainer:extend{
     pretty_name = "Kazakh",
 }
 
+local UTF8_CHAR = "[%z\1-\127\194-\244][\128-\191]*"
+
 -- U+0400–U+04FF (Cyrillic, including the Kazakh-specific ә ғ қ ң ө ұ ү һ і)
 -- is exactly the two-byte UTF-8 sequences with a lead byte of 0xD0–0xD3.
 local function hasCyrillic(text)
     return text:find("[\208-\211]") ~= nil
 end
 
+-- The nine letters Kazakh adds to the Russian alphabet.
+local KAZAKH_LETTERS = {}
+for c in ("әғқңөұүһі"):gmatch(UTF8_CHAR) do KAZAKH_LETTERS[c] = true end
+
 function Kazakh:init()
     self.max_candidates = G_reader_settings:readSetting("language_kazakh_max_candidates")
         or DEFAULT_MAX_CANDIDATES
-    self.dictionary = (self.ui and self.ui.dictionary) or ReaderDictionary:new()
     LanguageSupport:registerPlugin(self)
 end
 
 function Kazakh:supportsLanguage(language_code)
     return language_code == "kk" or language_code == "kaz" or language_code == "kk-KZ"
+end
+
+--- Whether this word is ours to analyse.
+--
+-- Language support calls every plugin as a fallback when none of them claims
+-- the document's language, because that metadata is so often missing or wrong.
+-- A Russian, Ukrainian or Bulgarian book therefore reaches this plugin too, and
+-- "contains Cyrillic" would claim all of them: the script is shared, so it is
+-- no more of a signal on its own than "contains Latin" would be for German.
+--
+-- In a book marked as Kazakh, any Cyrillic word is fair game. Everywhere else
+-- the word must carry one of the nine letters Kazakh adds to the Russian
+-- alphabet. No Russian or Bulgarian word does, so those readers pay nothing at
+-- all; the cost is that a mislabelled Kazakh book loses the analysis of roughly
+-- a quarter of its inflected words, which setting the language in Book
+-- information restores.
+function Kazakh:_isKazakhWord(word)
+    if not hasCyrillic(word) then return false end
+    local language = self.ui and self.ui.doc_props and self.ui.doc_props.language
+    if self:supportsLanguage(language) then return true end
+    for c in word:gmatch(UTF8_CHAR) do
+        if KAZAKH_LETTERS[c] then return true end
+    end
+    return false
 end
 
 --- Called from @{languagesupport.extraDictionaryFormCandidates} for Kazakh
@@ -59,9 +88,13 @@ end
 function Kazakh:onWordLookup(args)
     local text = args.text
     if not text or text == "" then return end
-    if not hasCyrillic(text) then return end
 
-    local lower = text:lower()
+    -- string.lower only maps ASCII, so Cyrillic has to go through utf8proc: a
+    -- capitalised word would otherwise keep its capital through the whole walk
+    -- and every rung would miss the lowercase headword it should have matched.
+    local lower = Utf8Proc.lowercase(text, false)
+    if not self:_isKazakhWord(lower) then return end
+
     local rungs = Stemmer.ladder(lower)
     if #rungs == 0 then return end
 
@@ -75,44 +108,11 @@ function Kazakh:onWordLookup(args)
     end
     if #candidates == 0 then return end
 
-    candidates = self:_keepRealHeadwords(candidates)
+    -- Every rung is offered, including the ones that are not words: language
+    -- support resolves candidates with exact search, so an analysis that is not
+    -- a headword returns nothing and costs only its place in the sdcv argv.
     logger.dbg("kazakh.koplugin: candidates for", text, "->", candidates)
-    if #candidates == 0 then return end
     return candidates
-end
-
---- Drop candidates that are not actually headwords.
---
--- Intermediate rungs are usually not words, and KOReader resolves candidates
--- with fuzzy search on, so each one returns near-spelling matches that sort
--- above the real article. Resolving them here with exact search first keeps
--- only those that exist, in ladder order, so the shallowest analysis leads.
---
--- On any failure the unfiltered list is returned: this can only add precision,
--- never lose a result.
-function Kazakh:_keepRealHeadwords(candidates)
-    if not self.dictionary or not self.dictionary.rawSdcv then
-        return candidates
-    end
-    -- fuzzy_search = false, and no progress message: this must be invisible.
-    local ok, cancelled, results =
-        pcall(self.dictionary.rawSdcv, self.dictionary, candidates, nil, false, false)
-    if not ok then
-        logger.dbg("kazakh.koplugin: candidate check failed:", cancelled)
-        return candidates
-    end
-    if cancelled or type(results) ~= "table" or #results == 0 then
-        return candidates
-    end
-
-    local kept = {}
-    for i, cand in ipairs(candidates) do
-        local r = results[i]
-        if type(r) == "table" and #r > 0 then
-            kept[#kept + 1] = cand
-        end
-    end
-    return kept
 end
 
 function Kazakh:genMenuItem()

--- a/plugins/kazakh.koplugin/main.lua
+++ b/plugins/kazakh.koplugin/main.lua
@@ -46,6 +46,26 @@ end
 local KAZAKH_LETTERS = {}
 for c in ("әғқңөұүһі"):gmatch(UTF8_CHAR) do KAZAKH_LETTERS[c] = true end
 
+-- A stem-final ы/і elides before the -у ending: оқы -> оқу, not оқыу.
+local ELIDES_BEFORE_U = { ["ы"] = true, ["і"] = true }
+
+--- The -у verbal noun of a verb stem: жаз -> жазу, сөйле -> сөйлеу, оқы -> оқу.
+--
+-- This is the form many dictionaries key a verb on, while the ladder can only
+-- strip suffixes and so bottoms out at the bare stem. Whether the stem really
+-- is a verb is left to the dictionary, as everywhere else here: candidates are
+-- resolved with exact search, so a word that does not exist costs nothing but
+-- its place in the query.
+local function verbalNoun(stem)
+    local last = stem:match(UTF8_CHAR .. "$")
+    -- Already a -у form; deriving another would only invent `оқуу`.
+    if not last or last == "у" then return nil end
+    if ELIDES_BEFORE_U[last] then
+        return stem:sub(1, #stem - #last) .. "у"
+    end
+    return stem .. "у"
+end
+
 function Kazakh:init()
     self.max_candidates = G_reader_settings:readSetting("language_kazakh_max_candidates")
         or DEFAULT_MAX_CANDIDATES
@@ -99,13 +119,31 @@ function Kazakh:onWordLookup(args)
     if #rungs == 0 then return end
 
     local candidates = {}
-    for i = 1, math.min(#rungs, self.max_candidates) do
-        -- KOReader already looks the tapped word up itself; offering it again
-        -- would only duplicate a result.
-        if rungs[i] ~= text and rungs[i] ~= lower then
-            candidates[#candidates + 1] = rungs[i]
+    -- KOReader already looks the tapped word up itself; offering it again
+    -- would only duplicate a result.
+    local seen = { [text] = true, [lower] = true }
+    local function offer(word)
+        if word and not seen[word] then
+            seen[word] = true
+            candidates[#candidates + 1] = word
         end
     end
+
+    for i = 1, math.min(#rungs, self.max_candidates) do
+        offer(rungs[i])
+    end
+
+    -- Then the verbal nouns, after the analyses themselves so those keep the
+    -- lead. Many dictionaries key a verb on its -у form rather than the bare
+    -- stem the ladder strips down to, and nothing in the ladder can bridge
+    -- that: it only removes suffixes. The tapped word gets one too, so that
+    -- tapping `сөйле` still reaches `сөйлеу`.
+    local analyses = #candidates
+    offer(verbalNoun(lower))
+    for i = 1, analyses do
+        offer(verbalNoun(candidates[i]))
+    end
+
     if #candidates == 0 then return end
 
     -- Every rung is offered, including the ones that are not words: language
@@ -126,7 +164,7 @@ function Kazakh:genMenuItem()
                     -- @translators %1 is the number of dictionary forms offered per lookup.
                     return T(_("Maximum candidates: %1"), self.max_candidates)
                 end,
-                help_text = _("How many dictionary-form candidates to offer per lookup. Lowering this makes lookups faster."),
+                help_text = _("How many analyses of the tapped word to offer per lookup. Each may add a verb form as well. Lowering this makes lookups faster."),
                 keep_menu_open = true,
                 callback = function(touchmenu_instance)
                     local SpinWidget = require("ui/widget/spinwidget")

--- a/plugins/kazakh.koplugin/rules.lua
+++ b/plugins/kazakh.koplugin/rules.lua
@@ -1,0 +1,296 @@
+--- Kazakh suffix inventory and layer ordering.
+-- Suffixes attach in a fixed order, so each position is a "layer" and the
+-- stemmer walks them left to right. `n` is the suffix length in CHARACTERS,
+-- not bytes, `h` is the vowel-harmony class the suffix demands, and `w` marks
+-- suffixes ambiguous with ordinary root material.
+--
+-- Generated from kazsearch/rules.py by tools/gen_lua_rules.py in
+-- <https://github.com/iDynbek/kazsearch-py>; do not edit by hand.
+--
+-- @module koplugin.kazakh.rules
+-- @alias M
+
+-- Licensed under the AGPLv3 or later.
+--
+-- Derived from pg-kazsearch <https://github.com/darkhanakh/pg-kazsearch>,
+-- LGPLv3 or later.
+
+local M = {}
+
+M.HARM_ANY, M.HARM_BACK, M.HARM_FRONT = 0, 1, 2
+
+M.LAYER_PRED, M.LAYER_CASE, M.LAYER_POSS = 1, 2, 3
+M.LAYER_PLUR, M.LAYER_DERIV = 4, 5
+M.LAYER_VPERSON, M.LAYER_VTENSE = 11, 12
+M.LAYER_VNEG, M.LAYER_VVOICE = 13, 14
+
+M.KIND_NOMINAL, M.KIND_VERBAL, M.KIND_DERIV = 1, 2, 3
+
+M.PRED = {
+  {s="сыңдар", n=6, h=0, w=false},
+  {s="сіңдер", n=6, h=0, w=false},
+  {s="сыздар", n=6, h=0, w=false},
+  {s="сіздер", n=6, h=0, w=false},
+  {s="сыз", n=3, h=1, w=false},
+  {s="сіз", n=3, h=2, w=false},
+  {s="сың", n=3, h=1, w=false},
+  {s="сің", n=3, h=2, w=false},
+  {s="мын", n=3, h=1, w=false},
+  {s="мін", n=3, h=2, w=false},
+  {s="бын", n=3, h=1, w=false},
+  {s="бін", n=3, h=2, w=false},
+  {s="пын", n=3, h=1, w=false},
+  {s="пін", n=3, h=2, w=false},
+  {s="мыз", n=3, h=1, w=false},
+  {s="міз", n=3, h=2, w=false},
+}
+
+M.CASE = {
+  {s="ның", n=3, h=1, w=false},
+  {s="нің", n=3, h=2, w=false},
+  {s="дың", n=3, h=1, w=false},
+  {s="дің", n=3, h=2, w=false},
+  {s="тың", n=3, h=1, w=false},
+  {s="тің", n=3, h=2, w=false},
+  {s="нан", n=3, h=1, w=false},
+  {s="нен", n=3, h=2, w=false},
+  {s="дан", n=3, h=1, w=false},
+  {s="ден", n=3, h=2, w=false},
+  {s="тан", n=3, h=1, w=false},
+  {s="тен", n=3, h=2, w=false},
+  {s="нда", n=3, h=1, w=false},
+  {s="нде", n=3, h=2, w=false},
+  {s="бен", n=3, h=0, w=false},
+  {s="пен", n=3, h=0, w=false},
+  {s="мен", n=3, h=0, w=false},
+  {s="ға", n=2, h=1, w=false},
+  {s="ге", n=2, h=2, w=false},
+  {s="қа", n=2, h=1, w=false},
+  {s="ке", n=2, h=2, w=false},
+  {s="на", n=2, h=1, w=false},
+  {s="не", n=2, h=2, w=false},
+  {s="ңа", n=2, h=1, w=false},
+  {s="ңе", n=2, h=2, w=false},
+  {s="ны", n=2, h=1, w=false},
+  {s="ні", n=2, h=2, w=false},
+  {s="а", n=1, h=1, w=true},
+  {s="е", n=1, h=2, w=true},
+  {s="ды", n=2, h=1, w=false},
+  {s="ді", n=2, h=2, w=false},
+  {s="ты", n=2, h=1, w=false},
+  {s="ті", n=2, h=2, w=false},
+  {s="ын", n=2, h=1, w=false},
+  {s="ін", n=2, h=2, w=false},
+  {s="да", n=2, h=1, w=false},
+  {s="де", n=2, h=2, w=false},
+  {s="та", n=2, h=1, w=false},
+  {s="те", n=2, h=2, w=false},
+  {s="н", n=1, h=0, w=true},
+}
+
+M.POSS = {
+  {s="ымыз", n=4, h=1, w=false},
+  {s="іміз", n=4, h=2, w=false},
+  {s="ыңыз", n=4, h=1, w=false},
+  {s="іңіз", n=4, h=2, w=false},
+  {s="лары", n=4, h=1, w=false},
+  {s="лері", n=4, h=2, w=false},
+  {s="дары", n=4, h=1, w=false},
+  {s="дері", n=4, h=2, w=false},
+  {s="тары", n=4, h=1, w=false},
+  {s="тері", n=4, h=2, w=false},
+  {s="мыз", n=3, h=1, w=false},
+  {s="міз", n=3, h=2, w=false},
+  {s="ңыз", n=3, h=1, w=false},
+  {s="ңіз", n=3, h=2, w=false},
+  {s="сы", n=2, h=1, w=true},
+  {s="сі", n=2, h=2, w=true},
+  {s="ым", n=2, h=1, w=false},
+  {s="ім", n=2, h=2, w=false},
+  {s="ың", n=2, h=1, w=false},
+  {s="ің", n=2, h=2, w=false},
+  {s="ы", n=1, h=1, w=true},
+  {s="і", n=1, h=2, w=true},
+  {s="м", n=1, h=0, w=true},
+  {s="ң", n=1, h=0, w=true},
+}
+
+M.PLUR = {
+  {s="дар", n=3, h=1, w=false},
+  {s="дер", n=3, h=2, w=false},
+  {s="лар", n=3, h=1, w=false},
+  {s="лер", n=3, h=2, w=false},
+  {s="тар", n=3, h=1, w=false},
+  {s="тер", n=3, h=2, w=false},
+}
+
+M.DERIV = {
+  {s="ндағы", n=5, h=1, w=false},
+  {s="ндегі", n=5, h=2, w=false},
+  {s="дағы", n=4, h=1, w=false},
+  {s="дегі", n=4, h=2, w=false},
+  {s="тағы", n=4, h=1, w=false},
+  {s="тегі", n=4, h=2, w=false},
+  {s="нікі", n=4, h=0, w=true},
+  {s="дікі", n=4, h=0, w=true},
+  {s="тікі", n=4, h=0, w=true},
+  {s="ырақ", n=4, h=1, w=false},
+  {s="ірек", n=4, h=2, w=false},
+  {s="рақ", n=3, h=1, w=false},
+  {s="рек", n=3, h=2, w=false},
+  {s="лау", n=3, h=1, w=false},
+  {s="леу", n=3, h=2, w=false},
+  {s="дау", n=3, h=1, w=false},
+  {s="деу", n=3, h=2, w=false},
+  {s="тау", n=3, h=1, w=false},
+  {s="теу", n=3, h=2, w=false},
+  {s="лы", n=2, h=1, w=true},
+  {s="лі", n=2, h=2, w=true},
+  {s="лық", n=3, h=1, w=false},
+  {s="лік", n=3, h=2, w=false},
+  {s="дық", n=3, h=1, w=false},
+  {s="дік", n=3, h=2, w=false},
+  {s="тық", n=3, h=1, w=false},
+  {s="тік", n=3, h=2, w=false},
+  {s="ушы", n=3, h=1, w=true},
+  {s="уші", n=3, h=2, w=true},
+  {s="шы", n=2, h=1, w=true},
+  {s="ші", n=2, h=2, w=true},
+  {s="ша", n=2, h=1, w=true},
+  {s="ше", n=2, h=2, w=true},
+  {s="сыз", n=3, h=1, w=false},
+  {s="сіз", n=3, h=2, w=false},
+  {s="ғы", n=2, h=1, w=true},
+  {s="гі", n=2, h=2, w=true},
+  {s="ншы", n=3, h=1, w=false},
+  {s="нші", n=3, h=2, w=false},
+  {s="дай", n=3, h=1, w=false},
+  {s="дей", n=3, h=2, w=false},
+  {s="тай", n=3, h=1, w=false},
+  {s="тей", n=3, h=2, w=false},
+  {s="ба", n=2, h=1, w=true},
+  {s="бе", n=2, h=2, w=true},
+}
+
+M.VPERSON = {
+  {s="сыңдар", n=6, h=0, w=false},
+  {s="сіңдер", n=6, h=0, w=false},
+  {s="сыздар", n=6, h=1, w=false},
+  {s="сіздер", n=6, h=2, w=false},
+  {s="мыз", n=3, h=1, w=false},
+  {s="міз", n=3, h=2, w=false},
+  {s="сыз", n=3, h=1, w=false},
+  {s="сіз", n=3, h=2, w=false},
+  {s="сың", n=3, h=1, w=false},
+  {s="сің", n=3, h=2, w=false},
+  {s="мын", n=3, h=1, w=false},
+  {s="мін", n=3, h=2, w=false},
+  {s="бын", n=3, h=1, w=false},
+  {s="бін", n=3, h=2, w=false},
+  {s="пын", n=3, h=1, w=false},
+  {s="пін", n=3, h=2, w=false},
+  {s="м", n=1, h=0, w=true},
+  {s="ң", n=1, h=0, w=true},
+  {s="қ", n=1, h=1, w=true},
+  {s="к", n=1, h=2, w=true},
+}
+
+M.VTENSE = {
+  {s="майды", n=5, h=1, w=false},
+  {s="мейді", n=5, h=2, w=false},
+  {s="байды", n=5, h=1, w=false},
+  {s="бейді", n=5, h=2, w=false},
+  {s="пайды", n=5, h=1, w=false},
+  {s="пейді", n=5, h=2, w=false},
+  {s="атын", n=4, h=1, w=false},
+  {s="етін", n=4, h=2, w=false},
+  {s="йтын", n=4, h=1, w=false},
+  {s="йтін", n=4, h=2, w=false},
+  {s="ыпты", n=4, h=1, w=false},
+  {s="іпті", n=4, h=2, w=false},
+  {s="пты", n=3, h=1, w=false},
+  {s="пті", n=3, h=2, w=false},
+  {s="йды", n=3, h=0, w=false},
+  {s="йді", n=3, h=0, w=false},
+  {s="ады", n=3, h=1, w=false},
+  {s="еді", n=3, h=2, w=false},
+  {s="ған", n=3, h=1, w=false},
+  {s="ген", n=3, h=2, w=false},
+  {s="қан", n=3, h=1, w=false},
+  {s="кен", n=3, h=2, w=false},
+  {s="май", n=3, h=1, w=false},
+  {s="мей", n=3, h=2, w=false},
+  {s="саң", n=3, h=1, w=false},
+  {s="сең", n=3, h=2, w=false},
+  {s="сақ", n=3, h=1, w=false},
+  {s="сек", n=3, h=2, w=false},
+  {s="тын", n=3, h=1, w=false},
+  {s="тін", n=3, h=2, w=false},
+  {s="мақ", n=3, h=1, w=false},
+  {s="мек", n=3, h=2, w=false},
+  {s="бақ", n=3, h=1, w=false},
+  {s="бек", n=3, h=2, w=false},
+  {s="пақ", n=3, h=1, w=false},
+  {s="пек", n=3, h=2, w=false},
+  {s="ды", n=2, h=1, w=false},
+  {s="ді", n=2, h=2, w=false},
+  {s="ты", n=2, h=1, w=false},
+  {s="ті", n=2, h=2, w=false},
+  {s="ып", n=2, h=1, w=false},
+  {s="іп", n=2, h=2, w=false},
+  {s="са", n=2, h=1, w=false},
+  {s="се", n=2, h=2, w=false},
+  {s="у", n=1, h=0, w=true},
+  {s="й", n=1, h=0, w=true},
+  {s="а", n=1, h=1, w=true},
+  {s="е", n=1, h=2, w=true},
+}
+
+M.VNEG = {
+  {s="ма", n=2, h=1, w=false},
+  {s="ме", n=2, h=2, w=false},
+  {s="ба", n=2, h=1, w=false},
+  {s="бе", n=2, h=2, w=false},
+  {s="па", n=2, h=1, w=false},
+  {s="пе", n=2, h=2, w=false},
+}
+
+M.VVOICE = {
+  {s="қыз", n=3, h=1, w=false},
+  {s="кіз", n=3, h=2, w=false},
+  {s="ғыз", n=3, h=1, w=false},
+  {s="гіз", n=3, h=2, w=false},
+  {s="тыр", n=3, h=1, w=false},
+  {s="тір", n=3, h=2, w=false},
+  {s="дыр", n=3, h=1, w=false},
+  {s="дір", n=3, h=2, w=false},
+  {s="ыл", n=2, h=1, w=false},
+  {s="іл", n=2, h=2, w=false},
+  {s="ыс", n=2, h=1, w=false},
+  {s="іс", n=2, h=2, w=false},
+  {s="ын", n=2, h=1, w=false},
+  {s="ін", n=2, h=2, w=false},
+}
+
+M.NOUN_LAYERS = {
+  {rules=M.PRED,  id=M.LAYER_PRED,  kind=M.KIND_NOMINAL},
+  {rules=M.CASE,  id=M.LAYER_CASE,  kind=M.KIND_NOMINAL},
+  {rules=M.POSS,  id=M.LAYER_POSS,  kind=M.KIND_NOMINAL},
+  {rules=M.PLUR,  id=M.LAYER_PLUR,  kind=M.KIND_NOMINAL},
+  {rules=M.DERIV, id=M.LAYER_DERIV, kind=M.KIND_DERIV},
+}
+
+M.VERB_LAYERS = {
+  {rules=M.VPERSON, id=M.LAYER_VPERSON, kind=M.KIND_VERBAL},
+  {rules=M.VTENSE,  id=M.LAYER_VTENSE,  kind=M.KIND_VERBAL},
+  {rules=M.VNEG,    id=M.LAYER_VNEG,    kind=M.KIND_VERBAL},
+  {rules=M.VVOICE,  id=M.LAYER_VVOICE,  kind=M.KIND_VERBAL},
+}
+
+-- Possessive suffixes whose removal can expose a sound change to undo.
+M.POSS_VOWEL = {}
+for _, s in ipairs({"сы","сі","ы","ым","ымыз","ың","ыңыз","і","ім","іміз","ің","іңіз"}) do
+  M.POSS_VOWEL[s] = true
+end
+
+return M

--- a/plugins/kazakh.koplugin/stemmer.lua
+++ b/plugins/kazakh.koplugin/stemmer.lua
@@ -1,0 +1,381 @@
+--- Kazakh ladder stemmer, in pure Lua.
+-- Walks the suffix layers backwards and returns every morphologically legal
+-- analysis of a word -- the "ladder" -- longest first, rather than picking one
+-- stem:
+--
+--     ladder("мектептерімізде") ->
+--         мектептерімізде, мектептеріміз, мектептері, мектептер, мектеп
+--
+-- @module koplugin.kazakh.stemmer
+-- @alias Stemmer
+
+-- Licensed under the AGPLv3 or later.
+--
+-- Ported from kazsearch.ladder <https://github.com/iDynbek/kazsearch-py>,
+-- itself a port of the Rust core of pg-kazsearch
+-- <https://github.com/darkhanakh/pg-kazsearch>, LGPLv3 or later. Distribution
+-- under the AGPLv3 is permitted by LGPLv3 section 2 and AGPLv3 section 13.
+
+local rules = require("rules")
+
+local Stemmer = {}
+
+local MIN_RUNG_CHARS = 2
+local MAX_STEM_CHARS = 64
+local MAX_STEPS = 8
+
+--- Vowel classification -----------------------------------------------------
+-- Kazakh vowel harmony: a suffix must agree with the class of the stem's last
+-- harmony-bearing vowel. Glides (у/и/ю) are transparent and carry no class,
+-- which is why loanwords like `туризм` accept suffixes of either class.
+
+local BACK, FRONT, GLIDE, LOAN = {}, {}, {}, {}
+local function fill(set, s)
+    for c in s:gmatch("[%z\1-\127\194-\244][\128-\191]*") do set[c] = true end
+end
+fill(BACK,  "аоұыу")
+fill(FRONT, "әеөүіиё")
+fill(GLIDE, "уию")
+fill(LOAN,  "яэ")
+
+local function is_vowel(c) return BACK[c] or FRONT[c] end
+local function is_vocalic(c) return BACK[c] or FRONT[c] or LOAN[c] end
+
+--- UTF-8 handling -----------------------------------------------------------
+-- Everything below indexes by CHARACTER, never by byte: Cyrillic is two bytes
+-- per character in UTF-8, so byte offsets would put every length check and
+-- every suffix boundary in the wrong place.
+
+local function decode(word)
+    local chars, offs, i = {}, {}, 1
+    for pos, c in word:gmatch("()([%z\1-\127\194-\244][\128-\191]*)") do
+        chars[i] = c
+        offs[i] = pos
+        i = i + 1
+    end
+    offs[i] = #word + 1
+    return chars, offs, i - 1
+end
+
+-- U+0400–U+04FF (Cyrillic) is exactly the two-byte UTF-8 sequences with a lead
+-- byte of 0xD0–0xD3.
+local function all_cyrillic(chars, n)
+    for i = 1, n do
+        local c = chars[i]
+        if #c ~= 2 then return false end
+        local b = c:byte(1)
+        if b < 0xD0 or b > 0xD3 then return false end
+    end
+    return true
+end
+
+--- Prefix tables ------------------------------------------------------------
+-- Precomputed so each harmony check inside the walk is a lookup rather than a
+-- rescan of the prefix.
+
+local function prefix_tables(chars, n)
+    local syll, harm_back, tail_back, has_strong = {}, {}, {}, {}
+    syll[0], harm_back[0], tail_back[0], has_strong[0] = 0, true, true, false
+
+    local nsyll, wb_back, strong = 0, true, false
+    local last1, last2 = nil, nil
+
+    for i = 1, n do
+        local c = chars[i]
+        if is_vocalic(c) then nsyll = nsyll + 1 end
+
+        if not GLIDE[c] then
+            if BACK[c] or c == "я" then
+                wb_back, strong = true, true
+            elseif FRONT[c] or c == "э" then
+                wb_back, strong = false, true
+            end
+            if is_vocalic(c) then
+                last1 = last2
+                last2 = c
+            end
+        end
+
+        local tb
+        if last2 == nil then
+            tb = true
+        elseif LOAN[last2] then
+            tb = (last1 ~= nil) and (BACK[last1] or false) or true
+        else
+            tb = BACK[last2] or false
+        end
+
+        syll[i], harm_back[i], tail_back[i], has_strong[i] = nsyll, wb_back, tb, strong
+    end
+    return syll, harm_back, tail_back, has_strong
+end
+
+local function harmony_ok(t, i, harmony)
+    if harmony == rules.HARM_ANY then return true end
+    if i == 0 then return false end
+    -- A harmony-neutral prefix accepts either class; without this no classed
+    -- ending could ever attach to a glide-only loanword.
+    if not t.has_strong[i] then return true end
+    local full_back = t.harm_back[i]
+    if harmony == rules.HARM_BACK and full_back then return true end
+    if harmony == rules.HARM_FRONT and not full_back then return true end
+    if t.syll[i] >= 4 then
+        local tb = t.tail_back[i]
+        if harmony == rules.HARM_BACK then return tb else return not tb end
+    end
+    return false
+end
+
+--- Per-layer legality guards ------------------------------------------------
+
+local POSS_TAILS = {
+    "ымыз", "іміз", "ыңыз", "іңіз", "мыз", "міз", "ңыз", "ңіз",
+    "ым", "ім", "ың", "ің", "сы", "сі", "ы", "і",
+}
+
+local function ends_with(s, suffix)
+    return s:sub(-#suffix) == suffix
+end
+
+local function count_syllables(chars, upto)
+    local n = 0
+    for i = 1, upto do
+        if is_vocalic(chars[i]) then n = n + 1 end
+    end
+    return n
+end
+
+local function count_strong_syllables(chars, upto)
+    local n = 0
+    for i = 1, upto do
+        local c = chars[i]
+        if is_vocalic(c) and not GLIDE[c] then n = n + 1 end
+    end
+    return n
+end
+
+local function layer_guard(layer_id, sfx, base_str, base_chars, base_len, steps)
+    if layer_id == rules.LAYER_CASE then
+        if sfx == "н" then
+            return ends_with(base_str, "сы") or ends_with(base_str, "сі")
+                or ends_with(base_str, "ы") or ends_with(base_str, "і")
+        end
+        if sfx == "а" or sfx == "е" then
+            for _, t in ipairs(POSS_TAILS) do
+                if ends_with(base_str, t) then return true end
+            end
+            local last = base_chars[base_len]
+            if last == "м" or last == "ң" then
+                if base_len >= 2 then return is_vowel(base_chars[base_len - 1]) end
+            end
+            return false
+        end
+        if base_len == 0 then return false end
+        local last = base_chars[base_len]
+        if sfx == "ны" or sfx == "ні" then
+            return is_vocalic(last)
+        end
+        if sfx == "ын" or sfx == "ін" or sfx == "ды" or sfx == "ді"
+            or sfx == "ты" or sfx == "ті" then
+            return not is_vocalic(last)
+        end
+
+    elseif layer_id == rules.LAYER_POSS then
+        if sfx == "м" or sfx == "ң" then
+            return base_len > 0 and is_vowel(base_chars[base_len]) or false
+        end
+
+    elseif layer_id == rules.LAYER_VTENSE then
+        if sfx == "у" then
+            return base_len >= 2 and count_syllables(base_chars, base_len) >= 1
+        end
+        if sfx == "й" then return steps > 0 end
+        if sfx == "а" or sfx == "е" then
+            return steps > 0 and count_syllables(base_chars, base_len) >= 2
+        end
+
+    elseif layer_id == rules.LAYER_VNEG then
+        return base_len >= 3
+
+    elseif layer_id == rules.LAYER_VPERSON then
+        if sfx == "м" or sfx == "ң" or sfx == "қ" or sfx == "к" then
+            return count_syllables(base_chars, base_len) >= 2
+        end
+
+    elseif layer_id == rules.LAYER_DERIV then
+        if sfx == "лық" or sfx == "лік" or sfx == "дық" or sfx == "дік"
+            or sfx == "тық" or sfx == "тік" then
+            return count_syllables(base_chars, base_len) >= 2
+        end
+        -- No lexicon is shipped, so the dictionary-base branch of this guard
+        -- (see kazsearch.explore.layer_guard) cannot apply; the syllable test
+        -- is the conservative half and is what the Python reference reduces to
+        -- when built without a lexicon.
+        if sfx == "лы" or sfx == "лі" then
+            return count_syllables(base_chars, base_len) >= 2
+        end
+        if sfx == "ушы" or sfx == "уші" then
+            return count_strong_syllables(base_chars, base_len) >= 2
+        end
+    end
+    return true
+end
+
+local DERIV_REENTER = {
+    ["ндағы"] = true, ["ндегі"] = true, ["дағы"] = true,
+    ["дегі"] = true, ["тағы"] = true, ["тегі"] = true,
+}
+
+local function next_state_idx(noun_track, cur, layer_id, sfx)
+    if not noun_track then
+        if layer_id == rules.LAYER_VVOICE then return 4 end
+        return cur + 1
+    end
+    if layer_id == rules.LAYER_DERIV and DERIV_REENTER[sfx] then return 3 end
+    if layer_id == rules.LAYER_DERIV then return 5 end
+    return cur + 1
+end
+
+--- Sound-change repair ------------------------------------------------------
+-- Stripping a vowel-initial possessive exposes changes that must be undone
+-- before the root looks like its dictionary form: кітабы -> кітаб -> кітап.
+
+local function apply_mutation(s)
+    if s == "" then return s end
+    if ends_with(s, "б") then return s:sub(1, #s - #"б") .. "п" end
+    if ends_with(s, "ғ") then return s:sub(1, #s - #"ғ") .. "қ" end
+    if ends_with(s, "г") then
+        local base = s:sub(1, #s - #"г")
+        local last = base:match("[%z\1-\127\194-\244][\128-\191]*$")
+        if last == "о" or last == "ө" or last == "ұ" or last == "ү" or last == "у" then
+            return s
+        end
+        return base .. "к"
+    end
+    return s
+end
+
+local function elision_restore(chars, n, s)
+    -- Only н/з-final stems elide, and only after a consonant: орны -> орн -> орын.
+    if n < 2 then return nil end
+    local last, prev = chars[n], chars[n - 1]
+    if last ~= "н" and last ~= "з" then return nil end
+    if is_vocalic(prev) and not (ends_with(s, "уз") or ends_with(s, "із")) then
+        return nil
+    end
+    local lv
+    for i = n, 1, -1 do
+        if is_vowel(chars[i]) then lv = chars[i] break end
+    end
+    if lv == nil then return nil end
+    local ins = BACK[lv] and "ы" or "і"
+    return s:sub(1, #s - #last) .. ins .. last
+end
+
+--- The walk -----------------------------------------------------------------
+
+--- Every morphologically legal analysis of `word`, longest first.
+-- @string word a single lowercase Kazakh word
+-- @treturn {string,...} candidate dictionary forms, including `word` itself
+function Stemmer.ladder(word)
+    if word == nil or word == "" then return {} end
+
+    local chars, offs, n = decode(word)
+    -- Nothing to add: KOReader already looks the original word up, so a word
+    -- too short to have any rung contributes no candidates. Returning the word
+    -- here instead would just duplicate the lookup it already performs.
+    if n < MIN_RUNG_CHARS then return {} end
+    -- A token with a digit, hyphen or apostrophe in it is not a Kazakh word,
+    -- and stripping what looks like a suffix off one invents forms: `аб'ба`
+    -- would yield `аб'`. The reference implementation refuses these outright,
+    -- so this does too.
+    if not all_cyrillic(chars, n) then return { word } end
+    if n >= MAX_STEM_CHARS then return { word } end
+
+    local syll, harm_back, tail_back, has_strong = prefix_tables(chars, n)
+    local t = { syll = syll, harm_back = harm_back,
+                tail_back = tail_back, has_strong = has_strong }
+
+    local function prefix(i) return word:sub(1, offs[i + 1] - 1) end
+
+    local found, nchars_of, order = {}, {}, {}
+    local function record(form, steps)
+        if form == nil or #form == 0 then return end
+        local _, nchars = form:gsub("[%z\1-\127\194-\244][\128-\191]*", "")
+        if nchars < MIN_RUNG_CHARS then return end
+        if found[form] == nil then
+            found[form] = steps
+            nchars_of[form] = nchars
+            order[#order + 1] = form
+        elseif steps < found[form] then
+            found[form] = steps
+        end
+    end
+
+    local tracks = { { rules.NOUN_LAYERS, true }, { rules.VERB_LAYERS, false } }
+    for _, track in ipairs(tracks) do
+        local layers, noun_track = track[1], track[2]
+        local nlayer = #layers
+
+        local queue = { { n, 1, 0, nil, 0 } }  -- len, layer, steps, last_sfx, nominal
+        local head = 1
+        local seen = { [n .. ":1:0"] = true }
+
+        while head <= #queue do
+            local st = queue[head]; head = head + 1
+            local len, li, steps, last_sfx, nominal = st[1], st[2], st[3], st[4], st[5]
+
+            local form = prefix(len)
+            record(form, steps)
+            -- A rung reached by stripping a possessive may need its sound
+            -- change undone before it matches a dictionary headword.
+            if steps > 0 and nominal > 0 and last_sfx and rules.POSS_VOWEL[last_sfx] then
+                local m = apply_mutation(form)
+                local mc, _, mn = decode(m)
+                record(elision_restore(mc, mn, m) or m, steps)
+            end
+
+            if li <= nlayer and steps < MAX_STEPS then
+                -- Option 1: skip this layer.
+                local k = len .. ":" .. (li + 1) .. ":" .. steps
+                if not seen[k] then
+                    seen[k] = true
+                    queue[#queue + 1] = { len, li + 1, steps, last_sfx, nominal }
+                end
+
+                -- Option 2: strip a suffix that matches here.
+                local layer = layers[li]
+                local cur = prefix(len)
+                for _, r in ipairs(layer.rules) do
+                    if r.n < len and ends_with(cur, r.s) then
+                        local base_len = len - r.n
+                        if base_len >= 2 and syll[base_len] >= 1
+                            and harmony_ok(t, base_len, r.h)
+                            and layer_guard(layer.id, r.s, prefix(base_len),
+                                            chars, base_len, steps) then
+                            local ni = next_state_idx(noun_track, li, layer.id, r.s)
+                            local nnom = nominal
+                            if layer.kind == rules.KIND_NOMINAL then nnom = nnom + 1 end
+                            local k2 = base_len .. ":" .. ni .. ":" .. (steps + 1)
+                            if not seen[k2] then
+                                seen[k2] = true
+                                queue[#queue + 1] = { base_len, ni, steps + 1, r.s, nnom }
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    -- Longest first, then shallowest. Sorting on #a would compare BYTES, which
+    -- diverges from the reference as soon as a token mixes scripts.
+    table.sort(order, function(a, b)
+        if nchars_of[a] ~= nchars_of[b] then return nchars_of[a] > nchars_of[b] end
+        if found[a] ~= found[b] then return found[a] < found[b] end
+        return a < b
+    end)
+    return order
+end
+
+return Stemmer

--- a/spec/unit/kazakh_plugin_spec.lua
+++ b/spec/unit/kazakh_plugin_spec.lua
@@ -84,6 +84,46 @@ describe("Kazakh plugin", function()
         assert.is_false(contains(candidates, "Мектеп"))
     end)
 
+    describe("verb forms", function()
+        -- Dictionaries commonly key a verb on its -у verbal noun, while the
+        -- ladder only strips suffixes and bottoms out at the bare stem.
+        it("should offer the -у form of an analysis", function()
+            assert.is_true(contains(lookup("kk", "сөйледі"), "сөйлеу"))
+            assert.is_true(contains(lookup("kk", "жазбаймын"), "жазу"))
+        end)
+
+        it("should offer the -у form of the tapped word itself", function()
+            -- Tapping the bare stem must still reach the dictionary's headword.
+            assert.is_true(contains(lookup("kk", "сөйле"), "сөйлеу"))
+        end)
+
+        it("should elide a stem-final ы/і before -у", function()
+            -- оқы -> оқу, never оқыу.
+            local c = lookup("kk", "оқыды")
+            assert.is_true(contains(c, "оқу"))
+            assert.is_false(contains(c, "оқыу"))
+        end)
+
+        it("should not add another -у to a form that already ends in one", function()
+            for _, w in ipairs(lookup("kk", "оқу") or {}) do
+                assert.is_not_equal("оқуу", w)
+            end
+        end)
+
+        it("should rank the analyses above the verb forms", function()
+            -- The dictionary sees candidates in order, so a real lemma should
+            -- not sit behind a speculative verb form.
+            local c = lookup("kk", "мектептерімізде")
+            local lemma, verb
+            for i, w in ipairs(c) do
+                if w == "мектеп" then lemma = i end
+                if w == "мектепу" then verb = i end
+            end
+            assert.is_not_nil(lemma)
+            if verb then assert.is_true(lemma < verb) end
+        end)
+    end)
+
     it("should decline text that is not Cyrillic at all", function()
         assert.is_nil(lookup("kk", "hello"))
         assert.is_nil(lookup("kk", ""))

--- a/spec/unit/kazakh_plugin_spec.lua
+++ b/spec/unit/kazakh_plugin_spec.lua
@@ -1,0 +1,91 @@
+describe("Kazakh plugin", function()
+    local DocumentRegistry, ReaderUI, UIManager, Screen
+    local readerui, kazakh
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        load_plugin("kazakh.koplugin")
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        UIManager = require("ui/uimanager")
+        Screen = require("device").screen
+
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument("spec/front/unit/data/sample.txt"),
+        }
+        kazakh = readerui.languagesupport.plugins["kazakh"]
+    end)
+
+    teardown(function()
+        ReaderUI.instance = readerui
+        readerui:closeDocument()
+        readerui:onClose()
+        UIManager:quit()
+        UIManager._exit_code = nil
+    end)
+
+    local function contains(list, want)
+        for _, v in ipairs(list or {}) do
+            if v == want then return true end
+        end
+        return false
+    end
+
+    -- The plugin reads the document language straight off doc_props, the same
+    -- way language support picks which plugin to try first.
+    local function lookup(language, word)
+        readerui.doc_props.language = language
+        return kazakh:onWordLookup{ text = word }
+    end
+
+    it("should register itself with language support", function()
+        assert.is_not_nil(kazakh)
+        assert.is_true(kazakh:supportsLanguage("kk"))
+        assert.is_false(kazakh:supportsLanguage("ru"))
+    end)
+
+    describe("in a book marked as Kazakh", function()
+        it("should analyse a word with no Kazakh-specific letter", function()
+            -- достарымен is spelt entirely in letters Russian has too.
+            assert.is_true(contains(lookup("kk", "достарымен"), "дос"))
+        end)
+
+        it("should analyse a word carrying a Kazakh-specific letter", function()
+            assert.is_true(contains(lookup("kk", "балаларға"), "бала"))
+        end)
+    end)
+
+    describe("in a book not marked as Kazakh", function()
+        it("should still analyse a word carrying a Kazakh-specific letter", function()
+            -- Reached through the language support fallback path.
+            assert.is_true(contains(lookup("ru", "балаларға"), "бала"))
+            assert.is_true(contains(lookup(nil, "балаларға"), "бала"))
+        end)
+
+        it("should decline a word spelt only in shared Cyrillic", function()
+            assert.is_nil(lookup("ru", "достарымен"))
+        end)
+
+        it("should decline Russian text that happens to look inflected", function()
+            -- домочадцы ends in -ы, which is a real Kazakh suffix; without the
+            -- letter check this would be offered to the dictionary as домочадц.
+            assert.is_nil(lookup("ru", "домочадцы"))
+            assert.is_nil(lookup("ru", "дома"))
+        end)
+    end)
+
+    it("should lowercase Cyrillic before analysing", function()
+        -- string.lower only maps ASCII, so a capitalised word has to go through
+        -- utf8proc or every rung keeps its capital and misses the headword.
+        local candidates = lookup("kk", "Мектептерімізде")
+        assert.is_true(contains(candidates, "мектеп"))
+        assert.is_false(contains(candidates, "Мектеп"))
+    end)
+
+    it("should decline text that is not Cyrillic at all", function()
+        assert.is_nil(lookup("kk", "hello"))
+        assert.is_nil(lookup("kk", ""))
+    end)
+end)

--- a/spec/unit/kazakh_spec.lua
+++ b/spec/unit/kazakh_spec.lua
@@ -1,0 +1,114 @@
+describe("Kazakh plugin stemmer", function()
+    local Stemmer
+
+    setup(function()
+        require("commonrequire")
+        package.path = "plugins/kazakh.koplugin/?.lua;" .. package.path
+        Stemmer = require("stemmer")
+    end)
+
+    local function nchars(s)
+        local n = 0
+        for _ in s:gmatch("[%z\1-\127\194-\244][\128-\191]*") do n = n + 1 end
+        return n
+    end
+
+    local function contains(list, want)
+        for _, v in ipairs(list) do
+            if v == want then return true end
+        end
+        return false
+    end
+
+    local function index_of(list, want)
+        for i, v in ipairs(list) do
+            if v == want then return i end
+        end
+        return nil
+    end
+
+    -- inflected surface form -> the lemma a dictionary is keyed on
+    local LEMMAS = {
+        { "мектептерімізде", "мектеп" },
+        { "кітаптарында",    "кітап"  },
+        { "балаларға",       "бала"   },
+        { "достарымен",      "дос"    },
+        { "жазбаймын",       "жаз"    },
+        { "сөйледі",         "сөйле"  },
+        { "жанышта",         "жаныш"  },
+        { "маманда",         "маман"  },
+    }
+
+    describe("ladder()", function()
+        it("should reach the lemma of an inflected word", function()
+            for _, case in ipairs(LEMMAS) do
+                local word, lemma = case[1], case[2]
+                assert.is_true(contains(Stemmer.ladder(word), lemma),
+                               word .. " should analyse down to " .. lemma)
+            end
+        end)
+
+        it("should offer the word itself first", function()
+            for _, case in ipairs(LEMMAS) do
+                assert.is_equal(case[1], Stemmer.ladder(case[1])[1])
+            end
+        end)
+
+        it("should order candidates longest first, in characters", function()
+            -- Sorting on string length would compare bytes, not characters.
+            for _, case in ipairs(LEMMAS) do
+                local rungs = Stemmer.ladder(case[1])
+                for i = 2, #rungs do
+                    assert.is_true(nchars(rungs[i - 1]) >= nchars(rungs[i]),
+                                   case[1] .. ": " .. rungs[i - 1] ..
+                                   " should not be shorter than " .. rungs[i])
+                end
+            end
+        end)
+
+        it("should rank маман above the over-stripped мама for маманда", function()
+            local rungs = Stemmer.ladder("маманда")
+            assert.is_true(index_of(rungs, "маман") < index_of(rungs, "мама"))
+        end)
+
+        it("should undo final-consonant voicing", function()
+            -- A stem-final б/ғ/г voiced by the suffix: кітап -> кітабы.
+            assert.is_true(contains(Stemmer.ladder("кітабы"), "кітап"))
+            assert.is_true(contains(Stemmer.ladder("бағы"), "бақ"))
+            assert.is_true(contains(Stemmer.ladder("жүрегінде"), "жүрек"))
+        end)
+
+        it("should restore an elided stem vowel", function()
+            -- орын loses its ы before a possessive: орын -> орны -> орнында.
+            assert.is_true(contains(Stemmer.ladder("орнында"), "орын"))
+        end)
+
+        it("should leave an uninflected lemma alone", function()
+            for _, word in ipairs({ "мектеп", "бала", "күн", "кітап" }) do
+                assert.are.same({ word }, Stemmer.ladder(word))
+            end
+        end)
+
+        it("should be idempotent on every rung it produces", function()
+            for _, case in ipairs(LEMMAS) do
+                for _, rung in ipairs(Stemmer.ladder(case[1])) do
+                    assert.is_equal(rung, Stemmer.ladder(rung)[1])
+                end
+            end
+        end)
+
+        it("should handle input that is not an inflected Kazakh word", function()
+            assert.are.same({}, Stemmer.ladder(""))
+            assert.are.same({}, Stemmer.ladder(nil))
+            assert.are.same({}, Stemmer.ladder("а"))
+            assert.are.same({ "hello" }, Stemmer.ladder("hello"))
+        end)
+
+        it("should not strip a suffix off a token that is not a word", function()
+            -- аб'ба ends in -ба, a real derivational suffix.
+            for _, token in ipairs({ "аб'ба", "мектеп-интернат", "мектеп2лер" }) do
+                assert.are.same({ token }, Stemmer.ladder(token))
+            end
+        end)
+    end)
+end)

--- a/spec/unit/languagesupport_spec.lua
+++ b/spec/unit/languagesupport_spec.lua
@@ -45,26 +45,30 @@ describe("LanguageSupport module", function()
             assert.are.same({ "kk-candidate" }, lookup("ru", "word"))
         end)
 
+        -- These look the document language up as "xx" so the plugin under test
+        -- is the one that claims it and is therefore tried first. Leaving the
+        -- language unknown would put both plugins in the same fallback loop,
+        -- where pairs() decides which one runs first and the test would only
+        -- sometimes exercise what it means to.
         it("should go on to the next plugin when one declines the text", function()
-            -- Returning nothing means "this is not my text". The search must
-            -- continue regardless of the order pairs() happens to visit them in.
+            -- Returning nothing means "this is not my text".
             local declined = false
             instance:registerPlugin(makePlugin("xx", function() declined = true end))
             instance:registerPlugin(makePlugin("yy", function() return { "candidate" } end))
-            assert.are.same({ "candidate" }, lookup("unknown", "word"))
+            assert.are.same({ "candidate" }, lookup("xx", "word"))
             assert.is_true(declined)
         end)
 
         it("should go on to the next plugin when one crashes", function()
             instance:registerPlugin(makePlugin("xx", function() error("boom") end))
             instance:registerPlugin(makePlugin("yy", function() return { "candidate" } end))
-            assert.are.same({ "candidate" }, lookup("unknown", "word"))
+            assert.are.same({ "candidate" }, lookup("xx", "word"))
         end)
 
         it("should return nothing when every plugin declines", function()
             instance:registerPlugin(makePlugin("xx", function() end))
             instance:registerPlugin(makePlugin("yy", function() end))
-            assert.is_nil(lookup("unknown", "word"))
+            assert.is_nil(lookup("xx", "word"))
         end)
 
         it("should return nothing when no plugins are registered", function()

--- a/spec/unit/languagesupport_spec.lua
+++ b/spec/unit/languagesupport_spec.lua
@@ -1,0 +1,74 @@
+describe("LanguageSupport module", function()
+    local LanguageSupport
+
+    setup(function()
+        require("commonrequire")
+        LanguageSupport = require("languagesupport")
+    end)
+
+    local instance
+
+    before_each(function()
+        -- The plugin list is a singleton shared by every instance, so a leftover
+        -- plugin from a previous test would be found by the one after it.
+        for name in pairs(LanguageSupport.plugins) do
+            LanguageSupport.plugins[name] = nil
+        end
+        instance = LanguageSupport:new{ ui = { doc_props = {} } }
+    end)
+
+    -- A plugin that claims the language matching its own name, and answers a
+    -- word lookup with whatever the handler returns.
+    local function makePlugin(name, onWordLookup)
+        return {
+            name = name,
+            supportsLanguage = function(_, language_code) return language_code == name end,
+            onWordLookup = onWordLookup,
+        }
+    end
+
+    local function lookup(language_code, text)
+        instance.ui.doc_props.language = language_code
+        return instance:extraDictionaryFormCandidates(text)
+    end
+
+    describe("extraDictionaryFormCandidates()", function()
+        it("should use the plugin matching the document language", function()
+            instance:registerPlugin(makePlugin("kk", function() return { "kk-candidate" } end))
+            instance:registerPlugin(makePlugin("ja", function() return { "ja-candidate" } end))
+            assert.are.same({ "kk-candidate" }, lookup("kk", "word"))
+            assert.are.same({ "ja-candidate" }, lookup("ja", "word"))
+        end)
+
+        it("should fall back to every other plugin when no plugin claims the language", function()
+            instance:registerPlugin(makePlugin("kk", function() return { "kk-candidate" } end))
+            assert.are.same({ "kk-candidate" }, lookup("ru", "word"))
+        end)
+
+        it("should go on to the next plugin when one declines the text", function()
+            -- Returning nothing means "this is not my text". The search must
+            -- continue regardless of the order pairs() happens to visit them in.
+            local declined = false
+            instance:registerPlugin(makePlugin("xx", function() declined = true end))
+            instance:registerPlugin(makePlugin("yy", function() return { "candidate" } end))
+            assert.are.same({ "candidate" }, lookup("unknown", "word"))
+            assert.is_true(declined)
+        end)
+
+        it("should go on to the next plugin when one crashes", function()
+            instance:registerPlugin(makePlugin("xx", function() error("boom") end))
+            instance:registerPlugin(makePlugin("yy", function() return { "candidate" } end))
+            assert.are.same({ "candidate" }, lookup("unknown", "word"))
+        end)
+
+        it("should return nothing when every plugin declines", function()
+            instance:registerPlugin(makePlugin("xx", function() end))
+            instance:registerPlugin(makePlugin("yy", function() end))
+            assert.is_nil(lookup("unknown", "word"))
+        end)
+
+        it("should return nothing when no plugins are registered", function()
+            assert.is_nil(lookup("unknown", "word"))
+        end)
+    end)
+end)


### PR DESCRIPTION
Kazakh is agglutinative: `мектептерімізде` is `мектеп` ("school") plus plural,
first-person-plural possessive and locative. Dictionaries are keyed on the lemma, so
tapping that word finds nothing, and fuzzy search does not bridge it -- it measures
spelling distance, not morphology.

This registers a `LanguageSupport` plugin, the same WordLookup hook japanese.koplugin
uses for deinflection. `Stemmer.ladder` walks the suffix layers backwards and returns
every morphologically legal analysis, longest first, and `onWordLookup` hands those to
the dictionary as extra candidates:

    мектептерімізде  ->  мектептеріміз, мектептері, мектептер, мектеп
    кітабы           ->  кітаб, кітап          (undoes б->п devoicing)
    орны             ->  орын                  (restores the elided vowel)

It offers every analysis instead of picking one stem, because any scorer is wrong in
both directions -- for `маманда` it strips past the real root `маман` down to `мама`,
for `жанышта` it strips nothing and never reaches `жаныш` -- and the dictionary is a
better filter than a score. No lexicon is shipped or loaded.

Candidates are resolved with exact search before being offered. Intermediate rungs are
usually not words, and KOReader resolves candidates with fuzzy search on, so each would
otherwise contribute near-spelling matches that sort above the real article. That check
is pcall-guarded and falls back to the unfiltered list, so it can only add precision.

The plugin is inert unless the book's language is kk/kaz/kk-KZ and the tapped word
contains Cyrillic. It needs a Kazakh StarDict dictionary in `data/dict/`; it works with
any, and ships none.

`rules.lua` is generated from the Python reference by tools/gen_lua_rules.py in
kazsearch-py <https://github.com/iDynbek/kazsearch-py>, itself a port of the Rust core
of pg-kazsearch <https://github.com/darkhanakh/pg-kazsearch>, LGPLv3 or later.
Distribution under the AGPLv3 is permitted by LGPLv3 section 2 and AGPLv3 section 13.

### Testing

`spec/unit/kazakh_spec.lua` covers `Stemmer.ladder`: lemma reachability, ordering by
character rather than byte, the shallowest analysis leading, consonant-devoicing and
vowel-elision repair, idempotence on every rung, and tokens that are not words.

Separately, tools/parity_lua.py in kazsearch-py diffs this port against the Python
reference word for word: 20,006 of 20,020 golden words give identical candidate lists,
the remaining 14 single characters this port drops by policy.

Exercised on desktop only, against a 215k-article Kazakh dictionary. No e-ink device
testing -- worth noting given the extra sdcv call per lookup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15837)
<!-- Reviewable:end -->
