### PR TITLE
Features for writers: text file menu items (New text file, Save as)

### DIFF
--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -680,6 +680,20 @@ function FileManager:getPlusDialogButtons()
             },
             {
                 {
+                    text = _("New text file"),
+                    enabled = self.texteditor and true or false,
+                    callback = function()
+                        UIManager:close(self.plus_dialog)
+                        if self.texteditor then
+                            local new_file_folder = folder
+                            if new_file_folder:sub(-1) ~= "/" then new_file_folder = new_file_folder .. "/" end
+                            self.texteditor:newFile(new_file_folder)
+                        end
+                    end,
+                },
+            },
+            {
+                {
                     text = _("Paste"),
                     enabled = self.clipboard and true or false,
                     callback = function()

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -680,18 +680,6 @@ function FileManager:getPlusDialogButtons()
             },
             {
                 {
-                    text = _("New text file"),
-                    enabled = self.texteditor and true or false,
-                    callback = function()
-                        UIManager:close(self.plus_dialog)
-                        if self.texteditor then
-                            self.texteditor:newFile(folder, nil, true)
-                        end
-                    end,
-                },
-            },
-            {
-                {
                     text = _("Paste"),
                     enabled = self.clipboard and true or false,
                     callback = function()
@@ -740,6 +728,18 @@ function FileManager:getPlusDialogButtons()
                 self.folder_shortcuts:genAddRemoveShortcutButton(folder, close_dialog_callback, refresh_titlebar_callback),
             },
         }
+
+        if self.texteditor then
+            table.insert(buttons, 3, {
+                {
+                    text = _("New text file"),
+                    callback = function()
+                        UIManager:close(self.plus_dialog)
+                        self.texteditor:newFile(folder, nil, true)
+                    end,
+                },
+            })
+        end
 
         if Device:hasExternalSD() then
             table.insert(buttons, 4, { -- after "Paste" or "Import files here" button

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -685,9 +685,7 @@ function FileManager:getPlusDialogButtons()
                     callback = function()
                         UIManager:close(self.plus_dialog)
                         if self.texteditor then
-                            local new_file_folder = folder
-                            if new_file_folder:sub(-1) ~= "/" then new_file_folder = new_file_folder .. "/" end
-                            self.texteditor:newFile(new_file_folder)
+                            self.texteditor:newFile(folder, nil, true)
                         end
                     end,
                 },

--- a/frontend/apps/filemanager/filemanager.lua
+++ b/frontend/apps/filemanager/filemanager.lua
@@ -729,18 +729,6 @@ function FileManager:getPlusDialogButtons()
             },
         }
 
-        if self.texteditor then
-            table.insert(buttons, 3, {
-                {
-                    text = _("New text file"),
-                    callback = function()
-                        UIManager:close(self.plus_dialog)
-                        self.texteditor:newFile(folder, nil, true)
-                    end,
-                },
-            })
-        end
-
         if Device:hasExternalSD() then
             table.insert(buttons, 4, { -- after "Paste" or "Import files here" button
                 {
@@ -771,6 +759,18 @@ function FileManager:getPlusDialogButtons()
                     callback = function()
                         UIManager:close(self.plus_dialog)
                         Device.importFile(folder)
+                    end,
+                },
+            })
+        end
+
+        if self.texteditor then
+            table.insert(buttons, 3, {
+                {
+                    text = _("New text file"),
+                    callback = function()
+                        UIManager:close(self.plus_dialog)
+                        self.texteditor:newFile(folder, nil, true)
                     end,
                 },
             })

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -681,7 +681,7 @@ function TextEditor:quickEditFile(file_path, done_callback, possible_new_file)
 end
 
 -- TitleBar left button tap
-function TextEditor:showMenu(file_path)
+function TextEditor:showMenu(edited_file_path)
     local dialog
     local buttons = {}
     local optionsutil = require("ui/data/optionsutil")
@@ -701,7 +701,7 @@ function TextEditor:showMenu(file_path)
         text = _("Save as"),
         callback = function()
             UIManager:close(dialog)
