### PR TITLE
Gestures/profiles: cycle through action options

### DIFF
--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -675,11 +675,14 @@ function Dispatcher:removeAction(name)
     return true
 end
 
-function Dispatcher.getActionArgs(settings)
+function Dispatcher.getActionArgs(settings, get_args)
     if Dispatcher:_itemsCount(settings) == 1 then
         local action = next(settings)
         if action == "settings" then action = next(settings, action) end
         local args = settingsList[action] and (settingsList[action].args_func or settingsList[action].args)
+        if get_args then
+            args = type(args) == "function" and args() or args
+        end
         return args, action
     end
 end
@@ -688,8 +691,7 @@ function Dispatcher.iter_func(settings, to_execute)
     local order, action
     local is_cycle = settings.settings and settings.settings.cycle
     if is_cycle and to_execute then
-        order, action = Dispatcher.getActionArgs(settings)
-        order = type(order) == "function" and order() or order -- args array
+        order, action = Dispatcher.getActionArgs(settings, true) -- args array
     else
         order = settings.settings and settings.settings.order -- actions array
     end
@@ -1185,8 +1187,10 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
         callback = function()
             local actions = location[settings]
             if actions and not util.tableGetValue(actions, "settings", "execute_one_by_one") then
-                util.tableSetValue(actions, 1, "settings", "execute_one_by_one") -- start from the first action
-                actions.settings.cycle = Dispatcher.getActionArgs(location[settings]) ~= nil or nil
+                local args, action = Dispatcher.getActionArgs(actions, true)
+                local start_idx = args and util.arrayContains(args, actions[action]) -- start from the selected option
+                util.tableSetValue(actions, start_idx or 1, "settings", "execute_one_by_one")
+                actions.settings.cycle = args and true
                 actions.settings.show_as_quickmenu = nil
                 actions.settings.quickmenu_separators = nil
                 actions.settings.keep_open_on_apply = nil

--- a/frontend/dispatcher.lua
+++ b/frontend/dispatcher.lua
@@ -675,8 +675,24 @@ function Dispatcher:removeAction(name)
     return true
 end
 
+function Dispatcher.getActionArgs(settings)
+    if Dispatcher:_itemsCount(settings) == 1 then
+        local action = next(settings)
+        if action == "settings" then action = next(settings, action) end
+        local args = settingsList[action] and (settingsList[action].args_func or settingsList[action].args)
+        return args, action
+    end
+end
+
 function Dispatcher.iter_func(settings, to_execute)
-    local order = util.tableGetValue(settings, "settings", "order")
+    local order, action
+    local is_cycle = settings.settings and settings.settings.cycle
+    if is_cycle and to_execute then
+        order, action = Dispatcher.getActionArgs(settings)
+        order = type(order) == "function" and order() or order -- args array
+    else
+        order = settings.settings and settings.settings.order -- actions array
+    end
     if order then
         local idx = settings.settings.execute_one_by_one
         if idx and to_execute then
@@ -688,6 +704,10 @@ function Dispatcher.iter_func(settings, to_execute)
             end
             idx = idx > #order and 1 or idx
             settings.settings.execute_one_by_one = idx == #order and 1 or idx + 1
+            if is_cycle then
+                settings[action] = order[idx] -- action next arg to execute with
+                return ipairs({ action })
+            end
             return ipairs({ order[idx] })
         end
         return ipairs(order)
@@ -707,7 +727,7 @@ function Dispatcher:_itemsCount(settings)
 end
 
 -- Returns a display name for the item.
-function Dispatcher:getNameFromItem(item, settings, dont_show_value)
+function Dispatcher:getNameFromItem(item, settings, dont_show_value, honor_cycle)
     if settingsList[item] == nil then
         return _("Unknown item")
     end
@@ -715,6 +735,9 @@ function Dispatcher:getNameFromItem(item, settings, dont_show_value)
     local title = settingsList[item].title
     if dont_show_value or value == nil then
         return title
+    elseif honor_cycle and settings and settings.settings and settings.settings.cycle
+            and Dispatcher.getActionArgs(settings) ~= nil then
+        return title .. " \u{F01E}" -- 'repeat'
     end
     local display_value
     local category = settingsList[item].category
@@ -764,6 +787,7 @@ function Dispatcher._addToOrder(location, settings, item)
             end
         end
         actions.settings = actions.settings or {}
+        actions.settings.cycle = nil -- available for single-action gestures/profiles only
         actions.settings.order = { first_item, item }
     elseif count > 2 then
         local order = util.tableGetValue(actions, "settings", "order")
@@ -802,7 +826,7 @@ function Dispatcher._removeFromOrder(location, settings, item)
 end
 
 -- Get a textual representation of the enabled actions to display in a menu item.
-function Dispatcher:menuTextFunc(settings)
+function Dispatcher:menuTextFunc(settings, honor_cycle)
     if settings then
         local count = Dispatcher:_itemsCount(settings)
         if count == 0 then
@@ -810,7 +834,7 @@ function Dispatcher:menuTextFunc(settings)
         elseif count == 1 then
             local item = next(settings)
             if item == "settings" then item = next(settings, item) end
-            return Dispatcher:getNameFromItem(item, settings)
+            return Dispatcher:getNameFromItem(item, settings, nil, honor_cycle)
         end
         return T(NC_("Dispatcher", "1 action", "%1 actions", count), count)
     end
