### PR TITLE
Annotations: fix invalid XPointers order

### DIFF
--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -380,30 +380,43 @@ function ReaderAnnotation:updateItemByXPointer(item)
     item.pageref = self:getPageRef(item.page, item.pageno)
 end
 
+function ReaderAnnotation:getInvalidXPointersOrder(a, b, key)
+    local is_a_valid = self.document:isXPointerInDocument(a[key])
+    local is_b_valid = self.document:isXPointerInDocument(b[key])
+    if is_a_valid and is_b_valid then return end
+    -- sort highlights with invalid xpointer to page 1
+    if is_a_valid then
+        return false
+    elseif is_b_valid then
+        return true
+    else -- both invalid
+        return a.datetime < b.datetime
+    end
+end
+
 function ReaderAnnotation:isItemInPositionOrderRolling(a, b)
+    local order = self:getInvalidXPointersOrder(a, b, "page")
+    if order ~= nil then
+        return order
+    end
     local a_page = self.document:getPageFromXPointer(a.page)
     local b_page = self.document:getPageFromXPointer(b.page)
-    if a_page == b_page then -- both items in the same page
-        if (not a.drawer) ~= (not b.drawer) then -- comparing a page bookmark and a highlight
-            return not a.drawer -- have page bookmarks before highlights
-        end
-        local compare_xp = self.document:compareXPointers(a.page, b.page)
-        if compare_xp then
-            if a.drawer and compare_xp == 0 then -- both highlights with the same start, compare ends
-                compare_xp = self.document:compareXPointers(a.pos1, b.pos1)
-                if compare_xp then
-                    return compare_xp > 0
-                end
-                logger.warn("Invalid xpointer in highlight:", a.pos1, b.pos1)
-                return true
-            end
-            return compare_xp > 0
-        end
-        -- if compare_xp is nil, some xpointer is invalid and "a" will be sorted first to page 1
-        logger.warn("Invalid xpointer in highlight:", a.page, b.page)
-        return true
+    if a_page ~= b_page then
+        return a_page < b_page
     end
-    return a_page < b_page
+    -- same page
+    if (not a.drawer) ~= (not b.drawer) then -- comparing a page bookmark and a highlight
+        return not a.drawer -- sort page bookmark before highlights
+    end
+    local compare_xp = self.document:compareXPointers(a.page, b.page)
+    if a.drawer and compare_xp == 0 then -- both highlights with the same start, compare ends
+        order = self:getInvalidXPointersOrder(a, b, "pos2")
+        if order ~= nil then
+            return order
+        end
+        return self.document:compareXPointers(a.pos1, b.pos1) > 0
+    end
+    return compare_xp > 0
 end
 
 function ReaderAnnotation:isItemInPositionOrderPaging(a, b)

--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -410,7 +410,7 @@ function ReaderAnnotation:isItemInPositionOrderRolling(a, b)
     end
     local compare_xp = self.document:compareXPointers(a.page, b.page)
     if a.drawer and compare_xp == 0 then -- both highlights with the same start, compare ends
-        order = self:getInvalidXPointersOrder(a, b, "pos2")
+        order = self:getInvalidXPointersOrder(a, b, "pos1")
         if order ~= nil then
             return order
         end


### PR DESCRIPTION
`doc:compareXPointers()` doesn't say which xpointer is invalid, need to check by `doc:isXPointerInDocument()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/15994)
<!-- Reviewable:end -->
