### PR TITLE
Wikipedia language selection based on the keyboard layout I use

### DIFF
--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -44,6 +44,9 @@ end
 -- end
 
 local function getKeyboardLayoutLanguage()
+    if not G_reader_settings:isTrue("wikipedia_use_keyboard_language") then
+        return nil
+    end
     local VirtualKeyboard = require("ui/widget/virtualkeyboard")
     local layout = VirtualKeyboard.getKeyboardLayout()
     if not layout or layout == "" then
@@ -199,6 +202,19 @@ function ReaderWikipedia:addToMainMenu(menu_items)
                     }
                     UIManager:show(wikilang_input)
                     wikilang_input:onShowKeyboard()
+                end,
+            },
+            {
+                text = ("Use virtual keyboard language"),
+                help_text = _([[
+When looking up a word or phrase typed with the virtual keyboard, search the Wikipedia of the current keyboard layout's language instead of your first Wikipedia language.
+
+This has no effect on lookups from text selection or from the Wikipedia history.]]),
+                checked_func = function()
+                    return G_reader_settings:isTrue("wikipedia_use_keyboard_language")
+                end,
+                callback = function()
+                    G_reader_settings:flipTrue("wikipedia_use_keyboard_language")
                 end,
                 separator = true,
             },

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -208,7 +208,7 @@ function ReaderWikipedia:addToMainMenu(menu_items)
             {
                 text = ("Use virtual keyboard language"),
                 help_text = _([[
-When looking up a word or phrase typed with the virtual keyboard, search the Wikipedia of the current keyboard layout's language instead of your first Wikipedia language.
+When looking up a word or phrase, search in the Wikipedia edition matching the current keyboard layout language.
 
 This has no effect on lookups from text selection or from the Wikipedia history.]]),
                 checked_func = function()

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -43,7 +43,7 @@ end
 --     onShowWikipediaLookup = { { "Alt", "W" }, { "Ctrl", "W" } }
 -- end
 
-function getKeyboardLayoutLanguage()
+local function getKeyboardLayoutLanguage()
     local VirtualKeyboard = require("ui/widget/virtualkeyboard")
     local layout = VirtualKeyboard.getKeyboardLayout()
     if not layout or layout == "" then

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -43,6 +43,15 @@ end
 --     onShowWikipediaLookup = { { "Alt", "W" }, { "Ctrl", "W" } }
 -- end
 
+function getKeyboardLayoutLanguage()
+    local VirtualKeyboard = require("ui/widget/virtualkeyboard")
+    local layout = VirtualKeyboard.getKeyboardLayout()
+    if not layout or layout == "" then
+        return nil
+    end
+    return layout:match("^[^_-]+")
+end
+
 function ReaderWikipedia:lookupInput()
     self.input_dialog = InputDialog:new{
         title = _("Enter a word or phrase to look up"),
@@ -64,7 +73,7 @@ function ReaderWikipedia:lookupInput()
                         if self.input_dialog:getInputText() == "" then return end
                         UIManager:close(self.input_dialog)
                         -- Trust that input text does not need any cleaning (allows querying for "-suffix")
-                        self:onLookupWikipedia(self.input_dialog:getInputText(), true)
+                        self:onLookupWikipedia(self.input_dialog:getInputText(), true, nil, nil, getKeyboardLayoutLanguage())
                     end,
                 },
             }

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -72,7 +72,7 @@ function ReaderWikipedia:lookupInput()
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
                         UIManager:close(self.input_dialog)
-                        local kb_lang = nil
+                        local kb_lang
                         if G_reader_settings:isTrue("wikipedia_use_keyboard_language") then
                             kb_lang = getKeyboardLayoutLanguage()
                         end

--- a/frontend/apps/reader/modules/readerwikipedia.lua
+++ b/frontend/apps/reader/modules/readerwikipedia.lua
@@ -44,9 +44,6 @@ end
 -- end
 
 local function getKeyboardLayoutLanguage()
-    if not G_reader_settings:isTrue("wikipedia_use_keyboard_language") then
-        return nil
-    end
     local VirtualKeyboard = require("ui/widget/virtualkeyboard")
     local layout = VirtualKeyboard.getKeyboardLayout()
     if not layout or layout == "" then
@@ -75,8 +72,12 @@ function ReaderWikipedia:lookupInput()
                     callback = function()
                         if self.input_dialog:getInputText() == "" then return end
                         UIManager:close(self.input_dialog)
+                        local kb_lang = nil
+                        if G_reader_settings:isTrue("wikipedia_use_keyboard_language") then
+                            kb_lang = getKeyboardLayoutLanguage()
+                        end
                         -- Trust that input text does not need any cleaning (allows querying for "-suffix")
-                        self:onLookupWikipedia(self.input_dialog:getInputText(), true, nil, nil, getKeyboardLayoutLanguage())
+                        self:onLookupWikipedia(self.input_dialog:getInputText(), true, nil, nil, kb_lang)
                     end,
                 },
             }


### PR DESCRIPTION
### Problem
I am using multiple keyboard layouts and the default Wikipedia search language is English (en), unless I add more languages in the settings. So the wiki search order depends on how i place my language codes. For example: "bn en" will try to fetch for "bn" first even if I type my word in English. It will be really handy if there is a direct search based on the keyboard layout that i am using.

### Proposal
Since koreader supports multi-language keyboard layouts, the solution is to get the layout language using the `VirtualKeyboard.getKeyboardLayout()` function and pass it on to `ReaderWikipedia:onLookupWikipedia(...)`. With the `nil` checks in place, none of the existing flow breaks. I have already tested this in my local device (arm64) and the emulator.

Open to any other changes/suggestions related to this small change. 

Also i could not find any open issues to link this PR with. Any guide here will be of much help

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15937)
<!-- Reviewable:end -->
