### PR TITLE
filemanagerfilesearcher: plain text default + opt-in Lua patterns checkbox

### DIFF
--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -21,6 +21,7 @@ local T = require("ffi/util").template
 local FileSearcher = InputContainer:extend{
     case_sensitive = false,
     include_subfolders = true,
+    use_patterns = false,
     include_metadata = false,
 }
 
@@ -44,8 +45,11 @@ function FileSearcher:addToMainMenu(menu_items)
         text = _("File search"),
         help_text = _([[Search a book by filename in the current or home folder and its subfolders.
 
-Wildcards for one '?' or more '*' characters can be used.
-A search for '*' will show all files.
+The query is matched as plain text, except that a search
+for '*' will show all files.
+
+Check 'Use Lua patterns' for advanced matching with Lua patterns
+(%d, [a-z], ^, …), where '*' and '?' act as wildcards.
 
 The sorting order is the same as in filemanager.
 
@@ -63,7 +67,7 @@ Tap a book in the search results to open it.]]),
 end
 
 function FileSearcher:onShowFileSearch(search_string)
-    local search_dialog, check_button_case, check_button_subfolders, check_button_metadata
+    local search_dialog, check_button_case, check_button_subfolders, check_button_patterns, check_button_metadata
     local function _doSearch()
         local search_str = search_dialog:getInputText()
         if search_str == "" then return end
@@ -71,6 +75,7 @@ function FileSearcher:onShowFileSearch(search_string)
         UIManager:close(search_dialog)
         self.case_sensitive = check_button_case.checked
         self.include_subfolders = check_button_subfolders.checked
+        self.use_patterns = check_button_patterns.checked
         self.include_metadata = check_button_metadata and check_button_metadata.checked
         local Trapper = require("ui/trapper")
         Trapper:wrap(function()
@@ -120,6 +125,12 @@ function FileSearcher:onShowFileSearch(search_string)
         parent = search_dialog,
     }
     search_dialog:addWidget(check_button_subfolders)
