### PR TITLE
Kindle: DRY orientation init code

### DIFF
--- a/frontend/device/kindle/device.lua
+++ b/frontend/device/kindle/device.lua
@@ -384,6 +384,86 @@ local function frameworkStopped()
     end
 end
 
+local function reOrientOasis(attribute)
+    -- temporarily wake up awesome
+    if os.getenv("AWESOME_STOPPED") == "yes" then
+        os.execute("killall -CONT awesome")
+    end
+
+    --- @note When starting KOReader with the device upside down ("D"), touch input is registered wrong
+    --        (i.e., probably upside down).
+    --        If it's started upright ("U"), everything's okay, and turning it upside down after that works just fine.
+    --        See #2206 & #2209 for the original KOA implementation, which obviously doesn't quite cut it here...
+    --        See also <https://www.mobileread.com/forums/showthread.php?t=298302&page=5>
+    --        See also #11159 for details about the solution (Kindle Scribe as an example)
+    --        In regular mode, awesome is woken up for a brief moment for lipc calls.
+    --        In no-framework mode, this works as is.
+    -- NOTE: It'd take some effort to actually start KOReader while in a LANDSCAPE orientation,
+    --       since they're only exposed inside the stock reader, and not the Home/KUAL Booklets.
+    local haslipc, lipc = pcall(require, "liblipclua")
+    if haslipc then
+        local lipc_handle = lipc.init("com.github.koreader.screen")
+        if lipc_handle then
+            local orientation_code = lipc_handle:get_string_property("com.lab126.winmgr", attribute)
+            logger.dbg("orientation_code =", orientation_code)
+            local rotation_mode = 0
+            if orientation_code then
+                if orientation_code == "U" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
+                elseif orientation_code == "R" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_CLOCKWISE
+                elseif orientation_code == "D" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
+                elseif orientation_code == "L" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE
+                end
+            end
+            if rotation_mode > 0 then
+                self.screen.native_rotation_mode = rotation_mode
+            end
+            self.screen:setRotationMode(rotation_mode)
+            lipc_handle:close()
+        end
+    end
+    -- put awesome back to sleep
+    if os.getenv("AWESOME_STOPPED") == "yes" then
+        os.execute("killall -STOP awesome")
+    end
+end
+
+local function reOrientScribe(attribute)
+    -- temporarily wake up awesome
+    if os.getenv("AWESOME_STOPPED") == "yes" then
+        os.execute("killall -CONT awesome")
+    end
+
+    local haslipc, lipc = pcall(require, "liblipclua")
+    if haslipc then
+        local lipc_handle = lipc.init("com.github.koreader.screen")
+        if lipc_handle then
+            local orientation_code = lipc_handle:get_string_property("com.lab126.winmgr", attribute)
+            logger.dbg("orientation_code =", orientation_code)
+            local rotation_mode = 0
+            if orientation_code then
+                if orientation_code == "U" or orientation_code == "L" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
+                elseif orientation_code == "D" or orientation_code == "R" then
+                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
+                end
+            end
+            if rotation_mode > 0 then
+                self.screen.native_rotation_mode = rotation_mode
+            end
+            self.screen:setRotationMode(rotation_mode)
+            lipc_handle:close()
+        end
+    end
+    -- put awesome back to sleep
+    if os.getenv("AWESOME_STOPPED") == "yes" then
+        os.execute("killall -STOP awesome")
+    end
+end
+
 local Kindle = Generic:extend{
     model = "Kindle",
     isKindle = yes,
@@ -1465,11 +1545,6 @@ local function OasisGyroTranslation(this, ev)
 end
 
 function KindleOasis:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1493,37 +1568,7 @@ function KindleOasis:init()
 
     Kindle.init(self)
 
-    --- @note See comments in KindleOasis2:init() for details.
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_CLOCKWISE
-                elseif orientation_code == "D" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                elseif orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientOasis("accelerometer")
 
     self.input:registerEventAdjustHook(OasisGyroTranslation)
     self.input.handleMiscEv = function(this, ev)
@@ -1571,11 +1616,6 @@ local function KindleGyroTransform(this, ev)
 end
 
 function KindleOasis2:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1597,46 +1637,7 @@ function KindleOasis2:init()
 
     Kindle.init(self)
 
-    --- @note When starting KOReader with the device upside down ("D"), touch input is registered wrong
-    --        (i.e., probably upside down).
-    --        If it's started upright ("U"), everything's okay, and turning it upside down after that works just fine.
-    --        See #2206 & #2209 for the original KOA implementation, which obviously doesn't quite cut it here...
-    --        See also <https://www.mobileread.com/forums/showthread.php?t=298302&page=5>
-    --        See also #11159 for details about the solution (Kindle Scribe as an example)
-    --        In regular mode, awesome is woken up for a brief moment for lipc calls.
-    --        In no-framework mode, this works as is.
-    -- NOTE: It'd take some effort to actually start KOReader while in a LANDSCAPE orientation,
-    --       since they're only exposed inside the stock reader, and not the Home/KUAL Booklets.
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_CLOCKWISE
-                elseif orientation_code == "D" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                elseif orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientOasis("accelerometer")
 
     self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
@@ -1647,11 +1648,6 @@ function KindleOasis2:init()
 end
 
 function KindleOasis3:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1674,37 +1670,7 @@ function KindleOasis3:init()
 
     Kindle.init(self)
 
-    --- @note The same quirks as on the Oasis 2 apply ;).
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_CLOCKWISE
-                elseif orientation_code == "D" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                elseif orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_COUNTER_CLOCKWISE
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientOasis("accelerometer")
 
     self.input:registerEventAdjustHook(KindleGyroTransform)
     self.input.handleMiscEv = function(this, ev)
