### PR TITLE
CoverBrowser detailed list: optimize focus move

### DIFF
--- a/frontend/ui/widget/container/underlinecontainer.lua
+++ b/frontend/ui/widget/container/underlinecontainer.lua
@@ -22,6 +22,8 @@ local UnderlineContainer = WidgetContainer:extend{
     color = Blitbuffer.COLOR_WHITE,
     vertical_align = "top",
     line_width = nil, -- (Don't use this, it's there because of the complex and ugly layout in TouchMenuItem)
+    -- Start of the line, from the container's edge (mirrored in RTL), for parents that paint over that corner.
+    line_x_offset = nil,
     -- The colour behind the focus bar, so we can erase it where we painted it.
     -- Set it to whatever the parent clears that row with. Leaving it nil means we can
     -- only draw the bar, never erase it, so repaintFocusIndicator declines.
@@ -52,10 +54,11 @@ end
 
 function UnderlineContainer:_getLineXAndWidth()
     local line_width = self.line_width or self.dimen.w
+    local line_x_offset = self.line_x_offset or 0
     if BD.mirroredUILayout() then
-        return self.dimen.x + self.dimen.w - line_width, line_width
+        return self.dimen.x + self.dimen.w - line_width - line_x_offset, line_width
     end
-    return self.dimen.x, line_width
+    return self.dimen.x + line_x_offset, line_width
 end
 
 function UnderlineContainer:_focusBarHeight()

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -160,13 +160,11 @@ function ListMenuItem:update()
             height = corner_mark_size,
         }
     end
-    -- Height left for text: the focus bar can be thicker than the underline, and descenders
-    -- need a gap above it.
-    local text_top_padding = Size.padding.small
+    -- Centre the text in the room above the focus bar, which can be thicker than the underline;
+    -- the padding keeps descenders off the bar.
+    local text_area_h = dimen.h - math.max(Size.line.focus_row - self.underline_h, 0)
     local text_dimen = dimen:copy()
-    text_dimen.h = dimen.h - text_top_padding
-                           - math.max(Size.line.focus_row - self.underline_h, 0)
-                           - Size.padding.small
+    text_dimen.h = text_area_h - 2 * Size.padding.small
     -- The shortcut square is painted over the bottom left corner: keep text and the focus bar out of it.
     local shortcut_width = self.shortcut_icon and self.shortcut_icon.dimen.w or 0
 
@@ -225,29 +223,21 @@ function ListMenuItem:update()
             height_adjust = true,
             height_overflow_show_ellipsis = true,
         }
-        local wleft_group = VerticalGroup:new{
-            VerticalSpan:new{ width = text_top_padding },
-            HorizontalGroup:new{
-                HorizontalSpan:new{ width = pad_width + shortcut_width },
-                wleft,
-            },
-        }
-        local wright_group = VerticalGroup:new{
-            VerticalSpan:new{ width = text_top_padding },
-            HorizontalGroup:new{
-                wright,
-                HorizontalSpan:new{ width = pad_width },
-            },
-        }
         widget = OverlapGroup:new{
             dimen = dimen:copy(),
             LeftContainer:new{
-                dimen = Geom:new{ w = dimen.w, h = wleft_group:getSize().h },
-                wleft_group,
+                dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                HorizontalGroup:new{
+                    HorizontalSpan:new{ width = pad_width + shortcut_width },
+                    wleft,
+                }
             },
             RightContainer:new{
-                dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
-                wright_group,
+                dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                HorizontalGroup:new{
+                    wright,
+                    HorizontalSpan:new{ width = pad_width },
+                },
             },
         }
     else -- file
@@ -434,7 +424,6 @@ function ListMenuItem:update()
                 for i, w in ipairs(wright_items) do
                     wright_width = math.max(wright_width, w:getSize().w)
                 end
-                table.insert(wright_items, 1, VerticalSpan:new{ width = text_top_padding })
                 wright = VerticalGroup:new(wright_items)
                 wright_right_padding = Screen:scaleBySize(10)
             end
@@ -606,14 +595,12 @@ function ListMenuItem:update()
                 logger.dbg(title, "recalculate title/author with", fontsize_title)
             end
 
-            local wmain_group = VerticalGroup:new{
-                VerticalSpan:new{ width = text_top_padding },
-                wtitle,
-                wauthors,
-            }
             local wmain = LeftContainer:new{
-                dimen = Geom:new{ w = text_dimen.w, h = wmain_group:getSize().h },
-                wmain_group,
+                dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
+                VerticalGroup:new{
+                    wtitle,
+                    wauthors,
+                }
             }
 
             -- Build the final widget
