### PR TITLE
Wallabag: skip archive/delete if it's the currently opened document

### DIFF
--- a/plugins/wallabag.koplugin/main.lua
+++ b/plugins/wallabag.koplugin/main.lua
@@ -1404,6 +1404,13 @@ end
 -- @tparam string path Local path of the article
 -- @treturn bool Successfully archived or not.
 function Wallabag:archiveLocalArticle(path)
+    -- Skip if it's the currently opened document
+    if self.ui.document then
+        if path == self.ui.document.file then
+            return false
+        end
+    end
+
     -- Check if the archive directory is valid
     local dir_mode = lfs.attributes(self.archive_directory, "mode")
     if dir_mode == nil then
@@ -1435,14 +1442,19 @@ end
 -- @tparam string path Local path of the article
 -- @treturn bool Successfully deleted or not.
 function Wallabag:deleteLocalArticle(path)
-    local result = false
+    -- Skip if it's the currently opened document
+    if self.ui.document then
+        if path == self.ui.document.file then
+            return false
+        end
+    end
 
     if lfs.attributes(path, "mode") == "file" then
         FileManager:deleteFile(path, true)
-        result = true
+        return true
     end
 
-    return result
+    return false
 end
 
 --- Extract the Wallabag ID from the file name.


### PR DESCRIPTION
Moving (or deleting) the file while it's still being open in the reader causes problems: its metadata will be written to the old location when it's eventually closed, and I think I've seen crashes as well (don't quite remember but something like switching to File Browser and then using the Open Last Book function or something).

The simplest solution is to just not archive it while it's still open. It will be archived on the next sync anyway.

Alternatively, we could do what movetoarchive.koplugin does, and ask the user whether they want to open it from the new location (if archiving) or switch back to File Browser:
https://github.com/koreader/koreader/blob/8c4d6c0a3ab8449ac65b413187d27d54f50fd946/plugins/movetoarchive.koplugin/main.lua#L153-L161
I don't think it's worth the complexity though — Move to Archive doing nothing is bad UX, obviously, but a Wallabag sync skipping one article until the next sync is fine, IMO.

I suspect this might also be related to this TODO note:
https://github.com/koreader/koreader/blob/8c4d6c0a3ab8449ac65b413187d27d54f50fd946/plugins/wallabag.koplugin/main.lua#L1428

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15961)
<!-- Reviewable:end -->
