### PR TITLE
Exporter improvement

### DIFF
--- a/plugins/cloudstorage.koplugin/main.lua
+++ b/plugins/cloudstorage.koplugin/main.lua
@@ -131,6 +131,24 @@ function Cloud:onShowCloudStorageList(caller_choose_folder_callback)
     base:show()
 end
 
+function Cloud:uploadFile(server, file_path, success_callback, failure_callback)
+    local provider = server and server.type and self.providers[server.type]
+    if not provider then return end
+    provider.base = util.tableDeepCopy(server)
+    provider.run(function()
+        local code_response = provider.uploadFile(server.url, file_path, nil, true) -- overwrite
+        if type(code_response) == "number" and code_response >= 200 and code_response < 300 then
+            if success_callback then
+                success_callback()
+            end
+        else
+            if failure_callback then
+                failure_callback()
+            end
+        end
+    end)
+end
+
 function Cloud:stopPlugin()
     Cloud.providers = nil
 end

--- a/plugins/exporter.koplugin/base.lua
+++ b/plugins/exporter.koplugin/base.lua
@@ -6,15 +6,23 @@ Each target should inherit from this class and implement *at least* an `export` 
 @module baseexporter
 ]]
 
+local ButtonDialog = require("ui/widget/buttondialog")
+local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local InfoMessage = require("ui/widget/infomessage")
+local Notification = require("ui/widget/notification")
+local UIManager = require("ui/uimanager")
 local http = require("socket.http")
 local ltn12 = require("ltn12")
 local rapidjson = require("rapidjson")
 local socket = require("socket")
 local socketutil = require("socketutil")
 local _ = require("gettext")
+local T = require("ffi/util").template
 
-local BaseExporter = {}
+local BaseExporter = {
+    settings_key = "exporter", -- same as in main.lua
+}
 
 function BaseExporter:new(o)
     o = o or {}
@@ -30,15 +38,20 @@ function BaseExporter:_init()
     self.version = self.version or "1.0.0"
     self.shareable = self.is_remote and nil or Device:canShareText()
     self:loadSettings()
-    if self.init_callback then
-        local changed, settings = self:init_callback(self.settings)
-        if changed then
-            self.settings = settings
-            self:saveSettings()
-        end
-    end
     return self
 end
+
+function BaseExporter:loadSettings()
+    local plugin_settings = G_reader_settings:readSetting(self.settings_key, {})
+    plugin_settings[self.name] = plugin_settings[self.name] or self.default_settings or {}
+    self.settings = plugin_settings[self.name]
+end
+
+function BaseExporter:getMarkdownSettings()
+    return G_reader_settings:readSetting(self.settings_key).markdown
+end
+
+function BaseExporter:saveSettings() end -- for backward compatibility
 
 --[[--
 Export timestamp
@@ -57,24 +70,6 @@ Exporter version
 ]]
 function BaseExporter:getVersion()
     return self.name .. "/" .. self.version