-            self:saveAs(file_path)
+            self:saveAs(edited_file_path)
         end,
     }})
     dialog = ButtonDialog:new{
@@ -718,12 +718,12 @@ end
 -- Save the current buffer to a new path chosen by the user, then continue
 -- editing that new file. Mirrors newFile()'s prompt (InputDialog + folder
 -- picker) and reuses saveFileContent()/checkEditFile().
-function TextEditor:saveAs(file_path)
+function TextEditor:saveAs(edited_file_path)
     local content = self.input and self.input:getInputText() or ""
-    local dir = (file_path and file_path:match("(.*)/")) or self.last_path
+    local dir = (edited_file_path and edited_file_path:match("(.*)/")) or self.last_path
     if not dir or dir == "" then dir = "/" end
-    local start_path = dir == "/" and "/" or dir .. "/"
-    self:_showSaveAsDialog(start_path, content)
+    local start_folder = dir == "/" and "/" or dir .. "/"
+    self:_showSaveAsDialog(start_folder, content)
 end
 
 function TextEditor:_showSaveAsDialog(new_path, content)

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -724,8 +724,7 @@ function TextEditor:showMenu(edited_file_path)
 end
 
 -- Save the current buffer to a new path chosen by the user, then continue
--- editing that new file. Mirrors newFile()'s prompt (InputDialog + folder
--- picker) and reuses saveFileContent()/checkEditFile().
+-- editing that new file.
 function TextEditor:saveAs(edited_file_path)
     local dir = (edited_file_path and edited_file_path:match("(.*)/")) or self.last_path
     if not dir or dir == "" then dir = "/" end

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -689,10 +689,19 @@ end
 -- TitleBar left button tap
 function TextEditor:showMenu(edited_file_path)
     local dialog
-    local buttons = {}
+    local buttons = {
+        {{
+            text = _("Save as"),
+            callback = function()
+                UIManager:close(dialog)
+                self:saveAs(edited_file_path)
+            end,
+        }},
+        {}, -- separator
+    }
     local optionsutil = require("ui/data/optionsutil")
     for i, mode in ipairs(optionsutil.rotation_modes) do
-        buttons[i] = {{
+        table.insert(buttons, {{
             text = optionsutil.rotation_labels[i],
             enabled_func = function()
                 return optionsutil.rotation_modes[i] ~= Screen:getRotationMode()
@@ -701,15 +710,8 @@ function TextEditor:showMenu(edited_file_path)
                 UIManager:close(dialog)
                 self.input:onSetRotationMode(optionsutil.rotation_modes[i])
             end,
-        }}
+        }})
     end
-    table.insert(buttons, {{
-        text = _("Save as"),
-        callback = function()
-            UIManager:close(dialog)
-            self:saveAs(edited_file_path)
-        end,
-    }})
     dialog = ButtonDialog:new{
         shrink_unneeded_width = true,
         buttons = buttons,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -779,10 +779,7 @@ function TextEditor:_showSaveAsDialog(new_path)
                                 -- field) runs against the correct dialog. saveFileContent above
                                 -- was called without a caller_callback, so self.caller_callback
                                 -- is already cleared and won't fire spuriously on this close.
-                                local current_editor = self.input
-                                if current_editor then
-                                    UIManager:close(current_editor)
-                                end
+                                UIManager:close(self.input)
                                 self:checkEditFile(save_path, false, true)
                             end
                         end

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -727,14 +727,13 @@ end
 -- editing that new file. Mirrors newFile()'s prompt (InputDialog + folder
 -- picker) and reuses saveFileContent()/checkEditFile().
 function TextEditor:saveAs(edited_file_path)
-    local content = self.input and self.input:getInputText() or ""
     local dir = (edited_file_path and edited_file_path:match("(.*)/")) or self.last_path
     if not dir or dir == "" then dir = "/" end
     local start_folder = dir == "/" and "/" or dir .. "/"
