### PR TITLE
VirtualKeyboard: preserve concurrent taps

### DIFF
--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -499,7 +499,23 @@ function Contact:tapState(new_tap)
     if tev.id == -1 then
         if buddy_contact and self.down then
             -- Both main contacts are actives and we are down
-            if self:isTwoFingerTap(buddy_contact) then
+            if gesture_detector.input.disable_two_finger_tap then
+                -- Send each contact as a separate tap. Dropping this contact
+                -- clears the buddy link but leaves the other contact active,
+                -- so its later lift will emit the second tap.
+                logger.dbg("Contact:tapState: Two active contacts -> independent tap @", tev.x, tev.y)
+                gesture_detector:dropContact(self)
+                return {
+                    ges = "tap",
+                    pos = Geom:new{
+                        x = tev.x,
+                        y = tev.y,
+                        w = 0,
+                        h = 0,
+                    },
+                    time = tev.timev,
+                }
+            elseif self:isTwoFingerTap(buddy_contact) then
                 -- Mark that slot
                 self.mt_gesture = "tap"
                 -- Neuter its buddy

--- a/frontend/device/gesturedetector.lua
+++ b/frontend/device/gesturedetector.lua
@@ -498,12 +498,12 @@ function Contact:tapState(new_tap)
     -- Contact lift
     if tev.id == -1 then
         if buddy_contact and self.down then