-end
-
---[[--
-Loads settings for the exporter
-]]
-function BaseExporter:loadSettings()
-    local plugin_settings = G_reader_settings:readSetting("exporter") or {}
-    self.settings = plugin_settings[self.name] or {}
-end
-
---[[--
-Saves settings for the exporter
-]]
-function BaseExporter:saveSettings()
-    local plugin_settings = G_reader_settings:readSetting("exporter") or {}
-    plugin_settings[self.name] = self.settings
-    G_reader_settings:saveSetting("exporter", plugin_settings)
-    self.new_settings = true
 end
 
 --[[--
@@ -135,7 +130,178 @@ Toggles exporter enabled state if it's ready to export
 function BaseExporter:toggleEnabled()
     if self:isReadyToExport() then
         self.settings.enabled = not self.settings.enabled
-        self:saveSettings()
+    end
+end
+
+function BaseExporter:genTargetMenu()
+    return {
+        text = self.title,
+        checked_func = function()
+            return self:isEnabled()
+        end,
+        hold_callback = function(touchmenu_instance)
+            self:toggleEnabled()
+            touchmenu_instance:updateItems()
+        end,
+        sub_item_table = self:genTargetSubMenu(), -- provided by targets
+    }
+end
+
+function BaseExporter:genToggleMenuItem(item_text, item_setting, separator)
+    return {
+        text = item_text,
+        checked_func = function()
+            return self.settings[item_setting]
+        end,
+        callback = function()
+            self.settings[item_setting] = not self.settings[item_setting] or nil
+        end,
+        separator = separator,
+    }
+end
+
+function BaseExporter:genExportToMenuItem()
+    return {
+        text = T(_("Export to %1"), self.title),
+        checked_func = function()
+            return self:isEnabled()
+        end,
+        enabled_func = function()
+            return self:isReadyToExport() and true or false
+        end,
+        callback = function()
+            self:toggleEnabled()
+        end,
+        separator = self.help_text == nil,
+    }
+end
+
+function BaseExporter:genHelpMenuItem()
+    return {
+        text = _("Help"),
+        keep_menu_open = true,
+        callback = function()
+            UIManager:show(InfoMessage:new{ text = self.help_text or self.title })
+        end,
+        separator = true,
+    }
+end
+
+function BaseExporter:genCloudStorageMenuItem()
+    return {
+        text_func = function()
+            return T("Upload to cloud storage: %1",
+                self.settings.upload_server and self.settings.upload_server.name or _("not set"))
+        end,
+        enabled_func = function()
+            return self.plugin.ui.cloudstorage ~= nil
+        end,
+        checked_func = function()
+            return self.plugin.ui.cloudstorage and self.settings.upload
+        end,
+        check_callback_updates_menu = true,
+        callback = function(touchmenu_instance)
+            self:setUploadServer(touchmenu_instance)
+        end,
+    }
+end
+
+function BaseExporter:genDeleteFileMenuItem()
+    return {
+        text = _("Delete local export file after uploading"),
+        enabled_func = function()
+            return self.plugin.ui.cloudstorage ~= nil and self.settings.upload ~= nil
+        end,
+        checked_func = function()
+            return self.plugin.ui.cloudstorage and self.settings.upload and self.settings.upload_delete_local
+        end,
+        callback = function()
+            self.settings.upload_delete_local = not self.settings.upload_delete_local or nil
+        end,
+        separator = true,
+    }
+end
+
+function BaseExporter:setUploadServer(touchmenu_instance)
+    local cs = self.plugin.ui.cloudstorage
+    local server = self.settings.upload_server
+    local server_dialogue
+    local text = cs:getServerNameType(server) or _("not set")
+    if server then
+        text = text .. "\n\n" .. T(_("Folder path:\n%1"), cs.getReadablePath(server)) .. "\n"
+    end
+    server_dialogue = ButtonDialog:new{
+        title = T(_("Cloud storage: %1"), text),
+        buttons = {
+            {
+                {
+                    text = _("Delete"),
+                    enabled = server ~= nil,
+                    callback = function()
+                        UIManager:show(ConfirmBox:new{
+                            text = _("Delete server info?"),
+                            ok_text = _("Delete"),
+                            ok_callback = function()
+                                UIManager:close(server_dialogue)
+                                self.settings.upload_server = nil
+                                self.settings.upload = nil
+                                touchmenu_instance:updateItems()
+                            end,
+                        })
+                    end,
+                },
+                {
+                    text = _("Edit"),
+                    callback = function()
+                        UIManager:close(server_dialogue)
+                        cs:onShowCloudStorageList(function(sv)
+                            self.settings.upload_server = sv
+                            touchmenu_instance:updateItems()
+                            self:setUploadServer(touchmenu_instance) -- keep the dialog open
+                        end)
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Close"),
+                    callback = function()
+                        UIManager:close(server_dialogue)
+                    end,
+                },
+                {
+                    text = self.settings.upload and _("Disable") or _("Enable"),
+                    enabled = server ~= nil,
+                    callback = function()
+                        UIManager:close(server_dialogue)
+                        self.settings.upload = not self.settings.upload or nil
+                        touchmenu_instance:updateItems()
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(server_dialogue)
+end
+
+function BaseExporter:uploadFile(file_path)
+    if self.settings.upload and self.plugin.ui.cloudstorage then
+        local function success_callback()
+            if self.settings.upload_delete_local then
+                os.remove(file_path)
+            end
+            UIManager:show(Notification:new{
+                text = _("Successfully uploaded export file"),
+                timeout = 3,
+            })
+        end
+        local function failure_callback()
+            UIManager:show(Notification:new{
+                text = _("Could not upload export file"),
+                timeout = 3,
+            })
+        end
+        self.plugin.ui.cloudstorage:uploadFile(self.settings.upload_server, file_path, success_callback, failure_callback)
     end
 end
 

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -60,7 +60,6 @@ local function updateHistoryClippings(clippings, new_clippings)
             end
         end
     end
-    return clippings
 end
 
 -- update clippings from Kindle annotation system
@@ -73,7 +72,6 @@ local function updateMyClippings(clippings, new_clippings)
             clippings[title] = booknotes
         end
     end
-    return clippings
 end
 
 local targets = {
@@ -88,37 +86,21 @@ local targets = {
     xmnote = require("target/xmnote"),
 }
 
-local function genExportersTable(path)
-    local t = {}
-    for k, v in pairs(targets) do
-        t[k] = v
-    end
-    if Provider:size("exporter") > 0 then
-        local tbl = Provider:getProvidersTable("exporter")
-        for k, v in pairs(tbl) do
-            t[k] = v
-        end
-    end
-    for _, v in pairs(t) do
-        v.path = path
-    end
-    return t
-end
-
 local Exporter = WidgetContainer:extend{
     name = "exporter",
+    settings_key = "exporter",
     default_clipping_dir = DataStorage:getFullDataDir() .. "/clipboard",
     default_clipping_filename_single   = "%D-%M %A - %T",   -- "yyyy-mm-dd-hh-mm-ss author - title"
     default_clipping_filename_multiple = "%D-%M all-books", -- see patterns in FileManagerBookInfo:expandString()
 }
 
 function Exporter:init()
-    self.settings = G_reader_settings:readSetting("exporter", {})
+    self.settings = G_reader_settings:readSetting(self.settings_key, {})
     self.parser = MyClipping:new{
         ui = self.ui,
         settings = self.settings,
     }
-    self.targets = genExportersTable(self.path)
+    self:genExportersTable()
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
     self.ui.folder_shortcuts.registerShortcut({
@@ -133,6 +115,23 @@ function Exporter:init()
     })
 end
 
+function Exporter:genExportersTable()
+    self.targets = {}
+    for k, v in pairs(targets) do
+        self.targets[k] = v
+    end
+    if Provider:size("exporter") > 0 then
+        local tbl = Provider:getProvidersTable("exporter")
+        for k, v in pairs(tbl) do
+            self.targets[k] = v
+        end
+    end
+    for _, v in pairs(self.targets) do
+        v.plugin = self
+        v.path = self.path
+    end
+end
+
 function Exporter:onDispatcherRegisterActions()
     Dispatcher:registerAction("export_current_notes",
         {category="none", event="ExportCurrentNotes", title=_("Export all notes in current book"), reader=true,})
@@ -140,8 +139,22 @@ function Exporter:onDispatcherRegisterActions()
         {category="none", event="ExportAllNotes", title=_("Export all notes in all books in history"), reader=true, filemanager=true})
 end
 
+function Exporter:getEnabledTargetCount()
+    local count = 0
+    local title
+    for _, v in pairs(self.targets) do
+        if v:isEnabled() then
+            count = count + 1
+            if count == 1 then
+                title = v.title or v.name
+            end
+        end
+    end
+    return count, title
+end
+
 function Exporter:isReady()
-    for k, v in pairs(self.targets) do
+    for _, v in pairs(self.targets) do
         if v:isEnabled() then
             return true
         end
@@ -166,9 +179,9 @@ function Exporter:requiresFile()
 end
 
 function Exporter:requiresNetwork()
-    for k, v in pairs(self.targets) do
+    for _, v in pairs(self.targets) do
         if v:isEnabled() then
-            if v.is_remote then
+            if v.is_remote or (v.settings.upload and self.ui.cloudstorage) then
                 return true
             end
         end
@@ -188,15 +201,9 @@ end
 function Exporter:onExportAllNotes()
     if not self:isReady() then return end
     local clippings = {}
-    clippings = updateHistoryClippings(clippings, self.parser:parseHistory())
+    updateHistoryClippings(clippings, self.parser:parseHistory())
     if Device:isKindle() then
-        clippings = updateMyClippings(clippings, self.parser:parseMyClippings())
-    end
-    for title, booknotes in pairs(clippings) do
-        -- chapter number is zero
-        if #booknotes == 0 then
-            clippings[title] = nil
-        end
+        updateMyClippings(clippings, self.parser:parseMyClippings())
     end
     self:exportClippings(clippings)
 end
@@ -204,13 +211,8 @@ end
 --- Parse and export highlights from selected documents.
 -- @tparam table files list of files as a table of {[file_path] = true}
 function Exporter:exportFilesNotes(files)
+    -- the popup dialog button is disabled if not self:isReady()
     local clippings = self.parser:parseFiles(files)
-    for title, booknotes in pairs(clippings) do
-        -- chapter number is zero
-        if #booknotes == 0 then
-            clippings[title] = nil
-        end
-    end
     self:exportClippings(clippings)
 end
 
@@ -218,7 +220,9 @@ function Exporter:exportClippings(clippings)
     if type(clippings) ~= "table" then return end
     local exportables = {}
     for _title, booknotes in pairs(clippings) do
-        table.insert(exportables, booknotes)
+        if #booknotes > 0 then
+            table.insert(exportables, booknotes)
+        end
     end
     if #exportables == 0 then
         UIManager:show(InfoMessage:new{ text = _("No highlights to export") })
@@ -243,6 +247,9 @@ function Exporter:exportClippings(clippings)
         clipping_filepath = clipping_dir .. "/" .. util.getSafeFilename(clipping_filename, nil, nil, -1)
     end
     local export_callback = function()
+        if self.settings.show_messages == false then
+            UIManager:setSilentMode(true)
+        end
         UIManager:nextTick(function()
             local statuses = {}
             for k, v in pairs(self.targets) do
@@ -256,7 +263,9 @@ function Exporter:exportClippings(clippings)
                         if v.is_remote then
                             table.insert(statuses, T(_("%1: Exported successfully."), v.name))
                         else
-                            table.insert(statuses, T(_("%1: Exported to %2."), v.name, v:getFilePath()))
+                            local file_path = v:getFilePath()
+                            table.insert(statuses, T(_("%1: Exported to %2."), v.name, file_path))
+                            v:uploadFile(file_path)
                         end
                     else
                         table.insert(statuses, T(_("%1: Failed to export."), v.name))
@@ -267,6 +276,7 @@ function Exporter:exportClippings(clippings)
             UIManager:show(InfoMessage:new{
                 text = table.concat(statuses, "\n"),
             })
+            UIManager:setSilentMode(false)
         end)
 
         UIManager:show(InfoMessage:new{
@@ -282,10 +292,10 @@ function Exporter:exportClippings(clippings)
 end
 
 function Exporter:addToMainMenu(menu_items)
-    self.targets = genExportersTable(self.path)
     local formats_submenu, share_submenu = {}, {}
     for k, v in pairs(self.targets) do
-        formats_submenu[#formats_submenu + 1] = v:getMenuTable()
+        formats_submenu[#formats_submenu + 1] = v.genTargetSubMenu and v:genTargetMenu()
+            or v:getMenuTable() -- for backward compatibility
         if v.shareable then
             share_submenu[#share_submenu + 1] = {
                 text = T(_("Share as %1"), v.name),
@@ -308,10 +318,10 @@ function Exporter:addToMainMenu(menu_items)
 
     local settings = self.settings
     local menu = {
-        text = _("Export highlights"),
+        text = _("Export highlights and notes"),
         sub_item_table = {
             {
-                text = _("Export all notes in current book"),
+                text = _("Export from current book"),
                 enabled_func = function()
                     return self:isReadyToExport()
                 end,
@@ -320,7 +330,7 @@ function Exporter:addToMainMenu(menu_items)
                 end,
             },
             {
-                text = _("Export all notes in all books in history"),
+                text = _("Export from all books in history"),
                 enabled_func = function()
                     return self:isReady()
                 end,
@@ -330,7 +340,14 @@ function Exporter:addToMainMenu(menu_items)
                 separator = #share_submenu == 0,
             },
             {
-                text = _("Choose formats and services"),
+                text_func = function()
+                    local text = _("Choose formats and services")
+                    local count, title = self:getEnabledTargetCount()
+                    if count > 0 then
+                        text = text .. " (" .. (count == 1 and title or count) .. ")"
+                    end
+                    return text
+                end,
                 sub_item_table = formats_submenu,
             },
             {
@@ -384,6 +401,15 @@ function Exporter:addToMainMenu(menu_items)
                     util.tableRemoveValue(settings, "filter", "color")
                     touchmenu_instance:updateItems()
                 end,
+            },
+            {
+                text = _("Show messages"),
+                checked_func = function()
+                    return settings.show_messages == nil
+                end,
+                callback = function()
+                    settings.show_messages = settings.show_messages ~= nil and nil
+                end,
                 separator = true,
             },
             {
@@ -416,7 +442,7 @@ function Exporter:addToMainMenu(menu_items)
             return v1.text < v2.text
         end)
         table.insert(menu.sub_item_table, 3, {
-            text = _("Share all notes in this book"),
+            text = _("Share from current book"),
             enabled_func = function()
                 return self:isDocReady()
             end,

--- a/plugins/exporter.koplugin/main.lua
+++ b/plugins/exporter.koplugin/main.lua
@@ -428,6 +428,7 @@ function Exporter:addToMainMenu(menu_items)
             },
             {
                 text = _("Use book folder for single export"),
+                help_text = _("When there is only a single book in the final export (current book export or no highlights in other books or highlight filtering) use the single book's folder for export."),
                 checked_func = function()
                     return settings.clipping_dir_book
                 end,

--- a/plugins/exporter.koplugin/target/html.lua
+++ b/plugins/exporter.koplugin/target/html.lua
@@ -1,11 +1,21 @@
 local logger = require("logger")
 local slt2 = require("template/slt2")
+local _ = require("gettext")
 
--- html exporter
-local HtmlExporter = require("base"):new {
+local HtmlExporter = require("base"):new{
     name = "html",
+    title = _("Html"),
     mimetype = "text/html",
 }
+
+function HtmlExporter:genTargetSubMenu()
+    return {
+        self:genExportToMenuItem(),
+        -- separator
+        self:genCloudStorageMenuItem(),
+        self:genDeleteFileMenuItem(),
+    }
+end
 
 local function format(booknotes)
     local chapters = {}

--- a/plugins/exporter.koplugin/target/joplin.lua
+++ b/plugins/exporter.koplugin/target/joplin.lua
@@ -1,4 +1,3 @@
-local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
 local http = require("socket.http")
@@ -8,12 +7,16 @@ local md = require("template/md")
 local T = require("ffi/util").template
 local _ = require("gettext")
 
--- joplin exporter
-local JoplinExporter = require("base"):new {
+local JoplinExporter = require("base"):new{
     name = "joplin",
+    title = _("Joplin"),
     is_remote = true,
     notebook_name = _("KOReader Notes"),
     version = "1.1.0",
+    help_text = T(_([[For Joplin setup instructions, see %1
+
+Markdown formatting can be configured in:
+Export highlights > Choose formats and services > Markdown.]]), "https://github.com/koreader/koreader/wiki/Joplin"),
 }
 
 local function ping(ip, port)
@@ -160,109 +163,92 @@ function JoplinExporter:isReadyToExport()
     return self.settings.ip and self.settings.port and self.settings.token
 end
 
-function JoplinExporter:getMenuTable()
+function JoplinExporter:genTargetSubMenu()
     return {
-        text = _("Joplin"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = _("Set Joplin IP and Port"),
-                keep_menu_open = true,
-                callback = function()
-                    local MultiInputDialog = require("ui/widget/multiinputdialog")
-                    local url_dialog
-                    url_dialog = MultiInputDialog:new {
-                        title = _("Set Joplin IP and port number"),
-                        fields = {
+        self:genExportToMenuItem(),
+        self:genHelpMenuItem(),
+        -- separator
+        {
+            text = _("Set Joplin IP and Port"),
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local MultiInputDialog = require("ui/widget/multiinputdialog")
+                local url_dialog
+                url_dialog = MultiInputDialog:new{
+                    title = _("Set Joplin IP and port number"),
+                    fields = {
+                        {
+                            text = self.settings.ip,
+                        },
+                        {
+                            text = self.settings.port,
+                            input_type = "number"
+                        },
+                    },
+                    buttons = {
+                        {
                             {
-                                text = self.settings.ip,
-                                input_type = "string"
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(url_dialog)
+                                end
                             },
                             {
-                                text = self.settings.port,
-                                input_type = "number"
-                            }
-                        },
-                        buttons = {
-                            {
-                                {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(url_dialog)
-                                    end
-                                },
-                                {
-                                    text = _("OK"),
-                                    callback = function()
-                                        local fields = url_dialog:getFields()
-                                        local ip = fields[1]
-                                        local port = tonumber(fields[2])
-                                        if ip ~= "" then
-                                            if port and port < 65355 then
-                                                self.settings.ip = ip
-                                                self.settings.port = port
-                                                self:saveSettings()
-                                            end
+                                text = _("OK"),
+                                callback = function()
+                                    local fields = url_dialog:getFields()
+                                    local ip = fields[1]
+                                    local port = tonumber(fields[2])
+                                    if ip ~= "" then
+                                        if port and port < 65355 then
+                                            self.settings.ip = ip
+                                            self.settings.port = port
                                         end
-                                        UIManager:close(url_dialog)
                                     end
-                                }
-                            }
-                        }
-                    }
-                    UIManager:show(url_dialog)
-                    url_dialog:onShowKeyboard()
-                end
-            },
-            {
-                text = _("Set authorization token"),
-                keep_menu_open = true,
-                callback = function()
-                    local auth_dialog
-                    auth_dialog = InputDialog:new {
-                        title = _("Set authorization token for Joplin"),
-                        input = self.settings.token,
-                        buttons = {
+                                    UIManager:close(url_dialog)
+                                    touchmenu_instance:updateItems()
+                                end
+                            },
+                        },
+                    },
+                }
+                UIManager:show(url_dialog)
+                url_dialog:onShowKeyboard()
+            end,
+        },
+        {
+            text = _("Set authorization token"),
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local auth_dialog
+                auth_dialog = InputDialog:new{
+                    title = _("Set authorization token for Joplin"),
+                    input = self.settings.token,
+                    buttons = {
+                        {
                             {
-                                {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(auth_dialog)
-                                    end
-                                },
-                                {
-                                    text = _("Set token"),
-                                    callback = function()
-                                        self.settings.token = auth_dialog:getInputText()
-                                        self:saveSettings()
-                                        UIManager:close(auth_dialog)
-                                    end
-                                }
-                            }
-                        }
-                    }
-                    UIManager:show(auth_dialog)
-                    auth_dialog:onShowKeyboard()
-                end
-            },
-            {
-                text = _("Export to Joplin"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-            {
-                text = _("Help"),
-                keep_menu_open = true,
-                callback = function()
-                    UIManager:show(InfoMessage:new {
-                        text = T(_([[For Joplin setup instructions, see %1
-
-Markdown formatting can be configured in:
-Export highlights > Choose formats and services > Markdown.]]), "https://github.com/koreader/koreader/wiki/Joplin")
-                    })
-                end
-            }
-        }
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(auth_dialog)
+                                end
+                            },
+                            {
+                                text = _("Set token"),
+                                callback = function()
+                                    self.settings.token = auth_dialog:getInputText()
+                                    UIManager:close(auth_dialog)
+                                    touchmenu_instance:updateItems()
+                                end
+                            },
+                        },
+                    },
+                }
+                UIManager:show(auth_dialog)
+                auth_dialog:onShowKeyboard()
+            end,
+        },
     }
 end
 
@@ -280,7 +266,6 @@ function JoplinExporter:export(t)
             logger.info("Joplin: created new notebook",
                 "name", self.notebook_name, "id", notebook)
             self.settings.notebook_guid = notebook
-            self:saveSettings()
         else
             logger.warn("Joplin: unable to create new notebook")
             return false
@@ -288,11 +273,9 @@ function JoplinExporter:export(t)
     else
         if not self.settings.notebook_guid then
             self.settings.notebook_guid = existing_notebook
-            self:saveSettings()
         end
     end
-    local plugin_settings = G_reader_settings:readSetting("exporter") or {}
-    local markdown_settings = plugin_settings.markdown
+    local markdown_settings = self:getMarkdownSettings()
     local notebook_id = self.settings.notebook_guid
     for _, booknotes in pairs(t) do
         local note_tbl = md.prepareBookContent(booknotes, markdown_settings.formatting_options, markdown_settings.highlight_formatting)

--- a/plugins/exporter.koplugin/target/json.lua
+++ b/plugins/exporter.koplugin/target/json.lua
@@ -2,9 +2,9 @@ local rapidjson = require("rapidjson")
 local md5 = require("ffi/MD5")
 local _ = require("gettext")
 
--- json exporter
-local JsonExporter = require("base"):new {
+local JsonExporter = require("base"):new{
     name = "json",
+    title = _("Json"),
     -- the proper mimetype is "application/json" as stated in
     -- https://www.iana.org/assignments/media-types/application/json
     -- but we follow google recommendations because we just share on android.
@@ -12,25 +12,14 @@ local JsonExporter = require("base"):new {
     mimetype = "text/json",
 }
 
-function JsonExporter:getMenuTable()
+function JsonExporter:genTargetSubMenu()
     return {
-        text = _("Json"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = _("Export to Json"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-            {
-                text = _("Include book checksum in export"),
-                checked_func = function() return self.settings.bookChecksum end,
-                callback = function()
-                    self.settings.bookChecksum = not self.settings.bookChecksum
-                    self:saveSettings()
-                end,
-            }
-        }
+        self:genExportToMenuItem(),
+        -- separator
+        self:genCloudStorageMenuItem(),
+        self:genDeleteFileMenuItem(),
+        -- separator
+        self:genToggleMenuItem(_("Include book checksum in export"), "bookChecksum"),
     }
 end
 

--- a/plugins/exporter.koplugin/target/markdown.lua
+++ b/plugins/exporter.koplugin/target/markdown.lua
@@ -1,29 +1,25 @@
+local ButtonSelector = require("ui/widget/buttonselector")
+local InputDialog = require("ui/widget/inputdialog")
 local ReaderHighlight = require("apps/reader/modules/readerhighlight")
 local UIManager = require("ui/uimanager")
 local md = require("template/md")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
--- markdown exporter
-local MarkdownExporter = require("base"):new {
+local MarkdownExporter = require("base"):new{
     name = "markdown",
+    title = _("Markdown"),
     extension = "md",
     mimetype = "text/markdown",
-
-    init_callback = function(self, settings)
-        local changed = false
-        if not settings.formatting_options or settings.highlight_formatting == nil then
-            settings.formatting_options = settings.formatting_options or {
-                lighten = "italic",
-                underscore = "underline_markdownit",
-                strikeout = "strikethrough",
-                invert = "bold",
-            }
-            settings.highlight_formatting = settings.highlight_formatting or true
-            changed = true
-        end
-        return changed, settings
-    end,
+    default_settings = {
+        highlight_formatting = true,
+        formatting_options = {
+            lighten    = "italic",
+            underscore = "underline_markdownit",
+            strikeout  = "strikethrough",
+            invert     = "bold",
+        },
+    },
 }
 
 local formatter_buttons = {
@@ -37,70 +33,74 @@ local formatter_buttons = {
     { _("Underline (with <u></u> tags)"), "underline_u_tag" },
 }
 
-function MarkdownExporter:editFormatStyle(drawer_style, label, touchmenu_instance)
-    local radio_buttons = {}
-    for _idx, v in ipairs(formatter_buttons) do
-        table.insert(radio_buttons, {
-            {
-                text = v[1],
-                checked = self.settings.formatting_options[drawer_style] == v[2],
-                provider = v[2],
-            },
-        })
-    end
-    UIManager:show(require("ui/widget/radiobuttonwidget"):new {
-        title_text = T(_("Formatting style for %1"), label),
-        width_factor = 0.8,
-        radio_buttons = radio_buttons,
-        callback = function(radio)
-            self.settings.formatting_options[drawer_style] = radio.provider
-            touchmenu_instance:updateItems()
-        end,
-    })
-end
-
-function MarkdownExporter:getMenuTable()
-    local menu = {
-        text = _("Markdown"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = _("Export to Markdown"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-            {
-                text = _("Export backlinks"),
-                checked_func = function() return self.settings.export_backlinks end,
-                callback = function() self.settings.export_backlinks = not self.settings.export_backlinks end,
-            },
-            {
-                text = _("Format highlights based on style"),
-                checked_func = function() return self.settings.highlight_formatting end,
-                callback = function() self.settings.highlight_formatting = not self.settings.highlight_formatting end,
-            },
-        },
-        hold_callback = function(touchmenu_instance)
-            self:toggleEnabled()
-            touchmenu_instance:updateItems()
-        end,
+function MarkdownExporter:genTargetSubMenu()
+    local sub_item_table = {
+        self:genExportToMenuItem(),
+        -- separator
+        self:genCloudStorageMenuItem(),
+        self:genDeleteFileMenuItem(),
+        -- separator
+        self:genToggleMenuItem(_("Export backlinks"), "export_backlinks", true),
+        -- separator
+        self:genToggleMenuItem(_("Format highlights based on style"), "highlight_formatting"),
     }
-
-    for _, entry in ipairs(ReaderHighlight.getHighlightStyles()) do
-        table.insert(menu.sub_item_table, {
+    for __, entry in ipairs(ReaderHighlight.getHighlightStyles()) do
+        local style_text, style = unpack(entry)
+        table.insert(sub_item_table, {
             text_func = function()
-                return entry[1] .. ": " .. md.formatters[self.settings.formatting_options[entry[2]]].label
+                local value = self.settings.formatting_options[style]
+                return T(_("%1: %2"), style_text, md.formatters[value] and md.formatters[value].label or value)
             end,
             enabled_func = function()
-                return self.settings.highlight_formatting
+                return self.settings.highlight_formatting and true or false
             end,
             keep_menu_open = true,
-            callback = function(touchmenu_instance)
-                self:editFormatStyle(entry[2], entry[1], touchmenu_instance)
+            callback = function(touchmenu_instance) -- default formats
+                UIManager:show(ButtonSelector:new{
+                    width_factor = 0.8,
+                    current_value = self.settings.formatting_options[style],
+                    values = formatter_buttons,
+                    callback = function(value)
+                        self.settings.formatting_options[style] = value
+                        touchmenu_instance:updateItems()
+                    end,
+                })
+            end,
+            hold_callback = function(touchmenu_instance) -- custom format
+                local value = self.settings.formatting_options[style]
+                local formatter_dialog
+                formatter_dialog = InputDialog:new{
+                    title = T("Format for: %1", style_text),
+                    input = md.formatters[value] and md.formatters[value].formatter or value,
+                    buttons = {
+                        {
+                            {
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(formatter_dialog)
+                                end,
+                            },
+                            {
+                                text = _("Save"),
+                                callback = function()
+                                    local new_value = formatter_dialog:getInputValue()
+                                    if new_value and new_value ~= "" and new_value ~= value then
+                                        UIManager:close(formatter_dialog)
+                                        self.settings.formatting_options[style] = new_value
+                                        touchmenu_instance:updateItems()
+                                    end
+                                end,
+                            },
+                        },
+                    },
+                }
+                UIManager:show(formatter_dialog)
+                formatter_dialog:onShowKeyboard()
             end,
         })
     end
-    return menu
+    return sub_item_table
 end
 
 function MarkdownExporter:export(t)

--- a/plugins/exporter.koplugin/target/my_clippings.lua
+++ b/plugins/exporter.koplugin/target/my_clippings.lua
@@ -1,14 +1,26 @@
-local util = require("ffi/util")
-local T = util.template
+local ffiUtil = require("ffi/util")
+local T = ffiUtil.template
 local _ = require("gettext")
 
--- myClippings exporter
-local ClippingsExporter = require("base"):new {
+local ClippingsExporter = require("base"):new{
     name = "myClippings",
+    title = _("myClippings"),
     extension = "txt",
     mimetype = "text/plain",
-    all_books_title = "myClippings"
+    all_books_title = "myClippings",
 }
+
+function ClippingsExporter:genTargetSubMenu()
+    return {
+        self:genExportToMenuItem(),
+        -- separator
+        self:genCloudStorageMenuItem(),
+        self:genDeleteFileMenuItem(),
+        -- separator
+        self:genToggleMenuItem(_("Overwrite export file"), "overwrite_export_file"),
+        self:genToggleMenuItem(_("Use Kindle export file name"), "kindle_export_file"),
+    }
+end
 
 local function format(booknotes)
     local tbl = {}
@@ -44,9 +56,18 @@ local function format(booknotes)
     return table.concat(tbl, "\n")
 end
 
+function ClippingsExporter:getFilePath()
+    if self.filepath then
+        if self.settings.kindle_export_file then
+            return ffiUtil.dirname(self.filepath) .. "/My Clippings.txt"
+        end
+        return self.filepath .. "." .. self.extension
+    end
+end
+
 function ClippingsExporter:export(t)
     local path = self:getFilePath(t)
-    local file = io.open(path, "a")
+    local file = io.open(path, self.settings.overwrite_export_file and "w" or "a")
     if not file then return false end
     for __, booknotes in ipairs(t) do
         local content = format(booknotes)

--- a/plugins/exporter.koplugin/target/nextcloud.lua
+++ b/plugins/exporter.koplugin/target/nextcloud.lua
@@ -1,4 +1,3 @@
-local InfoMessage = require("ui/widget/infomessage")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local UIManager = require("ui/uimanager")
 local mime = require("mime")

--- a/plugins/exporter.koplugin/target/nextcloud.lua
+++ b/plugins/exporter.koplugin/target/nextcloud.lua
@@ -7,11 +7,15 @@ local logger = require("logger")
 local T = require("ffi/util").template
 local _ = require("gettext")
 
--- nextcloud notes exporter
-local NextcloudExporter = require("base"):new {
+local NextcloudExporter = require("base"):new{
     name = "nextcloud_notes",
+    title = _("Nextcloud Notes"),
     default_category = _("KOReader"),
     is_remote = true,
+    help_text = T(_([[For Nextcloud Notes setup instructions, see %1
+
+Markdown formatting can be configured in:
+Export highlights > Choose formats and services > Markdown.]]), "https://github.com/koreader/koreader/wiki/Nextcloud-notes"),
 }
 
 -- fetching all notes from Nextcloud is costly, so we keep a copy here
@@ -22,105 +26,81 @@ function NextcloudExporter:isReadyToExport()
     return self.settings.host and self.settings.username and self.settings.password
 end
 
-function NextcloudExporter:getMenuTable()
+function NextcloudExporter:genTargetSubMenu()
     local dialog_title = _("Setup Nextcloud Notes plugin")
     return {
-        text = _("Nextcloud Notes"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = dialog_title,
-                keep_menu_open = true,
-                callback = function()
-                    local url_dialog
-                    url_dialog = MultiInputDialog:new {
-                        title = dialog_title,
-                        fields = {
-                            {
-                                description = _("Nextcloud URL"),
-                                hint = "https://yournextcloud.com",
-                                text = self.settings.host,
-                                input_type = "string"
-                            },
-                            {
-                                description = _("Username"),
-                                hint = _("Username"),
-                                text = self.settings.username,
-                                input_type = "string"
-                            },
-                            {
-                                description = _("App password"),
-                                hint = _("Security → Devices & sessions"),
-                                text = self.settings.password,
-                                input_type = "string"
-                            },
-                            {
-                                description = _("Category"),
-                                hint = _("Category applied to the note"),
-                                text = self.settings.category or self.default_category,
-                                input_type = "string"
-                            }
+        self:genExportToMenuItem(),
+        self:genHelpMenuItem(),
+        -- separator
+        {
+            text = dialog_title,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local url_dialog
+                url_dialog = MultiInputDialog:new{
+                    title = dialog_title,
+                    fields = {
+                        {
+                            description = _("Nextcloud URL"),
+                            hint = "https://yournextcloud.com",
+                            text = self.settings.host,
                         },
-                        buttons = {
+                        {
+                            description = _("Username"),
+                            hint = _("Username"),
+                            text = self.settings.username,
+                        },
+                        {
+                            description = _("App password"),
+                            hint = _("Security → Devices & sessions"),
+                            text = self.settings.password,
+                        },
+                        {
+                            description = _("Category"),
+                            hint = _("Category applied to the note"),
+                            text = self.settings.category or self.default_category,
+                        },
+                    },
+                    buttons = {
+                        {
                             {
-                                {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(url_dialog)
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(url_dialog)
+                                end,
+                            },
+                            {
+                                text = _("OK"),
+                                callback = function()
+                                    local fields = url_dialog:getFields()
+                                    local host = fields[1]
+                                    local username = fields[2]
+                                    local password = fields[3]
+                                    local category = fields[4]
+                                    if host ~= "" then
+                                        self.settings.host = host
                                     end
-                                },
-                                {
-                                    text = _("OK"),
-                                    callback = function()
-                                        local fields = url_dialog:getFields()
-                                        local host = fields[1]
-                                        local username = fields[2]
-                                        local password = fields[3]
-                                        local category = fields[4]
-                                        if host ~= "" then
-                                            self.settings.host = host
-                                            self:saveSettings()
-                                        end
-                                        if username ~= "" then
-                                            self.settings.username = username
-                                            self:saveSettings()
-                                        end
-                                        if password ~= "" then
-                                            self.settings.password = password
-                                            self:saveSettings()
-                                        end
-                                        if category ~= "" then
-                                            self.settings.category = category
-                                            self:saveSettings()
-                                        end
-                                        UIManager:close(url_dialog)
+                                    if username ~= "" then
+                                        self.settings.username = username
                                     end
-                                }
-                            }
-                        }
-                    }
-                    UIManager:show(url_dialog)
-                    url_dialog:onShowKeyboard()
-                end
-            },
-            {
-                text = _("Export to Nextcloud Notes"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-            {
-                text = _("Help"),
-                keep_menu_open = true,
-                callback = function()
-                    UIManager:show(InfoMessage:new {
-                        text = T(_([[For Nextcloud Notes setup instructions, see %1
-
-Markdown formatting can be configured in:
-Export highlights > Choose formats and services > Markdown.]]), "https://github.com/koreader/koreader/wiki/Nextcloud-notes")
-                    })
-                end
-            }
-        }
+                                    if password ~= "" then
+                                        self.settings.password = password
+                                    end
+                                    if category ~= "" then
+                                        self.settings.category = category
+                                    end
+                                    UIManager:close(url_dialog)
+                                    touchmenu_instance:updateItems()
+                                end,
+                            },
+                        },
+                    },
+                }
+                UIManager:show(url_dialog)
+                url_dialog:onShowKeyboard()
+            end,
+        },
     }
 end
 
@@ -128,10 +108,6 @@ function NextcloudExporter:export(t)
     if not self:isReadyToExport() then
         return false
     end
-
-    -- determine if markdown export is set
-    local plugin_settings = G_reader_settings:readSetting("exporter") or {}
-    local markdown_settings = plugin_settings.markdown
 
     -- setup Nextcloud variables
     local url_base = string.format("%s/index.php/apps/notes/api/v1/", self.settings.host)
@@ -158,6 +134,7 @@ function NextcloudExporter:export(t)
     end
 
     -- export each note
+    local markdown_settings = self:getMarkdownSettings()
     for _, booknotes in pairs(t) do
         local note = md.prepareBookContent(booknotes, markdown_settings.formatting_options, markdown_settings.highlight_formatting)
         local note_title = string.format("%s - %s", string.gsub(booknotes.author, "\n", ", "), booknotes.title)

--- a/plugins/exporter.koplugin/target/readwise.lua
+++ b/plugins/exporter.koplugin/target/readwise.lua
@@ -3,9 +3,9 @@ local UIManager = require("ui/uimanager")
 local logger = require("logger")
 local _ = require("gettext")
 
--- readwise exporter
-local ReadwiseExporter = require("base"):new {
+local ReadwiseExporter = require("base"):new{
     name = "readwise",
+    title = _("Readwise"),
     is_remote = true,
 }
 
@@ -14,49 +14,43 @@ function ReadwiseExporter:isReadyToExport()
     return false
 end
 
-function ReadwiseExporter:getMenuTable()
+function ReadwiseExporter:genTargetSubMenu()
+    local dialog_title = _("Set authorization token")
     return {
-        text = _("Readwise"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = _("Set authorization token"),
-                keep_menu_open = true,
-                callback = function()
-                    local auth_dialog
-                    auth_dialog = InputDialog:new {
-                        title = _("Set authorization token for Readwise"),
-                        input = self.settings.token,
-                        buttons = {
+        self:genExportToMenuItem(),
+        -- separator
+        {
+            text = dialog_title,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local auth_dialog
+                auth_dialog = InputDialog:new{
+                    title = dialog_title,
+                    input = self.settings.token,
+                    buttons = {
+                        {
                             {
-                                {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(auth_dialog)
-                                    end
-                                },
-                                {
-                                    text = _("Set token"),
-                                    callback = function()
-                                        self.settings.token = auth_dialog:getInputText()
-                                        self:saveSettings()
-                                        UIManager:close(auth_dialog)
-                                    end
-                                }
-                            }
-                        }
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(auth_dialog)
+                                end,
+                            },
+                            {
+                                text = _("Set token"),
+                                callback = function()
+                                    self.settings.token = auth_dialog:getInputText()
+                                    UIManager:close(auth_dialog)
+                                    touchmenu_instance:updateItems()
+                                end,
+                            },
+                        },
                     }
-                    UIManager:show(auth_dialog)
-                    auth_dialog:onShowKeyboard()
-                end
-            },
-            {
-                text = _("Export to Readwise"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-
-        }
+                }
+                UIManager:show(auth_dialog)
+                auth_dialog:onShowKeyboard()
+            end,
+        },
     }
 end
 

--- a/plugins/exporter.koplugin/target/text.lua
+++ b/plugins/exporter.koplugin/target/text.lua
@@ -1,13 +1,23 @@
-local util = require("ffi/util")
-local T = util.template
+local T = require("ffi/util").template
 local _ = require("gettext")
 
--- text exporter
-local TextExporter = require("base"):new {
+local TextExporter = require("base"):new{
     name = "text",
+    title = _("Text"),
     extension = "txt",
     mimetype = "text/plain",
 }
+
+function TextExporter:genTargetSubMenu()
+    return {
+        self:genExportToMenuItem(),
+        -- separator
+        self:genCloudStorageMenuItem(),
+        self:genDeleteFileMenuItem(),
+        -- separator
+        self:genToggleMenuItem(_("Overwrite export file"), "overwrite_export_file"),
+    }
+end
 
 local function format(booknotes)
     local tbl = {}
@@ -44,7 +54,7 @@ end
 
 function TextExporter:export(t)
     local path = self:getFilePath(t)
-    local file = io.open(path, "a")
+    local file = io.open(path, self.settings.overwrite_export_file and "w" or "a")
     if not file then return false end
     for __, booknotes in ipairs(t) do
         local tbl = format(booknotes)

--- a/plugins/exporter.koplugin/target/xmnote.lua
+++ b/plugins/exporter.koplugin/target/xmnote.lua
@@ -14,66 +14,52 @@ local T = ffiUtil.template
 
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
 
--- xmnote exporter
-local XMNoteExporter = require("base"):new {
+local XMNoteExporter = require("base"):new{
     name = "xmnote",
+    title = _("XMNote"),
     is_remote = true,
-    server_port = 8080
+    server_port = 8080,
+    help_text = _([[Before starting the export process, please make sure that your mobile and KOReader are connected to the same local network. Open XMNote and go to "My" - "Import Highlights" - "Import via API". At the bottom of the interface, you will find the IP address of your mobile device. Enter this IP address into KOReader to complete the configuration.]]),
 }
 
-function XMNoteExporter:getMenuTable()
-    return  {
-        text = _("XMNote"),
-        checked_func = function() return self:isEnabled() end,
-        sub_item_table = {
-            {
-                text = _("Set XMNote IP"),
-                keep_menu_open = true,
-                callback = function()
-                    local url_dialog
-                    url_dialog = InputDialog:new {
-                        title = _("Set XMNote IP"),
-                        input = self.settings.ip,
-                        buttons = {
+function XMNoteExporter:genTargetSubMenu()
+    local dialog_title = _("Set XMNote IP")
+    return {
+        self:genExportToMenuItem(),
+        self:genHelpMenuItem(),
+        -- separator
+        {
+            text = dialog_title,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local url_dialog
+                url_dialog = InputDialog:new{
+                    title = dialog_title,
+                    input = self.settings.ip,
+                    buttons = {
+                        {
                             {
-                                {
-                                    text = _("Cancel"),
-                                    callback = function()
-                                        UIManager:close(url_dialog)
-                                    end
-                                },
-                                {
-                                    text = _("Set IP"),
-                                    callback = function()
-                                        local ip = url_dialog:getInputText()
-                                        self.settings.ip = ip
-                                        self:saveSettings()
-                                        UIManager:close(url_dialog)
-                                    end
-                                }
-                            }
-                        }
-                    }
-                    UIManager:show(url_dialog)
-                    url_dialog:onShowKeyboard()
-                end
-            } ,
-            {
-                text = _("Export to XMNote"),
-                checked_func = function() return self:isEnabled() end,
-                callback = function() self:toggleEnabled() end,
-            },
-            {
-                text = _("Help"),
-                keep_menu_open = true,
-                callback = function()
-                    UIManager:show(InfoMessage:new {
-                        text = T(_([[Before starting the export process, please make sure that your mobile and KOReader are connected to the same local network. Open XMNote and go to "My" - "Import Highlights" - "Import via API". At the bottom of the interface, you will find the IP address of your mobile device. Enter this IP address into KOReader to complete the configuration.]])
-                    , BD.dirpath(DataStorage:getDataDir()))
-                    })
-                end
-            }
-        }
+                                text = _("Cancel"),
+                                id = "close",
+                                callback = function()
+                                    UIManager:close(url_dialog)
+                                end,
+                            },
+                            {
+                                text = _("Set IP"),
+                                callback = function()
+                                    self.settings.ip = url_dialog:getInputText()
+                                    UIManager:close(url_dialog)
+                                    touchmenu_instance:updateItems()
+                                end,
+                            },
+                        },
+                    },
+                }
+                UIManager:show(url_dialog)
+                url_dialog:onShowKeyboard()
+            end
+        },
     }
 end
 

--- a/plugins/exporter.koplugin/target/xmnote.lua
+++ b/plugins/exporter.koplugin/target/xmnote.lua
@@ -1,16 +1,12 @@
-local BD = require("ui/bidi")
 local DataStorage = require("datastorage")
 local DocSettings = require("docsettings")
 local InputDialog = require("ui/widget/inputdialog")
-local InfoMessage = require("ui/widget/infomessage")
 local SQ3 = require("lua-ljsqlite3/init")
 local UIManager = require("ui/uimanager")
 local datetime = require("datetime")
-local ffiUtil = require("ffi/util")
 local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
-local T = ffiUtil.template
 
 local db_location = DataStorage:getSettingsDir() .. "/statistics.sqlite3"
 

--- a/plugins/exporter.koplugin/template/md.lua
+++ b/plugins/exporter.koplugin/template/md.lua
@@ -50,7 +50,8 @@ local function prepareBookContent(book, formatting_options, highlight_formatting
         end
         table.insert(tbl, "### Page " .. entry.page .. " @ " .. os.date("%d %B %Y %I:%M:%S %p", entry.time))
         if highlight_formatting then
-            table.insert(tbl, string.format(formatters[formatting_options[entry.drawer]].formatter, entry.text))
+            local value = formatting_options[entry.drawer]
+            table.insert(tbl, string.format(formatters[value] and formatters[value].formatter or value, entry.text))
         else
             table.insert(tbl, entry.text)
         end


### PR DESCRIPTION
1. All non-remote targets: option to upload export file to the cloud storage.
2. myClippings: options for Kindle-like export.
Closes #14989.
3. Markdown: custom markdown formats for highlight styles.
Closes #13756.
4. General option to export silently without info messages.
5. Wordings.
Closes #15488.
6. Unified target menus, various code optimizations.

-----

Tools menu
<img width="400" height="407" alt="1" src="https://github.com/user-attachments/assets/d830171a-939c-46de-ba8e-6973931a1315" />

-----

Exporter menu
<img width="400" height="373" alt="2" src="https://github.com/user-attachments/assets/934f78d0-4f48-49b0-9156-9095097cbbea" />

-----

myClippings target menu
<img width="400" height="235" alt="3" src="https://github.com/user-attachments/assets/521e87b0-1132-47ee-b694-a6fb713b0cc8" />

-----

Markdown target menu
<img width="400" height="372" alt="4" src="https://github.com/user-attachments/assets/157d4964-0154-4aa5-bde6-b7f199364494" />

-----

Cloud storage settings
<img width="400" height="518" alt="5" src="https://github.com/user-attachments/assets/71d14c8f-0c51-4cae-b95b-5d478f907fd6" />

-----

Default markdown formats for highlight styles (on tap)
<img width="400" height="518" alt="6" src="https://github.com/user-attachments/assets/6db7cb15-f21d-45a8-82c4-f0455f35b66b" />

-----

Custom markdown format for highlight style (on long-pressing)
<img width="400" height="518" alt="7" src="https://github.com/user-attachments/assets/826b36df-daf9-4730-9ddc-0eced9a61c08" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15861)
<!-- Reviewable:end -->
