### PR TITLE
android: fix startup version check

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -91,7 +91,7 @@ update: all
 	rm -rf $(ANDROID_LAUNCHER_DIR)/assets/{libs,module}
 	# APK version.
 	mkdir -p $(ANDROID_ASSETS)/module $(ANDROID_LIBS)
-	echo $(VERSION) >$(ANDROID_ASSETS)/module/version.txt
+	echo '$(VERSION)_$(DIST)' >$(ANDROID_ASSETS)/module/version.txt
 	# Libraries.
 	cp -v $(INSTALL_DIR)/koreader/libs/*$(LIB_EXT) $(ANDROID_LIBS)/
 	# Binaries are stored as shared libraries to prevent W^X exception on Android 10+


### PR DESCRIPTION
Add distribution to `version.txt` so the check does not detect a new version every time.

Close #15924.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15944)
<!-- Reviewable:end -->
