### PR TITLE
Fix sharing highlights as JSON

### DIFF
--- a/plugins/exporter.koplugin/target/json.lua
+++ b/plugins/exporter.koplugin/target/json.lua
@@ -78,7 +78,7 @@ function JsonExporter:export(t)
 end
 
 function JsonExporter:share(t)
-    local content = format(t)
+    local content = format(t, self.settings)
     content.created_on = self.timestamp or os.time()
     content.version = self:getVersion()
     self:shareText(rapidjson.encode(content, {pretty = true}))

--- a/spec/unit/exporter_plugin_main_spec.lua
+++ b/spec/unit/exporter_plugin_main_spec.lua
@@ -94,4 +94,22 @@ describe("Exporter plugin module", function()
         ok = readerui.exporter.targets["readwise"]:export(sample_clippings)
         assert.not_truthy(ok)
     end)
+
+    it("should share clippings as json", function()
+        local rapidjson = require("rapidjson")
+        local target = readerui.exporter.targets["json"]
+        local original_share_text = target.shareText
+        local shared_content
+        target.shareText = function(_, content)
+            shared_content = content
+        end
+
+        target:share(sample_clippings.Title1)
+
+        target.shareText = original_share_text
+        local decoded = rapidjson.decode(shared_content)
+        assert.are.equal("Title1", decoded.title)
+        assert.are.equal("Some important stuff 1", decoded.entries[1].text)
+        assert.are.equal(2, #decoded.entries)
+    end)
 end)


### PR DESCRIPTION
## Summary

- pass the exporter settings to the JSON formatter when using **Share as JSON**
- add a regression test covering JSON sharing

## Problem

`JsonExporter:share()` called `format()` without the settings argument. The formatter then tried to read `settings.bookChecksum`, causing the share action to fail without a useful error message.

## Testing

- `git diff --check`
- installed the equivalent user patch on KOReader v2026.03 for Android and confirmed that KOReader loaded it successfully
- unit test suite not run locally because the available Windows environment does not provide KOReader's supported Linux test environment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15865)
<!-- Reviewable:end -->
