### PR TITLE
[ReaderKeySelection]: Add Fast dictionary mode

### DIFF
--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -259,7 +259,6 @@ function ReaderKeySelection:addToMainMenu(menu_items)
             UIManager:show(double_spin_widget)
         end,
     }
-    table.insert(menu_items.long_press.sub_item_table, crosshairs_speed_item)
     local crosshairs_speedup_item = {
         text = _("Increase crosshairs speed on consecutive keystrokes"),
         checked_func = function()
@@ -272,7 +271,6 @@ function ReaderKeySelection:addToMainMenu(menu_items)
             G_reader_settings:flipNilOrTrue("highlight_non_touch_spedup")
         end,
     }
-    table.insert(menu_items.long_press.sub_item_table, crosshairs_speedup_item)
     local crosshairs_interval_item = {
         text_func = function()
             local highlight_non_touch_interval = G_reader_settings:readSetting("highlight_non_touch_interval") or 1
@@ -301,7 +299,6 @@ function ReaderKeySelection:addToMainMenu(menu_items)
             UIManager:show(spin_widget)
         end,
     }
-    table.insert(menu_items.long_press.sub_item_table, crosshairs_interval_item)
 
     local text_label = _("Text selection tools")
 
@@ -320,9 +317,13 @@ function ReaderKeySelection:addToMainMenu(menu_items)
     end
 
     if menu_items.long_press then
+        table.insert(menu_items.long_press.sub_item_table, crosshairs_speed_item)
+        table.insert(menu_items.long_press.sub_item_table, crosshairs_speedup_item)
+        table.insert(menu_items.long_press.sub_item_table, crosshairs_interval_item)
+        menu_items.long_press.sub_item_table[1].separator = false
         local long_press_action = ReaderHighlight.long_press_action
         -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
-        -- Clone long_press settings, and change its label, making it much more meaningful for non-touch device users.
+        -- Surface long_press settings, and change its label, making it much more meaningful for non-touch device users.
         menu_items.selection_text = {
             text = text_label,
             sub_item_table = {

--- a/frontend/apps/reader/modules/readerkeyselection.lua
+++ b/frontend/apps/reader/modules/readerkeyselection.lua
@@ -316,10 +316,27 @@ function ReaderKeySelection:addToMainMenu(menu_items)
         return true
     end
 
+    local dict_mode_item = {
+        text = _("Fast dictionary mode (single word selection)"),
+        help_text = _("When enabled, pressing 'Down' will trigger fast dictionary mode while 'Up' will call regular text selection mode.")
+            .. "\n\n" .. _("Fast dictionary mode skips multi-word selection and opens the dictionary immediately on any single word selection."),
+        checked_func = function()
+            return self:dictionaryModeActive() and self:directDictSearchActive()
+        end,
+        enabled_func = function()
+            return not self.view.highlight.disabled and self:directDictSearchActive()
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("highlight_non_touch_dict_mode")
+        end,
+        separator = true,
+    }
+
     if menu_items.long_press then
         table.insert(menu_items.long_press.sub_item_table, crosshairs_speed_item)
         table.insert(menu_items.long_press.sub_item_table, crosshairs_speedup_item)
         table.insert(menu_items.long_press.sub_item_table, crosshairs_interval_item)
+        -- Dictionary on single word selection won't be alone
         menu_items.long_press.sub_item_table[1].separator = false
         local long_press_action = ReaderHighlight.long_press_action
         -- long_press settings are under the taps_and_gestures menu, which is not available for non-touch devices
@@ -328,6 +345,7 @@ function ReaderKeySelection:addToMainMenu(menu_items)
             text = text_label,
             sub_item_table = {
                 menu_items.long_press.sub_item_table[1], -- Dictionary on single word selection
+                dict_mode_item,
                 {
                     text_func = function()
                         local multi_word = G_reader_settings:readSetting("default_highlight_action")
@@ -373,6 +391,11 @@ end
 
 function ReaderKeySelection:onStartOrMoveHighlightIndicator(args)
     if not self._current_indicator_pos then
+        -- If dict mode is enabled, 'Down' (dy=1) calls fast_dict_mode, 'Up' (dy=-1) is regular text selection.
+        if self:dictionaryModeActive() and self:directDictSearchActive() then
+            local _, dy = unpack(args)
+            self._fast_dict_mode = dy == 1
+        end
         self:startHighlightIndicator()
     else
         self:moveHighlightIndicator(args)
@@ -382,6 +405,14 @@ end
 
 function ReaderKeySelection:isActive()
     return self._current_indicator_pos ~= nil
+end
+
+function ReaderKeySelection:directDictSearchActive()
+    return G_reader_settings:nilOrFalse("highlight_action_on_single_word") or G_reader_settings:readSetting("default_highlight_action") == "dictionary"
+end
+
+function ReaderKeySelection:dictionaryModeActive()
+    return G_reader_settings:isTrue("highlight_non_touch_dict_mode")
 end
 
 function ReaderKeySelection:clearOverlay()
@@ -474,6 +505,7 @@ function ReaderKeySelection:stopHighlightIndicator(need_clear_selection)
     self._edge_dx, self._edge_dy = nil, nil
     self._last_move_was_quick_move = nil
     self._previous_indicator_word = nil
+    self._fast_dict_mode = nil
     if self._indicator_overlay then
         self._indicator_overlay:freeSavedBB()
         UIManager:close(self._indicator_overlay)
@@ -496,7 +528,8 @@ function ReaderKeySelection:highlightPress(skip_tap_check)
         return true
     end
     -- Check if we're in select mode (or extending an existing highlight)
-    if self.ui.highlight.select_mode and self.ui.highlight.highlight_idx then
+    local in_select_mode = self.ui.highlight.select_mode and self.ui.highlight.highlight_idx
+    if in_select_mode or self._fast_dict_mode then
         self.ui.highlight:onHold(nil, self:_createHighlightGesture("hold"))
         self.ui.highlight:onHoldRelease(nil, self:_createHighlightGesture("hold_release"))
         self:stopHighlightIndicator()


### PR DESCRIPTION
### what's new

- Added a menu item (`dict_mode_item`) to enable "Fast dictionary mode" for single-word selection, with explanatory help text and proper enable/disable logic. When enabled, pressing 'Down' triggers the dictionary mode, and 'Up' triggers regular text selection.
- Added helper methods `directDictSearchActive` and `dictionaryModeActive` to encapsulate the logic for when fast dictionary mode should be available.

When a user calls `Fast dictionary mode` the crosshairs appear as normal but as soon as they select any word, a dictionary search is performed, this means there is no highlighting, or link following, or selection of existing highlights.

<p align="center">
<img src="https://github.com/user-attachments/assets/3aec382f-2a14-4c6b-83be-d010310d7191" width=40%> 
<img src="https://github.com/user-attachments/assets/b128278c-6829-43fd-a3a9-17d7d23f048c" width=40%> 
</p> 

### bug fix

- Refactored the way crosshairs-related settings (`crosshairs_speed_item`, `crosshairs_speedup_item`, `crosshairs_interval_item`) are inserted into the menu, previously on touch devices they were being inserted in two different places.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15951)
<!-- Reviewable:end -->
