### PR TITLE
SSH.koplugin: fix failing to kill server with no connections

### DIFF
--- a/plugins/SSH.koplugin/main.lua
+++ b/plugins/SSH.koplugin/main.lua
@@ -130,7 +130,7 @@ function SSH:stopPlugin(force)
     end
 
     local function send(sig, p)
-        return os.execute(string.format("pkill -%s -P %d && kill -%s %d", sig, p, sig, p)) == 0
+        return os.execute(string.format("pkill -%s -P %d; kill -%s %d", sig, p, sig, p)) == 0
     end
 
     send("TERM", pid)


### PR DESCRIPTION
Fixes #15867

The `pkill -P` fails if there are no child processes (no connections), so the `kill` is never hit. This makes killing the child processes optional.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15868)
<!-- Reviewable:end -->
