### PR TITLE
fix #15171: show correct stable page numbers with hidden flows

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -249,8 +249,22 @@ footerTextGeneratorMap = {
                 local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
                 local pages = footer.ui.document:getTotalPagesInFlow(flow)
                 local current_page_label = footer.ui.pagemap:getCurrentPageLabel(true)
-                local last_page_in_flow_xpointer = footer.ui.document:getPageXPointer(pages)
-                local last_page_label = footer.ui.pagemap:getXPointerPageLabel(last_page_in_flow_xpointer, true)
+
+                local total_pages = footer.ui.document:getPageCount()
+                local flows = footer.ui.document.flows
+
+                -- the "last page" displayed should be the actual last page of the document
+                -- unless it is hidden by a flow, in which case it should be the last page not in a flow
+                local last_flow = flows[#flows]
+                local last_flow_start = last_flow[1]
+                local last_flow_end = last_flow[1] + last_flow[2]
+                local last_page_label
+                if last_flow_end >= total_pages then
+                    local last_linear_page_xpointer = footer.ui.document:getPageXPointer(last_flow_start - 1)
+                    last_page_label = footer.ui.pagemap:getXPointerPageLabel(last_linear_page_xpointer, true)
+                else
+                    last_page_label = footer.ui.pagemap:getLastPageLabel(true)
+                end
 
                 if flow == 0 then
                     return ("%s // %s"):format(current_page_label, last_page_label)

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -240,11 +240,27 @@ footerTextGeneratorMap = {
             return prefix .. " " .. clock
         end
     end,
+
     page_progress = function(footer)
         if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
             -- (Page labels might not be numbers)
-            return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
-                                      footer.ui.pagemap:getLastPageLabel(true))
+            if footer.ui.document:hasHiddenFlows() then
+                local flow = footer.ui.document:getPageFlow(footer.pageno)
+                local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
+                local pages = footer.ui.document:getTotalPagesInFlow(flow)
+                local current_page_label = footer.ui.pagemap:getCurrentPageLabel(true)
+                local last_page_in_flow_xpointer = footer.ui.document:getPageXPointer(pages)
+                local last_page_label = footer.ui.pagemap:getXPointerPageLabel(last_page_in_flow_xpointer, true)
+
+                if flow == 0 then
+                    return ("%s // %s"):format(current_page_label, last_page_label)
+                else
+                    return ("%s [%d / %d]%d"):format(current_page_label, page, pages, flow)
+                end
+            else
+                return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
+                                          footer.ui.pagemap:getLastPageLabel(true))
+            end
         elseif footer.ui.document:hasHiddenFlows() then
             -- i.e., if we are hiding non-linear fragments and there's anything to hide,
             local flow = footer.ui.document:getPageFlow(footer.pageno)


### PR DESCRIPTION
This fixes #15171 

It's kind of hacky, I'm not sure if I should have instead created helper functions in ReaderPageMap, but it's not that much more logic than in the `else` branch which calculates page numbers on hidden flows without page labels...

I did have to introduce a new format for page numbers _within_ hidden flows. The normal hidden flow format is `[current_page_within_hidden_flow / hidden_flow_length]hidden_flow_number`, e.g. `[36/70]1`. However, that is not acceptable with stable page numbers, since 36 does not correspond to a stable page number. I chose instead the format: `stable_page_number [current_page_within_hidden_flow / hidden_flow_length]hidden_flow_number`, e.g. `371 [36/70]1`, which means "you're on page 371 according to stable page number; this is page 30 of 70 of hidden flow 1". 

However, this is suboptimal since the stable page number and the page number inside the brackets might move at different paces (one visual page turn will always increment page number by 1, but not stable page number). The alternative would be to e.g. ` [371 / 401]1` where 401 is the last page of the hidden flow. This only shows stable page numbers, but at the cost of losing information about the position _within_ the hidden flow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15882)
<!-- Reviewable:end -->
