### PR TITLE
KOSync: drain offline queue on book open

### DIFF
--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -190,6 +190,9 @@ end
 function KOSync:onReaderReady()
     if self.settings.auto_sync then
         UIManager:nextTick(function()
+            if NetworkMgr:isOnline() then
+                self:drainQueue()
+            end
             self:getProgress(true, false)
         end)
     end


### PR DESCRIPTION
## Summary
- Drain the offline progress queue in `onReaderReady` before pulling remote progress
- Fixes stuck queue items when wifi reconnects while no book is open (KOSync is `is_doc_only`)

## Background
The offline queue (added in #15324) only drains on `NetworkConnected`, which fires on wifi off-to-on transitions. Since KOSync is `is_doc_only`, if a user closes a book offline, returns to the file manager, and reconnects wifi there, no KOSync instance exists to receive the event. When the next book is opened, queued items remain stuck until another wifi cycle.

`drainQueue()` is a no-op when the queue is empty, so there is no overhead for the common case.

## Test plan
- [ ] Set wifi to "turn on automatically" and enable auto progress sync
- [ ] Open a book, read a few pages
- [ ] Turn wifi off, close the book (progress is queued in `kosync_queue.lua`)
- [ ] Turn wifi back on from the file manager
- [ ] Open any book: queued progress should now be pushed to the server

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15947)
<!-- Reviewable:end -->
