### PR TITLE
OPDS: offer "Read existing book" when the file already exists

### DIFF
--- a/plugins/opds.koplugin/main.lua
+++ b/plugins/opds.koplugin/main.lua
@@ -96,6 +96,9 @@ function OPDS:onShowOPDSCatalog()
         file_downloaded_callback = function(file)
             self:showFileDownloadedDialog(file)
         end,
+        file_read_now_callback = function(file)
+            self:openDownloadedFile(file)
+        end,
         close_callback = function()
             if self.opds_browser.download_list then
                 self.opds_browser.download_list.close_callback()
@@ -120,19 +123,25 @@ function OPDS:showFileDownloadedDialog(file)
         text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file)),
         ok_text = _("Read now"),
         ok_callback = function()
-            self.last_downloaded_file = nil
-            self.opds_browser.close_callback()
-            if self.ui.document then
-                self.ui:switchDocument(file)
-            else
-                self.ui:openFile(file)
-            end
+            self:openDownloadedFile(file)
         end,
     }
     -- As the InfoMessage "Downloading" is getting closed, show this ConfirmBox on the next UI tick to avoid e-Ink rendering congestion
     UIManager:nextTick(function()
         UIManager:show(confirm_box)
     end)
+end
+
+-- Closes the browser and opens the book, either freshly downloaded or already on disk
+function OPDS:openDownloadedFile(file)
+    -- No need to have close_callback() navigate the file browser to the file, we're opening it
+    self.last_downloaded_file = nil
+    self.opds_browser.close_callback()
+    if self.ui.document then
+        self.ui:switchDocument(file)
+    else
+        self.ui:openFile(file)
+    end
 end
 
 function OPDS:onFlushSettings()

--- a/plugins/opds.koplugin/opdsbrowser.lua
+++ b/plugins/opds.koplugin/opdsbrowser.lua
@@ -1085,7 +1085,8 @@ function OPDSBrowser:showDownloads(item)
                     callback = function()
                         UIManager:close(self.download_dialog)
                         local local_path = self:getLocalDownloadPath(filename, filetype, acquisition.href)
-                        self:checkDownloadFile(local_path, acquisition.href, self.root_catalog_username, self.root_catalog_password, self.file_downloaded_callback)
+                        self:checkDownloadFile(local_path, acquisition.href, self.root_catalog_username, self.root_catalog_password,
+                            self.file_downloaded_callback, self.file_read_now_callback)
                     end,
                     hold_callback = function()
                         UIManager:close(self.download_dialog)
@@ -1236,7 +1237,7 @@ function OPDSBrowser:getLocalDownloadPath(filename, filetype, remote_url)
 end
 
 -- Downloads a book (with "File already exists" dialog)
-function OPDSBrowser:checkDownloadFile(local_path, remote_url, username, password, caller_callback)
+function OPDSBrowser:checkDownloadFile(local_path, remote_url, username, password, caller_callback, read_now_callback)
     local function download()
         UIManager:scheduleIn(1, function()
             self:downloadFile(local_path, remote_url, username, password, caller_callback)
@@ -1247,12 +1248,21 @@ function OPDSBrowser:checkDownloadFile(local_path, remote_url, username, passwor
         })
     end
     if lfs.attributes(local_path) then
+        local other_buttons = {{
+            {
+                text = _("Read existing book"),
+                callback = function()
+                    read_now_callback(local_path)
+                end,
+            },
+        }}
         UIManager:show(ConfirmBox:new{
-            text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filepath(local_path)),
+            text = T(_("The file %1 already exists."), BD.filepath(local_path)),
             ok_text = _("Overwrite"),
             ok_callback = function()
                 download()
             end,
+            other_buttons = other_buttons,
         })
     else
         download()
@@ -1562,8 +1572,14 @@ function OPDSBrowser:showDownloadListItemDialog(item)
                         remove_item()
                         self._manager.file_downloaded_callback(local_path)
                     end
+                    local function file_read_now_callback(local_path)
+                        -- Keep the item in the download list, it has not been downloaded
+                        textviewer:onClose()
+                        self._manager.file_read_now_callback(local_path)
+                    end
                     NetworkMgr:runWhenConnected(function()
-                        self._manager:checkDownloadFile(dl_item.file, dl_item.url, dl_item.username, dl_item.password, file_downloaded_callback)
+                        self._manager:checkDownloadFile(dl_item.file, dl_item.url, dl_item.username, dl_item.password,
+                            file_downloaded_callback, file_read_now_callback)
                     end)
                 end,
             },


### PR DESCRIPTION
Downloading a book that is already in the download folder only offered
"Cancel" or "Overwrite", so the only way to reach the book was to download
it a second time (and then choose the "Read now" button), or to cancel
and go find it in the file browser.

Add a third button "Read existing book" that opens the local book
directly just as the "Read now" action of the post-download dialog does,
and matches the language used ("Would you like to read the downloaded
book now?").

The action is factored out of showFileDownloadedDialog() into
OPDS:openDownloadedFile(), so both dialogs share a single code
path. ConfirmBox renders other_buttons as an extra row, leaving the
existing Cancel/Overwrite row untouched.

As suggested, also remove the redundant "Do you want to overwrite it?"
question, since the buttons ("Cancel", "Overwrite") already spell out
the basic choice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15979)
<!-- Reviewable:end -->
