### PR TITLE
InputDialog: fix the on-screen keyboard toggle in fullscreen dialogs

### DIFF
--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -716,7 +716,10 @@ function InputDialog:toggleKeyboard(force_toggle)
     end
 
     -- Clear the FocusManager highlight, because that gets lost in the mess somehow...
-    self.button_table:getButtonById("keyboard"):onUnfocus()
+    local keyboard_button = self.button_table:getButtonById("keyboard") -- absent without touch
+    if keyboard_button then
+        keyboard_button:onUnfocus()
+    end
 
     -- Make sure we refresh the nav bar, as it will have moved, and it belongs to us, not to VK or our input widget...
     self:refreshButtons()
@@ -951,8 +954,8 @@ function InputDialog:_addScrollButtons(nav_bar)
         row = self.buttons[1]
     end
     if nav_bar then -- Add the Home & End buttons
-        -- Also add Keyboard hide/show button if we can
-        if self.fullscreen and not self.readonly then
+        -- Also add Keyboard hide/show button if we can -- not without touch, where a key does it.
+        if self.fullscreen and not self.readonly and Device:isTouchDevice() then
             table.insert(row, {
                 text = self.keyboard_visible and "↓⌨" or "↑⌨",
                 id = "keyboard",

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -961,8 +961,8 @@ function InputDialog:_addScrollButtons(nav_bar)
     end
     if nav_bar then -- Add the Home & End buttons
         -- Also add Keyboard hide/show button if we can -- not where a key already does it.
-        local has_keyboard_toggle_key = Device:hasScreenKB() or Device:hasSymKey()
-        if self.fullscreen and not self.readonly and not has_keyboard_toggle_key then
+        local has_keyboard_toggle = Device:hasScreenKB() or Device:hasSymKey()
+        if self.fullscreen and not self.readonly and not has_keyboard_toggle then
             table.insert(row, {
                 text = self.keyboard_visible and "↓⌨" or "↑⌨",
                 id = "keyboard",

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -667,6 +667,12 @@ function InputDialog:lockKeyboard(toggle)
     return self._input_widget:lockKeyboard(toggle)
 end
 
+-- Whether a key that toggles the keyboard has to reach us rather than the text widget: we are
+-- the one laid out around the keyboard, so we are the one that has to be laid out again.
+function InputDialog:shouldDelegateToggleKeyboard()
+    return self.fullscreen and self.add_nav_bar and not self.readonly
+end
+
 -- NOTE: Only called by fullscreen and/or add_nav_bar codepaths
 --       We do not currently have !fullscreen add_nav_bar callers...
 function InputDialog:toggleKeyboard(force_toggle)
@@ -716,7 +722,7 @@ function InputDialog:toggleKeyboard(force_toggle)
     end
 
     -- Clear the FocusManager highlight, because that gets lost in the mess somehow...
-    local keyboard_button = self.button_table:getButtonById("keyboard") -- absent without touch
+    local keyboard_button = self.button_table:getButtonById("keyboard") -- absent where a key toggles
     if keyboard_button then
         keyboard_button:onUnfocus()
     end
@@ -954,8 +960,9 @@ function InputDialog:_addScrollButtons(nav_bar)
         row = self.buttons[1]
     end
     if nav_bar then -- Add the Home & End buttons
-        -- Also add Keyboard hide/show button if we can -- not without touch, where a key does it.
-        if self.fullscreen and not self.readonly and Device:isTouchDevice() then
+        -- Also add Keyboard hide/show button if we can -- not where a key already does it.
+        local has_keyboard_toggle_key = Device:hasScreenKB() or Device:hasSymKey()
+        if self.fullscreen and not self.readonly and not has_keyboard_toggle_key then
             table.insert(row, {
                 text = self.keyboard_visible and "↓⌨" or "↑⌨",
                 id = "keyboard",

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -200,7 +200,8 @@ local InputDialog = FocusManager:extend{
     _buttons_backup = nil,
 }
 
-function InputDialog:init()
+-- `reinit`: the caller has already decided the keyboard's visibility, don't reset it.
+function InputDialog:init(reinit)
     self.layout = {{}}
     self.screen_width = Screen:getWidth()
     self.screen_height = Screen:getHeight()
@@ -223,7 +224,7 @@ function InputDialog:init()
     if self.fullscreen or self.add_nav_bar then
         self.deny_keyboard_hiding = true
     end
-    if (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:nilOrFalse("virtual_keyboard_enabled") then
+    if not reinit and (Device:hasKeyboard() or Device:hasScreenKB()) and G_reader_settings:nilOrFalse("virtual_keyboard_enabled") then
         self.keyboard_visible = false
         self.skip_first_show_keyboard = true
     end
@@ -401,7 +402,7 @@ function InputDialog:init()
     -- NOTE: Never send a Focus event, as, on hasDPad device, InputText's onFocus *will* call onShowKeyboard,
     --       and that will wreak havoc on toggleKeyboard...
     --       Plus, the widget at (1, 1) will not have changed, so we don't actually need to change the visual focus anyway?
-    -- If it turns out something actually needed this, make this conditional on a new `reinit` arg passed to `init`, for toggleKeyboard & co.
+    -- If it turns out something actually needed this, make it conditional on `reinit`.
     self:refocusWidget(FocusManager.RENDER_NOW, FocusManager.NOT_FOCUS)
     -- Complementary setup for some of our added buttons
     if self.save_callback then
@@ -514,7 +515,7 @@ function InputDialog:reinit()
 
     -- Same deal as in toggleKeyboard...
     self.keyboard_visible = visible and true or false
-    self:init()
+    self:init(true)
     if self.keyboard_visible then
         self:onShowKeyboard()
     end
@@ -541,7 +542,7 @@ function InputDialog:addWidget(widget, re_init, skip_focus_layout)
         table.insert(self._added_widgets, widget)
         if is_text_height_adjustable then
             self.text_height = nil
-            self:init()
+            self:init(true)
         end
     end
     -- insert widget before the bottom buttons and their previous vspan
@@ -669,6 +670,9 @@ end
 -- NOTE: Only called by fullscreen and/or add_nav_bar codepaths
 --       We do not currently have !fullscreen add_nav_bar callers...
 function InputDialog:toggleKeyboard(force_toggle)
+    -- An explicit toggle must not be eaten by the startup skip.
+    self.skip_first_show_keyboard = nil
+
     -- Remember the *current* visibility, as the following close will reset it
     local visible = self:isKeyboardVisible()
 
@@ -699,7 +703,7 @@ function InputDialog:toggleKeyboard(force_toggle)
     else
         self.keyboard_visible = not visible
     end
-    self:init()
+    self:init(true)
 
     -- NOTE: If we ever have non-fullscreen add_nav_bar callers, it might make sense *not* to lock the keyboard there?
     if self.keyboard_visible then
@@ -726,7 +730,7 @@ function InputDialog:onKeyboardClosed()
         self:onClose()
         self:free()
 
-        self:init()
+        self:init(true)
 
         self:refreshButtons()
     end

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -730,6 +730,7 @@ function InputDialog:onKeyboardClosed()
         self:onClose()
         self:free()
 
+        self.keyboard_visible = false -- it is already gone
         self:init(true)
 
         self:refreshButtons()

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -982,6 +982,12 @@ end
 
 -- Temporarily show/hide the on-screen keyboard, e.g. via Shift/ScreenKB + Home or a lone Sym/ScreenKB press.
 function InputText:toggleKeyboard()
+    -- A dialog that lays itself out around the keyboard has to do the toggling itself.
+    local parent = self.parent
+    if parent and parent.toggleKeyboard and parent.fullscreen and parent.add_nav_bar
+            and not parent.readonly then
+        return parent:toggleKeyboard()
+    end
     if self:isKeyboardVisible() then
         self:onCloseKeyboard()
     else

--- a/frontend/ui/widget/inputtext.lua
+++ b/frontend/ui/widget/inputtext.lua
@@ -982,10 +982,8 @@ end
 
 -- Temporarily show/hide the on-screen keyboard, e.g. via Shift/ScreenKB + Home or a lone Sym/ScreenKB press.
 function InputText:toggleKeyboard()
-    -- A dialog that lays itself out around the keyboard has to do the toggling itself.
     local parent = self.parent
-    if parent and parent.toggleKeyboard and parent.fullscreen and parent.add_nav_bar
-            and not parent.readonly then
+    if parent and parent.shouldDelegateToggleKeyboard and parent:shouldDelegateToggleKeyboard() then
         return parent:toggleKeyboard()
     end
     if self:isKeyboardVisible() then

--- a/frontend/ui/widget/multiinputdialog.lua
+++ b/frontend/ui/widget/multiinputdialog.lua
@@ -101,9 +101,9 @@ local MultiInputDialog = InputDialog:extend{
     enter_callback = nil, -- applied to all fields
 }
 
-function MultiInputDialog:init()
+function MultiInputDialog:init(reinit)
     -- init title and buttons in base class
-    InputDialog.init(self)
+    InputDialog.init(self, reinit)
     -- Kick InputDialog's own field out of the layout, we're not using it
     table.remove(self.layout, 1)
     -- Also murder said input field *and* its VK, or we get two of them and shit gets hilariously broken real fast...
@@ -291,7 +291,7 @@ function MultiInputDialog:onKeyboardHeightChanged()
     for i, field in ipairs(self.fields) do -- restore entered text
         field.text = fields[i].text
     end
-    self:init()
+    self:init(true)
     if self.keyboard_visible then
         self:onShowKeyboard()
     end

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -926,8 +926,10 @@ function VirtualKeyboard:onClose()
     return true
 end
 
--- A parent that laid itself out around us has to hear about it. Not from onClose: a
--- programmatic hide goes through that one, and would reenter the caller's own re-init.
+-- A fullscreen dialog reserves screen space for the keyboard, so when a key closes the
+-- keyboard, the dialog has to lay itself out again without it. onClose() cannot carry
+-- that news: the dialog's own re-init closes the keyboard through it, and answering back
+-- there would restart the re-init from inside itself.
 function VirtualKeyboard:onCloseWithKey()
     self:onClose()
     local parent = self.inputbox and self.inputbox.parent

--- a/frontend/ui/widget/virtualkeyboard.lua
+++ b/frontend/ui/widget/virtualkeyboard.lua
@@ -866,7 +866,7 @@ function VirtualKeyboard:init()
     self:initLayer(self.keyboard_layer)
     self.tap_interval_override = time.ms(G_reader_settings:readSetting("ges_tap_interval_on_keyboard_ms", 0))
     if Device:hasKeys() then
-        self.key_events.Close = { { "Back" } }
+        self.key_events.CloseWithKey = { { "Back" } }
     end
     if keyboard.wrapInputBox then
         self.uwrap_func = keyboard.wrapInputBox(self.inputbox) or self.uwrap_func
@@ -923,6 +923,17 @@ end
 
 function VirtualKeyboard:onClose()
     UIManager:close(self)
+    return true
+end
+
+-- A parent that laid itself out around us has to hear about it. Not from onClose: a
+-- programmatic hide goes through that one, and would reenter the caller's own re-init.
+function VirtualKeyboard:onCloseWithKey()
+    self:onClose()
+    local parent = self.inputbox and self.inputbox.parent
+    if parent and parent.onKeyboardClosed then
+        parent:onKeyboardClosed()
+    end
     return true
 end
 


### PR DESCRIPTION
In a fullscreen dialog the "show keyboard" button did nothing on devices with a physical
keyboard or a ScreenKB while "virtual_keyboard_enabled" is off, its default there since
bed8f558f: init() undid the decision toggleKeyboard() had just made. Reported in #14937.

InputDialog:onKeyboardClosed has had no caller since 8285f4e3b dropped the notification
along with the "return false" it shared a branch with. Closing the keyboard with Back left
the dialog laid out around it, and the next Back closed the whole editor.

Sym / ScreenKB / Shift + Home went straight to the keyboard widget, bypassing the dialog,
so the keyboard covered the text it was raised to type into.

The button is gone where there is no touch: a key does the same job there.

Three commits. Tested on a Kindle 3, with the virtual keyboard setting on and off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15854)
<!-- Reviewable:end -->