-    self:_showSaveAsDialog(start_folder, content)
+    self:_showSaveAsDialog(start_folder)
 end
 
-function TextEditor:_showSaveAsDialog(new_path, content)
+function TextEditor:_showSaveAsDialog(new_path)
     local file_input
     file_input = InputDialog:new{
         title = _("Save as"),
@@ -749,7 +748,7 @@ function TextEditor:_showSaveAsDialog(new_path, content)
                             select_file = false,
                             path = new_path:match("(.*)/"),
                             onConfirm = function(dir_path)
-                                self:_showSaveAsDialog(dir_path .. "/", content)
+                                self:_showSaveAsDialog(dir_path .. "/")
                             end,
                         })
                     end,
@@ -768,6 +767,7 @@ function TextEditor:_showSaveAsDialog(new_path, content)
                     is_enter_default = true,
                     callback = function()
                         local save_path = file_input:getInputText()
+                        local content = self.input and self.input:getInputText() or ""
                         UIManager:close(file_input)
                         if save_path and save_path ~= "" then
                             self.last_path = save_path:match("(.*)/")

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -336,9 +336,15 @@ function TextEditor:addToHistory(file_path)
     self.history = new_history
 end
 
-function TextEditor:newFile(new_path, caller_callback)
+function TextEditor:newFile(new_path, caller_callback, is_folder)
     self:loadSettings()
