### PR TITLE
Fix UIManager poweroff with empty window stack (#15761)

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -81,7 +81,7 @@ function UIManager:init()
         logger.info("Powering off the device...")
         self:broadcastEvent(Event:new("PowerOff"))
         self:broadcastEvent(Event:new("Close", { keep_screensaver = true }))
-        self:nextTick(function()
+        local function doQuit()
             Device:saveSettings()
             Device:powerOff()
             if Device:isKobo() then
@@ -89,7 +89,14 @@ function UIManager:init()
             else
                 self:quit()
             end
-        end)
+        end
+        if not self._window_stack[1] then
+            -- Leave screen as-is
+            doQuit()
+        else
+            -- Allow screensaver to be painted
+            self:nextTick(doQuit)
+        end
     end
     self.reboot_action = function()
         local Screensaver = require("ui/screensaver")
@@ -99,7 +106,7 @@ function UIManager:init()
         logger.info("Rebooting the device...")
         self:broadcastEvent(Event:new("Reboot"))
         self:broadcastEvent(Event:new("Close", { keep_screensaver = true }))
-        self:nextTick(function()
+        local function doQuit()
             Device:saveSettings()
             Device:reboot()
             if Device:isKobo() then
@@ -107,7 +114,14 @@ function UIManager:init()
             else
                 self:quit()
             end
-        end)
+        end
+        if not self._window_stack[1] then
+            -- Leave screen as-is
+            doQuit()
+        else
+            -- Allow screensaver to be painted
+            self:nextTick(doQuit)
+        end
     end
 
     -- Tell Device that we're now available, so that it can setup PM event handlers


### PR DESCRIPTION
With empty _window_stack UIManager exits before the scheduled function from poweroff_action runs. (handleInput() → _gated_quit() → run() exits).

This skips the scheduling if _window_stack is empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15876)
<!-- Reviewable:end -->
