### PR TITLE
[ReaderLink] fix stale cur_selected_link causing footnote popup to reopen on Press

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1364,8 +1364,10 @@ function ReaderLink:selectRelPageLink(rel)
 end
 
 function ReaderLink:onGotoSelectedPageLink()
-    if self.cur_selected_link then
-        return self:onGotoLink(self.cur_selected_link, false, isFootnoteLinkInPopupEnabled())
+    local link = self.cur_selected_link
+    if link then
+        self.cur_selected_link = nil
+        return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end
 end
 

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1366,6 +1366,8 @@ end
 function ReaderLink:onGotoSelectedPageLink()
     local link = self.cur_selected_link
     if link then
+        -- Clear selected_link so further presses to Press key,
+        -- don't incorrectly launch the footnote widget agian.
         self.cur_selected_link = nil
         return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1366,8 +1366,7 @@ end
 function ReaderLink:onGotoSelectedPageLink()
     local link = self.cur_selected_link
     if link then
-        -- Clear selected_link so further presses to Press key,
-        -- don't incorrectly launch the footnote widget agian.
+        -- a further key `Press`, might incorrectly launch the footnote widget again
         self.cur_selected_link = nil
         return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1366,7 +1366,7 @@ end
 function ReaderLink:onGotoSelectedPageLink()
     local link = self.cur_selected_link
     if link then
-        -- a further key `Press`, might incorrectly launch the footnote widget again
+        -- a further key `Press` might incorrectly launch the footnote widget again
         self.cur_selected_link = nil
         return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1366,7 +1366,7 @@ end
 function ReaderLink:onGotoSelectedPageLink()
     local link = self.cur_selected_link
     if link then
-        -- a further key `Press` might incorrectly launch the footnote widget again
+        -- avoid a further key `Press` incorrectly launching the footnote widget again
         self.cur_selected_link = nil
         return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1292,7 +1292,7 @@ end
 function ReaderLink:clearSelectedPageLink(dirty_ui)
     if self.ui.paging then return end
     self.cur_selected_page_link_num = nil
-    self.cur_selected_link = nil
+    self.cur_highlighted_link = nil
     self.document:highlightXPointer()
     if dirty_ui then
         UIManager:setDirty(self.dialog, "ui")
@@ -1346,7 +1346,7 @@ function ReaderLink:selectRelPageLink(rel)
         link_y = selected_link.end_y
     end
     -- Make it a link as expected by onGotoLink
-    self.cur_selected_link = {
+    self.cur_highlighted_link = {
         xpointer = selected_link.section or selected_link.uri,
         marker_xpointer = selected_link.section,
         from_xpointer = from_xpointer,
@@ -1358,22 +1358,22 @@ function ReaderLink:selectRelPageLink(rel)
         link_y = link_y,
     }
     self.document:highlightXPointer() -- clear any previous one
-    self.document:highlightXPointer(self.cur_selected_link.from_xpointer)
+    self.document:highlightXPointer(self.cur_highlighted_link.from_xpointer)
     UIManager:setDirty(self.dialog, "ui")
     return true
 end
 
 function ReaderLink:onGotoSelectedPageLink()
-    local link = self.cur_selected_link
+    local link = self.cur_highlighted_link
     if link then
         -- avoid a further key `Press` incorrectly launching the footnote widget again
-        self.cur_selected_link = nil
+        self.cur_highlighted_link = nil
         return self:onGotoLink(link, false, isFootnoteLinkInPopupEnabled())
     end
 end
 
 function ReaderLink:onPageUpdate()
-    if self.cur_selected_link or self.cur_selected_page_link_num then
+    if self.cur_highlighted_link or self.cur_selected_page_link_num then
         self:clearSelectedPageLink()
     end
 end

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1373,7 +1373,7 @@ function ReaderLink:onGotoSelectedPageLink()
 end
 
 function ReaderLink:onPageUpdate()
-    if self.cur_selected_link then
+    if self.cur_selected_link or self.cur_selected_page_link_num then
         self:clearSelectedPageLink()
     end
 end


### PR DESCRIPTION
### bug fix

  * After navigating to a selected link in `onGotoSelectedPageLink`, the `self.cur_selected_link` variable is reset to `nil` to avoid accidental repeated navigation after the footnote widget is long gone.
  
### related

* https://github.com/koreader/koreader/pull/15828#issuecomment-5316124745

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15888)
<!-- Reviewable:end -->
