### PR TITLE
FocusManager: repaint the focus indicator, not the whole window

### DIFF
--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -12,8 +12,8 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local UnderlineContainer = WidgetContainer:extend{
     linesize = Size.line.thick,
-    -- Painted while focused. It grows upwards, into the room linesize already reserves,
-    -- so switching focus repaints the line and nothing else.
+    -- Line thickness while focused. The extra thickness (focus_linesize - linesize) is
+    -- the focus bar, painted just above the line and inside the room linesize reserves.
     focus_linesize = nil,
     focused = false,
     padding = Size.padding.tiny,
@@ -21,7 +21,10 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
-    background = nil, -- what to clear the strip with; without it, the bar can only be drawn
+    -- The colour behind the line, so the focus bar can be erased where it was painted.
+    -- Set it to whatever the parent clears that row with. Leaving it nil means this
+    -- container can only draw the bar, never undraw it, so it declines the repaint below.
+    background = nil,
 }
 
 function UnderlineContainer:getSize()
@@ -32,8 +35,8 @@ function UnderlineContainer:getSize()
     }
 end
 
---- The strip this container paints its line and focus bar into, in screen coordinates.
---- Only after paintTo: dimen may be set from the outside, its coordinates are not.
+--- Where the line and the focus bar above it sit, in screen coordinates.
+--- Valid only after paintTo: dimen may be set from the outside, its coordinates are not.
 function UnderlineContainer:getFocusIndicatorRegion()
     if not self._painted then return end
     local line_x, line_width = self:_lineGeometry()
@@ -53,13 +56,11 @@ function UnderlineContainer:_lineGeometry()
     return self.dimen.x, line_width
 end
 
--- The bar, without the line: together they occupy focus_linesize.
 function UnderlineContainer:_focusBarHeight()
     if not self.focus_linesize then return 0 end
     return math.max(self.focus_linesize - self.linesize, 0)
 end
 
--- Right on top of our line, so dropping the bar leaves the line untouched.
 function UnderlineContainer:_focusBarTop(bottom)
     return bottom - self.linesize - self:_focusBarHeight()
 end
@@ -67,18 +68,18 @@ end
 function UnderlineContainer:_paintFocusBar(bb, line_x, bottom, line_width)
     local h = self:_focusBarHeight()
     if h == 0 then return end
-    -- An unfocused bar is erased with the background: only a focus-only repaint asks
-    -- for that, a full repaint has the parent clearing the row for us.
+    -- Erasing only happens on a focus-only repaint; on a full repaint the parent has
+    -- already cleared the row for us.
     local color = self.focused and self.color or self.background
     if not color then return end
     bb:paintRect(line_x, self:_focusBarTop(bottom), line_width, h, color)
 end
 
---- Repaint the strip -- our line and the bar above it -- and nothing else of the widget.
+--- Repaint the line and the focus bar above it, leaving the child content alone.
+--- Returns false when this container cannot do that by itself.
 function UnderlineContainer:repaintFocusIndicator(bb)
     if not self._painted then return false end
-    -- A bar of its own needs somewhere to go when unfocused; a line that merely changes
-    -- colour just gets repainted.
+    -- With no background there is nowhere to erase the bar to once it is unfocused.
     if self:_focusBarHeight() > 0 and not self.background then return false end
     local line_x, line_width = self:_lineGeometry()
     local bottom = self.dimen.y + self:getSize().h
@@ -104,8 +105,8 @@ function UnderlineContainer:paintTo(bb, x, y)
     local line_x, line_width = self:_lineGeometry()
     local bottom = y + container_size.h
 
-    -- Erase a bar left over from a previous focus before the content goes in: the strip
-    -- has no room of its own, so clearing it afterwards would cut into what we just drew.
+    -- Erase a bar left over from a previous focus before the content goes in: it sits
+    -- over the content's bottom, so clearing it afterwards would cut into what we drew.
     if not self.focused and self.background then
         self:_paintFocusBar(bb, line_x, bottom, line_width)
     end

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -39,7 +39,7 @@ end
 --- Valid only after paintTo: dimen may be set from the outside, its coordinates are not.
 function UnderlineContainer:getFocusIndicatorRegion()
     if not self._painted then return end