@@ -1835,11 +1801,6 @@ function KindleBasic5:init()
 end
 
 function KindleScribe:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1856,33 +1817,7 @@ function KindleScribe:init()
 
     Kindle.init(self)
 
-    --- @note The same quirks as on the Oasis 2 and 3 apply ;).
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" or orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "D" or orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientScribe("accelerometer")
 
     -- Setup accelerometer rotation input
     self.input:registerEventAdjustHook(KindleGyroTransform)
@@ -1897,11 +1832,6 @@ function KindleScribe:init()
 end
 
 function KindleScribe3:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1918,34 +1848,7 @@ function KindleScribe3:init()
 
     Kindle.init(self)
 
-    --- @note The same quirks as on the Oasis 2 and 3 apply ;).
-    --- @note This is an assumption carried over from the KS(2) -HD
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" or orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "D" or orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientScribe("accelerometer")
 
     -- Setup accelerometer rotation input
     self.input:registerEventAdjustHook(KindleGyroTransform)
@@ -1960,11 +1863,6 @@ function KindleScribe3:init()
 end
 
 function KindleScribeColorSoft:init()
-    -- temporarily wake up awesome
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -CONT awesome")
-    end
-
     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
     self.powerd = require("device/kindle/powerd"):new{
         device = self,
@@ -1981,34 +1879,7 @@ function KindleScribeColorSoft:init()
 
     Kindle.init(self)
 
-    --- @note The same quirks as on the Oasis 2 and 3 apply ;).
-    --- @note This is an assumption carried over from the KS(2) -HD
-    local haslipc, lipc = pcall(require, "liblipclua")
-    if haslipc then
-        local lipc_handle = lipc.init("com.github.koreader.screen")
-        if lipc_handle then
-            local orientation_code = lipc_handle:get_string_property(
-                "com.lab126.winmgr", "accelerometer")
-            logger.dbg("orientation_code =", orientation_code)
-            local rotation_mode = 0
-            if orientation_code then
-                if orientation_code == "U" or orientation_code == "L" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPRIGHT
-                elseif orientation_code == "D" or orientation_code == "R" then
-                    rotation_mode = self.screen.DEVICE_ROTATED_UPSIDE_DOWN
-                end
-            end
-            if rotation_mode > 0 then
-                self.screen.native_rotation_mode = rotation_mode
-            end
-            self.screen:setRotationMode(rotation_mode)
-            lipc_handle:close()
-        end
-    end
-    -- put awesome back to sleep
-    if os.getenv("AWESOME_STOPPED") == "yes" then
-        os.execute("killall -STOP awesome")
-    end
+    reOrientScribe("accelerometer")
 
     -- Setup accelerometer rotation input
     self.input:registerEventAdjustHook(KindleGyroTransform)


### PR DESCRIPTION
#15858
try putting 
`reOrientOasis("orientation")`
or
`reOrientScribe("orientation")`
in your device init code
and see if it solves the issue.
If yes we can add it in with a version gate.

Not tested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15934)
<!-- Reviewable:end -->
