### PR TITLE
kobo: send hostname in DHCP request with udhcpc

### DIFF
--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -56,5 +56,8 @@ done
 if [ -x "/sbin/dhcpcd" ]; then
     dhcpcd -d -t 30 -w "${INTERFACE}"
 else
-    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x "hostname:$(hostname)" -b -q
+    -- Stock sets hostname to kobo, mimic that in case we're on a custom OS that didn't set hostname.
+    hn="$(hostname -s)"
+    [ "${hn}" = "(none)" ] && hn="kobo"
+    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x "hostname:${hn}" -b -q
 fi

--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -56,5 +56,5 @@ done
 if [ -x "/sbin/dhcpcd" ]; then
     dhcpcd -d -t 30 -w "${INTERFACE}"
 else
-    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x hostname:$(hostname) -b -q
+    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x "hostname:$(hostname)" -b -q
 fi

--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -56,5 +56,5 @@ done
 if [ -x "/sbin/dhcpcd" ]; then
     dhcpcd -d -t 30 -w "${INTERFACE}"
 else
-    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -b -q
+    udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x hostname:$(hostname) -b -q
 fi

--- a/platform/kobo/obtain-ip.sh
+++ b/platform/kobo/obtain-ip.sh
@@ -56,7 +56,7 @@ done
 if [ -x "/sbin/dhcpcd" ]; then
     dhcpcd -d -t 30 -w "${INTERFACE}"
 else
-    -- Stock sets hostname to kobo, mimic that in case we're on a custom OS that didn't set hostname.
+    # Stock sets hostname to kobo, mimic that in case we're on a custom OS that didn't set hostname.
     hn="$(hostname -s)"
     [ "${hn}" = "(none)" ] && hn="kobo"
     udhcpc -S -i "${INTERFACE}" -s /etc/udhcpc.d/default.script -x "hostname:${hn}" -b -q


### PR DESCRIPTION
dhcpcd appears to do it by default but it is not the case with udhcpc

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15969)
<!-- Reviewable:end -->