-    local line_x, line_width = self:_lineGeometry()
+    local line_x, line_width = self:_getLineXAndWidth()
     return Geom:new{
         x = line_x,
         y = self:_focusBarTop(self.dimen.y + self:getSize().h),
@@ -48,7 +48,7 @@ function UnderlineContainer:getFocusIndicatorRegion()
     }
 end
 
-function UnderlineContainer:_lineGeometry()
+function UnderlineContainer:_getLineXAndWidth()
     local line_width = self.line_width or self.dimen.w
     if BD.mirroredUILayout() then
         return self.dimen.x + self.dimen.w - line_width, line_width
@@ -81,7 +81,7 @@ function UnderlineContainer:repaintFocusIndicator(bb)
     if not self._painted then return false end
     -- With no background there is nowhere to erase the bar to once it is unfocused.
     if self:_focusBarHeight() > 0 and not self.background then return false end
-    local line_x, line_width = self:_lineGeometry()
+    local line_x, line_width = self:_getLineXAndWidth()
     local bottom = self.dimen.y + self:getSize().h
     self:_paintFocusBar(bb, line_x, bottom, line_width)
     bb:paintRect(line_x, bottom - self.linesize, line_width, self.linesize, self.color)
@@ -102,7 +102,7 @@ function UnderlineContainer:paintTo(bb, x, y)
     end
     self._painted = true
 
-    local line_x, line_width = self:_lineGeometry()
+    local line_x, line_width = self:_getLineXAndWidth()
     local bottom = y + container_size.h
 
     -- Erase a bar left over from a previous focus before the content goes in: it sits

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -24,7 +24,7 @@ local UnderlineContainer = WidgetContainer:extend{
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
     -- The colour behind the focus bar, so we can erase it where we painted it.
     -- Set it to whatever the parent clears that row with. Leaving it nil means we can
-    -- only draw the bar, never undraw it, so repaintFocusIndicator declines.
+    -- only draw the bar, never erase it, so repaintFocusIndicator declines.
     background = nil,
 }
 
@@ -36,8 +36,9 @@ function UnderlineContainer:getSize()
     }
 end
 
---- Where the line and the focus bar above it sit, in screen coordinates.
---- Valid only after paintTo: dimen may be set from the outside, its coordinates are not.
+--- Returns the screen-coordinate region occupied by the line and the focus bar.
+--- Only valid after paintTo: `dimen` may be supplied externally, but
+--- its coordinates are not valid screen coordinates until then.
 function UnderlineContainer:getFocusIndicatorRegion()
     if not self._painted then return end
     local line_x, line_width = self:_getLineXAndWidth()
@@ -105,7 +106,7 @@ function UnderlineContainer:paintTo(bb, x, y)
     local line_x, line_width = self:_getLineXAndWidth()
     local bottom = y + container_size.h
 
-    -- Erase a bar left over from a previous focus before the content goes in: it sits
+    -- Erase any bar the previous focus left behind, before the content goes in: it sits
     -- over the content's bottom, so clearing it afterwards would cut into what we drew.
     if not self.focused and self.background then
         self:_paintFocusBar(bb, line_x, bottom, line_width)

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -13,7 +13,8 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local UnderlineContainer = WidgetContainer:extend{
     linesize = Size.line.thick,
     -- Line thickness while focused. The extra thickness (focus_linesize - linesize) is
-    -- the focus bar, painted just above the line and inside the room linesize reserves.
+    -- the focus bar, painted just above the line and over the bottom of the content:
+    -- getSize only ever reserves linesize.
     focus_linesize = nil,
     focused = false,
     padding = Size.padding.tiny,
@@ -21,9 +22,9 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
-    -- The colour behind the line, so the focus bar can be erased where it was painted.
+    -- The colour behind the focus bar, so it can be erased where it was painted.
     -- Set it to whatever the parent clears that row with. Leaving it nil means this
-    -- container can only draw the bar, never undraw it, so it declines the repaint below.
+    -- container can only draw the bar, never undraw it, so repaintFocusIndicator declines.
     background = nil,
 }
 

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -79,7 +79,7 @@ end
 --- Returns false when this container cannot do that by itself.
 function UnderlineContainer:repaintFocusIndicator(bb)
     if not self._painted then return false end