@@ -644,18 +631,17 @@ function ListMenuItem:update()
             end
             -- add padded main widget
             table.insert(widget, LeftContainer:new{
-                    dimen = Geom:new{ w = text_dimen.w, h = wmain:getSize().h },
+                    dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
                     wmain
                 })
             -- add right widget
             if wright then
-                local wright_group = HorizontalGroup:new{
-                    wright,
-                    HorizontalSpan:new{ width = wright_right_padding },
-                }
                 table.insert(widget, RightContainer:new{
-                    dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
-                    wright_group,
+                    dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                    HorizontalGroup:new{
+                        wright,
+                        HorizontalSpan:new{ width = wright_right_padding },
+                    },
                 })
             end
 
@@ -724,16 +710,12 @@ function ListMenuItem:update()
             local line_left = Screen:scaleBySize(10) + shortcut_width
             self._underline_container.line_x_offset = line_left
             self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
-            local text_group = VerticalGroup:new{
-                VerticalSpan:new{ width = text_top_padding },
+            widget = LeftContainer:new{
+                dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
                 HorizontalGroup:new{
                     HorizontalSpan:new{ width = Screen:scaleBySize(10) + shortcut_width },
                     text_widget
                 },
-            }
-            widget = LeftContainer:new{
-                dimen = Geom:new{ w = text_dimen.w, h = text_group:getSize().h },
-                text_group,
             }
             -- UnderlineContainer takes its height from its child: keep the row full height so the
             -- line stays at the bottom.
@@ -742,16 +724,12 @@ function ListMenuItem:update()
                 widget,
             }
             if wright then -- last read date, in History, even for deleted files
-                local wright_group = VerticalGroup:new{
-                    VerticalSpan:new{ width = text_top_padding },
+                table.insert(widget, RightContainer:new{
+                    dimen = Geom:new{ w = dimen.w, h = text_area_h },
                     HorizontalGroup:new{
                         wright,
                         HorizontalSpan:new{ width = wright_right_padding },
                     },
-                }
-                table.insert(widget, RightContainer:new{
-                    dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
-                    wright_group,
                 })
             end
         end

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -127,12 +127,6 @@ function ListMenuItem:init()
     self.init_done = true
 end
 
---- Right end of the focus underline: clear of the dogear on every row, so the line ends
---- at the same x down the list and a focus-only repaint never slices the mark.
-function ListMenuItem:getFocusLineRight(width)
-    return width - corner_mark_size - Screen:scaleBySize(6)
-end
-
 function ListMenuItem:update()
     -- We will be a distinctive widget whether we are a directory,
     -- a known file with image / without image, or a not yet known file
@@ -144,8 +138,7 @@ function ListMenuItem:update()
         h = self.height - 2 * self.underline_h
     }
 
-    -- Create or replace corner_mark if needed. Every row does this, so getFocusLineRight()
-    -- sees the size paintTo() draws.
+    -- Create or replace corner_mark if needed
     local mark_size = math.floor(dimen.h * (1/6))
     -- Just fits under the page info text, which in turn adapts to the ListMenuItem height.
     if mark_size ~= corner_mark_size then
@@ -205,9 +198,6 @@ function ListMenuItem:update()
         }
         local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right
         local wleft_width = dimen.w - wright:getWidth() - 3*pad_width
-        local line_left = pad_width + shortcut_width
-        self._underline_container.line_x_offset = line_left
-        self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
         local wleft = TextBoxWidget:new{
             text = BD.directory(self.text),
             face = Font:getFace("cfont", _fontSize(20, 24)),
@@ -235,6 +225,10 @@ function ListMenuItem:update()
                 },
             },
         }
+
+        local line_left = pad_width + shortcut_width
+        self._underline_container.line_x_offset = line_left
+        self._underline_container.line_width = math.max(dimen.w - corner_mark_size - Screen:scaleBySize(6) - line_left, 0)
     else -- file
         self.file_deleted = self.entry.dim -- entry with deleted file from History or selected file from FM
         local fgcolor = self.file_deleted and Blitbuffer.COLOR_DARK_GRAY or nil
@@ -432,10 +426,6 @@ function ListMenuItem:update()
             end
             local wmain_right_padding = Screen:scaleBySize(10) -- used only for next calculation
             local wmain_width = dimen.w - wleft_width - wmain_left_padding - wmain_right_padding - wright_width - wright_right_padding
