### PR TITLE
readtimer: add snooze button, stop stale timer wakeups

### DIFF
--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -79,13 +79,21 @@ function ReadTimer:init()
                 ok_text = _("Repeat"),
                 ok_callback = function()
                     logger.dbg("Schedule a new time:", self.last_interval_time)
-                    UIManager:close(confirm_box)
                     self:rescheduleIn(self.last_interval_time)
                 end,
                 cancel_text = _("Done"),
                 cancel_callback = function ()
                     self.last_interval_time = 0
                 end,
+                other_buttons = {{
+                    {
+                        text = T(_("+%1 min"), self:getSnoozeMinutes()),
+                        callback = function()
+                            logger.dbg("ReadTimer: snoozing for", self:getSnoozeMinutes(), "minutes")
+                            self:rescheduleIn(self:getSnoozeMinutes() * 60)
+                        end,
+                    },
+                }},
             }
             UIManager:show(confirm_box)
         else
@@ -157,25 +165,29 @@ function ReadTimer:init()
     self:onDispatcherRegisterActions()
 end
 
-function ReadTimer:update_status_bars(seconds)
+function ReadTimer:update_status_bars()
     if self.settings.show_value_in_header then
         UIManager:broadcastEvent(Event:new("UpdateHeader"))
     end
     if self.settings.show_value_in_footer then
         UIManager:broadcastEvent(Event:new("RefreshAdditionalContent"))
     end
-    -- if seconds schedule 1ms later
-    if seconds and seconds >= 0 then
-        UIManager:scheduleIn(math.max(math.floor(seconds)%60, 0.001), self.update_status_bars, self)
-    elseif seconds and seconds < 0 and self:scheduled() then
-        UIManager:scheduleIn(math.max(math.floor(self:remaining())%60, 0.001), self.update_status_bars, self)
-    else
-        UIManager:scheduleIn(60, self.update_status_bars, self)
+    if not self:scheduled() then
+        -- Timer expired or stopped: stop ticking, no need to keep waking up the device.
+        return
     end
+    -- Schedule the next tick for the remaining time's next minute boundary,
+    -- based on the actual remaining time (not a stale constant), so the
+    -- countdown display flips right when a minute is crossed.
+    UIManager:scheduleIn(math.max(self:remaining()%60, 0.001), self.update_status_bars, self)
 end
 
 function ReadTimer:scheduled()
     return self.time ~= 0
+end
+
+function ReadTimer:getSnoozeMinutes()
+    return self.settings.snooze_minutes or 5
 end
 
 function ReadTimer:remaining()
@@ -217,20 +229,20 @@ end
 function ReadTimer:addAdditionalHeaderContent()
     if self.ui.crelistener then
         self.ui.crelistener:addAdditionalHeaderContent(self.additional_header_content_func)
-        self:update_status_bars(-1)
+        self:update_status_bars()
     end
 end
 function ReadTimer:addAdditionalFooterContent()
     if self.ui.view then
         self.ui.view.footer:addAdditionalFooterContent(self.additional_footer_content_func)
-        self:update_status_bars(-1)
+        self:update_status_bars()
     end
 end
 
 function ReadTimer:removeAdditionalHeaderContent()
     if self.ui.crelistener then
         self.ui.crelistener:removeAdditionalHeaderContent(self.additional_header_content_func)
-        self:update_status_bars(-1)
+        self:update_status_bars()
         UIManager:broadcastEvent(Event:new("UpdateHeader"))
     end
 end
@@ -238,7 +250,7 @@ end
 function ReadTimer:removeAdditionalFooterContent()
     if self.ui.view then
         self.ui.view.footer:removeAdditionalFooterContent(self.additional_footer_content_func)
-        self:update_status_bars(-1)
+        self:update_status_bars()
         UIManager:broadcastEvent(Event:new("UpdateFooter", true))
     end
 end
@@ -256,7 +268,7 @@ function ReadTimer:rescheduleIn(seconds)
     self.time = time.now() + time.s(seconds)
     UIManager:scheduleIn(seconds, self.alarm_callback)
     if self.settings.show_value_in_header or self.settings.show_value_in_footer then
-        self:update_status_bars(seconds)
+        self:update_status_bars()
     end
 end
 