-    new_path = new_path or (self.last_path == "/" and "/" or self.last_path .. "/")
+    if not new_path then
+        new_path = self.last_path
+        is_folder = true
+    end
+    if is_folder and new_path ~= "/" and new_path:sub(-1) ~= "/" then
+        new_path = new_path .. "/"
+    end
     local file_input
     file_input = InputDialog:new{
         title =  _("Enter filename"),

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -733,6 +733,10 @@ function TextEditor:saveAs(edited_file_path)
     self:_showSaveAsDialog(start_folder)
 end
 
+function TextEditor:isValidSavePath(path)
+    return path ~= "" and path:sub(1, 1) == "/" and path:sub(-1) ~= "/"
+end
+
 function TextEditor:_showSaveAsDialog(new_path)
     local file_input
     file_input = InputDialog:new{
@@ -770,9 +774,16 @@ function TextEditor:_showSaveAsDialog(new_path)
                         local content = self.input and self.input:getInputText() or ""
                         UIManager:close(file_input)
                         if save_path ~= "" then
+                            if not self:isValidSavePath(save_path) then
+                                UIManager:show(InfoMessage:new{
+                                    text = T(_("Not a valid file path:\n\n%1"), BD.filepath(save_path)),
+                                })
+                                return
+                            end
                             self.last_path = save_path:match("(.*)/")
                             if not self.last_path or self.last_path == "" then self.last_path = "/" end
-                            if self:saveFileContent(save_path, content) then
+                            local ok, err = self:saveFileContent(save_path, content)
+                            if ok then
                                 -- Close the editor we launched Save as from before opening the
                                 -- new file, so we don't stack a second editor on the window
                                 -- stack and its close_callback (which reads the self.input
@@ -781,6 +792,10 @@ function TextEditor:_showSaveAsDialog(new_path)
                                 -- is already cleared and won't fire spuriously on this close.
                                 UIManager:close(self.input)
                                 self:checkEditFile(save_path, false, true)
+                            else
+                                UIManager:show(InfoMessage:new{
+                                    text = T(_("This file can not be saved:\n\n%1\n\nReason: %2"), BD.filepath(save_path), err),
+                                })
                             end
                         end
                     end,

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -544,7 +544,7 @@ function TextEditor:editFile(file_path, readonly, caller_callback)
         readonly = readonly,
         add_nav_bar = true,
         title_bar_left_icon = "appbar.menu",
-        title_bar_left_icon_tap_callback = function() self:showMenu() end,
+        title_bar_left_icon_tap_callback = function() self:showMenu(file_path) end,
         rotation_enabled = true,
         keyboard_visible = self.show_keyboard_on_start, -- InputDialog will enforce false if readonly
         scroll_by_pan = true,
@@ -681,7 +681,7 @@ function TextEditor:quickEditFile(file_path, done_callback, possible_new_file)
 end
 
 -- TitleBar left button tap
-function TextEditor:showMenu()
+function TextEditor:showMenu(file_path)
     local dialog
     local buttons = {}
     local optionsutil = require("ui/data/optionsutil")
@@ -697,6 +697,13 @@ function TextEditor:showMenu()
             end,
         }}
     end
+    table.insert(buttons, {{
+        text = _("Save as"),
+        callback = function()
+            UIManager:close(dialog)
+            self:saveAs(file_path)
+        end,
+    }})
     dialog = ButtonDialog:new{
         shrink_unneeded_width = true,
         buttons = buttons,
@@ -706,6 +713,78 @@ function TextEditor:showMenu()
         modal = true,
     }
     UIManager:show(dialog)
+end
+
+-- Save the current buffer to a new path chosen by the user, then continue
+-- editing that new file. Mirrors newFile()'s prompt (InputDialog + folder
+-- picker) and reuses saveFileContent()/checkEditFile().
+function TextEditor:saveAs(file_path)
+    local content = self.input and self.input:getInputText() or ""
+    local dir = (file_path and file_path:match("(.*)/")) or self.last_path
+    if not dir or dir == "" then dir = "/" end
+    local start_path = dir == "/" and "/" or dir .. "/"
+    self:_showSaveAsDialog(start_path, content)
+end
+
+function TextEditor:_showSaveAsDialog(new_path, content)
+    local file_input
+    file_input = InputDialog:new{
+        title = _("Save as"),
+        input = new_path,
+        buttons = {
+            {
+                {
+                    text = _("Choose folder"),
+                    callback = function()
+                        UIManager:close(file_input)
+                        UIManager:show(PathChooser:new{
+                            select_file = false,
+                            path = new_path:match("(.*)/"),
+                            onConfirm = function(dir_path)
+                                self:_showSaveAsDialog(dir_path .. "/", content)
+                            end,
+                        })
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(file_input)
+                    end,
+                },
+                {
+                    text = _("Save"),
+                    is_enter_default = true,
+                    callback = function()
+                        local save_path = file_input:getInputText()
+                        UIManager:close(file_input)
+                        if save_path and save_path ~= "" then
+                            self.last_path = save_path:match("(.*)/")
+                            if not self.last_path or self.last_path == "" then self.last_path = "/" end
+                            if self:saveFileContent(save_path, content) then
+                                -- Close the editor we launched Save as from before opening the
+                                -- new file, so we don't stack a second editor on the window
+                                -- stack and its close_callback (which reads the self.input
+                                -- field) runs against the correct dialog. saveFileContent above
+                                -- was called without a caller_callback, so self.caller_callback
+                                -- is already cleared and won't fire spuriously on this close.
+                                local current_editor = self.input
+                                if current_editor then
+                                    UIManager:close(current_editor)
+                                end
+                                self:checkEditFile(save_path, false, true)
+                            end
+                        end
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(file_input)
+    file_input:onShowKeyboard()
 end
 
 return TextEditor

--- a/plugins/texteditor.koplugin/main.lua
+++ b/plugins/texteditor.koplugin/main.lua
@@ -769,7 +769,7 @@ function TextEditor:_showSaveAsDialog(new_path)
                         local save_path = file_input:getInputText()
                         local content = self.input and self.input:getInputText() or ""
                         UIManager:close(file_input)
-                        if save_path and save_path ~= "" then
+                        if save_path ~= "" then
                             self.last_path = save_path:match("(.*)/")
                             if not self.last_path or self.last_path == "" then self.last_path = "/" end
                             if self:saveFileContent(save_path, content) then

--- a/spec/unit/filemanager_spec.lua
+++ b/spec/unit/filemanager_spec.lua
@@ -13,6 +13,16 @@ describe("FileManager module", function()
         makePath = require("util").makePath
         util = require("ffi/util")
     end)
+    local function findButtonText(buttons, text)
+        for _, row in ipairs(buttons) do
+            for _, btn in ipairs(row) do
+                if btn.text == text then
+                    return btn
+                end
+            end
+        end
+        return nil
+    end
     it("should show file manager", function()
         local filemanager = FileManager:new{
             dimen = Screen:getSize(),
@@ -106,5 +116,24 @@ describe("FileManager module", function()
         assert.is_nil(lfs.attributes(tmp_fn))
         assert.is_nil(lfs.attributes(tmp_sidecar))
         assert.is_nil(lfs.attributes(tmp_history))
+    end)
+    it("should only show \"New text file\" when the texteditor plugin is enabled", function()
+        local filemanager = FileManager:new{
+            dimen = Screen:getSize(),
+            root_path = "spec/front/unit/data",
+        }
+        UIManager:show(filemanager)
+        fastforward_ui_events()
+
+        filemanager.texteditor = nil
+        local _, buttons_without = filemanager:getPlusDialogButtons()
+        assert.is_nil(findButtonText(buttons_without, "New text file"))
+
+        filemanager.texteditor = {} -- stub: presence is all getPlusDialogButtons checks
+        local _, buttons_with = filemanager:getPlusDialogButtons()
+        assert.is_not_nil(findButtonText(buttons_with, "New text file"))
+
+        filemanager:onClose()
+        UIManager:quit()
     end)
 end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -1,5 +1,6 @@
 describe("TextEditor module", function()
     local TextEditor
+    local _ = require("gettext")
 
     setup(function()
         require("commonrequire")
@@ -70,6 +71,18 @@ describe("TextEditor module", function()
             local get_captured = capturedInput()
             TextEditor:newFile("/mnt/us/notebook.txt")
             assert.equals("/mnt/us/notebook.txt", get_captured().input)
+            require("ui/uimanager").show:revert()
+        end)
+    end)
+
+    describe("showMenu", function()
+        it("puts Save as first, followed by a separator, before the rotation buttons", function()
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            TextEditor:showMenu("/mnt/us/notes.txt")
+            assert.equals(_("Save as"), captured.buttons[1][1].text)
+            assert.equals(0, #captured.buttons[2])
+            assert.is_true(#captured.buttons > 2)
             require("ui/uimanager").show:revert()
         end)
     end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -190,6 +190,7 @@ describe("TextEditor module", function()
             captured.buttons[2][2].callback()
 
             assert.spy(close_spy).was_not.called_with(require("ui/uimanager"), TextEditor.input)
+            assert.is_truthy(captured.text and captured.text:find("Permission denied", 1, true))
 
             require("ui/uimanager").show:revert()
             require("ui/uimanager").close:revert()

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -15,15 +15,33 @@ describe("TextEditor module", function()
 
     describe("saveAs", function()
         it("derives the starting folder from the path of the file being edited", function()
-            local seen_path, seen_content
-            stub(TextEditor, "_showSaveAsDialog", function(_, new_path, content)
-                seen_path, seen_content = new_path, content
-            end)
-            TextEditor.input = { getInputText = function() return "buffer text" end }
+            local seen_path
+            stub(TextEditor, "_showSaveAsDialog", function(_, new_path) seen_path = new_path end)
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
             assert.equals("/mnt/us/notes/", seen_path)
-            assert.equals("buffer text", seen_content)
             TextEditor._showSaveAsDialog:revert()
+        end)
+
+        it("does not read the editor's buffer until Save is pressed", function()
+            local get_input_text = spy.new(function() return "buffer text" end)
+            TextEditor.input = { getInputText = get_input_text, handleEvent = function() end }
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+            assert.spy(get_input_text).was.called(0)
+
+            stub(captured, "getInputText", function() return "/mnt/us/notes/todo.txt" end)
+            stub(TextEditor, "saveFileContent", function() return true end)
+            stub(TextEditor, "checkEditFile", function() end)
+            captured.buttons[2][2].callback() -- "Save"
+
+            assert.spy(get_input_text).was.called(1)
+            assert.spy(TextEditor.saveFileContent).was.called_with(TextEditor, "/mnt/us/notes/todo.txt", "buffer text")
+
+            require("ui/uimanager").show:revert()
+            TextEditor.saveFileContent:revert()
+            TextEditor.checkEditFile:revert()
         end)
 
         it("falls back to self.last_path when no file is currently being edited", function()

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -26,7 +26,9 @@ describe("TextEditor module", function()
             local get_input_text = spy.new(function() return "buffer text" end)
             TextEditor.input = { getInputText = get_input_text, handleEvent = function() end }
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            -- UIManager:show(widget) is a method call, so the stub receives
+            -- (UIManager, widget) — capture the second argument, not the first.
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
 
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
             assert.spy(get_input_text).was.called(0)
@@ -47,7 +49,7 @@ describe("TextEditor module", function()
         it("does nothing when the Save as path is left empty", function()
             TextEditor.input = { getInputText = function() return "buffer text" end }
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
 
             stub(captured, "getInputText", function() return "" end)
@@ -63,7 +65,7 @@ describe("TextEditor module", function()
             local editor_widget = { getInputText = function() return "buffer text" end, handleEvent = function() end }
             TextEditor.input = editor_widget
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
 
             stub(captured, "getInputText", function() return "/mnt/us/notes/todo.txt" end)
@@ -93,7 +95,7 @@ describe("TextEditor module", function()
     describe("newFile", function()
         local function capturedInput()
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             return function() return captured end
         end
 
@@ -131,7 +133,7 @@ describe("TextEditor module", function()
     describe("showMenu", function()
         it("puts Save as first, followed by a separator, before the rotation buttons", function()
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             TextEditor:showMenu("/mnt/us/notes.txt")
             assert.equals(_("Save as"), captured.buttons[1][1].text)
             assert.equals(0, #captured.buttons[2])
@@ -162,7 +164,7 @@ describe("TextEditor module", function()
         it("shows an error and does not close the editor when the path is invalid", function()
             TextEditor.input = { getInputText = function() return "buffer text" end }
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
 
             stub(captured, "getInputText", function() return "/mnt/us/notes/" end)
@@ -181,7 +183,7 @@ describe("TextEditor module", function()
         it("shows an error and does not close the editor when saveFileContent fails", function()
             TextEditor.input = { getInputText = function() return "buffer text" end }
             local captured
-            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            stub(require("ui/uimanager"), "show", function(_, w) captured = w end)
             TextEditor:saveAs("/mnt/us/notes/todo.txt")
 
             stub(captured, "getInputText", function() return "/mnt/us/notes/todo.txt" end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -59,6 +59,26 @@ describe("TextEditor module", function()
             TextEditor.saveFileContent:revert()
         end)
 
+        it("closes the current editor by calling UIManager:close(self.input) directly", function()
+            local editor_widget = { getInputText = function() return "buffer text" end, handleEvent = function() end }
+            TextEditor.input = editor_widget
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+
+            stub(captured, "getInputText", function() return "/mnt/us/notes/todo.txt" end)
+            stub(TextEditor, "saveFileContent", function() return true end)
+            stub(TextEditor, "checkEditFile", function() end)
+            local close_spy = spy.on(require("ui/uimanager"), "close")
+            captured.buttons[2][2].callback()
+            assert.spy(close_spy).was.called_with(require("ui/uimanager"), editor_widget)
+
+            require("ui/uimanager").show:revert()
+            require("ui/uimanager").close:revert()
+            TextEditor.saveFileContent:revert()
+            TextEditor.checkEditFile:revert()
+        end)
+
         it("falls back to self.last_path when no file is currently being edited", function()
             local seen_path
             stub(TextEditor, "_showSaveAsDialog", function(_, new_path) seen_path = new_path end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -1,0 +1,38 @@
+describe("TextEditor module", function()
+    local TextEditor
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+    end)
+
+    before_each(function()
+        TextEditor = dofile("plugins/texteditor.koplugin/main.lua")
+        TextEditor.settings = nil
+    end)
+
+    describe("saveAs", function()
+        it("derives the starting folder from the path of the file being edited", function()
+            local seen_path, seen_content
+            stub(TextEditor, "_showSaveAsDialog", function(_, new_path, content)
+                seen_path, seen_content = new_path, content
+            end)
+            TextEditor.input = { getInputText = function() return "buffer text" end }
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+            assert.equals("/mnt/us/notes/", seen_path)
+            assert.equals("buffer text", seen_content)
+            TextEditor._showSaveAsDialog:revert()
+        end)
+
+        it("falls back to self.last_path when no file is currently being edited", function()
+            local seen_path
+            stub(TextEditor, "_showSaveAsDialog", function(_, new_path) seen_path = new_path end)
+            TextEditor.input = nil
+            TextEditor.last_path = "/mnt/us"
+            TextEditor:saveAs(nil)
+            assert.equals("/mnt/us/", seen_path)
+            TextEditor._showSaveAsDialog:revert()
+        end)
+    end)
+end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -44,6 +44,21 @@ describe("TextEditor module", function()
             TextEditor.checkEditFile:revert()
         end)
 
+        it("does nothing when the Save as path is left empty", function()
+            TextEditor.input = { getInputText = function() return "buffer text" end }
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+
+            stub(captured, "getInputText", function() return "" end)
+            stub(TextEditor, "saveFileContent", function() return true end)
+            captured.buttons[2][2].callback()
+            assert.spy(TextEditor.saveFileContent).was.called(0)
+
+            require("ui/uimanager").show:revert()
+            TextEditor.saveFileContent:revert()
+        end)
+
         it("falls back to self.last_path when no file is currently being edited", function()
             local seen_path
             stub(TextEditor, "_showSaveAsDialog", function(_, new_path) seen_path = new_path end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -35,4 +35,42 @@ describe("TextEditor module", function()
             TextEditor._showSaveAsDialog:revert()
         end)
     end)
+
+    describe("newFile", function()
+        local function capturedInput()
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            return function() return captured end
+        end
+
+        it("appends a trailing slash to a caller-provided folder that lacks one", function()
+            local get_captured = capturedInput()
+            TextEditor:newFile("/mnt/us/books", nil, true)
+            assert.equals("/mnt/us/books/", get_captured().input)
+            require("ui/uimanager").show:revert()
+        end)
+
+        it("leaves a caller-provided folder alone when it already ends in a slash", function()
+            local get_captured = capturedInput()
+            TextEditor:newFile("/mnt/us/books/", nil, true)
+            assert.equals("/mnt/us/books/", get_captured().input)
+            require("ui/uimanager").show:revert()
+        end)
+
+        it("falls back to self.last_path, normalized, when no path is given", function()
+            local get_captured = capturedInput()
+            TextEditor.settings = { readSetting = function() return nil end, has = function() return false end, nilOrTrue = function() return true end, isTrue = function() return false end }
+            TextEditor.last_path = "/mnt/us"
+            TextEditor:newFile(nil)
+            assert.equals("/mnt/us/", get_captured().input)
+            require("ui/uimanager").show:revert()
+        end)
+
+        it("does not touch a caller-provided file path when is_folder is not set", function()
+            local get_captured = capturedInput()
+            TextEditor:newFile("/mnt/us/notebook.txt")
+            assert.equals("/mnt/us/notebook.txt", get_captured().input)
+            require("ui/uimanager").show:revert()
+        end)
+    end)
 end)

--- a/spec/unit/texteditor_spec.lua
+++ b/spec/unit/texteditor_spec.lua
@@ -139,4 +139,61 @@ describe("TextEditor module", function()
             require("ui/uimanager").show:revert()
         end)
     end)
+
+    describe("isValidSavePath", function()
+        it("rejects a directory path (trailing slash)", function()
+            assert.is_false(TextEditor:isValidSavePath("/mnt/us/koreader/"))
+        end)
+
+        it("rejects a bare filename with no folder", function()
+            assert.is_false(TextEditor:isValidSavePath("foobar.txt"))
+        end)
+
+        it("rejects an empty path", function()
+            assert.is_false(TextEditor:isValidSavePath(""))
+        end)
+
+        it("accepts an absolute file path", function()
+            assert.is_true(TextEditor:isValidSavePath("/mnt/us/koreader/foobar.txt"))
+        end)
+    end)
+
+    describe("Save as failure handling", function()
+        it("shows an error and does not close the editor when the path is invalid", function()
+            TextEditor.input = { getInputText = function() return "buffer text" end }
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+
+            stub(captured, "getInputText", function() return "/mnt/us/notes/" end)
+            stub(TextEditor, "saveFileContent", function() return true end)
+            local close_spy = spy.on(require("ui/uimanager"), "close")
+            captured.buttons[2][2].callback()
+
+            assert.spy(TextEditor.saveFileContent).was.called(0)
+            assert.spy(close_spy).was_not.called_with(require("ui/uimanager"), TextEditor.input)
+
+            require("ui/uimanager").show:revert()
+            require("ui/uimanager").close:revert()
+            TextEditor.saveFileContent:revert()
+        end)
+
+        it("shows an error and does not close the editor when saveFileContent fails", function()
+            TextEditor.input = { getInputText = function() return "buffer text" end }
+            local captured
+            stub(require("ui/uimanager"), "show", function(w) captured = w end)
+            TextEditor:saveAs("/mnt/us/notes/todo.txt")
+
+            stub(captured, "getInputText", function() return "/mnt/us/notes/todo.txt" end)
+            stub(TextEditor, "saveFileContent", function() return false, "Permission denied" end)
+            local close_spy = spy.on(require("ui/uimanager"), "close")
+            captured.buttons[2][2].callback()
+
+            assert.spy(close_spy).was_not.called_with(require("ui/uimanager"), TextEditor.input)
+
+            require("ui/uimanager").show:revert()
+            require("ui/uimanager").close:revert()
+            TextEditor.saveFileContent:revert()
+        end)
+    end)
 end)


### PR DESCRIPTION
## Features for writers: text file menu items

Two small writing-focused additions that make KOReader more usable for creating and saving text files.

- **New text file** – a new entry in the File manager **+** menu (after *New folder*) that allows the user to create a file in the current folder and opens it in the Text editor.
- **Save as** – a new entry in the Text editor menu that writes the current buffer to a chosen path and continues editing the new file.

### New text file (`frontend/apps/filemanager/filemanager.lua`)
Adds a row to the **+** menu's normal-mode branch, immediately after *New folder*, delegating to the Text editor plugin's existing `newFile()` (`self.texteditor:newFile(folder)`). `newFile` prompts for the full filename (the user picks the name and extension). Greyed out when the Text editor plugin is disabled (mirrors the *Paste* row).

### Save as (`plugins/texteditor.koplugin/main.lua`)
Adds a *Save as* row to the editor's title-bar menu (`showMenu`); prompts for a destination path/filename (`InputDialog` + folder picker, mirroring `newFile`, so the extension is user-chosen), writes via the existing `saveFileContent`, and reopens the new file via `checkEditFile` so editing continues on it. The current editor is closed as part of the transition (no stacked editors). The normal **Save** still writes the original file.

Both delegate to existing plugin methods (no duplication of the large `editFile`).

### Testing
UI features (no unit tests). Verified that *New text file* appears after *New folder* and creates + opens a file; *Save as* writes to a new path and continues editing it while the original **Save** is unaffected; that both flows accept `.md` as well as `.txt` filenames; and that both entries behave correctly with the Text editor plugin disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/16014)
<!-- Reviewable:end -->
