### PR TITLE
Add httpasync module for faster image downloads in NewsDownloader and Wikipedia

### DIFF
--- a/frontend/httpasync.lua
+++ b/frontend/httpasync.lua
@@ -1,0 +1,374 @@
+--[[--
+Non-blocking HTTP(S) downloads and a coroutine-based concurrent scheduler.
+
+Unlike `httpclient.lua` (Turbo's I/O loop), this works without Turbo: it
+drives LuaSocket/LuaSec sockets in non-blocking mode, yielding to a
+`socket.select`-based scheduler so one Lua state can interleave many
+downloads.
+]]
+
+local logger = require("logger")
+local socket = require("socket")
+local socket_url = require("socket.url")
+local ssl = require("ssl")
+local socketutil = require("socketutil")
+local util = require("util")
+
+local HttpAsync = {}
+
+local MAX_REDIRECTS = 5
+local DEFAULT_CONCURRENCY = 10
+
+--- Non-blocking receive; yields (socket, "r"/"w") until data/error/EOF.
+-- Partial data returned with "timeout"/"wantread" is already consumed from
+-- the socket buffer, so carry it forward via the `receive` prefix argument.
+local function async_receive(sock, pattern)
+    local acc = ""
+    while true do
+        local res, err, partial = sock:receive(pattern, acc)
+        if err == "timeout" or err == "wantread" then
+            acc = partial or acc
+            coroutine.yield(sock, "r")
+        elseif err == "wantwrite" then
+            coroutine.yield(sock, "w")
+        else
+            return res, err, partial
+        end
+    end
+end
+
+--- Non-blocking send; yields (socket, "w"/"r") while it would block.
+local function async_send(sock, data)
+    local i = 1
+    local n = #data
+    while i <= n do
+        local res, err, last = sock:send(data, i)
+        if err == "timeout" or err == "wantwrite" then
+            coroutine.yield(sock, "w")
+            -- LuaSocket reports the index of the last byte sent on error.
+            if last then i = last + 1 end
+        elseif err == "wantread" then
+            coroutine.yield(sock, "r")
+        elseif err then
+            return nil, err
+        else
+            i = res + 1
+        end
+    end
+    return true
+end
+
+--- Non-blocking connect; yields (socket, "w") until connected or failed.
+local function async_connect(sock, host, port)
+    sock:settimeout(0)
+    while true do
+        local res, err = sock:connect(host, port)
+        if res or err == "already connected" then
+            return true
+        elseif err == "timeout" or err == "Operation already in progress" then
+            coroutine.yield(sock, "w")
+        else
+            return false, err
+        end
+    end
+end
+
+--- Non-blocking TLS handshake; yields (socket, "r"/"w") while it would block.
+local function async_handshake(sock)
+    while true do
+        local res, err = sock:dohandshake()
+        if res then
+            return true
+        elseif err == "wantread" then
+            coroutine.yield(sock, "r")
+        elseif err == "wantwrite" then
+            coroutine.yield(sock, "w")
+        else
+            return false, err
+        end
+    end
+end
+
+--- Fetch one URL over a raw non-blocking socket, yielding while it would
+-- block so the caller can interleave many downloads.
+-- @param url string
+-- @param redirect_count number internal recursion guard
+-- @param headers table optional extra request headers (e.g. cookie)
+-- @return (true, content_type, content) or (false, err)
+function HttpAsync.fetch_url(url, redirect_count, headers)
+    redirect_count = redirect_count or 0
+    if redirect_count > MAX_REDIRECTS then return false, "Too many redirects" end
+
+    local parsed = socket_url.parse(url)
+    if not parsed then return false, "invalid url" end
+    if parsed.path then
+        -- Encode invalid path chars (e.g., spaces) while preserving "/" and "%".
+        parsed.path = util.urlEncode(parsed.path, "/%%")
+        url = socket_url.build(parsed)
+    end
+
+    local host = parsed.host
+    if not host then return false, "invalid url" end
+    local port = parsed.port or (parsed.scheme == "https" and 443 or 80)
+    local path = parsed.path or "/"
+    if parsed.query then path = path .. "?" .. parsed.query end
+
+    local sock = socket.tcp()
+    local ok, err = async_connect(sock, host, port)
+    if not ok then
+        sock:close()
+        return false, "connect error: " .. tostring(err)
+    end
+
+    if parsed.scheme == "https" then
+        local ssl_params = {
+            mode = "client",
+            protocol = "any",
+            verify = "none",
+            options = {"all", "no_sslv2", "no_sslv3"},
+        }
+        local ssl_sock, wrap_err = ssl.wrap(sock, ssl_params)
+        if not ssl_sock then
+            sock:close()
+            return false, "ssl wrap error: " .. tostring(wrap_err)
+        end
+        sock = ssl_sock
+        sock:settimeout(0)
+        if sock.sni then
+            sock:sni(host)
+        end
+        local hok, herr = async_handshake(sock)
+        if not hok then
+            sock:close()
+            return false, "ssl handshake error: " .. tostring(herr)
+        end
+    end
+
+    local req_lines = {
+        string.format("GET %s HTTP/1.1", path),
+        string.format("Host: %s", host),
+        string.format("User-Agent: %s", socketutil.USER_AGENT),
+    }
+    if headers then
+        for k, v in pairs(headers) do
+            table.insert(req_lines, string.format("%s: %s", k, v))
+        end
+    end
+    table.insert(req_lines, "Connection: close")
+    table.insert(req_lines, "")
+    table.insert(req_lines, "")
+    local req = table.concat(req_lines, "\r\n")
+
+    local sok, serr = async_send(sock, req)
+    if not sok then
+        sock:close()
+        return false, "send error: " .. tostring(serr)
+    end
+
+    -- Read status line and headers.
+    local resp_headers = {}
+    local status_line
+    while true do
+        local line, lerr = async_receive(sock, "*l")
+        if not line then
+            sock:close()
+            return false, "read error: " .. tostring(lerr)
+        end
+        if line == "" then break end
+        if not status_line then
+            status_line = line
+        else
+            local k, v = line:match("^(.-):%s*(.*)")
+            if k and v then resp_headers[k:lower()] = v end
+        end
+    end
+
+    if not status_line then
+        sock:close()
+        return false, "no status line received"
+    end
+
+    local code = tonumber(status_line:match("HTTP/%d%.%d%s+(%d%d%d)"))
+
+    if code and code >= 300 and code < 400 and resp_headers["location"] then
+        sock:close()
+        local location = resp_headers["location"]:gsub("\r$", "")
+        local new_url = socket_url.absolute(url, location)
+        return HttpAsync.fetch_url(new_url, redirect_count + 1, headers)
+    end
+
+    if code and code >= 400 then
+        sock:close()
+        return false, "HTTP error " .. tostring(code)
+    end
+
+    -- Read the body, handling both chunked and fixed/until-close encodings.
+    local body = {}
+    local transfer_encoding = resp_headers["transfer-encoding"]
+    if transfer_encoding and transfer_encoding:lower():find("chunked", 1, true) then
+        while true do
+            local chunk_size_str = async_receive(sock, "*l")
+            if not chunk_size_str then break end
+            local hex = chunk_size_str:match("^%x+")
+            if not hex then break end
+            local chunk_size = tonumber(hex, 16)
+            if not chunk_size or chunk_size == 0 then break end
+
+            local chunk_data = async_receive(sock, chunk_size)
+            if chunk_data and #chunk_data > 0 then table.insert(body, chunk_data) end
+            async_receive(sock, 2) -- trailing CRLF
+        end
+    else
+        local content_length = tonumber(resp_headers["content-length"])
+        if content_length then
+            local remaining = content_length
+            while remaining > 0 do
+                local chunk = async_receive(sock, remaining)
+                if not chunk then break end
+                table.insert(body, chunk)
+                remaining = remaining - #chunk
+            end
+        else
+            while true do
+                local chunk, cerr, partial = async_receive(sock, 8192)
+                if chunk then
+                    table.insert(body, chunk)
+                else
+                    if partial and #partial > 0 then table.insert(body, partial) end
+                    if cerr == "closed" then break end
+                    if cerr ~= "timeout" and cerr ~= "wantread" then
+                        -- Some other error: stop reading.
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    sock:close()
+    local content = table.concat(body)
+    return true, resp_headers["content-type"], content
+end
+
+--- Download many tasks concurrently via a coroutine scheduler.
+--
+-- Each task is a caller-supplied value; `opts.get_url(task)` yields its URL.
+-- The scheduler runs up to `opts.concurrency` fetches at once, resuming each
+-- coroutine whenever `socket.select` says its socket is ready.
+--
+-- @param tasks list of arbitrary task values
+-- @param opts table:
+--   concurrency  number  max simultaneous fetches (default 10)
+--   get_url(task) -> string  (default: identity, i.e. tasks are URL strings)
+--   fetch(url)    -> (success, content)  (default: HttpAsync.fetch_url)
+--   on_success(task, content) called for each successful download
+--   on_failure(task, err)     called for each failed download
+--   on_progress(completed, total) -> bool  called periodically; return false to cancel
+-- @return true if cancelled, false if all tasks completed
+function HttpAsync.fetch_many(tasks, opts)
+    opts = opts or {}
+    local concurrency = opts.concurrency or DEFAULT_CONCURRENCY
+    local get_url = opts.get_url or function(task) return task end
+    local fetch = opts.fetch or function(url)
+        local ok, _, content = HttpAsync.fetch_url(url)
+        return ok, content
+    end
+    local on_success = opts.on_success
+    local on_failure = opts.on_failure
+    local on_progress = opts.on_progress
+
+    local pending = {}
+    for i, task in ipairs(tasks) do
+        table.insert(pending, {task = task, index = i})
+    end
+    local total = #pending
+
+    local active = {}   -- running coroutines
+    local co2sock = {}  -- coroutine -> socket it's waiting on
+    local co2mode = {}  -- coroutine -> "r" or "w"
+    local completed = 0
+
+    local function refill_pool()
+        while #active < concurrency and #pending > 0 do
+            local item = table.remove(pending, 1)
+            local co = coroutine.create(function()
+                local ok, content = fetch(get_url(item.task))
+                coroutine.yield("RESULT", item, ok, content)
+            end)
+            table.insert(active, co)
+        end
+    end
+
+    refill_pool()
+
+    local cancelled = false
+    while #active > 0 and not cancelled do
+        -- Gather sockets we're waiting on and select() on them.
+        local recvt, sendt = {}, {}
+        for _, co in ipairs(active) do
+            local sock = co2sock[co]
+            if sock then
+                if co2mode[co] == "r" then table.insert(recvt, sock) end
+                if co2mode[co] == "w" then table.insert(sendt, sock) end
+            end
+        end
+
+        local ready
+        if #recvt > 0 or #sendt > 0 then
+            local r, w = socket.select(recvt, sendt, 0.1)
+            ready = {}
+            for _, s in ipairs(r or {}) do ready[s] = true end
+            for _, s in ipairs(w or {}) do ready[s] = true end
+        end
+
+        -- Resume coroutines that are ready (or haven't yielded a socket yet).
+        local next_active = {}
+        for _, co in ipairs(active) do
+            local sock = co2sock[co]
+            local is_ready = not sock or (ready and ready[sock])
+
+            if not is_ready then
+                table.insert(next_active, co)
+            else
+                if sock then
+                    co2sock[co] = nil
+                    co2mode[co] = nil
+                end
+
+                local ok, yield_type, yield_arg2, success, content = coroutine.resume(co)
+
+                if not ok then
+                    logger.warn("httpasync coroutine error:", yield_type)
+                    completed = completed + 1
+                elseif coroutine.status(co) == "dead" then
+                    -- Finished without a RESULT yield; treat as done.
+                    completed = completed + 1
+                elseif yield_type == "RESULT" then
+                    completed = completed + 1
+                    local item = yield_arg2
+                    if success and content then
+                        if on_success then on_success(item.task, content) end
+                    else
+                        if on_failure then on_failure(item.task, content) end
+                    end
+                else
+                    -- The coroutine yielded a socket and mode ("r"/"w").
+                    co2sock[co] = yield_type
+                    co2mode[co] = yield_arg2
+                    table.insert(next_active, co)
+                end
+            end
+        end
+        active = next_active
+
+        refill_pool()
+
+        if on_progress and not on_progress(completed, total) then
+            cancelled = true
+        end
+    end
+
+    return cancelled
+end
+
+return HttpAsync

--- a/frontend/httpasync.lua
+++ b/frontend/httpasync.lua
@@ -23,6 +23,9 @@ local HttpAsync = {}
 local MAX_REDIRECTS = 5
 local DEFAULT_CONCURRENCY = 10
 
+-- Yielded by a fetch coroutine to signal completion (followed by item, success, content). Any other first yield value is a socket + "r"/"w" mode.
+local DONE = "DONE"
+
 --- Non-blocking receive; yields (socket, "r"/"w") until data/error/EOF.
 -- LuaSocket's receive(pattern, prefix) prepends `prefix` to the buffer it
 -- reads into, so any partial data already consumed from the socket on a
@@ -265,6 +268,13 @@ end
 -- The scheduler runs up to `opts.concurrency` fetches at once, resuming each
 -- coroutine whenever `socket.select` says its socket is ready.
 --
+-- Yield contract: a fetch coroutine either yields a socket object together
+-- with a "r"/"w" mode (meaning "I'm blocked waiting on this socket, resume me
+-- when it's ready"), or yields the sentinel `DONE` followed by
+-- (item, success, content) to signal completion. The scheduler never sees the
+-- downloaded content as a yield value, so a response body cannot be mistaken
+-- for the completion sentinel.
+--
 -- @param tasks list of arbitrary task values
 -- @param opts table:
 --   concurrency  number  max simultaneous fetches (default 10)
@@ -302,7 +312,7 @@ function HttpAsync.fetch_many(tasks, opts)
             local item = table.remove(pending, 1)
             local co = coroutine.create(function()
                 local ok, content = fetch(get_url(item.task))
-                coroutine.yield("RESULT", item, ok, content)
+                coroutine.yield(DONE, item, ok, content)
             end)
             table.insert(active, co)
         end
@@ -350,9 +360,9 @@ function HttpAsync.fetch_many(tasks, opts)
                     logger.warn("httpasync coroutine error:", yield_type)
                     completed = completed + 1
                 elseif coroutine.status(co) == "dead" then
-                    -- Finished without a RESULT yield; treat as done.
+                    -- Finished without a DONE yield; treat as done.
                     completed = completed + 1
-                elseif yield_type == "RESULT" then
+                elseif yield_type == DONE then
                     completed = completed + 1
                     local item = yield_arg2
                     if success and content then

--- a/frontend/httpasync.lua
+++ b/frontend/httpasync.lua
@@ -20,14 +20,19 @@ local MAX_REDIRECTS = 5
 local DEFAULT_CONCURRENCY = 10
 
 --- Non-blocking receive; yields (socket, "r"/"w") until data/error/EOF.
--- Partial data returned with "timeout"/"wantread" is already consumed from
--- the socket buffer, so carry it forward via the `receive` prefix argument.
+-- LuaSocket's receive(pattern, prefix) prepends `prefix` to the buffer it
+-- reads into, so any partial data already consumed from the socket on a
+-- previous (timed-out) call must be passed back as the prefix on the next
+-- call. We accumulate that partial data in `accumulated` and always prepend
+-- it, so a resumed receive continues exactly where it left off instead of
+-- discarding bytes already pulled from the socket.
 local function async_receive(sock, pattern)
-    local acc = ""
+    local accumulated = ""
     while true do
-        local res, err, partial = sock:receive(pattern, acc)
+        local res, err, partial = sock:receive(pattern, accumulated)
         if err == "timeout" or err == "wantread" then
-            acc = partial or acc
+            -- Carry forward the partial data already consumed from the socket.
+            accumulated = partial or accumulated
             coroutine.yield(sock, "r")
         elseif err == "wantwrite" then
             coroutine.yield(sock, "w")

--- a/frontend/httpasync.lua
+++ b/frontend/httpasync.lua
@@ -283,7 +283,7 @@ end
 --   on_success(task, content) called for each successful download
 --   on_failure(task, err)     called for each failed download
 --   on_progress(completed, total) -> bool  called periodically; return false to cancel
--- @return true if cancelled, false if all tasks completed
+-- @return true if all tasks completed, false if cancelled
 function HttpAsync.fetch_many(tasks, opts)
     opts = opts or {}
     local concurrency = opts.concurrency or DEFAULT_CONCURRENCY
@@ -387,7 +387,8 @@ function HttpAsync.fetch_many(tasks, opts)
         end
     end
 
-    return cancelled
+    -- true = all tasks completed (success), false = cancelled by on_progress.
+    return not cancelled
 end
 
 return HttpAsync

--- a/frontend/httpasync.lua
+++ b/frontend/httpasync.lua
@@ -5,6 +5,10 @@ Unlike `httpclient.lua` (Turbo's I/O loop), this works without Turbo: it
 drives LuaSocket/LuaSec sockets in non-blocking mode, yielding to a
 `socket.select`-based scheduler so one Lua state can interleave many
 downloads.
+
+Sources:
+- The coroutine scheduler is based on <https://www.lua.org/pil/9.4.html>
+- The HTTP request/response handling (request lines, header parsing, redirects, chunked and content-length body reading) is adapted from LuaSocket (http.lua / the LTN12/http client).
 ]]
 
 local logger = require("logger")

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -1635,7 +1635,14 @@ abbr.abbr {
                 -- InfoMessage is displayed.
                 if time.to_ms(time.since(time_prev)) > 1000 then
                     time_prev = time.now()
-                    local go_on = UI:info(T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    local errors = #failed_images
+                    local go_on = true
+                    if errors > 0 then
+                        go_on = UI:info(T(_("Retrieving images… %1 / %2 completed (%3 errors)"), completed, total, errors), completed >= 1)
+                    else
+                        go_on = UI:info(T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    end
+
                     if not go_on then
                         return false -- cancel
                     end

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -2,6 +2,7 @@ local JSON = require("json")
 local RenderImage = require("ui/renderimage")
 local Screen = require("device").screen
 local ffiutil = require("ffi/util")
+local httpasync = require("httpasync")
 local lfs = require("libs/libkoreader-lfs")
 local logger = require("logger")
 local time = require("ui/time")
@@ -1588,51 +1589,73 @@ abbr.abbr {
     -- ----------------------------------------------------------------
     -- OEBPS/images/*
     if include_images then
-        local nb_images = #images
         local before_images_time = time.now()
         local time_prev = before_images_time
+        local failed_images = {}
+
+        local tasks = {}
         for inum, img in ipairs(images) do
-            -- Process can be interrupted every second between image downloads
-            -- by tapping while the InfoMessage is displayed
-            -- We use the fast_refresh option from image #2 for a quicker download
-            local go_on
-            if time.to_ms(time.since(time_prev)) > 1000 then
-                time_prev = time.now()
-                go_on = UI:info(T(_("Retrieving image %1 / %2 …"), inum, nb_images), inum >= 2)
-                if not go_on then
-                    cancelled = true
-                    break
+            table.insert(tasks, {inum = inum, img = img})
+        end
+
+        local cancelled_download = httpasync.fetch_many(tasks, {
+            get_url = function(task)
+                local src = task.img.src
+                if use_img_2x and task.img.src2x then
+                    src = task.img.src2x
                 end
-            else
-                UI:info(T(_("Retrieving image %1 / %2 …"), inum, nb_images), inum >= 2, true)
-            end
-            local src = img.src
-            if use_img_2x and img.src2x then
-                src = img.src2x
-            end
-            logger.dbg("Getting img ", src)
-            local success, content = getUrlContent(src, nil, nil, true) -- reuse_cookie
-            -- success, content = getUrlContent(src..".unexistant") -- to simulate failure
-            if success then
-                logger.dbg("success, size:", #content)
-            else
-                logger.info("failed fetching:", src)
-            end
-            if success then
+                return src
+            end,
+            fetch = function(src)
+                logger.dbg("Getting img async:", src)
+                local success, _, content = httpasync.fetch_url(src, 0, {
+                    cookie = cached_cookie,
+                    referer = "https://en.wikipedia.org/",
+                })
+                if not success then
+                    -- Fallback to the synchronous getter for edge cases.
+                    success, content = getUrlContent(src, nil, nil, true) -- reuse_cookie
+                end
+                return success, content
+            end,
+            on_success = function(task, content)
                 -- Images do not need to be compressed, so spare some cpu cycles
-                if img.mimetype ~= "image/svg+xml" then -- except for SVG images (which are XML text)
+                if task.img.mimetype ~= "image/svg+xml" then -- except for SVG images (which are XML text)
                     epub:setZipCompression("store")
                 end
-                epub:addFileFromMemory("OEBPS/"..img.imgpath, content, mtime)
+                epub:addFileFromMemory("OEBPS/"..task.img.imgpath, content, mtime)
                 epub:setZipCompression("deflate")
-            else
-                go_on = UI:confirm(T(_("Downloading image %1 failed. Continue anyway?"), inum), _("Stop"), _("Continue"))
-                if not go_on then
-                    cancelled = true
-                    break
+            end,
+            on_failure = function(task, err)
+                logger.info("failed fetching:", task.img.src, err)
+                table.insert(failed_images, task.inum)
+            end,
+            on_progress = function(completed, total)
+                -- Process can be interrupted every second by tapping while the
+                -- InfoMessage is displayed.
+                if time.to_ms(time.since(time_prev)) > 1000 then
+                    time_prev = time.now()
+                    local go_on = UI:info(T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    if not go_on then
+                        return false -- cancel
+                    end
                 end
+                return true
+            end,
+        })
+
+        if cancelled_download then
+            cancelled = true
+        end
+
+        -- Report any failures once, rather than interrupting on each one.
+        if not cancelled and #failed_images > 0 then
+            local go_on = UI:confirm(T(_("%1 images failed to download. Continue creating the EPUB?"), #failed_images), _("Stop"), _("Continue"))
+            if not go_on then
+                cancelled = true
             end
         end
+
         logger.dbg("Image download time for:", page_htmltitle, time.to_ms(time.since(before_images_time)), "ms")
     end
 

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -1636,7 +1636,7 @@ abbr.abbr {
                 if time.to_ms(time.since(time_prev)) > 1000 then
                     time_prev = time.now()
                     local errors = #failed_images
-                    local go_on = true
+                    local go_on
                     if errors > 0 then
                         go_on = UI:info(T(_("Retrieving images… %1 / %2 completed (%3 errors)"), completed, total, errors), completed >= 1)
                     else

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -1598,7 +1598,7 @@ abbr.abbr {
             table.insert(tasks, {inum = inum, img = img})
         end
 
-        local cancelled_download = httpasync.fetch_many(tasks, {
+        local download_completed = httpasync.fetch_many(tasks, {
             get_url = function(task)
                 local src = task.img.src
                 if use_img_2x and task.img.src2x then
@@ -1651,7 +1651,7 @@ abbr.abbr {
             end,
         })
 
-        if cancelled_download then
+        if not download_completed then
             cancelled = true
         end
 

--- a/frontend/ui/wikipedia.lua
+++ b/frontend/ui/wikipedia.lua
@@ -1608,15 +1608,10 @@ abbr.abbr {
             end,
             fetch = function(src)
                 logger.dbg("Getting img async:", src)
-                local success, _, content = httpasync.fetch_url(src, 0, {
+                return httpasync.fetch_url(src, 0, {
                     cookie = cached_cookie,
                     referer = "https://en.wikipedia.org/",
                 })
-                if not success then
-                    -- Fallback to the synchronous getter for edge cases.
-                    success, content = getUrlContent(src, nil, nil, true) -- reuse_cookie
-                end
-                return success, content
             end,
             on_success = function(task, content)
                 -- Images do not need to be compressed, so spare some cpu cycles

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -8,6 +8,7 @@ local logger = require("logger")
 local ltn12 = require("ltn12")
 local socket = require("socket")
 local socket_url = require("socket.url")
+local ssl = require("ssl")
 local socketutil = require("socketutil")
 local time = require("ui/time")
 local util = require("util")
@@ -394,6 +395,224 @@ local ext_to_mimetype = {
     ttf = "application/truetype",
     woff = "application/font-woff",
 }
+
+local MAX_CONCURRENT_DOWNLOADS = 10
+
+--- Non-blocking receive; yields (socket, "r"/"w") until data/error/EOF.
+-- Partial data returned with "timeout"/"wantread" is already consumed from
+-- the socket buffer, so carry it forward via the `receive` prefix argument.
+local function async_receive(sock, pattern)
+    local acc = ""
+    while true do
+        local res, err, partial = sock:receive(pattern, acc)
+        if err == "timeout" or err == "wantread" then
+            acc = partial or acc
+            coroutine.yield(sock, "r")
+        elseif err == "wantwrite" then
+            coroutine.yield(sock, "w")
+        else
+            return res, err, partial
+        end
+    end
+end
+
+--- Non-blocking send; yields (socket, "w"/"r") while it would block.
+local function async_send(sock, data)
+    local i = 1
+    local n = #data
+    while i <= n do
+        local res, err, last = sock:send(data, i)
+        if err == "timeout" or err == "wantwrite" then
+            coroutine.yield(sock, "w")
+            -- LuaSocket reports the index of the last byte sent on error.
+            if last then i = last + 1 end
+        elseif err == "wantread" then
+            coroutine.yield(sock, "r")
+        elseif err then
+            return nil, err
+        else
+            i = res + 1
+        end
+    end
+    return true
+end
+
+--- Non-blocking connect; yields (socket, "w") until connected or failed.
+local function async_connect(sock, host, port)
+    sock:settimeout(0)
+    while true do
+        local res, err = sock:connect(host, port)
+        if res or err == "already connected" then
+            return true
+        elseif err == "timeout" or err == "Operation already in progress" then
+            coroutine.yield(sock, "w")
+        else
+            return false, err
+        end
+    end
+end
+
+--- Non-blocking TLS handshake; yields (socket, "r"/"w") while it would block.
+local function async_handshake(sock)
+    while true do
+        local res, err = sock:dohandshake()
+        if res then
+            return true
+        elseif err == "wantread" then
+            coroutine.yield(sock, "r")
+        elseif err == "wantwrite" then
+            coroutine.yield(sock, "w")
+        else
+            return false, err
+        end
+    end
+end
+
+--- Fetch one image over a raw non-blocking socket, yielding while it would
+-- block so the caller can interleave many downloads.
+local function download_image_async(url, redirect_count)
+    redirect_count = redirect_count or 0
+    if redirect_count > 5 then return false, "Too many redirects" end
+
+    local parsed = socket_url.parse(url)
+    if not parsed then return false, "invalid url" end
+    if parsed.path then
+        -- Encode invalid path chars (e.g., spaces) while preserving "/" and "%".
+        parsed.path = util.urlEncode(parsed.path, "/%%")
+        url = socket_url.build(parsed)
+    end
+
+    local host = parsed.host
+    if not host then return false, "invalid url" end
+    local port = parsed.port or (parsed.scheme == "https" and 443 or 80)
+    local path = parsed.path or "/"
+    if parsed.query then path = path .. "?" .. parsed.query end
+
+    local sock = socket.tcp()
+    local ok, err = async_connect(sock, host, port)
+    if not ok then
+        sock:close()
+        return false, "connect error: " .. tostring(err)
+    end
+
+    if parsed.scheme == "https" then
+        local ssl_params = {
+            mode = "client",
+            protocol = "any",
+            verify = "none",
+            options = {"all", "no_sslv2", "no_sslv3"},
+        }
+        local ssl_sock, wrap_err = ssl.wrap(sock, ssl_params)
+        if not ssl_sock then
+            sock:close()
+            return false, "ssl wrap error: " .. tostring(wrap_err)
+        end
+        sock = ssl_sock
+        sock:settimeout(0)
+        if sock.sni then
+            sock:sni(host)
+        end
+        local hok, herr = async_handshake(sock)
+        if not hok then
+            sock:close()
+            return false, "ssl handshake error: " .. tostring(herr)
+        end
+    end
+
+    local req = string.format(
+        "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: %s\r\nConnection: close\r\n\r\n",
+        path, host, socketutil.USER_AGENT)
+    local sok, serr = async_send(sock, req)
+    if not sok then
+        sock:close()
+        return false, "send error: " .. tostring(serr)
+    end
+
+    -- Read status line and headers.
+    local headers = {}
+    local status_line
+    while true do
+        local line, lerr = async_receive(sock, "*l")
+        if not line then
+            sock:close()
+            return false, "read error: " .. tostring(lerr)
+        end
+        if line == "" then break end
+        if not status_line then
+            status_line = line
+        else
+            local k, v = line:match("^(.-):%s*(.*)")
+            if k and v then headers[k:lower()] = v end
+        end
+    end
+
+    if not status_line then
+        sock:close()
+        return false, "no status line received"
+    end
+
+    local code = tonumber(status_line:match("HTTP/%d%.%d%s+(%d%d%d)"))
+
+    if code and code >= 300 and code < 400 and headers["location"] then
+        sock:close()
+        local location = headers["location"]:gsub("\r$", "")
+        local new_url = socket_url.absolute(url, location)
+        return download_image_async(new_url, redirect_count + 1)
+    end
+
+    if code and code >= 400 then
+        sock:close()
+        return false, "HTTP error " .. tostring(code)
+    end
+
+    -- Read the body, handling both chunked and fixed/until-close encodings.
+    local body = {}
+    local transfer_encoding = headers["transfer-encoding"]
+    if transfer_encoding and transfer_encoding:lower():find("chunked", 1, true) then
+        while true do
+            local chunk_size_str = async_receive(sock, "*l")
+            if not chunk_size_str then break end
+            local hex = chunk_size_str:match("^%x+")
+            if not hex then break end
+            local chunk_size = tonumber(hex, 16)
+            if not chunk_size or chunk_size == 0 then break end
+
+            local chunk_data = async_receive(sock, chunk_size)
+            if chunk_data and #chunk_data > 0 then table.insert(body, chunk_data) end
+            async_receive(sock, 2) -- trailing CRLF
+        end
+    else
+        local content_length = tonumber(headers["content-length"])
+        if content_length then
+            local remaining = content_length
+            while remaining > 0 do
+                local chunk = async_receive(sock, remaining)
+                if not chunk then break end
+                table.insert(body, chunk)
+                remaining = remaining - #chunk
+            end
+        else
+            while true do
+                local chunk, cerr, partial = async_receive(sock, 8192)
+                if chunk then
+                    table.insert(body, chunk)
+                else
+                    if partial and #partial > 0 then table.insert(body, partial) end
+                    if cerr == "closed" then break end
+                    if cerr ~= "timeout" and cerr ~= "wantread" then
+                        -- Some other error: stop reading.
+                        break
+                    end
+                end
+            end
+        end
+    end
+
+    sock:close()
+    local content = table.concat(body)
+    return true, headers["content-type"], content
+end
+
 -- Create an epub file (with possibly images)
 function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, message, filter_enable, filter_element, block_element)
     logger.dbg("EpubDownloadBackend:createEpub(", epub_path, ")")
@@ -673,48 +892,133 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
         local nb_images = #images
         local before_images_time = time.now()
         local time_prev = before_images_time
+
+        -- Download images concurrently: each coroutine yields its socket when
+        -- it would block, and socket.select tells us which are ready to resume.
+        local pending_tasks = {}
         for inum, img in ipairs(images) do
+            table.insert(pending_tasks, {inum = inum, img = img})
+        end
+
+        local active = {}        -- coroutines currently running
+        local co2sock = {}       -- coroutine -> socket it is waiting on
+        local co2mode = {}       -- coroutine -> "r" or "w"
+        local completed = 0
+        local failed_images = {}
+
+        local function refill_pool()
+            while #active < MAX_CONCURRENT_DOWNLOADS and #pending_tasks > 0 do
+                local task = table.remove(pending_tasks, 1)
+                local co = coroutine.create(function()
+                    local src = task.img.src
+                    if use_img_2x and task.img.src2x then
+                        src = task.img.src2x
+                    end
+                    logger.dbg("Getting img async:", src)
+                    local success, err_msg_or_headers, content = download_image_async(src)
+
+                    if not success then
+                        logger.warn("async download failed:", err_msg_or_headers, "falling back to getUrlContent")
+                        -- Fallback to the synchronous getter for edge cases.
+                        success, dummy, content = getUrlContent(src)
+                    end
+
+                    coroutine.yield("RESULT", task, success, content)
+                end)
+                table.insert(active, co)
+            end
+        end
+
+        refill_pool()
+
+        while #active > 0 do
+            -- Gather sockets we're waiting on and select() on them.
+            local recvt = {}
+            local sendt = {}
+            for _, co in ipairs(active) do
+                local sock = co2sock[co]
+                if sock then
+                    if co2mode[co] == "r" then table.insert(recvt, sock) end
+                    if co2mode[co] == "w" then table.insert(sendt, sock) end
+                end
+            end
+
+            local ready
+            if #recvt > 0 or #sendt > 0 then
+                local r, w = socket.select(recvt, sendt, 0.1)
+                ready = {}
+                for _, s in ipairs(r or {}) do ready[s] = true end
+                for _, s in ipairs(w or {}) do ready[s] = true end
+            end
+
+            -- Resume coroutines that are ready (or haven't yielded a socket yet).
+            local next_active = {}
+            for _, co in ipairs(active) do
+                local sock = co2sock[co]
+                local is_ready = not sock or (ready and ready[sock])
+
+                if not is_ready then
+                    table.insert(next_active, co)
+                else
+                    if sock then
+                        co2sock[co] = nil
+                        co2mode[co] = nil
+                    end
+
+                    local ok, yield_type, task_or_mode, success, content = coroutine.resume(co)
+
+                    if not ok then
+                        logger.warn("image download coroutine error:", yield_type)
+                        completed = completed + 1
+                    elseif coroutine.status(co) == "dead" then
+                        -- Finished without a RESULT yield; treat as done.
+                        completed = completed + 1
+                    elseif yield_type == "RESULT" then
+                        local task = task_or_mode
+                        completed = completed + 1
+                        if success and content then
+                            -- Images do not need to be compressed, so spare some cpu cycles
+                            local no_compression = true
+                            if task.img.mimetype == "image/svg+xml" then -- except for SVG images (which are XML text)
+                                no_compression = false
+                            end
+                            epub:addFileFromMemory("OEBPS/"..task.img.imgpath, content, no_compression, mtime)
+                        else
+                            logger.info("failed fetching:", task.img.src)
+                            table.insert(failed_images, task.inum)
+                        end
+                    else
+                        -- The coroutine yielded a socket to wait on.
+                        co2sock[co] = yield_type
+                        co2mode[co] = task_or_mode
+                        table.insert(next_active, co)
+                    end
+                end
+            end
+            active = next_active
+
+            refill_pool()
+
             -- Process can be interrupted every second between image downloads
-            -- by tapping while the InfoMessage is displayed
-            -- We use the fast_refresh option from image #2 for a quicker download
-            local go_on
+            -- by tapping while the InfoMessage is displayed.
             if time.to_ms(time.since(time_prev)) > 1000 then
                 time_prev = time.now()
-                go_on = UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving image %1 / %2 …"), inum, nb_images), inum >= 2)
-                if not go_on then
-                    cancelled = true
-                    break
-                end
-            else
-                UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving image %1 / %2 …"), inum, nb_images), inum >= 2, true)
-            end
-            local src = img.src
-            if use_img_2x and img.src2x then
-                src = img.src2x
-            end
-            logger.dbg("Getting img ", src)
-            local success, __, content = getUrlContent(src)
-            -- success, _, content = getUrlContent(src..".unexistant") -- to simulate failure
-            if success then
-                logger.dbg("success, size:", #content)
-            else
-                logger.info("failed fetching:", src)
-            end
-            if success then
-                -- Images do not need to be compressed, so spare some cpu cycles
-                local no_compression = true
-                if img.mimetype == "image/svg+xml" then -- except for SVG images (which are XML text)
-                    no_compression = false
-                end
-                epub:addFileFromMemory("OEBPS/"..img.imgpath, content, no_compression, mtime)
-            else
-                go_on = UI:confirm(T(_("Downloading image %1 failed. Continue anyway?"), inum), _("Stop"), _("Continue"))
+                local go_on = UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving images… %1 / %2 completed"), completed, nb_images), completed >= 1)
                 if not go_on then
                     cancelled = true
                     break
                 end
             end
         end
+
+        -- Report any failures once, rather than interrupting on each one.
+        if not cancelled and #failed_images > 0 then
+            local go_on = UI:confirm(T(_("%1 images failed to download. Continue creating the EPUB?"), #failed_images), _("Stop"), _("Continue"))
+            if not go_on then
+                cancelled = true
+            end
+        end
+
         logger.dbg("Image download time for:", page_htmltitle, time.to_ms(time.since(before_images_time)), "ms")
     end
 

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -8,8 +8,8 @@ local logger = require("logger")
 local ltn12 = require("ltn12")
 local socket = require("socket")
 local socket_url = require("socket.url")
-local ssl = require("ssl")
 local socketutil = require("socketutil")
+local httpasync = require("httpasync")
 local time = require("ui/time")
 local util = require("util")
 local _ = require("gettext")
@@ -398,219 +398,13 @@ local ext_to_mimetype = {
 
 local MAX_CONCURRENT_DOWNLOADS = 10
 
---- Non-blocking receive; yields (socket, "r"/"w") until data/error/EOF.
--- Partial data returned with "timeout"/"wantread" is already consumed from
--- the socket buffer, so carry it forward via the `receive` prefix argument.
-local function async_receive(sock, pattern)
-    local acc = ""
-    while true do
-        local res, err, partial = sock:receive(pattern, acc)
-        if err == "timeout" or err == "wantread" then
-            acc = partial or acc
-            coroutine.yield(sock, "r")
-        elseif err == "wantwrite" then
-            coroutine.yield(sock, "w")
-        else
-            return res, err, partial
-        end
+-- Fetch one image, falling back to the synchronous getter on failure.
+local function download_image(url)
+    local success, _, content = httpasync.fetch_url(url)
+    if not success then
+        success, _, content = getUrlContent(url)
     end
-end
-
---- Non-blocking send; yields (socket, "w"/"r") while it would block.
-local function async_send(sock, data)
-    local i = 1
-    local n = #data
-    while i <= n do
-        local res, err, last = sock:send(data, i)
-        if err == "timeout" or err == "wantwrite" then
-            coroutine.yield(sock, "w")
-            -- LuaSocket reports the index of the last byte sent on error.
-            if last then i = last + 1 end
-        elseif err == "wantread" then
-            coroutine.yield(sock, "r")
-        elseif err then
-            return nil, err
-        else
-            i = res + 1
-        end
-    end
-    return true
-end
-
---- Non-blocking connect; yields (socket, "w") until connected or failed.
-local function async_connect(sock, host, port)
-    sock:settimeout(0)
-    while true do
-        local res, err = sock:connect(host, port)
-        if res or err == "already connected" then
-            return true
-        elseif err == "timeout" or err == "Operation already in progress" then
-            coroutine.yield(sock, "w")
-        else
-            return false, err
-        end
-    end
-end
-
---- Non-blocking TLS handshake; yields (socket, "r"/"w") while it would block.
-local function async_handshake(sock)
-    while true do
-        local res, err = sock:dohandshake()
-        if res then
-            return true
-        elseif err == "wantread" then
-            coroutine.yield(sock, "r")
-        elseif err == "wantwrite" then
-            coroutine.yield(sock, "w")
-        else
-            return false, err
-        end
-    end
-end
-
---- Fetch one image over a raw non-blocking socket, yielding while it would
--- block so the caller can interleave many downloads.
-local function download_image_async(url, redirect_count)
-    redirect_count = redirect_count or 0
-    if redirect_count > 5 then return false, "Too many redirects" end
-
-    local parsed = socket_url.parse(url)
-    if not parsed then return false, "invalid url" end
-    if parsed.path then
-        -- Encode invalid path chars (e.g., spaces) while preserving "/" and "%".
-        parsed.path = util.urlEncode(parsed.path, "/%%")
-        url = socket_url.build(parsed)
-    end
-
-    local host = parsed.host
-    if not host then return false, "invalid url" end
-    local port = parsed.port or (parsed.scheme == "https" and 443 or 80)
-    local path = parsed.path or "/"
-    if parsed.query then path = path .. "?" .. parsed.query end
-
-    local sock = socket.tcp()
-    local ok, err = async_connect(sock, host, port)
-    if not ok then
-        sock:close()
-        return false, "connect error: " .. tostring(err)
-    end
-
-    if parsed.scheme == "https" then
-        local ssl_params = {
-            mode = "client",
-            protocol = "any",
-            verify = "none",
-            options = {"all", "no_sslv2", "no_sslv3"},
-        }
-        local ssl_sock, wrap_err = ssl.wrap(sock, ssl_params)
-        if not ssl_sock then
-            sock:close()
-            return false, "ssl wrap error: " .. tostring(wrap_err)
-        end
-        sock = ssl_sock
-        sock:settimeout(0)
-        if sock.sni then
-            sock:sni(host)
-        end
-        local hok, herr = async_handshake(sock)
-        if not hok then
-            sock:close()
-            return false, "ssl handshake error: " .. tostring(herr)
-        end
-    end
-
-    local req = string.format(
-        "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: %s\r\nConnection: close\r\n\r\n",
-        path, host, socketutil.USER_AGENT)
-    local sok, serr = async_send(sock, req)
-    if not sok then
-        sock:close()
-        return false, "send error: " .. tostring(serr)
-    end
-
-    -- Read status line and headers.
-    local headers = {}
-    local status_line
-    while true do
-        local line, lerr = async_receive(sock, "*l")
-        if not line then
-            sock:close()
-            return false, "read error: " .. tostring(lerr)
-        end
-        if line == "" then break end
-        if not status_line then
-            status_line = line
-        else
-            local k, v = line:match("^(.-):%s*(.*)")
-            if k and v then headers[k:lower()] = v end
-        end
-    end
-
-    if not status_line then
-        sock:close()
-        return false, "no status line received"
-    end
-
-    local code = tonumber(status_line:match("HTTP/%d%.%d%s+(%d%d%d)"))
-
-    if code and code >= 300 and code < 400 and headers["location"] then
-        sock:close()
-        local location = headers["location"]:gsub("\r$", "")
-        local new_url = socket_url.absolute(url, location)
-        return download_image_async(new_url, redirect_count + 1)
-    end
-
-    if code and code >= 400 then
-        sock:close()
-        return false, "HTTP error " .. tostring(code)
-    end
-
-    -- Read the body, handling both chunked and fixed/until-close encodings.
-    local body = {}
-    local transfer_encoding = headers["transfer-encoding"]
-    if transfer_encoding and transfer_encoding:lower():find("chunked", 1, true) then
-        while true do
-            local chunk_size_str = async_receive(sock, "*l")
-            if not chunk_size_str then break end
-            local hex = chunk_size_str:match("^%x+")
-            if not hex then break end
-            local chunk_size = tonumber(hex, 16)
-            if not chunk_size or chunk_size == 0 then break end
-
-            local chunk_data = async_receive(sock, chunk_size)
-            if chunk_data and #chunk_data > 0 then table.insert(body, chunk_data) end
-            async_receive(sock, 2) -- trailing CRLF
-        end
-    else
-        local content_length = tonumber(headers["content-length"])
-        if content_length then
-            local remaining = content_length
-            while remaining > 0 do
-                local chunk = async_receive(sock, remaining)
-                if not chunk then break end
-                table.insert(body, chunk)
-                remaining = remaining - #chunk
-            end
-        else
-            while true do
-                local chunk, cerr, partial = async_receive(sock, 8192)
-                if chunk then
-                    table.insert(body, chunk)
-                else
-                    if partial and #partial > 0 then table.insert(body, partial) end
-                    if cerr == "closed" then break end
-                    if cerr ~= "timeout" and cerr ~= "wantread" then
-                        -- Some other error: stop reading.
-                        break
-                    end
-                end
-            end
-        end
-    end
-
-    sock:close()
-    local content = table.concat(body)
-    return true, headers["content-type"], content
+    return success, content
 end
 
 -- Create an epub file (with possibly images)
@@ -889,126 +683,56 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
     -- ----------------------------------------------------------------
     -- OEBPS/images/*
     if include_images then
-        local nb_images = #images
         local before_images_time = time.now()
         local time_prev = before_images_time
-
-        -- Download images concurrently: each coroutine yields its socket when
-        -- it would block, and socket.select tells us which are ready to resume.
-        local pending_tasks = {}
-        for inum, img in ipairs(images) do
-            table.insert(pending_tasks, {inum = inum, img = img})
-        end
-
-        local active = {}        -- coroutines currently running
-        local co2sock = {}       -- coroutine -> socket it is waiting on
-        local co2mode = {}       -- coroutine -> "r" or "w"
-        local completed = 0
         local failed_images = {}
 
-        local function refill_pool()
-            while #active < MAX_CONCURRENT_DOWNLOADS and #pending_tasks > 0 do
-                local task = table.remove(pending_tasks, 1)
-                local co = coroutine.create(function()
-                    local src = task.img.src
-                    if use_img_2x and task.img.src2x then
-                        src = task.img.src2x
-                    end
-                    logger.dbg("Getting img async:", src)
-                    local success, err_msg_or_headers, content = download_image_async(src)
-
-                    if not success then
-                        logger.warn("async download failed:", err_msg_or_headers, "falling back to getUrlContent")
-                        -- Fallback to the synchronous getter for edge cases.
-                        success, dummy, content = getUrlContent(src)
-                    end
-
-                    coroutine.yield("RESULT", task, success, content)
-                end)
-                table.insert(active, co)
-            end
+        local tasks = {}
+        for inum, img in ipairs(images) do
+            table.insert(tasks, {inum = inum, img = img})
         end
 
-        refill_pool()
-
-        while #active > 0 do
-            -- Gather sockets we're waiting on and select() on them.
-            local recvt = {}
-            local sendt = {}
-            for _, co in ipairs(active) do
-                local sock = co2sock[co]
-                if sock then
-                    if co2mode[co] == "r" then table.insert(recvt, sock) end
-                    if co2mode[co] == "w" then table.insert(sendt, sock) end
+        local cancelled_download = httpasync.fetch_many(tasks, {
+            concurrency = MAX_CONCURRENT_DOWNLOADS,
+            get_url = function(task)
+                local src = task.img.src
+                if use_img_2x and task.img.src2x then
+                    src = task.img.src2x
                 end
-            end
-
-            local ready
-            if #recvt > 0 or #sendt > 0 then
-                local r, w = socket.select(recvt, sendt, 0.1)
-                ready = {}
-                for _, s in ipairs(r or {}) do ready[s] = true end
-                for _, s in ipairs(w or {}) do ready[s] = true end
-            end
-
-            -- Resume coroutines that are ready (or haven't yielded a socket yet).
-            local next_active = {}
-            for _, co in ipairs(active) do
-                local sock = co2sock[co]
-                local is_ready = not sock or (ready and ready[sock])
-
-                if not is_ready then
-                    table.insert(next_active, co)
-                else
-                    if sock then
-                        co2sock[co] = nil
-                        co2mode[co] = nil
-                    end
-
-                    local ok, yield_type, task_or_mode, success, content = coroutine.resume(co)
-
-                    if not ok then
-                        logger.warn("image download coroutine error:", yield_type)
-                        completed = completed + 1
-                    elseif coroutine.status(co) == "dead" then
-                        -- Finished without a RESULT yield; treat as done.
-                        completed = completed + 1
-                    elseif yield_type == "RESULT" then
-                        local task = task_or_mode
-                        completed = completed + 1
-                        if success and content then
-                            -- Images do not need to be compressed, so spare some cpu cycles
-                            local no_compression = true
-                            if task.img.mimetype == "image/svg+xml" then -- except for SVG images (which are XML text)
-                                no_compression = false
-                            end
-                            epub:addFileFromMemory("OEBPS/"..task.img.imgpath, content, no_compression, mtime)
-                        else
-                            logger.info("failed fetching:", task.img.src)
-                            table.insert(failed_images, task.inum)
-                        end
-                    else
-                        -- The coroutine yielded a socket to wait on.
-                        co2sock[co] = yield_type
-                        co2mode[co] = task_or_mode
-                        table.insert(next_active, co)
+                return src
+            end,
+            fetch = function(src)
+                logger.dbg("Getting img async:", src)
+                return download_image(src)
+            end,
+            on_success = function(task, content)
+                -- Images do not need to be compressed, so spare some cpu cycles
+                local no_compression = true
+                if task.img.mimetype == "image/svg+xml" then -- except for SVG images (which are XML text)
+                    no_compression = false
+                end
+                epub:addFileFromMemory("OEBPS/"..task.img.imgpath, content, no_compression, mtime)
+            end,
+            on_failure = function(task, err)
+                logger.info("failed fetching:", task.img.src, err)
+                table.insert(failed_images, task.inum)
+            end,
+            on_progress = function(completed, total)
+                -- Process can be interrupted every second by tapping while the
+                -- InfoMessage is displayed.
+                if time.to_ms(time.since(time_prev)) > 1000 then
+                    time_prev = time.now()
+                    local go_on = UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    if not go_on then
+                        return false -- cancel
                     end
                 end
-            end
-            active = next_active
+                return true
+            end,
+        })
 
-            refill_pool()
-
-            -- Process can be interrupted every second between image downloads
-            -- by tapping while the InfoMessage is displayed.
-            if time.to_ms(time.since(time_prev)) > 1000 then
-                time_prev = time.now()
-                local go_on = UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving images… %1 / %2 completed"), completed, nb_images), completed >= 1)
-                if not go_on then
-                    cancelled = true
-                    break
-                end
-            end
+        if cancelled_download then
+            cancelled = true
         end
 
         -- Report any failures once, rather than interrupting on each one.

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -398,15 +398,6 @@ local ext_to_mimetype = {
 
 local MAX_CONCURRENT_DOWNLOADS = 10
 
--- Fetch one image, falling back to the synchronous getter on failure.
-local function download_image(url)
-    local success, _, content = httpasync.fetch_url(url)
-    if not success then
-        success, _, content = getUrlContent(url)
-    end
-    return success, content
-end
-
 -- Create an epub file (with possibly images)
 function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, message, filter_enable, filter_element, block_element)
     logger.dbg("EpubDownloadBackend:createEpub(", epub_path, ")")
@@ -703,7 +694,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
             end,
             fetch = function(src)
                 logger.dbg("Getting img async:", src)
-                return download_image(src)
+                return httpasync.fetch_url(src)
             end,
             on_success = function(task, content)
                 -- Images do not need to be compressed, so spare some cpu cycles

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -692,7 +692,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
             table.insert(tasks, {inum = inum, img = img})
         end
 
-        local cancelled_download = httpasync.fetch_many(tasks, {
+        local download_completed = httpasync.fetch_many(tasks, {
             concurrency = MAX_CONCURRENT_DOWNLOADS,
             get_url = function(task)
                 local src = task.img.src
@@ -739,7 +739,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
             end,
         })
 
-        if cancelled_download then
+        if not download_completed then
             cancelled = true
         end
 

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -723,7 +723,7 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 if time.to_ms(time.since(time_prev)) > 1000 then
                     time_prev = time.now()
                     local errors = #failed_images
-                    local go_on = true
+                    local go_on
                     local prefix = message and message ~= "" and message .. "\n\n" or ""
                     if errors > 0 then
                         go_on = UI:info(prefix .. T(_("Retrieving images… %1 / %2 completed (%3 errors)"), completed, total, errors), completed >= 1)

--- a/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
+++ b/plugins/newsdownloader.koplugin/epubdownloadbackend.lua
@@ -722,7 +722,15 @@ function EpubDownloadBackend:createEpub(epub_path, html, url, include_images, me
                 -- InfoMessage is displayed.
                 if time.to_ms(time.since(time_prev)) > 1000 then
                     time_prev = time.now()
-                    local go_on = UI:info((message and message ~= "" and message .. "\n\n" or "") .. T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    local errors = #failed_images
+                    local go_on = true
+                    local prefix = message and message ~= "" and message .. "\n\n" or ""
+                    if errors > 0 then
+                        go_on = UI:info(prefix .. T(_("Retrieving images… %1 / %2 completed (%3 errors)"), completed, total, errors), completed >= 1)
+                    else
+                        go_on = UI:info(prefix .. T(_("Retrieving images… %1 / %2 completed"), completed, total), completed >= 1)
+                    end
+
                     if not go_on then
                         return false -- cancel
                     end


### PR DESCRIPTION
Roughly based on <https://www.lua.org/pil/9.4.html>.

@poire-z Two years in the making. (Albeit also with two years minus a few days of not doing anything about it.) 

Somewhat surprisingly, on Wikipedia it also seems to be faster. The current download slowly downloads ~30 images one by one, waits 11 seconds, slowly downloads another ~30, waits another 11 seconds, etc.

This method squeezes in ~60 images in significantly less time before having to wait 11 seconds. I guess it takes a few seconds for their rate limiter to kick in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15877)
<!-- Reviewable:end -->
