### PR TITLE
OPDS: fix duplicate PDF download button

### DIFF
--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -523,9 +523,7 @@ function OPDSBrowser:getServerFileName(item_url, filetype)
     end
 
     if filename and filetype then
-        -- Add extension if missing or unusable. getFileNameSuffix() returns an
-        -- empty string (not nil) when there is no suffix at all, and the last
-        -- dotted part of a name like "2509.07924v1" is not one either.
+        -- Add extension if missing or unusable.
         local current_suffix = util.getFileNameSuffix(filename)
         if not DocumentRegistry:hasProvider("dummy." .. current_suffix) then
             filename = filename .. "." .. filetype:lower()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -825,6 +825,7 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                 -- a publication. Arxiv uses title. Specifically, it uses
                 -- a title attribute that contains pdf. (title="pdf")
                 if link.rel or link.title then
+                    local acquisitions_nb = #item.acquisitions
                     if link.rel == self.borrow_rel then
                         table.insert(item.acquisitions, {
                             type = "borrow",
@@ -869,8 +870,11 @@ function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
                     end
                     -- This statement grabs the catalog items that are
                     -- indicated by title="pdf" or whose type is
-                    -- "application/pdf"
-                    if link.title == "pdf" or link.type == "application/pdf"
+                    -- "application/pdf", and that have not already been
+                    -- added as an acquisition above (which would result in
+                    -- duplicate download buttons)
+                    if #item.acquisitions == acquisitions_nb
+                        and (link.title == "pdf" or link.type == "application/pdf")
                         and link.rel ~= "subsection" then
                         -- Check for the presence of the pdf suffix and add it
                         -- if it's missing.

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -523,9 +523,11 @@ function OPDSBrowser:getServerFileName(item_url, filetype)
     end
 
     if filename and filetype then
+        -- Add extension if missing or unusable. getFileNameSuffix() returns an
+        -- empty string (not nil) when there is no suffix at all, and the last
+        -- dotted part of a name like "2509.07924v1" is not one either.
         local current_suffix = util.getFileNameSuffix(filename)
-        -- Add extension if missing
-        if not current_suffix then
+        if not DocumentRegistry:hasProvider("dummy." .. current_suffix) then
             filename = filename .. "." .. filetype:lower()
         end
     end

--- a/spec/unit/opds_spec.lua
+++ b/spec/unit/opds_spec.lua
@@ -584,5 +584,21 @@ describe("OPDS module", function()
             assert.are.same(1, #acquisitions)
             assert.are.same("http://example.org/get/PDF/123/library", acquisitions[1].href)
         end)
+
+        it("should add the file extension to a server filename that lacks a usable one #internet", function()
+            local orig_fetchFeed = OPDSBrowser.fetchFeed
+            OPDSBrowser.fetchFeed = function() return nil end -- no headers: fall back to the URL
+            finally(function() OPDSBrowser.fetchFeed = orig_fetchFeed end)
+
+            -- No suffix at all.
+            assert.are.same("library.pdf",
+                OPDSBrowser:getServerFileName("http://example.org/get/PDF/123/library", "pdf"))
+            -- A dotted tail that is not a known extension is not a suffix either.
+            assert.are.same("2509.07924v1.pdf",
+                OPDSBrowser:getServerFileName("http://arxiv.org/pdf/2509.07924v1", "pdf"))
+            -- An existing, usable extension is left alone.
+            assert.are.same("file.pdf",
+                OPDSBrowser:getServerFileName("http://example.org/books/file.pdf?opds", "pdf"))
+        end)
     end)
 end)

--- a/spec/unit/opds_spec.lua
+++ b/spec/unit/opds_spec.lua
@@ -338,6 +338,22 @@ local pdf_query_sample = [[
 </feed>
 ]]
 
+local pdf_acquisition_sample = [[
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/" xmlns:os="http://a9.com/-/spec/opensearch/1.1/" xmlns:opds="http://opds-spec.org/2010/catalog">
+    <id>tag:root:pdfacquisition</id>
+    <title>PDF Acquisition Test</title>
+    <updated>2025-09-11T00:00:00Z</updated>
+    <entry>
+        <title>Sample PDF Without Suffix</title>
+        <id>urn:pdf:no:suffix</id>
+        <updated>2025-09-11T00:00:00Z</updated>
+        <content type="text">A PDF whose download link carries no .pdf suffix.</content>
+        <link href="/get/PDF/123/library" type="application/pdf" rel="http://opds-spec.org/acquisition" />
+    </entry>
+</feed>
+]]
+
 describe("OPDS module", function()
     local socketutil
     local OPDSParser, OPDSBrowser
@@ -554,6 +570,19 @@ describe("OPDS module", function()
             assert(href:match("file%.pdf%?opds$"))
             -- And must NOT have an extra .pdf appended after the query string.
             assert(not href:match("opds%.pdf$"))
+        end)
+
+        it("should not duplicate a PDF acquisition whose href has no .pdf suffix #internet", function()
+            local catalog = OPDSParser:parse(pdf_acquisition_sample)
+            local item_table = OPDSBrowser:genItemTableFromCatalog(catalog, "http://example.org/opds")
+
+            assert.truthy(item_table)
+            assert.are.same(1, #item_table)
+            local acquisitions = item_table[1].acquisitions
+            assert.truthy(acquisitions)
+            -- The acquisition link is added once, by the rel handling above.
+            assert.are.same(1, #acquisitions)
+            assert.are.same("http://example.org/get/PDF/123/library", acquisitions[1].href)
         end)
     end)
 end)


### PR DESCRIPTION
Fixes #15849.

The arxiv `.pdf`-suffix workaround in `genItemTableFromCatalog` runs unconditionally after the `rel` if/elseif chain, so a link that has already been turned into an acquisition is added a second time with `.pdf` appended to the path. #14304 stopped the append when the path already ends in `.pdf`, which removed the duplicate for query-string URLs, but any PDF href without a `.pdf` suffix still produces two identical download buttons — the second pointing at a URL that 404s on servers that do not tolerate the extra suffix.

The first commit applies the workaround only when the `rel` handling above produced no acquisition for that link, so genuine title-only links (`title="pdf"` with no usable `type`) still get their suffix fixup.

Note that arxiv itself was affected: its `title="pdf" rel="related" type="application/pdf"` links are already caught by the `hasProvider(nil, link.type)` branch, so they rendered as `pdf⬇` + `PDF⬇`.

The second commit fixes a pre-existing bug that removing the duplicate button exposes. `getServerFileName()` restores a missing extension with:

```lua
local current_suffix = util.getFileNameSuffix(filename)
if not current_suffix then
```

but `util.getFileNameSuffix()` returns `""`, never `nil`, for a name with no suffix, so that branch was dead code. With **Use server filenames** enabled and no `content-disposition` or redirect `Location` to go on, a URL-basename fallback like `/get/PDF/123/library` saved without any extension. It now tests for a usable extension through the document registry, which also covers dotted tails such as `2509.07924v1`.

Adds regression tests alongside the existing #14300 one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15850)
<!-- Reviewable:end -->