@@ -1140,6 +1164,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
                     util.tableRemoveValue(actions, "settings", "show_as_quickmenu")
                     caller.updated = true
                 elseif util.tableGetValue(actions, "settings", "execute_one_by_one") then
+                    actions.settings.cycle = nil
                     util.tableRemoveValue(actions, "settings", "execute_one_by_one")
                     caller.updated = true
                 end
@@ -1149,16 +1174,19 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
     table.insert(menu, {
         text = _("Execute one by one"),
         enabled_func = function()
-            return util.tableGetValue(location[settings], "settings", "order") and true or false
+            return (util.tableGetValue(location[settings], "settings", "order")
+                or Dispatcher.getActionArgs(location[settings]) ~= nil) and true or false
         end,
         checked_func = function()
             return util.tableGetValue(location[settings], "settings", "execute_one_by_one")
+                and Dispatcher.getActionArgs(location[settings]) ~= nil
         end,
         radio = true,
         callback = function()
             local actions = location[settings]
             if actions and not util.tableGetValue(actions, "settings", "execute_one_by_one") then
                 util.tableSetValue(actions, 1, "settings", "execute_one_by_one") -- start from the first action
+                actions.settings.cycle = Dispatcher.getActionArgs(location[settings]) ~= nil or nil
                 actions.settings.show_as_quickmenu = nil
                 actions.settings.quickmenu_separators = nil
                 actions.settings.keep_open_on_apply = nil
@@ -1178,6 +1206,7 @@ function Dispatcher:addSubMenu(caller, menu, location, settings)
             local actions = location[settings]
             if actions and not util.tableGetValue(actions, "settings", "show_as_quickmenu") then
                 util.tableSetValue(actions, true, "settings", "show_as_quickmenu")
+                actions.settings.cycle = nil
                 actions.settings.execute_one_by_one = nil
                 caller.updated = true
             end

--- a/plugins/gestures.koplugin/main.lua
+++ b/plugins/gestures.koplugin/main.lua
@@ -300,7 +300,7 @@ end
 
 function Gestures:gestureTitleFunc(ges)
     local title = gestures_list[ges] or self:friendlyMultiswipeName(ges)
-    return T(_("%1   (%2)"), title, Dispatcher:menuTextFunc(self.gestures[ges]))
+    return T(_("%1   (%2)"), title, Dispatcher:menuTextFunc(self.gestures[ges], true)) -- honor cycle
 end
 
 function Gestures:genMenu(ges)
@@ -581,7 +581,7 @@ function Gestures:onShowGestureOverview()
             end
             local gest = self.gestures[ges_name]
             if gest then
-                local value = Dispatcher:menuTextFunc(gest)
+                local value = Dispatcher:menuTextFunc(gest, true) -- honor cycle
                 if value ~= nothing then
                     local key = gestures_list[ges_name] or self:friendlyMultiswipeName(ges_name)
                     local callback
@@ -603,7 +603,7 @@ function Gestures:onShowGestureOverview()
                     if gest.settings then
                         if gest.settings.show_as_quickmenu then
                             value = value .. " \u{F0CA}"
-                        elseif gest.settings.execute_one_by_one then
+                        elseif gest.settings.execute_one_by_one and not gest.settings.cycle then
                             value = value .. " \u{F051}"
                         end
                     end

--- a/plugins/hotkeys.koplugin/main.lua
+++ b/plugins/hotkeys.koplugin/main.lua
@@ -298,7 +298,7 @@ end
 function HotKeys:shortcutTitleFunc(hotkey)
     local title = hotkeys_list[hotkey]
     local action_list = self.hotkeys[hotkey]
-    local action_text = action_list and Dispatcher:menuTextFunc(action_list) or _("No action")
+    local action_text = action_list and Dispatcher:menuTextFunc(action_list, true) or _("No action")
     return T(_("%1: (%2)"), title, action_text)
 end
 

--- a/plugins/profiles.koplugin/main.lua
+++ b/plugins/profiles.koplugin/main.lua
@@ -207,7 +207,7 @@ function Profiles:getSubMenuItems()
             },
             {
                 text_func = function()
-                    return T(_("Edit actions: (%1)"), Dispatcher:menuTextFunc(v))
+                    return T(_("Edit actions: (%1)"), Dispatcher:menuTextFunc(v, true)) -- honor cycle
                 end,
                 sub_item_table_func = function()
                     local edit_actions_sub_items = {}


### PR DESCRIPTION
If a gesture/profile contains single action and this action has selectable options (on/off, font face etc.) this allows to cycle through the options one by one.
Activated by choosing "Execute one by one" in the action menu.
Saves the last executed option between sessions (same as multi-action profiles executed "one by one").

For example, the "Font" action assigned to the Bottom left corner tap:
<img width="400" height="202" alt="1" src="https://github.com/user-attachments/assets/b214c8ae-aee7-4bef-b243-a5b397a03d8d" />

-----

Activate cycling:
<img width="400" height="339" alt="2" src="https://github.com/user-attachments/assets/08129ba7-1436-4646-9a90-57fc50e0c585" />

-----

Indicate cycling:
<img width="400" height="201" alt="3" src="https://github.com/user-attachments/assets/4a988122-b051-4344-8757-b9d9d256c01d" />

-----

Gesture overview:
<img width="400" height="529" alt="4" src="https://github.com/user-attachments/assets/cfa693ac-3364-4a2e-8469-818a2ba0e0f0" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15958)
<!-- Reviewable:end -->