-    -- With no background there is nowhere to erase the bar to once it is unfocused.
+    -- Without a background we don't know what colour to paint the now-unfocused bar.
     if self:_focusBarHeight() > 0 and not self.background then return false end
     local line_x, line_width = self:_getLineXAndWidth()
     local bottom = self.dimen.y + self:getSize().h

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -21,6 +21,8 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
+    line_x_offset = nil, -- shifts the line right (left in RTL), to keep it clear of other content
+    background = nil, -- what to clear the strip with; without it, the bar can only be drawn
 }
 
 function UnderlineContainer:getSize()
@@ -29,6 +31,62 @@ function UnderlineContainer:getSize()
         w = contentSize.w,
         h = contentSize.h + self.linesize + 2*self.padding
     }
+end
+
+--- The strip this container paints its line and focus bar into, in screen coordinates.
+--- Only after paintTo: dimen may be set from the outside, its coordinates are not.
+function UnderlineContainer:getFocusIndicatorRegion()
+    if not self._painted then return end
+    local line_x, line_width = self:_lineGeometry()
+    return Geom:new{
+        x = line_x,
+        y = self:_focusBarTop(self.dimen.y + self:getSize().h),
+        w = line_width,
+        h = self:_focusBarHeight() + self.linesize,
+    }
+end
+
+function UnderlineContainer:_lineGeometry()
+    local line_width = self.line_width or self.dimen.w
+    local line_x_offset = self.line_x_offset or 0
+    if BD.mirroredUILayout() then
+        return self.dimen.x + self.dimen.w - line_width - line_x_offset, line_width
+    end
+    return self.dimen.x + line_x_offset, line_width
+end
+
+-- The bar, without the line: together they occupy focus_linesize.
+function UnderlineContainer:_focusBarHeight()
+    if not self.focus_linesize then return 0 end
+    return math.max(self.focus_linesize - self.linesize, 0)
+end
+
+-- Right on top of our line, so dropping the bar leaves the line untouched.
+function UnderlineContainer:_focusBarTop(bottom)
+    return bottom - self.linesize - self:_focusBarHeight()
+end
+
+function UnderlineContainer:_paintFocusBar(bb, line_x, bottom, line_width)
+    local h = self:_focusBarHeight()
+    if h == 0 then return end
+    -- An unfocused bar is erased with the background: only a focus-only repaint asks
+    -- for that, a full repaint has the parent clearing the row for us.
+    local color = self.focused and self.color or self.background
+    if not color then return end
+    bb:paintRect(line_x, self:_focusBarTop(bottom), line_width, h, color)
+end
+
+--- Repaint the strip -- our line and the bar above it -- and nothing else of the widget.
+function UnderlineContainer:repaintFocusIndicator(bb)
+    if not self._painted then return false end
+    -- A bar of its own needs somewhere to go when unfocused; a line that merely changes
+    -- colour just gets repainted.
+    if self:_focusBarHeight() > 0 and not self.background then return false end
+    local line_x, line_width = self:_lineGeometry()
+    local bottom = self.dimen.y + self:getSize().h
+    self:_paintFocusBar(bb, line_x, bottom, line_width)
+    bb:paintRect(line_x, bottom - self.linesize, line_width, self.linesize, self.color)
+    return true
 end
 
 function UnderlineContainer:paintTo(bb, x, y)
@@ -43,11 +101,15 @@ function UnderlineContainer:paintTo(bb, x, y)
         self.dimen.x = x
         self.dimen.y = y
     end
+    self._painted = true
 
-    local line_width = self.line_width or self.dimen.w
-    local line_x = x
-    if BD.mirroredUILayout() then
-        line_x = line_x + self.dimen.w - line_width
+    local line_x, line_width = self:_lineGeometry()
+    local bottom = y + container_size.h
+
+    -- Erase a bar left over from a previous focus before the content goes in: the strip
+    -- has no room of its own, so clearing it afterwards would cut into what we just drew.
+    if not self.focused and self.background then
+        self:_paintFocusBar(bb, line_x, bottom, line_width)
     end
 
     local content_size = self[1]:getSize()