+    check_button_patterns = CheckButton:new{
+        text = _("Use Lua patterns"),
+        checked = self.use_patterns,
+        parent = search_dialog,
+    }
+    search_dialog:addWidget(check_button_patterns)
     if self.ui.coverbrowser then
         check_button_metadata = CheckButton:new{
             text = _("Also search in book metadata"),
@@ -135,14 +146,17 @@ end
 
 function FileSearcher:doSearch()
     local search_hash = FileSearcher.search_path .. (FileSearcher.search_string or "") ..
-        tostring(self.case_sensitive) .. tostring(self.include_subfolders) .. tostring(self.include_metadata)
+        tostring(self.case_sensitive) .. tostring(self.include_subfolders) ..
+        tostring(self.use_patterns) .. tostring(self.include_metadata)
     local not_cached = FileSearcher.search_hash ~= search_hash
+    local invalid_pattern
     if not_cached then
         local Trapper = require("ui/trapper")
         local info = InfoMessage:new{ text = _("Searching… (tap to cancel)") }
         UIManager:show(info)
         UIManager:forceRePaint()
-        local completed, dirs, files, no_metadata_count = Trapper:dismissableRunInSubprocess(function()
+        local completed, dirs, files, no_metadata_count
+        completed, dirs, files, no_metadata_count, invalid_pattern = Trapper:dismissableRunInSubprocess(function()
             return self:getList()
         end, info)
         if not completed then return end
@@ -165,12 +179,13 @@ function FileSearcher:doSearch()
     if #FileSearcher.search_results > 0 then
         self:onShowSearchResults(not_cached)
     else
-        self:showSearchResultsMessage(true)
+        self:showSearchResultsMessage(true, not_cached and invalid_pattern)
     end
 end
 
 function FileSearcher:getList()
     self.no_metadata_count = 0 -- will be updated in doSearch() with result from subprocess
+    self.invalid_pattern = false
     local sys_folders = { -- do not search in sys_folders
         ["/dev"] = true,
         ["/proc"] = true,
@@ -182,12 +197,19 @@ function FileSearcher:getList()
         if not self.case_sensitive then
             search_string = util.stringLower(search_string)
         end
-        -- replace '.' with '%.'
-        search_string = search_string:gsub("%.","%%%.")
-        -- replace '*' with '.*'
-        search_string = search_string:gsub("%*","%.%*")
-        -- replace '?' with '.'
-        search_string = search_string:gsub("%?","%.")
+        -- fully escaped variant of the raw query
+        local literal_pattern = search_string:gsub("([%^%$%(%)%%%.%[%]%+%-%*%?])", "%%%1")
+        if self.use_patterns then
+            -- replace '.' with '%.'
+            search_string = search_string:gsub("%.","%%%.")
+            -- replace '*' with '.*'
+            search_string = search_string:gsub("%*","%.%*")
+            -- replace '?' with '.'
+            search_string = search_string:gsub("%?","%.")
+        else
+            -- plain text search: match the query literally
+            search_string = literal_pattern
+        end
     end
 
     local dirs, files = {}, {}
@@ -228,7 +250,7 @@ function FileSearcher:getList()
         end
         scan_dirs = new_dirs
     end
-    return dirs, files, self.no_metadata_count
+    return dirs, files, self.no_metadata_count, self.invalid_pattern
 end
 
 function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
@@ -238,7 +260,13 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
     if not self.case_sensitive then
         filename = util.stringLower(filename)
     end
-    if string.find(filename, search_string) then
+    local ok, from = pcall(string.find, filename, search_string)
+    if not ok then
+        -- invalid pattern (e.g., unbalanced '(' or '['); LuaJIT only detects this while matching
+        self.invalid_pattern = true
+        return false
+    end
+    if from then
         return true
     end
     if self.include_metadata and is_file and DocumentRegistry:hasProvider(fullpath) then
@@ -251,8 +279,11 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
     end
 end
 
-function FileSearcher:showSearchResultsMessage(no_results)
+function FileSearcher:showSearchResultsMessage(no_results, invalid_pattern)
     local text = no_results and T(_("No results for '%1'."), FileSearcher.search_string)
+    if invalid_pattern then
+        text = T(_("Invalid Lua pattern: '%1'.\nUncheck 'Use Lua patterns' to search as plain text."), FileSearcher.search_string)
+    end
     if self.no_metadata_count == 0 then
         UIManager:show(ConfirmBox:new{
             text = text,

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -149,14 +149,12 @@ function FileSearcher:doSearch()
         tostring(self.case_sensitive) .. tostring(self.include_subfolders) ..
         tostring(self.use_patterns) .. tostring(self.include_metadata)
     local not_cached = FileSearcher.search_hash ~= search_hash
-    local invalid_pattern
     if not_cached then
         local Trapper = require("ui/trapper")
         local info = InfoMessage:new{ text = _("Searching… (tap to cancel)") }
         UIManager:show(info)
         UIManager:forceRePaint()
-        local completed, dirs, files, no_metadata_count
-        completed, dirs, files, no_metadata_count, invalid_pattern = Trapper:dismissableRunInSubprocess(function()
+        local completed, dirs, files, no_metadata_count, invalid_pattern = Trapper:dismissableRunInSubprocess(function()
             return self:getList()
         end, info)
         if not completed then return end

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -162,7 +162,7 @@ function FileSearcher:doSearch()
         if not completed then return end
         UIManager:close(info)
         if invalid_pattern then
-            self:onShowFileSearch(FileSearcher.search_string)
+            self:onShowFileSearch()
             UIManager:show(InfoMessage:new{ text = _("Incorrect pattern") })
             return
         end
@@ -184,7 +184,7 @@ function FileSearcher:doSearch()
     if #FileSearcher.search_results > 0 then
         self:onShowSearchResults(not_cached)
     else
-        self:showSearchResultsMessage(true, not_cached and invalid_pattern)
+        self:showSearchResultsMessage(true)
     end
 end
 
@@ -285,12 +285,7 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
     end
 end
 
-function FileSearcher:showSearchResultsMessage(no_results, invalid_pattern)
-    if invalid_pattern then
-        self:onShowFileSearch(FileSearcher.search_string)
-        UIManager:show(InfoMessage:new{ text = _("Incorrect pattern") })
-        return
-    end
+function FileSearcher:showSearchResultsMessage(no_results)
     local text = no_results and T(_("No results for '%1'."), FileSearcher.search_string)
     if self.no_metadata_count == 0 then
         UIManager:show(ConfirmBox:new{

--- a/frontend/apps/filemanager/filemanagerfilesearcher.lua
+++ b/frontend/apps/filemanager/filemanagerfilesearcher.lua
@@ -48,7 +48,7 @@ function FileSearcher:addToMainMenu(menu_items)
 The query is matched as plain text, except that a search
 for '*' will show all files.
 
-Check 'Use Lua patterns' for advanced matching with Lua patterns
+Check 'Use patterns' for advanced matching with Lua patterns
 (%d, [a-z], ^, …), where '*' and '?' act as wildcards.
 
 The sorting order is the same as in filemanager.
@@ -126,7 +126,7 @@ function FileSearcher:onShowFileSearch(search_string)
     }
     search_dialog:addWidget(check_button_subfolders)
     check_button_patterns = CheckButton:new{
-        text = _("Use Lua patterns"),
+        text = _("Use patterns"),
         checked = self.use_patterns,
         parent = search_dialog,
     }
@@ -161,6 +161,11 @@ function FileSearcher:doSearch()
         end, info)
         if not completed then return end
         UIManager:close(info)
+        if invalid_pattern then
+            self:onShowFileSearch(FileSearcher.search_string)
+            UIManager:show(InfoMessage:new{ text = _("Incorrect pattern") })
+            return
+        end
         FileSearcher.search_hash = search_hash
         self.no_metadata_count = no_metadata_count
         -- Cannot do this in getList() within Trapper (cannot serialize function)
@@ -197,8 +202,6 @@ function FileSearcher:getList()
         if not self.case_sensitive then
             search_string = util.stringLower(search_string)
         end
-        -- fully escaped variant of the raw query
-        local literal_pattern = search_string:gsub("([%^%$%(%)%%%.%[%]%+%-%*%?])", "%%%1")
         if self.use_patterns then
             -- replace '.' with '%.'
             search_string = search_string:gsub("%.","%%%.")
@@ -206,9 +209,6 @@ function FileSearcher:getList()
             search_string = search_string:gsub("%*","%.%*")
             -- replace '?' with '.'
             search_string = search_string:gsub("%?","%.")
-        else
-            -- plain text search: match the query literally
-            search_string = literal_pattern
         end
     end
 
@@ -260,14 +260,20 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
     if not self.case_sensitive then
         filename = util.stringLower(filename)
     end
-    local ok, from = pcall(string.find, filename, search_string)
-    if not ok then
-        -- invalid pattern (e.g., unbalanced '(' or '['); LuaJIT only detects this while matching
-        self.invalid_pattern = true
-        return false
-    end
-    if from then
-        return true
+    if self.use_patterns then
+        local ok, from = pcall(string.find, filename, search_string)
+        if not ok then
+            -- invalid pattern (e.g., unbalanced '(' or '['); LuaJIT only detects this while matching
+            self.invalid_pattern = true
+            return false
+        end
+        if from then
+            return true
+        end
+    else
+        if string.find(filename, search_string, 1, true) then
+            return true
+        end
     end
     if self.include_metadata and is_file and DocumentRegistry:hasProvider(fullpath) then
         local book_props = self.ui.bookinfo:getDocProps(fullpath, nil, true) -- do not open the document
@@ -280,10 +286,12 @@ function FileSearcher:isFileMatch(filename, fullpath, search_string, is_file)
 end
 
 function FileSearcher:showSearchResultsMessage(no_results, invalid_pattern)
-    local text = no_results and T(_("No results for '%1'."), FileSearcher.search_string)
     if invalid_pattern then
-        text = T(_("Invalid Lua pattern: '%1'.\nUncheck 'Use Lua patterns' to search as plain text."), FileSearcher.search_string)
+        self:onShowFileSearch(FileSearcher.search_string)
+        UIManager:show(InfoMessage:new{ text = _("Incorrect pattern") })
+        return
     end
+    local text = no_results and T(_("No results for '%1'."), FileSearcher.search_string)
     if self.no_metadata_count == 0 then
         UIManager:show(ConfirmBox:new{
             text = text,


### PR DESCRIPTION
Follow-up to #15036

### Problem

#15036 restored passing file search queries straight to `string.find` as Lua
patterns. That keeps pattern matching working, but any query that happens to
form an *invalid* Lua pattern now raises inside the scan subprocess:
`Trapper:dismissableRunInSubprocess` loses the child, and the user gets a bare,
misleading "No results" (or, before Trapper hardening, an `ipairs(nil)` error).

Repro: File search for `(paxos` with a file named `(paxos).pdf` present →
"No results" or a silently aborted search. Same for `100%`, `haha [`, any
unbalanced `(`/`[`/`%`. The exception is even filename-dependent, because
LuaJIT validates patterns lazily while matching (`unfinished capture` only
fires when the subject lets the match walk into the broken construct).
When the child dies, `doSearch` also crashes on `ipairs(dirs)` with
`dirs == nil` (logged as a WARN via `Trapper:wrap`, search silently aborted):

```
error in subprocess:	frontend/apps/filemanager/filemanagerfilesearcher.lua:241: unfinished capture
...
WARN  error in wrapped function: frontend/apps/filemanager/filemanagerfilesearcher.lua:155: bad argument #1 to 'ipairs' (table expected, got nil)
```

(from an unpatched build's `crash.log`)

### Change

Single file: `frontend/apps/filemanager/filemanagerfilesearcher.lua`.

- New **"Use Lua patterns"** checkbox in the search dialog, unchecked by default.
- Unchecked (default): the query is matched as **plain text** — every character
  literal, all pattern magic characters escaped. This is what most users typing
  ordinary filenames expect, and malformed queries can no longer kill the scan.
  The pre-existing bare-`*` show-all shortcut is preserved.
- Checked: legacy Lua-pattern behavior exactly as #15036 restored it, for users
  who rely on `%d`, `[a-z]`, `^…`, etc.
- In patterns mode, matching is wrapped in `pcall`; when a query turns out to be
  invalid during the scan, results are not silently wrong — a dedicated
  *"Invalid Lua patterns"* message replaces the bare "No results".
- The menu item help text documents both modes.

Note: plain text mode intentionally does *not* keep the old undocumented-ish
glob behavior for `*`/`?` (only bare `*` = show all remains). If maintainers
prefer keeping glob wildcards in plain mode, that's a two-line tweak in
`getList()` — happy to flip.

### Known caveat

LuaJIT detects invalid patterns lazily while matching (there is no separate
validation pass in `lib_string.c`), so some malformed queries never raise and
still yield a silent "No results" — e.g. `(abc` against subjects too short to
reach the unfinished capture, or `[z-a]`, which LuaJIT treats as an empty class
rather than an error. Full upfront validation would mean reimplementing the
pattern parser and was deliberately rejected; the pcall guard converts the
previously fatal cases into either a clean error message or a plain miss.

### Testing

- Behavioral harness over the transform+match logic (wildcard semantics,
  magic-char escaping, invalid-pattern paths).
- On-device (Kindle), reproduced with plugins disabled / no user patches.
  Full matrix:

<details>
<summary>Device test matrix (all PASS)</summary>

Files under test: `(paxos).pdf`, `(paxos2).pdf`, `100% done.epub`.

**Plain text mode (checkbox off — new default)**

| Query | Expected | Result |
|-------|----------|--------|
| `pax` | both paxos files | PASS |
| `(pax` | both files (original bug case) | PASS |
| `100%` | `100% done.epub` only (`%` literal) | PASS |
| `[p]axos` | no results (brackets are plain chars) | PASS |
| `*.pdf` | no results (`*` is a literal char) | PASS |
| literal `?` in name (`test?`) | exact file only, no false positives | PASS |
| `*` | all files (preserved show-all shortcut) | PASS |

**Pattern mode (checkbox on)**

| Query | Expected | Result |
|-------|----------|--------|
| `[p]axos` | both files (character class) | PASS |
| `*.pdf` | pdfs only (`*`=any sequence, `.`=literal dot) | PASS |
| `^%(pax` | both paxos files (anchor + escaped paren) | PASS |
| `pax?s%d` | `(paxos2).pdf` only (`?`=any char, `%d`=digit) | PASS |

**Invalid-pattern surfacing & plumbing**

| Action | Expected | Result |
|--------|----------|--------|
| `(pax` with checkbox on | *"Invalid Lua pattern"* dialog | PASS |
| `%` with checkbox on | same (unconditional error per file) | PASS |
| Uncheck box after error dialog, re-search | dialog flow intact, correct results | PASS |
| Same query with checkbox toggled | fresh results (cache key includes mode) | PASS |
| Repeat successful search | instant cached results | PASS |

</details>

### Screenshots

| Help text | Search dialog | Invalid pattern message |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/c8e84b2a-1340-4205-a3f7-0dca5f579592" width="300"> | <img src="https://github.com/user-attachments/assets/e7120cb1-fdcc-4484-8638-34a413c337a9" width="300"> | <img src="https://github.com/user-attachments/assets/4ef3cad0-8bd2-480f-91f4-bcd8d3e6cc6c" width="300"> |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15938)
<!-- Reviewable:end -->