@@ -349,6 +361,28 @@ function ReadTimer:addToMainMenu(menu_items)
                     self:onStopTimer(touchmenu_instance)
                 end,
                 separator = true,
+            },
+            {
+                text_func = function()
+                    return T(_("Snooze time: %1"), T(_("%1 min"), self:getSnoozeMinutes()))
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    local SpinWidget = require("ui/widget/spinwidget")
+                    UIManager:show(SpinWidget:new{
+                        title_text = _("Snooze time"),
+                        info_text = _("Extra minutes added when tapping the snooze button on the timer expiry dialog."),
+                        value = self:getSnoozeMinutes(),
+                        value_min = 1,
+                        value_max = 60,
+                        value_hold_step = 5,
+                        ok_text = _("Set"),
+                        callback = function(spin)
+                            self.settings.snooze_minutes = spin.value
+                            touchmenu_instance:updateItems()
+                        end,
+                    })
+                end,
             },
             {
                 text_func = function()
@@ -515,6 +549,8 @@ function ReadTimer:onStopTimer(touchmenu_instance)
     if self:scheduled() then
         self.last_interval_time = 0
         self:unschedule()
+        -- Final refresh so the timer value disappears from the status bar right away.
+        self:update_status_bars()
         if touchmenu_instance then
             touchmenu_instance:updateItems()
         else

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -79,15 +79,15 @@ function ReadTimer:init()
                 cancel_callback = function()
                     self.last_interval_time = 0
                 end,
-                choice1_text = _("Repeat"),
+                choice1_text = T(_("+%1 min"), self:getSnoozeMinutes()),
                 choice1_callback = function()
-                    logger.dbg("Schedule a new time:", self.last_interval_time)
-                    self:rescheduleIn(self.last_interval_time)
-                end,
-                choice2_text = T(_("+%1 min"), self:getSnoozeMinutes()),
-                choice2_callback = function()
                     logger.dbg("ReadTimer: snoozing for", self:getSnoozeMinutes(), "minutes")
                     self:rescheduleIn(self:getSnoozeMinutes() * 60)
+                end,
+                choice2_text = _("Repeat"),
+                choice2_callback = function()
+                    logger.dbg("Schedule a new time:", self.last_interval_time)
+                    self:rescheduleIn(self.last_interval_time)
                 end,
             })
         else

--- a/plugins/readtimer.koplugin/main.lua
+++ b/plugins/readtimer.koplugin/main.lua
@@ -1,6 +1,6 @@
 local CheckButton = require("ui/widget/checkbutton")
-local ConfirmBox = require("ui/widget/confirmbox")
 local DateTimeWidget = require("ui/widget/datetimewidget")
+local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
@@ -70,32 +70,26 @@ function ReadTimer:init()
             maybeRescheduleInterval()
             return
         end
-        local confirm_box
         -- only interval support repeat
         if self.last_interval_time > 0 and not self.settings.auto_reschedule_interval then
             logger.dbg("can_repeat, show confirm_box")
-            confirm_box = ConfirmBox:new{
+            UIManager:show(MultiConfirmBox:new{
                 text = tip_text,
-                ok_text = _("Repeat"),
-                ok_callback = function()
+                cancel_text = _("Done"),
+                cancel_callback = function()
+                    self.last_interval_time = 0
+                end,
+                choice1_text = _("Repeat"),
+                choice1_callback = function()
                     logger.dbg("Schedule a new time:", self.last_interval_time)
                     self:rescheduleIn(self.last_interval_time)
                 end,
-                cancel_text = _("Done"),
-                cancel_callback = function ()
-                    self.last_interval_time = 0
+                choice2_text = T(_("+%1 min"), self:getSnoozeMinutes()),
+                choice2_callback = function()
+                    logger.dbg("ReadTimer: snoozing for", self:getSnoozeMinutes(), "minutes")
+                    self:rescheduleIn(self:getSnoozeMinutes() * 60)
                 end,
-                other_buttons = {{
-                    {
-                        text = T(_("+%1 min"), self:getSnoozeMinutes()),
-                        callback = function()
-                            logger.dbg("ReadTimer: snoozing for", self:getSnoozeMinutes(), "minutes")
-                            self:rescheduleIn(self:getSnoozeMinutes() * 60)
-                        end,
-                    },
-                }},
-            }
-            UIManager:show(confirm_box)
+            })
         else
             logger.dbg("can`t_repeat, show infomessage")
             local top_wg = UIManager:getTopmostVisibleWidget()


