### PR TITLE
statistics, vocabbuilder: sync silently unless the user asked

### DIFF
--- a/plugins/cloudstorage.koplugin/main.lua
+++ b/plugins/cloudstorage.koplugin/main.lua
@@ -194,6 +194,9 @@ end
 -- After merging, the income file is no longer needed and is deleted. The local file is uploaded and then a copy of it is saved
 -- and renamed to replace the old cached file (thus the naming). The cached file stays (in the same folder) till being replaced
 -- in the next round.
+--
+-- `is_silent` suppresses both the failure message and the success notification, so a caller can run
+-- a sync the user did not ask for without interrupting what they are doing.
 function Cloud:sync(server, file_path, sync_cb, is_silent, caller_pre_callback)
     local provider = server and server.type and self.providers[server.type]
     if not provider then return end
@@ -238,10 +241,12 @@ function Cloud:sync(server, file_path, sync_cb, is_silent, caller_pre_callback)
             if type(code_response) == "number" and code_response >= 200 and code_response < 300 then
                 os.remove(cached_file_path)
                 ffiUtil.copyFile(file_path, cached_file_path)
-                UIManager:show(Notification:new{
-                    text = _("Successfully synchronized."),
-                    timeout = 2,
-                })
+                if not is_silent then
+                    UIManager:show(Notification:new{
+                        text = _("Successfully synchronized."),
+                        timeout = 2,
+                    })
+                end
             else
                 show_msg()
             end

--- a/plugins/cloudstorage.koplugin/main.lua
+++ b/plugins/cloudstorage.koplugin/main.lua
@@ -211,7 +211,11 @@ function Cloud:sync(server, file_path, sync_cb, is_silent, caller_pre_callback)
             local cached_file_path = file_path .. ".sync" -- file uploaded to server last time
             local fail_msg = _("Something went wrong when syncing, please check your network connection and try again later.")
             local show_msg = function(msg)
-                if is_silent then return end
+                if is_silent then
+                    -- nobody is watching: log it
+                    logger.warn("cloud sync failed:", msg or fail_msg)
+                    return
+                end
                 UIManager:show(InfoMessage:new{
                     text = msg or fail_msg,
                     timeout = 3,

--- a/plugins/statistics.koplugin/main.lua
+++ b/plugins/statistics.koplugin/main.lua
@@ -106,7 +106,7 @@ function ReaderStatistics:onDispatcherRegisterActions()
     Dispatcher:registerAction("stats_calendar_day_view",
         {category="none", event="ShowCalendarDayView", title=_("Reading statistics: show today's timeline"), general=true})
     Dispatcher:registerAction("stats_sync",
-        {category="none", event="SyncBookStats", title=_("Reading statistics: synchronize"), general=true, separator=true})
+        {category="none", event="SyncBookStats", arg=true, title=_("Reading statistics: synchronize"), general=true, separator=true})
     Dispatcher:registerAction("book_statistics",
         {category="none", event="ShowBookStats", title=_("Reading statistics: current book"), reader=true})
 end
@@ -1247,7 +1247,7 @@ Time is in hours and minutes.]]),
             {
                 text = _("Sync now"),
                 callback = function()
-                    self:onSyncBookStats()
+                    self:onSyncBookStats(true)
                 end,
                 enabled_func = function()
                     return self:canSync()
@@ -3092,15 +3092,21 @@ function ReaderStatistics:setSyncRemoteFolder(touchmenu_instance)
     UIManager:show(dialogue)
 end
 
-function ReaderStatistics:onSyncBookStats()
+-- `interactive` marks a sync the user asked for: the menu entry and the Dispatcher action both pass
+-- it. A plugin driving a periodic sync sends the bare event and gets a silent one, leaving the page
+-- the user is reading alone. Same flag as KOSync:updateProgress.
+function ReaderStatistics:onSyncBookStats(interactive)
     if self:canSync() then
-        local caller_pre_callback = function()
-            UIManager:show(InfoMessage:new {
-                text = _("Syncing book statistics…"),
-                timeout = 1,
-            })
+        local caller_pre_callback
+        if interactive then
+            caller_pre_callback = function()
+                UIManager:show(InfoMessage:new {
+                    text = _("Syncing book statistics…"),
+                    timeout = 1,
+                })
+            end
         end
-        self.ui.cloudstorage:sync(self.settings.sync_server, db_location, self.onSync, nil, caller_pre_callback)
+        self.ui.cloudstorage:sync(self.settings.sync_server, db_location, self.onSync, not interactive, caller_pre_callback)
     end
 end
 

--- a/plugins/vocabbuilder.koplugin/main.lua
+++ b/plugins/vocabbuilder.koplugin/main.lua
@@ -241,7 +241,7 @@ function MenuDialog:setupPluginMenu()
                     callback = function()
                         UIManager:close(self.sync_dialogue)
                         UIManager:close(self)
-                        self.vocabbuilder.vocabbuilder:onSyncVocabBuilder()
+                        self.vocabbuilder.vocabbuilder:onSyncVocabBuilder(true)
                     end,
                 },
             },
