### PR TITLE
[FootnoteWidget]: NT use buttons to move to prev/next footnote

### DIFF
--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1611,6 +1611,15 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
             end
             self._footnote_popup_discard_previous_close_callback = nil
         end,
+        navigate_footnote_callback = function(direction)
+            UIManager:close(popup)
+            if direction == "next" then
+                self:onSelectNextPageLink()
+            else
+                self:onSelectPrevPageLink()
+            end
+            self:onGotoSelectedPageLink()
+        end,
         dialog = self.dialog,
     }
     UIManager:show(popup)

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1613,7 +1613,7 @@ function ReaderLink:showAsFootnotePopup(link, neglect_current_location)
         end,
         navigate_footnote_callback = function(direction)
             UIManager:close(popup)
-            if direction == "next" then
+            if direction > 0 then
                 self:onSelectNextPageLink()
             else
                 self:onSelectPrevPageLink()

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -417,13 +417,13 @@ end
 
 function FootnoteWidget:onNextFootnote()
     if not self.navigate_footnote_callback then return false end
-    self.navigate_footnote_callback("next")
+    self.navigate_footnote_callback(1)
     return true
 end
 
 function FootnoteWidget:onPrevFootnote()
     if not self.navigate_footnote_callback then return false end
-    self.navigate_footnote_callback("prev")
+    self.navigate_footnote_callback(-1)
     return true
 end
 

--- a/frontend/ui/widget/footnotewidget.lua
+++ b/frontend/ui/widget/footnotewidget.lua
@@ -134,6 +134,7 @@ local FootnoteWidget = InputContainer:extend{
     follow_callback = nil,
     on_tap_close_callback = nil,
     close_callback = nil,
+    navigate_footnote_callback = nil,
     dialog = nil,
     covers_footer = true,
 }
@@ -203,10 +204,13 @@ function FootnoteWidget:init()
         }
     end
     if Device:hasKeys() then
-        self.key_events = {
-            Close = { { Device.input.group.Back } },
-            Follow = { { "Press" } },
-        }
+        self.key_events.Close = { { Device.input.group.Back } }
+        self.key_events.Follow = { { "Press" } }
+        if Device:hasScreenKB() or Device:hasKeyboard() then
+            local modifier = Device:hasScreenKB() and "ScreenKB" or "Shift"
+            self.key_events.NextFootnote = { { modifier, Device.input.group.PgFwd  } }
+            self.key_events.PrevFootnote = { { modifier, Device.input.group.PgBack } }
+        end
     end
 
     -- Workaround bugs in MuPDF:
@@ -409,6 +413,18 @@ function FootnoteWidget:onFollow()
         end
         return self.follow_callback()
     end
+end
+
+function FootnoteWidget:onNextFootnote()
+    if not self.navigate_footnote_callback then return false end
+    self.navigate_footnote_callback("next")
+    return true
+end
+
+function FootnoteWidget:onPrevFootnote()
+    if not self.navigate_footnote_callback then return false end
+    self.navigate_footnote_callback("prev")
+    return true
 end
 
 function FootnoteWidget:onTapClose(arg, ges)


### PR DESCRIPTION
### what's new

* Added a `navigate_footnote_callback` to the `FootnoteWidget` and passed it from `ReaderLink:showAsFootnotePopup`, enabling the widget to notify when the user wants to navigate to the next or previous footnote. 
* Introduced shortcuts for navigating to the next and previous footnotes (`NextFootnote` and `PrevFootnote`).
* Implemented `onNextFootnote` and `onPrevFootnote` methods in `FootnoteWidget` to handle these navigation events and trigger the callback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15911)
<!-- Reviewable:end -->
