### PR TITLE
HighlightDialog: add long-press actions for Search and Dictionary buttons

### DIFF
--- a/frontend/apps/reader/modules/readerdictionary.lua
+++ b/frontend/apps/reader/modules/readerdictionary.lua
@@ -1150,7 +1150,7 @@ function ReaderDictionary:dismissLookupInfo()
     self.lookup_progress_msg = nil
 end
 
-function ReaderDictionary:onShowDictionaryLookup()
+function ReaderDictionary:onShowDictionaryLookup(selection)
     local buttons = {}
     local preset_names = Presets.getPresets(self.preset_obj)
     if preset_names and #preset_names > 0 then
@@ -1188,7 +1188,7 @@ function ReaderDictionary:onShowDictionaryLookup()
 
     self.dictionary_lookup_dialog = InputDialog:new{
         title = _("Enter a word or phrase to look up"),
-        input = "",
+        input = selection or "",
         input_type = "text",
         buttons = buttons,
     }

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -176,7 +176,7 @@ function ReaderHighlight:init()
                     this:lookupDict(index)
                     this:onClose(true) -- keep highlight for dictionary lookup
                 end,
-                hold_callback = function() -- Dictionary lookup dialog
+                hold_callback = function()
                     this.ui.dictionary:onShowDictionaryLookup(util.cleanupSelectedText(this.selected_text.text))
                     this:onClose()
                 end,
@@ -206,7 +206,7 @@ function ReaderHighlight:init()
                     -- search matches on the current page, and self:clear()
                     -- would redraw and remove crengine native highlights
                 end,
-                hold_callback = function() -- Fulltext search dialog
+                hold_callback = function()
                     self.ui.search:onShowFulltextSearchInput(util.cleanupSelectedText(this.selected_text.text))
                     this:onClose()
                 end,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -176,6 +176,10 @@ function ReaderHighlight:init()
                     this:lookupDict(index)
                     this:onClose(true) -- keep highlight for dictionary lookup
                 end,
+                hold_callback = function() -- Dictionary lookup dialog
+                    this.ui.dictionary:onShowDictionaryLookup(util.cleanupSelectedText(this.selected_text.text))
+                    this:onClose()
+                end,
             }
         end,
         ["07_translate"] = function(this, index)
@@ -201,6 +205,10 @@ function ReaderHighlight:init()
                     -- We don't call this:onClose(), crengine will highlight
                     -- search matches on the current page, and self:clear()
                     -- would redraw and remove crengine native highlights
+                end,
+                hold_callback = function() -- Fulltext search dialog
+                    self.ui.search:onShowFulltextSearchInput(util.cleanupSelectedText(this.selected_text.text))
+                    this:onClose()
                 end,
             }
         end,


### PR DESCRIPTION
New long-press actions:

#### Search button

- Opens Fulltext search dialog with selected text filled in
- User is able to edit text prior to searching
- User can select either next/previous search or 'All', independent of Fulltext search settings

#### Dictionary button

- Opens Dictionary lookup dialog with selected text filled in
- User can edit the text prior to look-up
- Helpful for example when fuzzy search doesn't produce suitable results (c.f., [comment](https://github.com/koreader/koreader/pull/15837#issuecomment-5226874808))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15859)
<!-- Reviewable:end -->