@@ -59,8 +121,10 @@ function UnderlineContainer:paintTo(bb, x, y)
     end
     self[1]:paintTo(bb, x, p_y)
     local linesize = self.focused and self.focus_linesize or self.linesize
-    bb:paintRect(line_x, y + container_size.h - linesize,
-        line_width, linesize, self.color)
+    bb:paintRect(line_x, bottom - linesize, line_width, linesize, self.color)
+    if self.focused then
+        self:_paintFocusBar(bb, line_x, bottom, line_width)
+    end
 end
 
 return UnderlineContainer

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -68,8 +68,7 @@ end
 function UnderlineContainer:_paintFocusBar(bb, line_x, bottom, line_width)
     local h = self:_focusBarHeight()
     if h == 0 then return end
-    -- Erasing only happens on a focus-only repaint; on a full repaint the parent has
-    -- already cleared the row for us.
+    -- Unfocused, the bar gets painted over with the background: that is what undraws it.
     local color = self.focused and self.color or self.background
     if not color then return end
     bb:paintRect(line_x, self:_focusBarTop(bottom), line_width, h, color)

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -21,7 +21,6 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
-    line_x_offset = nil, -- shifts the line right (left in RTL), to keep it clear of other content
     background = nil, -- what to clear the strip with; without it, the bar can only be drawn
 }
 
@@ -48,11 +47,10 @@ end
 
 function UnderlineContainer:_lineGeometry()
     local line_width = self.line_width or self.dimen.w
-    local line_x_offset = self.line_x_offset or 0
     if BD.mirroredUILayout() then
-        return self.dimen.x + self.dimen.w - line_width - line_x_offset, line_width
+        return self.dimen.x + self.dimen.w - line_width, line_width
     end
-    return self.dimen.x + line_x_offset, line_width
+    return self.dimen.x, line_width
 end
 
 -- The bar, without the line: together they occupy focus_linesize.

--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -13,8 +13,8 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local UnderlineContainer = WidgetContainer:extend{
     linesize = Size.line.thick,
     -- Line thickness while focused. The extra thickness (focus_linesize - linesize) is
-    -- the focus bar, painted just above the line and over the bottom of the content:
-    -- getSize only ever reserves linesize.
+    -- the focus bar: we paint it just above the line, over the bottom of the content,
+    -- as getSize only ever reserves linesize.
     focus_linesize = nil,
     focused = false,
     padding = Size.padding.tiny,
@@ -22,9 +22,9 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
-    -- The colour behind the focus bar, so it can be erased where it was painted.
-    -- Set it to whatever the parent clears that row with. Leaving it nil means this
-    -- container can only draw the bar, never undraw it, so repaintFocusIndicator declines.
+    -- The colour behind the focus bar, so we can erase it where we painted it.
+    -- Set it to whatever the parent clears that row with. Leaving it nil means we can
+    -- only draw the bar, never undraw it, so repaintFocusIndicator declines.
     background = nil,
 }
 
@@ -69,14 +69,14 @@ end
 function UnderlineContainer:_paintFocusBar(bb, line_x, bottom, line_width)
     local h = self:_focusBarHeight()
     if h == 0 then return end
-    -- Unfocused, the bar gets painted over with the background: that is what undraws it.
+    -- Unfocused, we paint the bar over with the background: that is what undraws it.
     local color = self.focused and self.color or self.background
     if not color then return end
     bb:paintRect(line_x, self:_focusBarTop(bottom), line_width, h, color)
 end
 
 --- Repaint the line and the focus bar above it, leaving the child content alone.
---- Returns false when this container cannot do that by itself.
+--- Returns false when we cannot do that by ourselves.
 function UnderlineContainer:repaintFocusIndicator(bb)
     if not self._painted then return false end
     -- Without a background we don't know what colour to paint the now-unfocused bar.

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -320,7 +320,7 @@ end
 
 --- Repaint after focus moved from one item to another.
 --- When both items can paint their focus indicator on their own, only those two