-            -- Start the underline past the cover or the shortcut square, so a focus-only repaint doesn't slice them.
-            local line_left = (self.do_cover_image and wleft_width or shortcut_width) + wmain_left_padding
-            self._underline_container.line_x_offset = line_left
-            self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
 
             local fontname_title = "cfont"
             local fontname_authors = "cfont"
@@ -639,6 +629,11 @@ function ListMenuItem:update()
                 })
             end
 
+            -- Start the underline past the cover or the shortcut square, so a focus-only repaint doesn't slice them.
+            local line_left = (self.do_cover_image and wleft_width or shortcut_width) + wmain_left_padding
+            self._underline_container.line_x_offset = line_left
+            self._underline_container.line_width = math.max(dimen.w - corner_mark_size - Screen:scaleBySize(6) - line_left, 0)
+
         else -- bookinfo not found
             if self.init_done then
                 -- Non-initial update(), but our widget is still not found:
@@ -705,9 +700,6 @@ function ListMenuItem:update()
                 -- reduce font size for next loop, in case text widget is too large to fit into ListMenuItem
                 fontsize_no_bookinfo = fontsize_no_bookinfo - fontsize_dec_step
             until text_widget:getSize().h <= dimen.h
-            local line_left = Screen:scaleBySize(10) + shortcut_width
-            self._underline_container.line_x_offset = line_left
-            self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
             widget = LeftContainer:new{
                 dimen = dimen:copy(),
                 HorizontalGroup:new{
@@ -728,6 +720,10 @@ function ListMenuItem:update()
                     },
                 }
             end
+
+            local line_left = Screen:scaleBySize(10) + shortcut_width
+            self._underline_container.line_x_offset = line_left
+            self._underline_container.line_width = math.max(dimen.w - corner_mark_size - Screen:scaleBySize(6) - line_left, 0)
         end
     end
 

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -160,12 +160,7 @@ function ListMenuItem:update()
             height = corner_mark_size,
         }
     end
-    -- Centre the text in the room above the focus bar, which can be thicker than the underline;
-    -- the padding keeps descenders off the bar.
-    local text_area_h = dimen.h - math.max(Size.line.focus_row - self.underline_h, 0)
-    local text_dimen = dimen:copy()
-    text_dimen.h = text_area_h - 2 * Size.padding.small
-    -- The shortcut square is painted over the bottom left corner: keep text and the focus bar out of it.
+    -- The shortcut square sits over the bottom left corner: start the focus underline past it.
     local shortcut_width = self.shortcut_icon and self.shortcut_icon.dimen.w or 0
 
     local function _fontSize(nominal, max)
@@ -209,7 +204,7 @@ function ListMenuItem:update()
             face = Font:getFace("infont", _fontSize(14, 18)),
         }
         local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right
-        local wleft_width = dimen.w - wright:getWidth() - 3*pad_width - shortcut_width
+        local wleft_width = dimen.w - wright:getWidth() - 3*pad_width
         local line_left = pad_width + shortcut_width
         self._underline_container.line_x_offset = line_left
         self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
@@ -219,21 +214,21 @@ function ListMenuItem:update()
             width = wleft_width,
             alignment = "left",
             bold = true,
