### PR TITLE
[AutoWarmth] schedule each distinct native warmth step

### DIFF
--- a/plugins/autowarmth.koplugin/main.lua
+++ b/plugins/autowarmth.koplugin/main.lua
@@ -39,7 +39,6 @@ local activate_closer_midnight = 4
 local midnight_index = 11
 
 local device_max_warmth = Device:hasNaturalLight() and Powerd.fl_warmth_max or 100
-local device_warmth_fit_scale = device_max_warmth * (1/100)
 
 local function frac(x)
     return x - math.floor(x)
@@ -335,9 +334,10 @@ function AutoWarmth:scheduleMidnightUpdate(from_resume)
             local delta_w = warmth_diff > 0 and 1 or -1
             for i = 1, math.abs(warmth_diff) - 1 do
                 local next_warmth = math.min(self.warmth[index1], 100) + delta_w * i
-                -- only apply warmth for steps the hardware has (e.g. Tolino has 0-10 hw steps
-                -- which map to warmth 0, 10, 20, 30 ... 100)
-                if frac(next_warmth * device_warmth_fit_scale) == 0 then
+                local next_native_warmth = Powerd:toNativeWarmth(next_warmth)
+                -- Only apply warmth when reaching a new native hardware step.
+                if next_native_warmth ~= Powerd:toNativeWarmth(next_warmth - delta_w)
+                    and next_native_warmth ~= Powerd:toNativeWarmth(math.min(self.warmth[index2], 100)) then
                     table.insert(self.sched_times_s, time1_s + delta_t * i)
                     table.insert(self.sched_warmths, next_warmth)
                 end

--- a/spec/unit/autowarmth_spec.lua
+++ b/spec/unit/autowarmth_spec.lua
@@ -1,0 +1,76 @@
+describe("AutoWarmth plugin", function()
+    local Device, original_has_natural_light, original_powerd
+    local original_package_path, SunTime, UIManager
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        original_package_path = package.path
+        package.path = "plugins/autowarmth.koplugin/?.lua;" .. package.path
+        Device = require("device")
+        SunTime = require("suntime")
+        UIManager = require("ui/uimanager")
+        original_has_natural_light = Device.hasNaturalLight
+        original_powerd = Device.powerd
+    end)
+
+    teardown(function()
+        package.path = original_package_path
+    end)
+
+    before_each(function()
+        Device.hasNaturalLight = function() return true end
+        Device.powerd = {
+            fl_warmth_max = 24,
+            toNativeWarmth = function(_, warmth)
+                return math.floor(warmth * 24 / 100 + 0.5)
+            end,
+        }
+        stub(SunTime, "setPosition")
+        stub(SunTime, "setAdvanced")
+        stub(SunTime, "setDate")
+        stub(SunTime, "calculateTimes")
+        stub(SunTime, "getTimeInSec", function(_, hours)
+            return hours and hours * 3600 or 0
+        end)
+        stub(UIManager, "unschedule")
+        stub(UIManager, "scheduleIn")
+    end)
+
+    after_each(function()
+        Device.hasNaturalLight = original_has_natural_light
+        Device.powerd = original_powerd
+        SunTime.setPosition:revert()
+        SunTime.setAdvanced:revert()
+        SunTime.setDate:revert()
+        SunTime.calculateTimes:revert()
+        SunTime.getTimeInSec:revert()
+        UIManager.unschedule:revert()
+        UIManager.scheduleIn:revert()
+    end)
+
+    it("schedules every distinct native warmth step", function()
+        local AutoWarmth = dofile("plugins/autowarmth.koplugin/main.lua")
+        local widget = setmetatable({
+            activate = 2,
+            easy_mode = false,
+            location = "",
+            latitude = 0,
+            longitude = 0,
+            timezone = 0,
+            altitude = 0,
+            scheduler_times = { 0, 1 },
+            warmth = { 100, 0 },
+            scheduleNextWarmthChange = function() end,
+            scheduleToggleFrontlight = function() end,
+            toggleFrontlight = function() end,
+        }, { __index = AutoWarmth })
+
+        widget:scheduleMidnightUpdate()
+
+        assert.are.equal(25, #widget.sched_warmths)
+        for i, warmth in ipairs(widget.sched_warmths) do
+            assert.are.equal(25 - i, Device.powerd:toNativeWarmth(warmth))
+        end
+    end)
+end)


### PR DESCRIPTION
Closes #15942

## Problem

AutoWarmth currently retains intermediate percentages only when `percentage * (fl_warmth_max / 100)` is exactly integral. On Kindle's 24-level warmth range, a 90% → 20% ramp consequently schedules only 90, 75, 50, 25, and 20, skipping most native levels.

## Change

Use the power driver's authoritative `toNativeWarmth` conversion when generating progressive schedules. An intermediate percentage is retained only when it reaches a new native level; a level matching the segment endpoint is left for the existing endpoint event, avoiding a redundant schedule.

This remains general for devices with other native warmth ranges and does not change endpoint timing or frontlight-setting behavior.

## Test

Added `spec/unit/autowarmth_spec.lua`, which exercises the full 100% → 0% range with a Kindle-like 24-level power driver and verifies exactly 25 distinct native levels (24 through 0).

Local verification:

- Production schedule executed through a minimal LuaJIT harness: 25 distinct native levels across 100% → 0%.
- Sabotage run with the old predicate: expected test failure, only 5 entries.
- Focused canonical test in the CircleCI container: `make testfront --assume-old=all T=autowarmth` passes.
- Lua syntax checks: pass.
- `git diff --check`: pass.
- `make static-check`: command completed, but reported that `luacheck` is unavailable on the host; the CircleCI container's `.ci/check.sh` passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15943)
<!-- Reviewable:end -->
