### PR TITLE
calibre: change "extensionPathLengths" to actually only be the length of the extension

### DIFF
--- a/plugins/calibre.koplugin/extensions.lua
+++ b/plugins/calibre.koplugin/extensions.lua
@@ -31,8 +31,8 @@ local valid_ext = {
     "zip",
 }
 
--- if the file "calibre-extensions.lua", under dataDir, returns a table
--- then use it instead of default extensions.
+--- if the file "calibre-extensions.lua", under dataDir, returns a table
+--- then use it instead of default extensions.
 local function getCustomConfig()
     local path = require("datastorage"):getDataDir()
     local ok, extensions = pcall(dofile, string.format("%s/%s", path, "calibre-extensions.lua"))
@@ -45,6 +45,7 @@ local CalibreExtensions = {
     user_overrides = getCustomConfig(),
 }
 
+--- Get all formats that we report as supported for calibre
 function CalibreExtensions:get()
     if type(self.user_overrides) == "table" then
         return self.user_overrides

--- a/plugins/calibre.koplugin/extensions.lua
+++ b/plugins/calibre.koplugin/extensions.lua
@@ -31,7 +31,7 @@ local valid_ext = {
     "zip",
 }
 
---- if the file "calibre-extensions.lua", under dataDir, returns a table
+--- If the file "calibre-extensions.lua", under dataDir, returns a table,
 --- then use it instead of default extensions.
 local function getCustomConfig()
     local path = require("datastorage"):getDataDir()

--- a/plugins/calibre.koplugin/extensions.lua
+++ b/plugins/calibre.koplugin/extensions.lua
@@ -45,7 +45,7 @@ local CalibreExtensions = {
     user_overrides = getCustomConfig(),
 }
 
---- Get all formats that we report as supported for calibre
+--- Get all formats that we report as supported for calibre.
 function CalibreExtensions:get()
     if type(self.user_overrides) == "table" then
         return self.user_overrides

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -81,13 +81,13 @@ end
 --- Supported formats list.
 local extensions = CalibreExtensions:get()
 
---- Get all extension required length.
+--- Get all the required length of all extensions.
 --- In calibre 9.14, this length is the amount protected against being shortend at the end of the path
 --- and is defined as "dotless extension".
 local function getExtensionPathLengths()
     local t = {}
     for _, v in ipairs(extensions) do
-        -- set the required length to the actual extension's length
+        -- Set the required length to length of the actual extension.
         t[v] = string.len(v)
     end
     return t

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -81,12 +81,14 @@ end
 -- supported formats
 local extensions = CalibreExtensions:get()
 
+--- Get all extension required length.
+--- In calibre 9.14, this length is the amount protected against being shortend at the end of the path
+--- and is defined as "dotless extension".
 local function getExtensionPathLengths()
     local t = {}
     for _, v in ipairs(extensions) do
-        -- magic number from calibre, see
-        -- https://github.com/koreader/koreader/pull/6177#discussion_r430753964
-        t[v] = 37
+        -- set the required length to the actual extension's length
+        t[v] = string.len(v)
     end
     return t
 end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -78,7 +78,7 @@ if false then
 end
 -- luacheck: pop
 
--- supported formats
+--- Supported formats list.
 local extensions = CalibreExtensions:get()
 
 --- Get all extension required length.

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -81,7 +81,7 @@ end
 --- Supported formats list.
 local extensions = CalibreExtensions:get()
 
---- Get all the required length of all extensions.
+--- Get all the required lengths of all extensions.
 --- In calibre 9.14, this length is the amount protected against being shortend at the end of the path
 --- and is defined as "dotless extension".
 local function getExtensionPathLengths()


### PR DESCRIPTION
Instead of a static 37 documented as a magic number, which it not quite is anymore.

Additionally, documents some return types in the call chain as they showed up as "unknown". (please note that this is my first time using the LuaLS annoations, i hope they are to style)

As https://github.com/koreader/koreader/issues/15928#issuecomment-5501989736 already notes, this is only a band-aid / interim fix for the calibre wireless driver to get *slighty* more characters before being shortend.
To be exact, there are now at least 30 more characters available.
This should not have any impact on existing books (ie duplicates), as they are tracked in the calibre metadata / drive file managed by the plugin.

fixes #15928

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15987)
<!-- Reviewable:end -->
