### PR TITLE
CoverBrowser mosaic: repaint the cursor there too

### DIFF
--- a/plugins/coverbrowser.koplugin/mosaicmenu.lua
+++ b/plugins/coverbrowser.koplugin/mosaicmenu.lua
@@ -752,6 +752,14 @@ function MosaicMenuItem:paintTo(bb, x, y)
     end
 end
 
+function MosaicMenuItem:getFocusIndicatorRegion()
+    return self._underline_container and self._underline_container:getFocusIndicatorRegion()
+end
+
+function MosaicMenuItem:repaintFocusIndicator(bb)
+    return self._underline_container and self._underline_container:repaintFocusIndicator(bb)
+end
+
 -- As done in MenuItem
 function MosaicMenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK


### PR DESCRIPTION
Follow-up to #15897. `MosaicMenuItem` carries an `UnderlineContainer` like
`MenuItem` and `TouchMenuItem` do, but did not implement the two methods, so a
cursor step in the mosaic views still repainted the whole window.

Kindle 3 (600x800), v2026.07.1 against the same build with #15897 and this patch:

| cursor step | before | after |
|---|---|---|
| area | 1.0 screen | 0.0039 screen (two 186x5 updates) |
| ioctl | 83.5 ms | 22.6 ms |
| repaint pass, median | 640 ms (19 steps) | 31.6 ms (33 steps) |

Same on a narrower grid (108 px cells): 31.1 ms. No leftovers when the cursor
leaves a cell.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15978)
<!-- Reviewable:end -->
