### PR TITLE
Kindle: ensure frontlightIntensityHW doesn't return "nil" on failed HW read

### DIFF
--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -116,7 +116,7 @@ end
 -- in order to be able to toggle it back on at the right intensity.
 function KindlePowerD:isFrontlightOnHW()
     local hw_intensity = self:frontlightIntensityHW()
-    return hw_intensity > self.fl_min
+    return hw_intensity ~= nil and hw_intensity > self.fl_min
 end
 
 function KindlePowerD:setIntensityHW(intensity)

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -116,7 +116,7 @@ end
 -- in order to be able to toggle it back on at the right intensity.
 function KindlePowerD:isFrontlightOnHW()
     local hw_intensity = self:frontlightIntensityHW()
-    return hw_intensity ~= nil and hw_intensity > self.fl_min
+    return hw_intensity > self.fl_min
 end
 
 function KindlePowerD:setIntensityHW(intensity)

--- a/frontend/device/kindle/powerd.lua
+++ b/frontend/device/kindle/powerd.lua
@@ -81,9 +81,11 @@ function KindlePowerD:frontlightIntensityHW()
     if self.lipc_handle ~= nil then
         -- Handle the step 0 switcheroo on ! canTurnFrontlightOff devices...
         if self.device:canTurnFrontlightOff() then
-            return self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
+            -- Fall back to fl_min if the HW read fails (e.g. failed frontlight component)
+            return self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity") or self.fl_min
         else
-            local lipc_fl_intensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity")
+            -- Fall back to fl_min if the HW read fails (e.g. failed frontlight component)
+            local lipc_fl_intensity = self.lipc_handle:get_int_property("com.lab126.powerd", "flIntensity") or self.fl_min
             -- NOTE: If lipc returns 0, compare against what the kernel says,
             --       to avoid breaking on/off detection on devices where lipc 0 doesn't actually turn it off (<= PW3),
             --       c.f., #5986


### PR DESCRIPTION
This fix prevents a crash due to attempting to compare number with "nil" value on Kindle devices where the frontlight hardware is broken (where lipc's flIntensity property returns nil instead of a number).



**Background:**  I have a gen 11 Kindle Paperwhite, which has a dead frontlight. Koreader was crashing during launching from KUAL. due to "./luajit: frontend/device/kindle/powerd.lua:119: attempt to compare number with nilstack traceback:	frontend/device/kindle/powerd.lua:119: in function 'isFrontlightOnHW'"

I did the fix locally on my Kindle, now Koreader launches without problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15839)
<!-- Reviewable:end -->