-            -- Both main contacts are actives and we are down
-            if gesture_detector.input.disable_two_finger_tap then
-                -- Send each contact as a separate tap. Dropping this contact
-                -- clears the buddy link but leaves the other contact active,
-                -- so its later lift will emit the second tap.
-                logger.dbg("Contact:tapState: Two active contacts -> independent tap @", tev.x, tev.y)
+            -- The current contact was down and is still paired with another main contact.
+            if gesture_detector.input.allow_concurrent_taps then
+                -- Preserve this contact as a tap instead of combining it with its buddy.
+                -- Dropping this contact clears the buddy link but leaves the other
+                -- contact active, so its later lift emits the second tap.
+                logger.dbg("Contact:tapState: Concurrent contact emitted as tap @", tev.x, tev.y)
                 gesture_detector:dropContact(self)
                 return {
                     ges = "tap",

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -164,6 +164,7 @@ local Input = {
 
     timer_callbacks = nil, -- instance-specific table, because the object may get destroyed & recreated at runtime
     disable_double_tap = true,
+    disable_two_finger_tap = false,
     tap_interval_override = nil,
 
     -- keyboard state:

--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -164,7 +164,7 @@ local Input = {
 
     timer_callbacks = nil, -- instance-specific table, because the object may get destroyed & recreated at runtime
     disable_double_tap = true,
-    disable_two_finger_tap = false,
+    allow_concurrent_taps = false,
     tap_interval_override = nil,
 
     -- keyboard state:

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -187,7 +187,7 @@ function UIManager:show(widget, refreshtype, refreshregion, x, y, refreshdither)
     -- check if this widget disables double tap gesture
     Input.disable_double_tap = widget.disable_double_tap ~= false
     -- a widget may handle concurrent contacts as independent taps
-    Input.disable_two_finger_tap = widget.disable_two_finger_tap == true
+    Input.allow_concurrent_taps = widget.allow_concurrent_taps == true
     -- a widget may override tap interval (when it doesn't, nil restores the default)
     Input.tap_interval_override = widget.tap_interval_override
     -- If input was disabled, re-enable it while this widget is shown so we can actually interact with it.
@@ -227,7 +227,7 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     widget:handleEvent(Event:new("CloseWidget"))
     -- Make sure it's disabled by default and check if there are any widgets that want it disabled or enabled.
     Input.disable_double_tap = true
-    Input.disable_two_finger_tap = false
+    Input.allow_concurrent_taps = false
     local requested_disable_double_tap = nil
     local is_covered = false
     local start_idx = 1
@@ -270,7 +270,7 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     if self._window_stack[1] then
         local top_widget = self._window_stack[#self._window_stack].widget
         -- set input overrides to what the topmost widget specifies
-        Input.disable_two_finger_tap = top_widget.disable_two_finger_tap == true
+        Input.allow_concurrent_taps = top_widget.allow_concurrent_taps == true
         Input.tap_interval_override = top_widget.tap_interval_override
     end
     if dirty and not widget.invisible then

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -186,6 +186,8 @@ function UIManager:show(widget, refreshtype, refreshregion, x, y, refreshdither)
     widget:handleEvent(Event:new("Show"))
     -- check if this widget disables double tap gesture
     Input.disable_double_tap = widget.disable_double_tap ~= false
+    -- a widget may handle concurrent contacts as independent taps
+    Input.disable_two_finger_tap = widget.disable_two_finger_tap == true
     -- a widget may override tap interval (when it doesn't, nil restores the default)
     Input.tap_interval_override = widget.tap_interval_override
     -- If input was disabled, re-enable it while this widget is shown so we can actually interact with it.
@@ -225,6 +227,7 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
     widget:handleEvent(Event:new("CloseWidget"))
     -- Make sure it's disabled by default and check if there are any widgets that want it disabled or enabled.
     Input.disable_double_tap = true
+    Input.disable_two_finger_tap = false
     local requested_disable_double_tap = nil
     local is_covered = false
     local start_idx = 1
@@ -265,8 +268,10 @@ function UIManager:close(widget, refreshtype, refreshregion, refreshdither)
         Input.disable_double_tap = requested_disable_double_tap
     end
     if self._window_stack[1] then
-        -- set tap interval override to what the topmost widget specifies (when it doesn't, nil restores the default)
-        Input.tap_interval_override = self._window_stack[#self._window_stack].widget.tap_interval_override
+        local top_widget = self._window_stack[#self._window_stack].widget
+        -- set input overrides to what the topmost widget specifies
+        Input.disable_two_finger_tap = top_widget.disable_two_finger_tap == true
+        Input.tap_interval_override = top_widget.tap_interval_override
     end
     if dirty and not widget.invisible then
         -- schedule the remaining visible (i.e., uncovered) widgets to be painted

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -511,7 +511,7 @@ end
 VirtualKeyPopup = FocusManager:extend{
     modal = true,
     disable_double_tap = true,
-    disable_two_finger_tap = true,
+    allow_concurrent_taps = true,
     inputbox = nil,
     layout = nil, -- array
 }
@@ -787,7 +787,7 @@ local VirtualKeyboard = FocusManager:extend{
     covers_footer = true,
     modal = true,
     disable_double_tap = true,
-    disable_two_finger_tap = true,
+    allow_concurrent_taps = true,
     inputbox = nil,
     KEYS = nil, -- table to store layouts
     shiftmode_keys = nil, -- table

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -511,6 +511,7 @@ end
 VirtualKeyPopup = FocusManager:extend{
     modal = true,
     disable_double_tap = true,
+    disable_two_finger_tap = true,
     inputbox = nil,
     layout = nil, -- array
 }
@@ -786,6 +787,7 @@ local VirtualKeyboard = FocusManager:extend{
     covers_footer = true,
     modal = true,
     disable_double_tap = true,
+    disable_two_finger_tap = true,
     inputbox = nil,
     KEYS = nil, -- table to store layouts
     shiftmode_keys = nil, -- table

--- a/spec/unit/gesturedetector_spec.lua
+++ b/spec/unit/gesturedetector_spec.lua
@@ -1,8 +1,70 @@
 describe("gesturedetector module", function()
-    local GestureDetector
+    local GestureDetector, time
     setup(function()
         require("commonrequire")
         GestureDetector = require("device/gesturedetector")
+        time = require("ui/time")
+    end)
+
+    local function feedTwoFingerTap(disable_two_finger_tap)
+        local input = {
+            main_finger_slot = 0,
+            disable_double_tap = true,
+            disable_two_finger_tap = disable_two_finger_tap,
+            tap_interval_override = nil,
+            setTimeout = function() end,
+            clearTimeout = function() end,
+        }
+        local gesture_detector = GestureDetector:new{
+            input = input,
+            screen = {
+                scaleByDPI = function(_, value) return value end,
+            },
+            active_contacts = {},
+            contact_count = 0,
+            previous_tap = {},
+            clock_id = 0,
+        }
+        local slot0 = {
+            slot = 0,
+            id = 1,
+            x = 10,
+            y = 20,
+            timev = time.s(1),
+        }
+        local slot1 = {
+            slot = 1,
+            id = 2,
+            x = 80,
+            y = 20,
+            timev = time.s(1) + time.ms(10),
+        }
+
+        gesture_detector:feedEvent{slot0, slot1}
+        slot0.id = -1
+        slot0.timev = time.s(1) + time.ms(20)
+        slot1.id = -1
+        slot1.timev = time.s(1) + time.ms(30)
+        return gesture_detector:feedEvent{slot0, slot1}
+    end
+
+    describe("two finger taps", function()
+        it("should combine concurrent contacts by default", function()
+            local gestures = feedTwoFingerTap(false)
+
+            assert.are.equal(1, #gestures)
+            assert.are.equal("two_finger_tap", gestures[1].ges)
+        end)
+
+        it("should keep concurrent contacts independent when requested", function()
+            local gestures = feedTwoFingerTap(true)
+
+            assert.are.equal(2, #gestures)
+            assert.are.equal("tap", gestures[1].ges)
+            assert.are.equal(10, gestures[1].pos.x)
+            assert.are.equal("tap", gestures[2].ges)
+            assert.are.equal(80, gestures[2].pos.x)
+        end)
     end)
 
     describe("adjustGesCoordinate", function()

--- a/spec/unit/gesturedetector_spec.lua
+++ b/spec/unit/gesturedetector_spec.lua
@@ -6,11 +6,11 @@ describe("gesturedetector module", function()
         time = require("ui/time")
     end)
 
-    local function feedTwoFingerTap(disable_two_finger_tap)
+    local function feedConcurrentTaps(allow_concurrent_taps)
         local input = {
             main_finger_slot = 0,
             disable_double_tap = true,
-            disable_two_finger_tap = disable_two_finger_tap,
+            allow_concurrent_taps = allow_concurrent_taps,
             tap_interval_override = nil,
             setTimeout = function() end,
             clearTimeout = function() end,
@@ -43,27 +43,33 @@ describe("gesturedetector module", function()
         gesture_detector:feedEvent{slot0, slot1}
         slot0.id = -1
         slot0.timev = time.s(1) + time.ms(20)
+        local first_lift_gestures = gesture_detector:feedEvent{slot0}
+
         slot1.id = -1
         slot1.timev = time.s(1) + time.ms(30)
-        return gesture_detector:feedEvent{slot0, slot1}
+        local second_lift_gestures = gesture_detector:feedEvent{slot1}
+
+        return first_lift_gestures, second_lift_gestures
     end
 
-    describe("two finger taps", function()
+    describe("concurrent taps", function()
         it("should combine concurrent contacts by default", function()
-            local gestures = feedTwoFingerTap(false)
+            local first_lift_gestures, second_lift_gestures = feedConcurrentTaps(false)
 
-            assert.are.equal(1, #gestures)
-            assert.are.equal("two_finger_tap", gestures[1].ges)
+            assert.are.equal(1, #first_lift_gestures)
+            assert.are.equal("two_finger_tap", first_lift_gestures[1].ges)
+            assert.are.equal(0, #second_lift_gestures)
         end)
 
         it("should keep concurrent contacts independent when requested", function()
-            local gestures = feedTwoFingerTap(true)
+            local first_lift_gestures, second_lift_gestures = feedConcurrentTaps(true)
 
-            assert.are.equal(2, #gestures)
-            assert.are.equal("tap", gestures[1].ges)
-            assert.are.equal(10, gestures[1].pos.x)
-            assert.are.equal("tap", gestures[2].ges)
-            assert.are.equal(80, gestures[2].pos.x)
+            assert.are.equal(1, #first_lift_gestures)
+            assert.are.equal("tap", first_lift_gestures[1].ges)
+            assert.are.equal(10, first_lift_gestures[1].pos.x)
+            assert.are.equal(1, #second_lift_gestures)
+            assert.are.equal("tap", second_lift_gestures[1].ges)
+            assert.are.equal(80, second_lift_gestures[1].pos.x)
         end)
     end)
 


### PR DESCRIPTION
## What changed

The virtual keyboard now asks the input layer to treat concurrent contacts as separate taps. The gesture detector emits one tap when each contact lifts while this setting is active. Other widgets still receive the existing `two_finger_tap` gesture.

The same setting is active in the virtual key popup. The regression test covers both the normal two finger gesture and the separate keyboard tap behavior.

## Why

Fast typing with two thumbs can put the second finger down before the first finger lifts. KOReader then combines both contacts into one `two_finger_tap` and clears the second contact. The virtual keyboard has no handler for that gesture, so neither key is inserted.

I reproduced the problem in dictionary search on a Kindle Paperwhite running firmware 5.19.5 and KOReader v2026.03. Alternating `f` and `j` quickly could produce no characters. The same test worked in the Kindle reader keyboard. A user patch with the same contact behavior fixed the problem on the device, and fast typing now registers both keys.

The gesture code that causes the problem is still present on current master at `e9c0a6e3`. The new test runs against current master.

## Checks

* `./kodev test front gesturedetector` reports 1 test passed and 0 failed.
* `luacheck` reports 0 warnings and 0 errors in the five changed Lua files.
* `git diff --check` passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15840)
<!-- Reviewable:end -->
