### PR TITLE
android: restore saved warmth at startup

### DIFF
--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -35,19 +35,9 @@ function AndroidPowerD:init()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
 
-        -- BasePowerD:new() assigns warmth_scale to the class rather than the instance, and
-        -- only *after* init() returns -- and the module-level BasePowerD:new{} that built
-        -- this class already set it to 1, from the default fl_warmth_max of 100. setWarmth()
-        -- below would otherwise scale with that stale 1 and hand the controller an
-        -- unscaled value, so compute the real one here (c.f. KoboPowerD:init).
+        -- BasePowerD only sets warmth_scale after init() returns, c.f. KoboPowerD:init.
         self.warmth_scale = 100 / self.fl_warmth_max
 
-        -- Nothing else restores warmth on Android. Brightness is restored by the framework,
-        -- but warmth is only ever written when the user moves the slider, so whatever the
-        -- hardware happens to hold at startup wins. That is harmless where the hardware
-        -- keeps our value, but not where a vendor layer re-applies its own: on the Nook
-        -- Glowlight 4 Plus, B&N's colour temperature service resets warmth to cold on every
-        -- unlock. Push our saved value back so that ours is the one that sticks.
         local warmth = G_reader_settings:readSetting("frontlight_warmth")
         if warmth then
             self.fl_warmth = warmth

--- a/frontend/device/android/powerd.lua
+++ b/frontend/device/android/powerd.lua
@@ -34,6 +34,25 @@ function AndroidPowerD:init()
         self.fl_warmth_min = android.getScreenMinWarmth()
         self.fl_warmth_max = android.getScreenMaxWarmth()
         self.warm_diff = self.fl_warmth_max - self.fl_warmth_min
+
+        -- BasePowerD:new() assigns warmth_scale to the class rather than the instance, and
+        -- only *after* init() returns -- and the module-level BasePowerD:new{} that built
+        -- this class already set it to 1, from the default fl_warmth_max of 100. setWarmth()
+        -- below would otherwise scale with that stale 1 and hand the controller an
+        -- unscaled value, so compute the real one here (c.f. KoboPowerD:init).
+        self.warmth_scale = 100 / self.fl_warmth_max
+
+        -- Nothing else restores warmth on Android. Brightness is restored by the framework,
+        -- but warmth is only ever written when the user moves the slider, so whatever the
+        -- hardware happens to hold at startup wins. That is harmless where the hardware
+        -- keeps our value, but not where a vendor layer re-applies its own: on the Nook
+        -- Glowlight 4 Plus, B&N's colour temperature service resets warmth to cold on every
+        -- unlock. Push our saved value back so that ours is the one that sticks.
+        local warmth = G_reader_settings:readSetting("frontlight_warmth")
+        if warmth then
+            self.fl_warmth = warmth
+            self:setWarmth(warmth, true)
+        end
     end
 end
 


### PR DESCRIPTION
## What's missing

Brightness survives a restart on Android — the framework restores it and `AndroidPowerD` reads it back. Warmth does not. Nothing ever writes warmth to the hardware except a user-initiated `setWarmth()`, so whatever value the hardware happens to hold at launch wins, and KOReader silently adopts it as `fl_warmth`.

`AndroidPowerD:init()` only computes the min/max ranges. `turnOnFrontlightHW()` does write warmth, but only when `hasStandaloneWarmth()` is true, and only on an off→on frontlight transition — which doesn't happen at startup, and doesn't happen on resume either, since `AndroidPowerD` doesn't override `beforeSuspend`/`afterResume` the way Kobo and Kindle do.

## Why it matters

This is invisible on devices whose hardware simply keeps the last value. It is very visible where a vendor layer re-applies one of its own.

On the Nook Glowlight 4 Plus, B&N's colour temperature service re-applies a warmth value on every `SCREEN_ON`. If its mode preference is lost — an unclean shutdown does it — it forces the light to cold on every unlock. Full diagnosis in koreader/android-luajit-launcher#620, which is the device-side half of this fix: it makes a warmth write *persist*. This PR is what makes a warmth write *happen* at startup, so the device self-heals instead of requiring the user to nudge the slider.

## The change

Do what `KoboPowerD:init` already does, and push the saved warmth back to the hardware at startup.

### Why `warmth_scale` is recomputed

`BasePowerD:new()` assigns `warmth_scale` to the class rather than the instance, and only *after* `init()` returns — and the module-level `BasePowerD:new{}` that builds `AndroidPowerD` has already set it to `1`, from the default `fl_warmth_max` of 100. Without recomputing it, `setWarmth()` scales with that stale `1` and hands the controller an unscaled 0..100 value, which a 0..10 controller rejects outright:

```
W Lights: warmth value out of range: 100
```

I hit exactly that on the first attempt, and warmth stayed at 0. `KoboPowerD:init` sets `warmth_scale` for the same reason.

## Verification

Tested on a Nook Glowlight 4 Plus together with the companion launcher change. With the device in the broken state (warmth forced to 0 on every wake), launching KOReader now restores it with no slider interaction:

```
Lights  : Setting warmth to 10 of 10
Lights  : CTM mode set to manual
CTMService: setupCTM:0
LightsService: kk-1-brightness(color):10
```

and the value then survives screen cycles and reboots.

## Blast radius, and what I could not test

This changes startup behaviour for **every** Android device with natural light, and I only have the one device.

On hardware that retains warmth across a restart, the added call writes the value that is already set, so it should be a no-op. Where the hardware has drifted from KOReader's saved value, KOReader's value now wins — which is what Kobo already does. Reviewers with Tolino or Onyx hardware may want to sanity-check that, since those are the other `hasNaturalLight` Android paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/16004)
<!-- Reviewable:end -->