---- indicators are painted and refreshed; otherwise the parent is repainted as before.
+--- indicators are painted and refreshed; otherwise the parent repaints it all.
 --- A fast repaint does not count toward a flashing eink refresh.
 function FocusManager:_repaintFocusChange(prev_item, next_item)
     local parent = self.show_parent or self

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -319,8 +319,8 @@ local function canFastRepaint(item)
 end
 
 --- Repaint after focus moved from one item to another.
---- When both items can paint their focus indicator on their own, only those strips are
---- painted and refreshed; otherwise the parent is repainted as before.
+--- When both items can paint their focus indicator on their own, only those two
+--- indicators are painted and refreshed; otherwise the parent is repainted as before.
 --- A fast repaint does not count toward a flashing eink refresh.
 function FocusManager:_repaintFocusChange(prev_item, next_item)
     local parent = self.show_parent or self
@@ -335,7 +335,7 @@ function FocusManager:_repaintFocusChange(prev_item, next_item)
     end
     if prev_bar and next_bar
             and prev_item:repaintFocusIndicator(Screen.bb) and next_item:repaintFocusIndicator(Screen.bb) then
-        -- Refresh each strip on its own, so nothing between the two items is touched.
+        -- Refresh each one on its own, so nothing between the two items is touched.
         UIManager:setDirty(nil, "fast", prev_bar)
         UIManager:setDirty(nil, "fast", next_bar)
         return

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -324,7 +324,7 @@ end
 --- A fast repaint does not count toward a flashing eink refresh.
 function FocusManager:_repaintFocusChange(prev_item, next_item)
     local parent = self.show_parent or self
-    -- Painting outside UIManager's paint pass skips Screen:beforePaint(), which is
+    -- Painting outside UIManager's paint-pass skips Screen:beforePaint(), which is
     -- where forced HW rotation gets asserted; leave those screens the stock path.
     if not Screen.forced_rotation
             and canFastRepaint(prev_item) and canFastRepaint(next_item)

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -445,7 +445,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
                 if unfocused_item then
                     self:_repaintFocusChange(unfocused_item, target_item)
                 else
-                    -- We blasted the whole container above, so it all has to go out.
+                    -- No single item was unfocused, so there is nothing to narrow to.
                     UIManager:setDirty(self.show_parent or self, "fast")
                 end
             end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -324,21 +324,21 @@ end
 --- A fast repaint does not count toward a flashing eink refresh.
 function FocusManager:_repaintFocusChange(prev_item, next_item)
     local parent = self.show_parent or self
-    local prev_bar, next_bar
     -- Painting outside UIManager's paint pass skips Screen:beforePaint(), which is
     -- where forced HW rotation gets asserted; leave those screens the stock path.
     if not Screen.forced_rotation
             and canFastRepaint(prev_item) and canFastRepaint(next_item)
             and UIManager:getTopmostVisibleWidget() == parent then
-        prev_bar = prev_item:getFocusIndicatorRegion()
-        next_bar = next_item:getFocusIndicatorRegion()
-    end
-    if prev_bar and next_bar
-            and prev_item:repaintFocusIndicator(Screen.bb) and next_item:repaintFocusIndicator(Screen.bb) then
-        -- Refresh each one on its own, so nothing between the two items is touched.
-        UIManager:setDirty(nil, "fast", prev_bar)
-        UIManager:setDirty(nil, "fast", next_bar)
-        return
+        local prev_region = prev_item:getFocusIndicatorRegion()
+        local next_region = next_item:getFocusIndicatorRegion()
+        if prev_region and next_region
+                and prev_item:repaintFocusIndicator(Screen.bb)
+                and next_item:repaintFocusIndicator(Screen.bb) then
+            -- Refresh each one on its own, so nothing between the two items is touched.
+            UIManager:setDirty(nil, "fast", prev_region)
+            UIManager:setDirty(nil, "fast", next_region)
+            return
+        end
     end
     -- The widget has to be repainted whole. We don't narrow the refresh here: a focus
     -- border may grow outside the item's dimen (FrameContainer widens its own on focus),

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -319,8 +319,8 @@ local function canFastRepaint(item)
 end
 
 --- Repaint after focus moved from one item to another.