@@ -1450,7 +1450,7 @@ function VocabularyBuilderWidget:refreshFooter()
         margin = 0,
         show_parent = self,
         callback = function()
-            self.vocabbuilder:onSyncVocabBuilder()
+            self.vocabbuilder:onSyncVocabBuilder(true)
         end
     }
     self.footer_sync.label_widget.fgcolor = Blitbuffer.COLOR_GRAY_3
@@ -2073,7 +2073,7 @@ function VocabBuilder:onDispatcherRegisterActions()
     Dispatcher:registerAction("show_vocab_builder",
         {category="none", event="ShowVocabBuilder", title=_("Open vocabulary builder"), general=true})
     Dispatcher:registerAction("sync_vocab_builder",
-        {category="none", event="SyncVocabBuilder", title=_("Sync vocabulary builder"), general=true, separator=true})
+        {category="none", event="SyncVocabBuilder", arg=true, title=_("Sync vocabulary builder"), general=true, separator=true})
 end
 
 function VocabBuilder:onShowVocabBuilder()
@@ -2086,12 +2086,15 @@ function VocabBuilder:onShowVocabBuilder()
     return true
 end
 
-function VocabBuilder:onSyncVocabBuilder()
+-- `interactive` marks a sync the user asked for: the sync buttons and the Dispatcher action both
+-- pass it. A plugin driving a periodic sync sends the bare event and gets a silent one, leaving the
+-- page the user is reading alone. Same flag as KOSync:updateProgress.
+function VocabBuilder:onSyncVocabBuilder(interactive)
     if settings.server and self.ui.cloudstorage then
         if self.widget then
             DB:batchUpdateItems(self.widget.item_table)
         end
-        self.ui.cloudstorage:sync(settings.server, DB.path, DB.onSync, false)
+        self.ui.cloudstorage:sync(settings.server, DB.path, DB.onSync, not interactive)
         if self.widget then
             self.widget:reloadItems()
         end


### PR DESCRIPTION
A third-party plugin can keep the statistics and vocabulary databases in step by
broadcasting the Dispatcher events these plugins register; syncery.koplugin does so
every five minutes. Each round paints a centred InfoMessage plus a success
notification over the page being read, so during a reading session it lands every few
pages.

Both handlers now take the `interactive` flag that KOSync:updateProgress already uses
for this distinction: the menu entries pass it, the Dispatcher actions carry it as
their `arg`, and a bare event syncs silently. The flag reaches Cloud:sync as
`is_silent`, which so far suppressed the failure message alone.

Tested on two Kindle 3 (v2026.07.1) through an equivalent userpatch: the background
sync is silent, the manual one unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15976)
<!-- Reviewable:end -->
