### PR TITLE
Status bar: honor stable pages and hidden flows

### DIFF
--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -241,55 +241,67 @@ footerTextGeneratorMap = {
         end
     end,
     page_progress = function(footer)
-        if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
-            -- (Page labels might not be numbers)
-            return ("%s / %s"):format(footer.ui.pagemap:getCurrentPageLabel(true),
-                                      footer.ui.pagemap:getLastPageLabel(true))
-        elseif footer.ui.document:hasHiddenFlows() then
-            -- i.e., if we are hiding non-linear fragments and there's anything to hide,
+        local page_label = footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels()
+            and footer.ui.pagemap:getCurrentPageLabel(true)
+        if footer.ui.document:hasHiddenFlows() then
             local flow = footer.ui.document:getPageFlow(footer.pageno)
             local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
             local pages = footer.ui.document:getTotalPagesInFlow(flow)
             if flow == 0 then
+                if page_label then
+                    local last_page = footer.ui.document:getLastLinearPage()
+                    local last_page_label = footer.ui.pagemap:getPageLastLabel(last_page)
+                    return ("{%s / %s} %d // %d"):format(page_label, last_page_label, page, pages)
+                end
                 return ("%d // %d"):format(page, pages)
             else
+                if page_label then
+                    local first_page = footer.ui.document:getFirstPageInFlow(flow)
+                    local last_page_label = footer.ui.pagemap:getPageLastLabel(first_page + pages - 1)
+                    return ("{%s / %s} [%d / %d]%d"):format(page_label, last_page_label, page, pages, flow)
+                end
                 return ("[%d / %d]%d"):format(page, pages, flow)
             end
         else
+            if page_label then
+                return ("{%s / %s} %d / %d"):format(page_label, footer.ui.pagemap:getLastPageLabel(true),
+                    footer.pageno, footer.pages)
+            end
             return ("%d / %d"):format(footer.pageno, footer.pages)
         end
     end,
     pages_left_book = function(footer)
         local symbol_type = footer.settings.item_prefix
         local prefix = symbol_prefix[symbol_type].pages_left_book
-        if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
-            -- (Page labels might not be numbers)
-            local label, idx, count = footer.ui.pagemap:getCurrentPageLabel(false) -- luacheck: no unused
-            local remaining = count - idx
-            if footer.settings.pages_left_includes_current_page then
-                remaining = remaining + 1
-            end
-            return ("%s %s / %s"):format(prefix, remaining, footer.ui.pagemap:getLastPageLabel(true))
-        elseif footer.ui.document:hasHiddenFlows() then
-            -- i.e., if we are hiding non-linear fragments and there's anything to hide,
+        local curr = footer.settings.pages_left_includes_current_page and 1 or 0
+        if footer.ui.document:hasHiddenFlows() then
             local flow = footer.ui.document:getPageFlow(footer.pageno)
             local page = footer.ui.document:getPageNumberInFlow(footer.pageno)
             local pages = footer.ui.document:getTotalPagesInFlow(flow)
-            local remaining = pages - page
-            if footer.settings.pages_left_includes_current_page then
-                remaining = remaining + 1
-            end
+            local page_label_idx = footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels()
+                and select(2, footer.ui.pagemap:getCurrentPageLabel())
             if flow == 0 then
-                return ("%s %d // %d"):format(prefix, remaining, pages)
+                if page_label_idx then
+                    local last_page = footer.ui.document:getLastLinearPage()
+                    local _, last_page_label_idx = footer.ui.pagemap:getPageLastLabel(last_page)
+                    return ("%s {%d / %d}"):format(prefix, last_page_label_idx - page_label_idx + curr, last_page_label_idx)
+                end
+                return ("%s %d // %d"):format(prefix, pages - page + curr, pages)
             else
-                return ("%s [%d / %d]%d"):format(prefix, remaining, pages, flow)
+                if page_label_idx then
+                    local first_page = footer.ui.document:getFirstPageInFlow(flow)
+                    local _, last_page_label_idx = footer.ui.pagemap:getPageLastLabel(first_page + pages - 1)
+                    return ("%s {[%d / %d]%d}"):format(prefix, last_page_label_idx - page_label_idx + curr, last_page_label_idx, flow)
+                end
+                return ("%s [%d / %d]%d"):format(prefix, pages - page + curr, pages, flow)
             end
         else
-            local remaining = footer.pages - footer.pageno
-            if footer.settings.pages_left_includes_current_page then
-                remaining = remaining + 1
+            if footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
+                local _, idx, count = footer.ui.pagemap:getCurrentPageLabel()
+                return ("%s {%d / %s}"):format(prefix, count - idx + curr, footer.ui.pagemap:getLastPageLabel(true))
+            else
+                return ("%s %d / %d"):format(prefix, footer.pages - footer.pageno + curr, footer.pages)
             end
-            return ("%s %d / %d"):format(prefix, remaining, footer.pages)
         end
     end,
     pages_left = function(footer)

--- a/frontend/apps/reader/modules/readerhandmade.lua
+++ b/frontend/apps/reader/modules/readerhandmade.lua
@@ -651,7 +651,7 @@ function ReaderHandMade:updateDocFlows()
             first_linear_page = flow[1] + flow[2]
         end
         flow = flows[#flows]
-        if flow[1] + flow[2] == nb_pages then -- book last page is in a hidden flow
+        if flow[1] + flow[2] - 1 == nb_pages then -- book last page is in a hidden flow
             last_linear_page = flow[1] - 1
         end
     end

--- a/frontend/apps/reader/modules/readerpagemap.lua
+++ b/frontend/apps/reader/modules/readerpagemap.lua
@@ -381,6 +381,25 @@ function ReaderPageMap:getPageLabelProps(page_label)
     end
 end
 
+function ReaderPageMap:getPageLastLabel(page)
+    -- for the cases when the page contains several labels
+    -- or top of the page belongs to the previous label
+    local labels_nb = self:getPageLabelProps() -- ensure cache and backup the array sole entry
+    self.page_labels_cache[1] = nil -- hash table only for pairs
+    local last_label_idx = 0
+    local last_label
+    for label, label_prop in pairs(self.page_labels_cache) do
+        if page == label_prop[2] and last_label_idx < label_prop[1] then
+            last_label_idx = label_prop[1]
+            last_label = label
+        end
+    end
+    self.page_labels_cache[1] = labels_nb -- restore
+    -- if there is no label in the page (no cache entry for this page), use page xpointer
+    last_label = last_label or self:getXPointerPageLabel(self.ui.document:getPageXPointer(page), true)
+    return last_label, self.page_labels_cache[last_label][1] -- index
+end
+
 function ReaderPageMap:onDocumentRerendered()
     self.page_labels_cache = nil
 end


### PR DESCRIPTION
Discussed in
- #15171 
- #15882

-----

Honor stable pages and hidden flows in status bar indicators: "Page progress", "Pages left in book".
If stable pages enabled, "Page progress" shows them together with the screen pages.
Curly brackets mean stable pages.

For example, the book of 180 screen pages. 
2 custom hidden flows: screen pages 7-9 and 177-180.
Synthetic 1500 cpp produces 117 stable pages.

-----

(1) Stable pages disabled, hidden flows disabled
<img width="500" height="18" alt="1" src="https://github.com/user-attachments/assets/6d56e589-8af5-43bb-9eef-a856cfe24e23" />

-----

(2) Stable pages enabled, hidden flows disabled
<img width="500" height="18" alt="2" src="https://github.com/user-attachments/assets/cde50292-6e3b-44cb-8f52-10cf7d124386" />

-----

(3) Stable pages disabled, hidden flows enabled, linear flow
<img width="500" height="18" alt="3" src="https://github.com/user-attachments/assets/b4261f9b-777c-4d99-99b4-d18c222cc622" />

-----

(4) Stable pages enabled, hidden flows enabled, linear flow (114 means the last stable page of the linear flow)
<img width="500" height="18" alt="4" src="https://github.com/user-attachments/assets/e862dd65-ecc2-4ad3-a732-b12b5516d5b1" />

-----

(5) Stable pages disabled, hidden flows enabled, hidden flow
<img width="500" height="18" alt="5" src="https://github.com/user-attachments/assets/2d000f94-2fa4-4a65-9023-795fba33c4fd" />

-----

(6) Stable pages enabled, hidden flows enabled, hidden flow (117 means the last stable page of the hidden flow)
<img width="500" height="18" alt="6" src="https://github.com/user-attachments/assets/73963ad4-3f20-4eaf-bfb0-da5ccc6bdba5" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15936)
<!-- Reviewable:end -->
