### PR TITLE
kindle: stop the KPP chrome status bar while KOReader runs

### DIFF
--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -76,6 +76,11 @@ PASSCODE_DISABLED="no"
 
 # List of services we stop in order to reclaim a tiny sliver of RAM...
 TOGGLED_SERVICES="stored webreader kfxreader kfxview todo tmd rcm archive scanner otav3 otaupd"
+# The KPP chrome status bar runs as a separate job, so disabling pillow doesn't stop it drawing over us
+# Verified on: PW6 @ FW 5.17.1.0.4 & 5.19.4.0.1; PW4 @ 5.18.1
+if [ -f "/etc/upstart/statusbar.conf" ]; then
+    TOGGLED_SERVICES="${TOGGLED_SERVICES} statusbar"
+fi
 
 REEXEC_FLAGS=""
 # Keep track of if we were started through KUAL


### PR DESCRIPTION
The KPP chrome status bar runs as a separate upstart job, so disabling pillow doesn't stop it drawing over KOReader.  Added a check for presence of statusbar config in `/etc/upstart/` which if true appends `statusbar` to the list of toggled Kindle processes when KOReader starts/exits.

Personally tested on PW6 5.17.1.0.4, PW6 5.19.4.0.1, and PW4 5.18.1, and observed that it resolved the issue of Kindle refreshes causing bleedthrough of status bar items like clock, wifi icon, etc on top of the KOReader interface, and status bar was properly restored on exit.

Fixes #11896 #12508 #6659

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15846)
<!-- Reviewable:end -->
