### PR TITLE
Highlights: invert highlight color in night mode

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -495,6 +495,19 @@ function ReaderHighlight:addToMainMenu(menu_items)
         end,
     })
     table.insert(hl_sub_item_table, {
+        text = _("Invert highlight color in night mode"),
+        enabled_func = function()
+            return self.view.highlight.saved_drawer ~= "invert"
+        end,
+        checked_func = function()
+            return self.view.highlight.saved_drawer ~= "invert" and G_reader_settings:isTrue("highlight_selection_invert_highlight_color")
+        end,
+        callback = function()
+            G_reader_settings:flipNilOrFalse("highlight_selection_invert_highlight_color")
+            UIManager:setDirty(self.dialog, "ui")
+        end,
+    })
+    table.insert(hl_sub_item_table, {
         text = _("Use highlight color for selection"),
         enabled_func = function()
             return self.view.highlight.saved_drawer ~= "invert"

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -673,6 +673,9 @@ function ReaderView:drawHighlightRect(bb, _x, _y, rect, drawer, color, draw_note
             bb:darkenRect(x, y, w, h, lighten_factor)
         else
             if bb:getInverse() == 1 then
+                if G_reader_settings:isTrue("highlight_selection_invert_highlight_color") then
+                    color = color:invert()
+                end
                 -- MUL doesn't really work on a black background, so, switch to OVER if we're in software nightmode...
                 -- NOTE: If we do *not* invert the color here, it *will* get inverted by the blitter given that the target bb is inverted.
                 --       While not particularly pretty, this (roughly) matches with hardware nightmode, *and* how MuPDF renders highlights...


### PR DESCRIPTION
- Kobo #14667 
- Kindle #15997

Manual setting. A temporary solution until somebody with a color eink device fixes it.
Should be unchecked on the PC and some Android (I have Xiaomi).
<img width="400" height="407" alt="1" src="https://github.com/user-attachments/assets/78a0a76a-b63a-4d5e-83d9-07aea12a2f1e" />

-----

Long ago this code worked well:
https://github.com/koreader/koreader/blob/5ec0242b50ce821e4edd06a033b548e6e99880b9/frontend/apps/reader/modules/readerview.lua#L675-L681

Then in some Kindle firmware update Amazon began to handle the night mode in other way, and highlights became inverted.
I don't know how to determine if the color is inverted by the system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/16006)
<!-- Reviewable:end -->