---- When both items can paint their focus indicator on their own, only those two
---- indicators are painted and refreshed; otherwise the parent repaints it all.
+--- When both items can paint their focus indicator on their own, we paint and refresh
+--- only those two indicators; otherwise we let the parent repaint it all.
 --- A fast repaint does not count toward a flashing eink refresh.
 function FocusManager:_repaintFocusChange(prev_item, next_item)
     local parent = self.show_parent or self
@@ -340,7 +340,7 @@ function FocusManager:_repaintFocusChange(prev_item, next_item)
             return
         end
     end
-    -- The widget has to be repainted whole. We don't narrow the refresh here: a focus
+    -- We have to repaint the widget whole. We don't narrow the refresh here: a focus
     -- border may grow outside the item's dimen (FrameContainer widens its own on focus),
     -- and we have no way to tell how far.
     UIManager:setDirty(parent, "fast")
@@ -445,7 +445,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
                 if unfocused_item then
                     self:_repaintFocusChange(unfocused_item, target_item)
                 else
-                    -- No single item was unfocused, so there is nothing to narrow to.
+                    -- We did not unfocus a single item, so there is nothing to narrow to.
                     UIManager:setDirty(self.show_parent or self, "fast")
                 end
             end

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -336,13 +336,10 @@ function FocusManager:_repaintFocusChange(prev_item, next_item)
         UIManager:setDirty(nil, "fast", next_bar)
         return
     end
-    -- The widget has to be repainted whole, but only the two items change: refresh the box
-    -- holding them both, and the whole thing when we don't know where one of them is.
-    local region
-    if prev_item.dimen and next_item.dimen then
-        region = prev_item.dimen:combine(next_item.dimen)
-    end
-    UIManager:setDirty(parent, "fast", region)
+    -- The widget has to be repainted whole. We don't narrow the refresh here: a focus
+    -- border may grow outside the item's dimen (FrameContainer widens its own on focus),
+    -- and we have no way to tell how far.
+    UIManager:setDirty(parent, "fast")
 end
 
 function FocusManager:onPhysicalKeyboardConnected()

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -313,6 +313,11 @@ function FocusManager:onFocusMove(args)
     return true
 end
 
+-- An item that knows where its focus indicator is, and can paint it on its own.
+local function canFastRepaint(item)
+    return item.getFocusIndicatorRegion and item.repaintFocusIndicator
+end
+
 --- Repaint after focus moved from one item to another.
 --- When both items can paint their focus indicator on their own, only those strips are
 --- painted and refreshed; otherwise the parent is repainted as before.
@@ -323,8 +328,7 @@ function FocusManager:_repaintFocusChange(prev_item, next_item)
     -- Painting outside UIManager's paint pass skips Screen:beforePaint(), which is
     -- where forced HW rotation gets asserted; leave those screens the stock path.
     if not Screen.forced_rotation
-            and prev_item.getFocusIndicatorRegion and next_item.getFocusIndicatorRegion
-            and prev_item.repaintFocusIndicator and next_item.repaintFocusIndicator
+            and canFastRepaint(prev_item) and canFastRepaint(next_item)
             and UIManager:getTopmostVisibleWidget() == parent then
         prev_bar = prev_item:getFocusIndicatorRegion()
         next_bar = next_item:getFocusIndicatorRegion()

--- a/frontend/ui/widget/focusmanager.lua
+++ b/frontend/ui/widget/focusmanager.lua
@@ -6,6 +6,7 @@ local UIManager = require("ui/uimanager")
 local bit = require("bit")
 local logger = require("logger")
 local util = require("util")
