### PR TITLE
Add warning about Amazon formats on Kindles in Quick Start Guide

### DIFF
--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -91,7 +91,7 @@ You can access the complete user manual from [our GitHub page](https://github.co
 end
 
 if Device:isKindle() then
-    table.insert(quickstart_guide, _([[**IMPORTANT: KOReader's best supported format is EPUB. Other formats like MOBI may not support all features. KFX is not supported at all. DRMed books are not supported either.**
+    table.insert(quickstart_guide, _([[**IMPORTANT: KOReader's best supported format is EPUB. Other formats like MOBI may not support all features. KFX is not supported at all. DRM-protected books are not supported either.**
             ]])
     ) -- insert warning about formats for Kindle devices
 end

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -93,7 +93,7 @@ end
 if Device:isKindle() then
     table.insert(quickstart_guide, _([[**IMPORTANT: KOReader's best supported format is EPUB. Other formats like MOBI may not support all features. KFX is not supported at all. DRM-protected books are not supported either.**
             ]])
-    ) -- insert warning about formats for Kindle devices
+    )
 end
 
 -- User interface

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -90,6 +90,12 @@ You can access the complete user manual from [our GitHub page](https://github.co
     ) -- insert toc
 end
 
+if Device:Kindle() then
+    table.insert(quickstart_guide, _([[**IMPORTANT: KOReader barely supports Amazon-specific book formats like MOBI, KFX, AZW3. Use EPUB instead.**
+            ]])
+    ) -- insert warning about formats for Kindle devices
+end
+
 -- User interface
 if Device:hasScreenKB() then
     -- Use correct k4 illustration and appropriate button mapping

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -92,7 +92,7 @@ end
 
 if Device:isKindle() then
     table.insert(quickstart_guide, _([[**IMPORTANT: KOReader's best supported format is EPUB. Other formats like MOBI may not support all features. KFX is not supported at all. DRM-protected books are not supported either.**
-            ]])
+]])
     )
 end
 

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -91,7 +91,7 @@ You can access the complete user manual from [our GitHub page](https://github.co
 end
 
 if Device:isKindle() then
-    table.insert(quickstart_guide, _([[**IMPORTANT: KOReader barely supports Amazon-specific book formats like MOBI, KFX, AZW3. Use EPUB instead.**
+    table.insert(quickstart_guide, _([[**IMPORTANT: KOReader's best supported format is EPUB. Other formats like MOBI may not support all features. KFX is not supported at all. DRMed books are not supported either.**
             ]])
     ) -- insert warning about formats for Kindle devices
 end

--- a/frontend/ui/quickstart.lua
+++ b/frontend/ui/quickstart.lua
@@ -90,7 +90,7 @@ You can access the complete user manual from [our GitHub page](https://github.co
     ) -- insert toc
 end
 
-if Device:Kindle() then
+if Device:isKindle() then
     table.insert(quickstart_guide, _([[**IMPORTANT: KOReader barely supports Amazon-specific book formats like MOBI, KFX, AZW3. Use EPUB instead.**
             ]])
     ) -- insert warning about formats for Kindle devices


### PR DESCRIPTION
If you approve, this will improve understanding that KOReader barely supports Amazon-specific formats for newcomers. We keep seeing "oh KOReader open kxf" and such. 

Also duplicated in https://github.com/koreader/koreader/wiki/Installation-on-Kindle-devices

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15954)
<!-- Reviewable:end -->