### PR DESCRIPTION
### Feature: snooze on interval expiry

The interval-expiry dialog only offered **Repeat** (restart the full interval)
or **Done** — no way to say "just a few more minutes". This adds a third
button, **"+N min"**, that extends the current wait by a configurable amount:

- `snooze_minutes` setting (default 5), persisted with the plugin's settings
- Configurable via a new **Snooze time** entry in the Read timer submenu
  (SpinWidget, 1–60 min); always editable, not tied to timer state
- Snoozing re-fires the same expiry dialog when the extension runs out, so it
  chains naturally; Repeat/Done/auto-reschedule behavior is unchanged
- Only shown for interval timers (alarms keep their current message-only flow)

Implemented with ConfirmBox's native `other_buttons` support — no new widget.

### Fix 1: status-bar ticker kept running after the timer died

`update_status_bars()` rescheduled itself unconditionally in two cases:

- the `seconds >= 0` branch re-scheduled with its *stale* argument after the
  alarm fired (`time = 0`, but the pending tick still carried e.g. `300`),
  producing an endless tick chain;
- the bare `else` branch scheduled a tick every 60 s regardless of timer state.

Net effect: with "Show timer in status bar/alt status bar" enabled, the device
woke up every minute forever after the timer expired — pointless work on an
e-ink reader. Worse, with whole-minute intervals (every UI-provided value),
the `math.floor(seconds)%60 == 0 → 0.001 s` clamp degenerated into ~1000
wakeups per *second* at every minute boundary of the countdown itself.

Scheduling is now based on the actual remaining time instead of the frozen
constant, honoring the [original review guidance](https://github.com/koreader/koreader/pull/12002#discussion_r1641933099)
("If we are at (01:00) then do the update 1ms later") at ~2 ticks per boundary,
and stopping entirely as soon as the timer is no longer scheduled. The now-dead
`seconds` parameter was removed.

### Fix 2: stopped timer lingered in the status bar

Stopping a timer unscheduled everything but never refreshed the screen, so the
countdown stayed visible until the next page turn (previously masked within
60 s by the buggy ticker from Fix 1). `onStopTimer` now triggers one final
`update_status_bars()` pass — which broadcasts the refresh and, thanks to the
new guard, schedules nothing.

### Testing

All scenarios below were run on a Kindle with the patched plugin and verified
by the submitter:

<details>
<summary>Device test matrix (all PASS)</summary>

**Snooze feature**

| Scenario | Result |
|----------|--------|
| Expiry dialog shows Done / Repeat / +N min | PASS |
| +N min restarts countdown at configured duration; chains across repeated expiries | PASS |
| Snooze time editable via menu; button label reflects change; persists across restart | PASS |
| Auto-reschedule checked → expiry auto-restarts with no dialog (unchanged) | PASS |
| Unchecking auto-reschedule restores the three-button dialog | PASS |

**Fix verification**

| Scenario | Result |
|----------|--------|
| Stop timer mid-countdown → countdown vanishes from both status bars immediately | PASS |
| Timer expiry → countdown cleared cleanly from both bars | PASS |
| Tick chain terminates after expiry (no further scheduling) | PASS |
| Repeat / Done / snooze chains restart the tick chain exactly once each | PASS |

**Regression guards**

| Scenario | Result |
|----------|--------|
| Timer survives closing and reopening the book | PASS |
| Both alt status bar and bottom status bar display modes work | PASS |

</details>

### Screenshots

| Expiry dialog | Snooze time menu |
|---|---|
| <img src="https://github.com/user-attachments/assets/017e14b2-e088-4034-b2b6-3d385d66ce1f" width="300"> | <img src="https://github.com/user-attachments/assets/9639c8e8-ad63-4fdc-a8e8-199d0c504590" width="300"> |

Additional notes:
- The scheduling rework was simulated against all termination paths (natural
  expiry, manual stop, widget close, resume-after-suspend) before device testing.
- Known pre-existing issue found during development (out of scope here):
  suspending past an auto-rescheduled interval's expiry silently cancels it
  (`onResume` calls `alarm_callback()` — which honors auto-reschedule — and then
  unconditionally `unschedule()`s the fresh schedule).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15940)
<!-- Reviewable:end -->