-            height = text_dimen.h,
+            height = dimen.h,
             height_adjust = true,
             height_overflow_show_ellipsis = true,
         }
         widget = OverlapGroup:new{
             dimen = dimen:copy(),
             LeftContainer:new{
-                dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                dimen = dimen:copy(),
                 HorizontalGroup:new{
-                    HorizontalSpan:new{ width = pad_width + shortcut_width },
+                    HorizontalSpan:new{ width = pad_width },
                     wleft,
                 }
             },
             RightContainer:new{
-                dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                dimen = dimen:copy(),
                 HorizontalGroup:new{
                     wright,
                     HorizontalSpan:new{ width = pad_width },
@@ -276,9 +271,6 @@ function ListMenuItem:update()
             -- Build the left widget : image if wanted
             local wleft = nil
             local wleft_width = 0 -- if not do_cover_image
-            if not self.do_cover_image then
-                wleft_width = shortcut_width
-            end
             local wleft_height
             if self.do_cover_image then
                 wleft_height = dimen.h
@@ -424,7 +416,10 @@ function ListMenuItem:update()
                 for i, w in ipairs(wright_items) do
                     wright_width = math.max(wright_width, w:getSize().w)
                 end
-                wright = VerticalGroup:new(wright_items)
+                wright = CenterContainer:new{
+                    dimen = Geom:new{ w = wright_width, h = dimen.h },
+                    VerticalGroup:new(wright_items),
+                }
                 wright_right_padding = Screen:scaleBySize(10)
             end
 
@@ -437,8 +432,8 @@ function ListMenuItem:update()
             end
             local wmain_right_padding = Screen:scaleBySize(10) -- used only for next calculation
             local wmain_width = dimen.w - wleft_width - wmain_left_padding - wmain_right_padding - wright_width - wright_right_padding
-            -- Start the underline past the cover, so a focus-only repaint doesn't slice it.
-            local line_left = wleft_width + wmain_left_padding
+            -- Start the underline past the cover or the shortcut square, so a focus-only repaint doesn't slice them.
+            local line_left = (self.do_cover_image and wleft_width or shortcut_width) + wmain_left_padding
             self._underline_container.line_x_offset = line_left
             self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
 
@@ -558,7 +553,7 @@ function ListMenuItem:update()
                     build_authors()
                     height = height + wauthors:getSize().h
                 end
-                if height <= text_dimen.h then
+                if height <= dimen.h then
                     -- We fit!
                     break
                 end
@@ -572,7 +567,7 @@ function ListMenuItem:update()
                     local authors_min_height = 2 * authors_line_height -- unscaled_size_check: ignore
                     -- Chop lines, starting with authors, until
                     -- both labels fit in the allocated space.
-                    while title_height + authors_height > text_dimen.h do
+                    while title_height + authors_height > dimen.h do
                         if authors_height > authors_min_height then
                             authors_height = authors_height - authors_line_height
                         elseif title_height > title_min_height then
@@ -596,7 +591,7 @@ function ListMenuItem:update()
             end
 
             local wmain = LeftContainer:new{
-                dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
+                dimen = dimen:copy(),
                 VerticalGroup:new{
                     wtitle,
                     wauthors,
@@ -624,20 +619,19 @@ function ListMenuItem:update()
             else
                 -- pad main widget on the left
                 wmain = HorizontalGroup:new{
-                        HorizontalSpan:new{ width = wleft_width },
                         HorizontalSpan:new{ width = wmain_left_padding },
                         wmain
                 }
             end
             -- add padded main widget
             table.insert(widget, LeftContainer:new{
-                    dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
+                    dimen = dimen:copy(),
                     wmain
                 })
             -- add right widget
             if wright then
                 table.insert(widget, RightContainer:new{
-                    dimen = Geom:new{ w = dimen.w, h = text_area_h },
+                    dimen = dimen:copy(),
                     HorizontalGroup:new{
                         wright,
                         HorizontalSpan:new{ width = wright_right_padding },
@@ -678,10 +672,14 @@ function ListMenuItem:update()
                     face = Font:getFace("cfont", fontsize_info),
                 }
                 wright_width = wfileinfo:getSize().w
-                wright = VerticalGroup:new{
-                    align = "right",
-                    wfileinfo,
-                    wpageinfo,
+                wright = CenterContainer:new{
+                    dimen = Geom:new{ w = wright_width, h = dimen.h },
+                    VerticalGroup:new{
+                        align = "right",
+                        VerticalSpan:new{ width = Screen:scaleBySize(2) },
+                        wfileinfo,
+                        wpageinfo,
+                    }
                 }
                 wright_right_padding = Screen:scaleBySize(10)
             end
@@ -700,37 +698,35 @@ function ListMenuItem:update()
                 text_widget = TextBoxWidget:new{
                     text = text .. hint,
                     face = Font:getFace("cfont", fontsize_no_bookinfo),
-                    width = dimen.w - 2 * Screen:scaleBySize(10) - shortcut_width - wright_width - wright_right_padding,
+                    width = dimen.w - 2 * Screen:scaleBySize(10) - wright_width - wright_right_padding,
                     alignment = "left",
                     fgcolor = fgcolor,
                 }
                 -- reduce font size for next loop, in case text widget is too large to fit into ListMenuItem
                 fontsize_no_bookinfo = fontsize_no_bookinfo - fontsize_dec_step
-            until text_widget:getSize().h <= text_dimen.h
+            until text_widget:getSize().h <= dimen.h
             local line_left = Screen:scaleBySize(10) + shortcut_width
             self._underline_container.line_x_offset = line_left
             self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
             widget = LeftContainer:new{
-                dimen = Geom:new{ w = text_dimen.w, h = text_area_h },
+                dimen = dimen:copy(),
                 HorizontalGroup:new{
-                    HorizontalSpan:new{ width = Screen:scaleBySize(10) + shortcut_width },
+                    HorizontalSpan:new{ width = Screen:scaleBySize(10) },
                     text_widget
                 },
             }
-            -- UnderlineContainer takes its height from its child: keep the row full height so the
-            -- line stays at the bottom.
-            widget = OverlapGroup:new{
-                dimen = dimen:copy(),
-                widget,
-            }
             if wright then -- last read date, in History, even for deleted files
-                table.insert(widget, RightContainer:new{
-                    dimen = Geom:new{ w = dimen.w, h = text_area_h },
-                    HorizontalGroup:new{
-                        wright,
-                        HorizontalSpan:new{ width = wright_right_padding },
+                widget = OverlapGroup:new{
+                    dimen = dimen:copy(),
+                    widget,
+                    RightContainer:new{
+                        dimen = dimen:copy(),
+                        HorizontalGroup:new{
+                            wright,
+                            HorizontalSpan:new{ width = wright_right_padding },
+                        },
                     },
-                })
+                }
             end
         end
     end
@@ -762,14 +758,15 @@ function ListMenuItem:paintTo(bb, x, y)
 
     -- to which we paint over the shortcut icon
     if self.shortcut_icon then
-        -- align it on the bottom left corner of the item
+        -- align it on bottom left corner of sub-widget
+        local target = self[1][1][2]
         local ix
         if BD.mirroredUILayout() then
-            ix = self.width - self.shortcut_icon.dimen.w - 2 * self.shortcut_icon.bordersize
+            ix = target.dimen.w - self.shortcut_icon.dimen.w - 2 * self.shortcut_icon.bordersize
         else
             ix = 0
         end
-        local iy = self.height - self.shortcut_icon.dimen.h - 2 * self.shortcut_icon.bordersize
+        local iy = target.dimen.h - self.shortcut_icon.dimen.h - self.shortcut_icon.bordersize
         self.shortcut_icon:paintTo(bb, x+ix, y+iy)
     end
 
@@ -814,7 +811,6 @@ function ListMenuItem:paintTo(bb, x, y)
     end
 end
 
--- As done in MenuItem
 function ListMenuItem:getFocusIndicatorRegion()
     return self._underline_container and self._underline_container:getFocusIndicatorRegion()
 end
@@ -823,6 +819,7 @@ function ListMenuItem:repaintFocusIndicator(bb)
     return self._underline_container and self._underline_container:repaintFocusIndicator(bb)
 end
 
+-- As done in MenuItem
 function ListMenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK
     self._underline_container.focused = true

--- a/plugins/coverbrowser.koplugin/listmenu.lua
+++ b/plugins/coverbrowser.koplugin/listmenu.lua
@@ -116,6 +116,7 @@ function ListMenuItem:init()
         },
         linesize = self.underline_h,
         focus_linesize = Size.line.focus_row,
+        background = Blitbuffer.COLOR_WHITE,
         -- widget : will be filled in self:update()
     }
     self[1] = self._underline_container
@@ -124,6 +125,12 @@ function ListMenuItem:init()
     -- have to do it more than once if item not found in db
     self:update()
     self.init_done = true
+end
+
+--- Right end of the focus underline: clear of the dogear on every row, so the line ends
+--- at the same x down the list and a focus-only repaint never slices the mark.
+function ListMenuItem:getFocusLineRight(width)
+    return width - corner_mark_size - Screen:scaleBySize(6)
 end
 
 function ListMenuItem:update()
@@ -136,6 +143,32 @@ function ListMenuItem:update()
         w = self.width,
         h = self.height - 2 * self.underline_h
     }
+
+    -- Create or replace corner_mark if needed. Every row does this, so getFocusLineRight()
+    -- sees the size paintTo() draws.
+    local mark_size = math.floor(dimen.h * (1/6))
+    -- Just fits under the page info text, which in turn adapts to the ListMenuItem height.
+    if mark_size ~= corner_mark_size then
+        corner_mark_size = mark_size
+        if corner_mark then
+            corner_mark:free()
+        end
+        corner_mark = IconWidget:new{
+            icon = "dogear.opaque",
+            rotation_angle = BD.mirroredUILayout() and 180 or 270,
+            width = corner_mark_size,
+            height = corner_mark_size,
+        }
+    end
+    -- Height left for text: the focus bar can be thicker than the underline, and descenders
+    -- need a gap above it.
+    local text_top_padding = Size.padding.small
+    local text_dimen = dimen:copy()
+    text_dimen.h = dimen.h - text_top_padding
+                           - math.max(Size.line.focus_row - self.underline_h, 0)
+                           - Size.padding.small
+    -- The shortcut square is painted over the bottom left corner: keep text and the focus bar out of it.
+    local shortcut_width = self.shortcut_icon and self.shortcut_icon.dimen.w or 0
 
     local function _fontSize(nominal, max)
         -- The nominal font size is based on 64px ListMenuItem height.
@@ -178,32 +211,43 @@ function ListMenuItem:update()
             face = Font:getFace("infont", _fontSize(14, 18)),
         }
         local pad_width = Screen:scaleBySize(10) -- on the left, in between, and on the right
-        local wleft_width = dimen.w - wright:getWidth() - 3*pad_width
+        local wleft_width = dimen.w - wright:getWidth() - 3*pad_width - shortcut_width
+        local line_left = pad_width + shortcut_width
+        self._underline_container.line_x_offset = line_left
+        self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
         local wleft = TextBoxWidget:new{
             text = BD.directory(self.text),
             face = Font:getFace("cfont", _fontSize(20, 24)),
             width = wleft_width,
             alignment = "left",
             bold = true,
-            height = dimen.h,
+            height = text_dimen.h,
             height_adjust = true,
             height_overflow_show_ellipsis = true,
+        }
+        local wleft_group = VerticalGroup:new{
+            VerticalSpan:new{ width = text_top_padding },
+            HorizontalGroup:new{
+                HorizontalSpan:new{ width = pad_width + shortcut_width },
+                wleft,
+            },
+        }
+        local wright_group = VerticalGroup:new{
+            VerticalSpan:new{ width = text_top_padding },
+            HorizontalGroup:new{
+                wright,
+                HorizontalSpan:new{ width = pad_width },
+            },
         }
         widget = OverlapGroup:new{
             dimen = dimen:copy(),
             LeftContainer:new{
-                dimen = dimen:copy(),
-                HorizontalGroup:new{
-                    HorizontalSpan:new{ width = pad_width },
-                    wleft,
-                }
+                dimen = Geom:new{ w = dimen.w, h = wleft_group:getSize().h },
+                wleft_group,
             },
             RightContainer:new{
-                dimen = dimen:copy(),
-                HorizontalGroup:new{
-                    wright,
-                    HorizontalSpan:new{ width = pad_width },
-                },
+                dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
+                wright_group,
             },
         }
     else -- file
@@ -242,6 +286,9 @@ function ListMenuItem:update()
             -- Build the left widget : image if wanted
             local wleft = nil
             local wleft_width = 0 -- if not do_cover_image
+            if not self.do_cover_image then
+                wleft_width = shortcut_width
+            end
             local wleft_height
             if self.do_cover_image then
                 wleft_height = dimen.h
@@ -387,27 +434,9 @@ function ListMenuItem:update()
                 for i, w in ipairs(wright_items) do
                     wright_width = math.max(wright_width, w:getSize().w)
                 end
-                wright = CenterContainer:new{
-                    dimen = Geom:new{ w = wright_width, h = dimen.h },
-                    VerticalGroup:new(wright_items),
-                }
+                table.insert(wright_items, 1, VerticalSpan:new{ width = text_top_padding })
+                wright = VerticalGroup:new(wright_items)
                 wright_right_padding = Screen:scaleBySize(10)
-            end
-
-            -- Create or replace corner_mark if needed
-            local mark_size = math.floor(dimen.h * (1/6))
-            -- Just fits under the page info text, which in turn adapts to the ListMenuItem height.
-            if mark_size ~= corner_mark_size then
-                corner_mark_size = mark_size
-                if corner_mark then
-                    corner_mark:free()
-                end
-                corner_mark = IconWidget:new{
-                    icon = "dogear.opaque",
-                    rotation_angle = BD.mirroredUILayout() and 180 or 270,
-                    width = corner_mark_size,
-                    height = corner_mark_size,
-                }
             end
 
             -- Build the middle main widget, in the space available
@@ -419,6 +448,10 @@ function ListMenuItem:update()
             end
             local wmain_right_padding = Screen:scaleBySize(10) -- used only for next calculation
             local wmain_width = dimen.w - wleft_width - wmain_left_padding - wmain_right_padding - wright_width - wright_right_padding
+            -- Start the underline past the cover, so a focus-only repaint doesn't slice it.
+            local line_left = wleft_width + wmain_left_padding
+            self._underline_container.line_x_offset = line_left
+            self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
 
             local fontname_title = "cfont"
             local fontname_authors = "cfont"
@@ -536,7 +569,7 @@ function ListMenuItem:update()
                     build_authors()
                     height = height + wauthors:getSize().h
                 end
-                if height <= dimen.h then
+                if height <= text_dimen.h then
                     -- We fit!
                     break
                 end
@@ -550,7 +583,7 @@ function ListMenuItem:update()
                     local authors_min_height = 2 * authors_line_height -- unscaled_size_check: ignore
                     -- Chop lines, starting with authors, until
                     -- both labels fit in the allocated space.
-                    while title_height + authors_height > dimen.h do
+                    while title_height + authors_height > text_dimen.h do
                         if authors_height > authors_min_height then
                             authors_height = authors_height - authors_line_height
                         elseif title_height > title_min_height then
@@ -573,12 +606,14 @@ function ListMenuItem:update()
                 logger.dbg(title, "recalculate title/author with", fontsize_title)
             end
 
+            local wmain_group = VerticalGroup:new{
+                VerticalSpan:new{ width = text_top_padding },
+                wtitle,
+                wauthors,
+            }
             local wmain = LeftContainer:new{
-                dimen = dimen:copy(),
-                VerticalGroup:new{
-                    wtitle,
-                    wauthors,
-                }
+                dimen = Geom:new{ w = text_dimen.w, h = wmain_group:getSize().h },
+                wmain_group,
             }
 
             -- Build the final widget
@@ -602,23 +637,25 @@ function ListMenuItem:update()
             else
                 -- pad main widget on the left
                 wmain = HorizontalGroup:new{
+                        HorizontalSpan:new{ width = wleft_width },
                         HorizontalSpan:new{ width = wmain_left_padding },
                         wmain
                 }
             end
             -- add padded main widget
             table.insert(widget, LeftContainer:new{
-                    dimen = dimen:copy(),
+                    dimen = Geom:new{ w = text_dimen.w, h = wmain:getSize().h },
                     wmain
                 })
             -- add right widget
             if wright then
+                local wright_group = HorizontalGroup:new{
+                    wright,
+                    HorizontalSpan:new{ width = wright_right_padding },
+                }
                 table.insert(widget, RightContainer:new{
-                    dimen = dimen:copy(),
-                    HorizontalGroup:new{
-                        wright,
-                        HorizontalSpan:new{ width = wright_right_padding },
-                    },
+                    dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
+                    wright_group,
                 })
             end
 
@@ -655,14 +692,10 @@ function ListMenuItem:update()
                     face = Font:getFace("cfont", fontsize_info),
                 }
                 wright_width = wfileinfo:getSize().w
-                wright = CenterContainer:new{
-                    dimen = Geom:new{ w = wright_width, h = dimen.h },
-                    VerticalGroup:new{
-                        align = "right",
-                        VerticalSpan:new{ width = Screen:scaleBySize(2) },
-                        wfileinfo,
-                        wpageinfo,
-                    }
+                wright = VerticalGroup:new{
+                    align = "right",
+                    wfileinfo,
+                    wpageinfo,
                 }
                 wright_right_padding = Screen:scaleBySize(10)
             end
@@ -681,32 +714,45 @@ function ListMenuItem:update()
                 text_widget = TextBoxWidget:new{
                     text = text .. hint,
                     face = Font:getFace("cfont", fontsize_no_bookinfo),
-                    width = dimen.w - 2 * Screen:scaleBySize(10) - wright_width - wright_right_padding,
+                    width = dimen.w - 2 * Screen:scaleBySize(10) - shortcut_width - wright_width - wright_right_padding,
                     alignment = "left",
                     fgcolor = fgcolor,
                 }
                 -- reduce font size for next loop, in case text widget is too large to fit into ListMenuItem
                 fontsize_no_bookinfo = fontsize_no_bookinfo - fontsize_dec_step
-            until text_widget:getSize().h <= dimen.h
-            widget = LeftContainer:new{
-                dimen = dimen:copy(),
+            until text_widget:getSize().h <= text_dimen.h
+            local line_left = Screen:scaleBySize(10) + shortcut_width
+            self._underline_container.line_x_offset = line_left
+            self._underline_container.line_width = math.max(self:getFocusLineRight(dimen.w) - line_left, 0)
+            local text_group = VerticalGroup:new{
+                VerticalSpan:new{ width = text_top_padding },
                 HorizontalGroup:new{
-                    HorizontalSpan:new{ width = Screen:scaleBySize(10) },
+                    HorizontalSpan:new{ width = Screen:scaleBySize(10) + shortcut_width },
                     text_widget
                 },
             }
+            widget = LeftContainer:new{
+                dimen = Geom:new{ w = text_dimen.w, h = text_group:getSize().h },
+                text_group,
+            }
+            -- UnderlineContainer takes its height from its child: keep the row full height so the
+            -- line stays at the bottom.
+            widget = OverlapGroup:new{
+                dimen = dimen:copy(),
+                widget,
+            }
             if wright then -- last read date, in History, even for deleted files
-                widget = OverlapGroup:new{
-                    dimen = dimen:copy(),
-                    widget,
-                    RightContainer:new{
-                        dimen = dimen:copy(),
-                        HorizontalGroup:new{
-                            wright,
-                            HorizontalSpan:new{ width = wright_right_padding },
-                        },
+                local wright_group = VerticalGroup:new{
+                    VerticalSpan:new{ width = text_top_padding },
+                    HorizontalGroup:new{
+                        wright,
+                        HorizontalSpan:new{ width = wright_right_padding },
                     },
                 }
+                table.insert(widget, RightContainer:new{
+                    dimen = Geom:new{ w = dimen.w, h = wright_group:getSize().h },
+                    wright_group,
+                })
             end
         end
     end
@@ -738,15 +784,14 @@ function ListMenuItem:paintTo(bb, x, y)
 
     -- to which we paint over the shortcut icon
     if self.shortcut_icon then
-        -- align it on bottom left corner of sub-widget
-        local target = self[1][1][2]
+        -- align it on the bottom left corner of the item
         local ix
         if BD.mirroredUILayout() then
-            ix = target.dimen.w - self.shortcut_icon.dimen.w - 2 * self.shortcut_icon.bordersize
+            ix = self.width - self.shortcut_icon.dimen.w - 2 * self.shortcut_icon.bordersize
         else
             ix = 0
         end
-        local iy = target.dimen.h - self.shortcut_icon.dimen.h - self.shortcut_icon.bordersize
+        local iy = self.height - self.shortcut_icon.dimen.h - 2 * self.shortcut_icon.bordersize
         self.shortcut_icon:paintTo(bb, x+ix, y+iy)
     end
 
@@ -792,6 +837,14 @@ function ListMenuItem:paintTo(bb, x, y)
 end
 
 -- As done in MenuItem
+function ListMenuItem:getFocusIndicatorRegion()
+    return self._underline_container and self._underline_container:getFocusIndicatorRegion()
+end
+
+function ListMenuItem:repaintFocusIndicator(bb)
+    return self._underline_container and self._underline_container:repaintFocusIndicator(bb)
+end
+
 function ListMenuItem:onFocus()
     self._underline_container.color = Blitbuffer.COLOR_BLACK
     self._underline_container.focused = true


### PR DESCRIPTION
CoverBrowser's list view repainted the whole window on every cursor step.
`ListMenuItem` now implements `getFocusIndicatorRegion` / `repaintFocusIndicator`
(#15897), so a focus move repaints the indicator alone. Kindle 3: median step
538 ms → 17.9 ms (253–1138 → 12.8–51.4), refresh region 600×800 → 564×5.

The narrow repaint erases the bar's strip with white, so the row keeps master's
layout and the bar paints over its bottom; on a Kindle 4 the frame differs from
master only in the underline rows.

`UnderlineContainer` gains `line_x_offset`; `ListMenuItem` sets it to start the
line past the cover column and the shortcut square, and `getFocusLineRight` stops
it before the dogear, so the repaint never slices the mark. Every row uses that
cutoff, so the line ends at the same x down the list (600 px screen: directory
36–583, file 69–583).

Kindle 3, same folder, same page, cursor on the first row. Before / after, no covers:

<img src="https://github.com/user-attachments/assets/f88dda6f-3719-4db9-8883-581349cc0aca" width="45%"> <img src="https://github.com/user-attachments/assets/2c6a1277-11cd-4eaa-9329-5794fa3b907c" width="45%">

With covers:

<img src="https://github.com/user-attachments/assets/aa7b383a-538e-47c3-ba2f-ff45dbfc6f79" width="45%"> <img src="https://github.com/user-attachments/assets/22118626-2f0d-4b59-b50c-5f1a76fe4f9f" width="45%">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/16012)
<!-- Reviewable:end -->
