### PR TITLE
[ReaderKeySelection]: get correct coordinates from hyphenated words

### DIFF
--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -435,9 +435,9 @@ function ReaderKeySelection:startHighlightIndicator()
         local nearest_word = self:_getNearestWordFromScreenPoint(center_x, center_y)
         if nearest_word then
             self:_setIndicatorToWord(nearest_word)
-            -- Flash nearest_word in case the crosshairs if hard to find.
-            local coor = nearest_word.sbox
-            if self.ui.highlight:highlightWordAtCoordinates(coor.x + coor.w * 0.5, coor.y + coor.h * 0.5) then
+            -- Flash nearest_word in case the crosshairs are hard to find.
+            local anchor_x, anchor_y = self:_getWordAnchorCoordinates(nearest_word)
+            if self.ui.highlight:highlightWordAtCoordinates(anchor_x, anchor_y) then
                 self._flashing_nearest_word = true
                 UIManager:scheduleIn(G_defaults:readSetting("DELAY_CLEAR_HIGHLIGHT_S"), function()
                     self:clearFlashHighlight()


### PR DESCRIPTION
### bug fix

  * In `frontend/apps/reader/modules/readerkeyselection.lua`, the highlight anchor point for the nearest word is now determined using the `_getWordAnchorCoordinates` method, replacing the previous calculation that used the center of the word's bounding box. This ensures that starting the indicator in a split and hyphenated word, correctly flashes said word.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15945)
<!-- Reviewable:end -->