+local Screen = Device.screen
 --[[
 Wrapper Widget that manages focus for a whole dialog
 
@@ -302,16 +303,46 @@ function FocusManager:onFocusMove(args)
         if self.layout[self.selected.y][self.selected.x] ~= current_item
         or not self.layout[self.selected.y][self.selected.x].is_inactive then
             -- we found a different object to focus
+            local next_item = self.layout[self.selected.y][self.selected.x]
             current_item:handleEvent(Event:new("Unfocus"))
-            self.layout[self.selected.y][self.selected.x]:handleEvent(Event:new("Focus"))
-            -- Trigger a fast repaint, this does not count toward a flashing eink refresh
-            -- NOTE: Ideally, we'd only have to repaint the specific subwidget we're highlighting,
-            --       but we may not know its exact coordinates, so, redraw the parent widget instead.
-            UIManager:setDirty(self.show_parent or self, "fast")
+            next_item:handleEvent(Event:new("Focus"))
+            self:_repaintFocusChange(current_item, next_item)
             break
         end
     end
     return true
+end
+
+--- Repaint after focus moved from one item to another.
+--- When both items can paint their focus indicator on their own, only those strips are
+--- painted and refreshed; otherwise the parent is repainted as before.
+--- A fast repaint does not count toward a flashing eink refresh.
+function FocusManager:_repaintFocusChange(prev_item, next_item)
+    local parent = self.show_parent or self
+    local prev_bar, next_bar
+    -- Painting outside UIManager's paint pass skips Screen:beforePaint(), which is
+    -- where forced HW rotation gets asserted; leave those screens the stock path.
+    if not Screen.forced_rotation
+            and prev_item.getFocusIndicatorRegion and next_item.getFocusIndicatorRegion
+            and prev_item.repaintFocusIndicator and next_item.repaintFocusIndicator
+            and UIManager:getTopmostVisibleWidget() == parent then
+        prev_bar = prev_item:getFocusIndicatorRegion()
+        next_bar = next_item:getFocusIndicatorRegion()
+    end
+    if prev_bar and next_bar
+            and prev_item:repaintFocusIndicator(Screen.bb) and next_item:repaintFocusIndicator(Screen.bb) then
+        -- Refresh each strip on its own, so nothing between the two items is touched.
+        UIManager:setDirty(nil, "fast", prev_bar)
+        UIManager:setDirty(nil, "fast", next_bar)
+        return
+    end
+    -- The widget has to be repainted whole, but only the two items change: refresh the box
+    -- holding them both, and the whole thing when we don't know where one of them is.
+    local region
+    if prev_item.dimen and next_item.dimen then
+        region = prev_item.dimen:combine(next_item.dimen)
+    end
+    UIManager:setDirty(parent, "fast", region)
 end
 
 function FocusManager:onPhysicalKeyboardConnected()
@@ -380,6 +411,8 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
     if self.layout[y] then
         target_item = self.layout[y][x]
     end
+    -- The item we sent Unfocus to, when we could pin it down to a single one.
+    local unfocused_item
     if target_item then
         logger.dbg("FocusManager: Move focus position to:", x, ",", y)
         self.selected.x = x
@@ -398,6 +431,7 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
                 if current_item and current_item ~= target_item then
                     -- This is the absolute best-case scenario, when self.layout's integrity is sound
                     current_item:handleEvent(Event:new("Unfocus"))
+                    unfocused_item = current_item
                 else
                     -- Couldn't find the current item, or it matches the target_item: blast the whole widget container,
                     -- just in case we still have a different, older widget visually focused.
@@ -407,7 +441,12 @@ function FocusManager:moveFocusTo(x, y, focus_flags)
             end
             if bit.band(focus_flags, FocusManager.NOT_FOCUS) ~= FocusManager.NOT_FOCUS then
                 target_item:handleEvent(Event:new("Focus"))
-                UIManager:setDirty(self.show_parent or self, "fast")
+                if unfocused_item then
+                    self:_repaintFocusChange(unfocused_item, target_item)
+                else
+                    -- We blasted the whole container above, so it all has to go out.
+                    UIManager:setDirty(self.show_parent or self, "fast")
+                end
             end
         end
         return true

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -426,7 +426,9 @@ function MenuItem:init()
         color = self.line_color,
         linesize = self.linesize,
         focus_linesize = Size.line.focus_indicator,
-        background = self.text_bgcolor or Blitbuffer.COLOR_WHITE,
+        -- A row with a coloured patch behind its text has no single background to clear
+        -- the focus strip with, so it keeps the stock repaint.
+        background = not self.text_bgcolor and Blitbuffer.COLOR_WHITE or nil,
         vertical_align = "center",
         padding = 0,
         dimen = Geom:new{

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -426,6 +426,7 @@ function MenuItem:init()
         color = self.line_color,
         linesize = self.linesize,
         focus_linesize = Size.line.focus_indicator,
+        background = self.text_bgcolor or Blitbuffer.COLOR_WHITE,
         vertical_align = "center",
         padding = 0,
         dimen = Geom:new{
@@ -485,6 +486,14 @@ function MenuItem:getDotsText(face)
         }
     end
     return _dots_cached_info.text, _dots_cached_info.min_width
+end
+
+function MenuItem:getFocusIndicatorRegion()
+    return self._underline_container and self._underline_container:getFocusIndicatorRegion()
+end
+
+function MenuItem:repaintFocusIndicator(bb)
+    return self._underline_container and self._underline_container:repaintFocusIndicator(bb)
 end
 
 function MenuItem:onFocus()

--- a/frontend/ui/widget/menu.lua
+++ b/frontend/ui/widget/menu.lua
@@ -426,8 +426,9 @@ function MenuItem:init()
         color = self.line_color,
         linesize = self.linesize,
         focus_linesize = Size.line.focus_indicator,
-        -- A row with a coloured patch behind its text has no single background to clear
-        -- the focus strip with, so it keeps the stock repaint.
+        -- With text_bgcolor the row has a coloured frame behind its text only, so no
+        -- single colour erases the focus bar over the whole width; without background
+        -- set, such a row falls back to the stock full repaint.
         background = not self.text_bgcolor and Blitbuffer.COLOR_WHITE or nil,
         vertical_align = "center",
         padding = 0,

--- a/frontend/ui/widget/touchmenu.lua
+++ b/frontend/ui/widget/touchmenu.lua
@@ -148,6 +148,7 @@ function TouchMenuItem:init()
     self._underline_container = UnderlineContainer:new{
         vertical_align = "center",
         focus_linesize = Size.line.focus_indicator,
+        background = Blitbuffer.COLOR_WHITE,
         dimen = self.dimen:copy(),
         line_width = self.item_frame:getSize().w, -- we'll draw a shorter line
         self.item_frame,
@@ -157,6 +158,14 @@ function TouchMenuItem:init()
     function self:isEnabled()
         return item_enabled ~= false and true
     end
+end
+
+function TouchMenuItem:getFocusIndicatorRegion()
+    return self._underline_container and self._underline_container:getFocusIndicatorRegion()
+end
+
+function TouchMenuItem:repaintFocusIndicator(bb)
+    return self._underline_container and self._underline_container:repaintFocusIndicator(bb)
 end
 
 function TouchMenuItem:onFocus()


### PR DESCRIPTION
A focus move repaints the whole parent widget and refreshes the whole screen. On slow eink that is the dominant cost: on a Kindle 3 a cursor step in a menu is one 600x800 ioctl of 110 ms plus a 568-802 ms paint pass.

A widget can now report the strip its focus indicator lives in and repaint just that. UnderlineContainer reports the rect it draws its line and focus bar into and can repaint it on its own; MenuItem and TouchMenuItem forward both methods. FocusManager uses them when available and refreshes the two strips separately, so nothing between the items is touched. Everything else keeps the stock path, unbounded refresh included: a focus border may grow outside the item's dimen, and there are no dependable bounds for that here.

The same is wired into moveFocusTo, but only when Unfocus went to one specific item; the "blast the whole container" branch is untouched.

A row with a bookmark colour paints that colour behind its text only, at most as wide as the text column, so it has no single background to clear the strip with; those rows stay on the stock path.

Measured on a Kindle 3 with a probe wrapping setDirty, _repaint and refreshPartialImp. Of 49 repaint blocks, 39 were cursor steps on the narrow path: two ioctls totalling 42.7 ms, 45.1 ms per step, against 84-91 ms of ioctl plus 246-284 ms of paint on the stock path in the same session. No artefacts.

Supersedes #15782: that one narrows the refresh, this narrows both the refresh and the paint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15897)
<!-- Reviewable:end -->
