### PR TITLE
Calibre: add collection synchronization

### DIFF
--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -874,8 +874,7 @@ function CalibreWireless:updateCollections(arg)
             local coll = ReadCollection.coll[coll_name]
             if coll then
                 for _, file in ipairs(files) do
-                    if ReadCollection:isFileInCollection(file, coll_name) then
-                        ReadCollection:removeItem(file, coll_name, true)
+                    if ReadCollection:removeItem(file, coll_name, true) then
                         updated_collections[coll_name] = true
                     end
                 end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -810,20 +810,14 @@ end
 
 function CalibreWireless:getCollections(arg)
     local collections = {}
-
     for collection_name, collection in pairs(ReadCollection.coll) do
         local files = rapidjson.array()
-
         for file in pairs(collection) do
             table.insert(files, file)
         end
-
         collections[collection_name] = files
     end
-
-    self:sendJsonData("OK", {
-        collections = collections,
-    })
+    self:sendJsonData("OK", {collections = collections})
 end
 
 function CalibreWireless:updateCollections(arg)
@@ -859,16 +853,12 @@ function CalibreWireless:updateCollections(arg)
     if arg.add then
         for coll_name, files in pairs(arg.add) do
             local coll = ReadCollection.coll[coll_name]
-
             if coll then
                 for _, file in ipairs(files) do
                     if lfs.attributes(file, "mode") == "file"
                         and not ReadCollection:isFileInCollection(file, coll_name)
                     then
-                        ReadCollection:addItem(
-                            file,
-                            coll_name
-                        )
+                        ReadCollection:addItem(file, coll_name)
                         updated_collections[coll_name] = true
                     end
                 end
@@ -882,15 +872,10 @@ function CalibreWireless:updateCollections(arg)
     if arg.remove then
         for coll_name, files in pairs(arg.remove) do
             local coll = ReadCollection.coll[coll_name]
-
             if coll then
                 for _, file in ipairs(files) do
                     if ReadCollection:isFileInCollection(file, coll_name) then
-                        ReadCollection:removeItem(
-                            file,
-                            coll_name,
-                            true
-                        )
+                        ReadCollection:removeItem(file, coll_name, true)
                         updated_collections[coll_name] = true
                     end
                 end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -13,6 +13,7 @@ local FFIUtil = require("ffi/util")
 local InputDialog = require("ui/widget/inputdialog")
 local InfoMessage = require("ui/widget/infomessage")
 local NetworkMgr = require("ui/network/manager")
+local ReadCollection = require("readcollection")
 local Trapper = require("ui/trapper")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -23,8 +24,6 @@ local sha = require("ffi/sha2")
 local util = require("util")
 local _ = require("gettext")
 local T = FFIUtil.template
-local ReadCollection = require("readcollection")
-local filemanagerutil = require("apps/filemanager/filemanagerutil")
 
 require("ffi/zeromq_h")
 
@@ -809,59 +808,6 @@ function CalibreWireless:isCalibreAtLeast(x, y, z)
     return semanticVersion(v[1], v[2], v[3]) >= semanticVersion(x, y, z)
 end
 
-local function getCollectionHome()
-    return filemanagerutil.getHomeFolder():gsub("/+$", "")
-end
-
-local function toCollectionLpath(file)
-    if type(file) ~= "string" then
-        return nil
-    end
-
-    local home = getCollectionHome()
-
-    local prefix = home .. "/"
-
-    if file:sub(1, #prefix) == prefix then
-        return file:sub(#prefix + 1)
-    end
-
-    logger.warn(
-        "CalibreWireless: collection file outside KOReader home:",
-        file
-    )
-
-    return nil
-end
-
-local function fromCollectionLpath(lpath)
-    if type(lpath) ~= "string" or lpath == "" then
-        logger.warn(
-            "CalibreWireless: invalid collection lpath:",
-            lpath
-        )
-        return nil
-    end
-
-    if lpath:sub(1, 1) == "/" then
-        logger.warn(
-            "CalibreWireless: absolute collection lpath rejected:",
-            lpath
-        )
-        return nil
-    end
-
-    if lpath:match("(^|/)%.%.(/|$)") then
-        logger.warn(
-            "CalibreWireless: collection lpath traversal rejected:",
-            lpath
-        )
-        return nil
-    end
-
-    return getCollectionHome() .. "/" .. lpath
-end
-
 function CalibreWireless:getCollections(arg)
     local collections = {}
 
@@ -869,11 +815,7 @@ function CalibreWireless:getCollections(arg)
         local files = rapidjson.array()
 
         for file in pairs(collection) do
-            local lpath = toCollectionLpath(file)
-
-            if lpath then
-                table.insert(files, lpath)
-            end
+            table.insert(files, file)
         end
 
         collections[collection_name] = files
@@ -920,24 +862,18 @@ function CalibreWireless:updateCollections(arg)
 
             if coll then
                 for _, file in ipairs(files) do
-                    local physical_file = fromCollectionLpath(file)
-
-                    if physical_file
-                        and lfs.attributes(physical_file, "mode") == "file"
-                        and not coll[physical_file]
+                    if lfs.attributes(file, "mode") == "file"
+                        and not ReadCollection:isFileInCollection(file, coll_name)
                     then
                         ReadCollection:addItem(
-                            physical_file,
+                            file,
                             coll_name
                         )
                         updated_collections[coll_name] = true
                     end
                 end
             else
-                logger.warn(
-                    "CalibreWireless: collection missing for add:",
-                    coll_name
-                )
+                logger.warn("CalibreWireless: collection missing for add:", coll_name)
             end
         end
     end
@@ -949,11 +885,9 @@ function CalibreWireless:updateCollections(arg)
 
             if coll then
                 for _, file in ipairs(files) do
-                    local physical_file = fromCollectionLpath(file)
-
-                    if physical_file and coll[physical_file] then
+                    if ReadCollection:isFileInCollection(file, coll_name) then
                         ReadCollection:removeItem(
-                            physical_file,
+                            file,
                             coll_name,
                             true
                         )
@@ -961,10 +895,7 @@ function CalibreWireless:updateCollections(arg)
                     end
                 end
             else
-                logger.warn(
-                    "CalibreWireless: collection missing for remove:",
-                    coll_name
-                )
+                logger.warn("CalibreWireless: collection missing for remove:", coll_name)
             end
         end
     end

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -834,8 +834,8 @@ function CalibreWireless:updateCollections(arg)
         for _, coll_name in ipairs(arg.remove_collections) do
             if ReadCollection.coll[coll_name] then
                 ReadCollection:removeCollection(coll_name)
+                updated_collections[coll_name] = true
             end
-            updated_collections[coll_name] = true
         end
     end
 
@@ -844,8 +844,8 @@ function CalibreWireless:updateCollections(arg)
         for _, coll_name in ipairs(arg.add_collections) do
             if not ReadCollection.coll[coll_name] then
                 ReadCollection:addCollection(coll_name)
+                updated_collections[coll_name] = true
             end
-            updated_collections[coll_name] = true
         end
     end
 

--- a/plugins/calibre.koplugin/wireless.lua
+++ b/plugins/calibre.koplugin/wireless.lua
@@ -23,6 +23,8 @@ local sha = require("ffi/sha2")
 local util = require("util")
 local _ = require("gettext")
 local T = FFIUtil.template
+local ReadCollection = require("readcollection")
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
 
 require("ffi/zeromq_h")
 
@@ -52,6 +54,8 @@ local OPCODES = {
     CALIBRE_BUSY              = 18,
     SET_LIBRARY_INFO          = 19,
     ERROR                     = 20,
+    GET_COLLECTIONS           = 21,
+    UPDATE_COLLECTIONS        = 22,
 }
 
 -- Mark some strings for translation.
@@ -440,6 +444,10 @@ function CalibreWireless:onReceiveJSON(data)
                 self:sendToCalibre(arg)
             elseif opcode == OPCODES.DISPLAY_MESSAGE then
                 self:serverFeedback(arg)
+            elseif opcode == OPCODES.GET_COLLECTIONS then
+                self:getCollections(arg)
+            elseif opcode == OPCODES.UPDATE_COLLECTIONS then
+                self:updateCollections(arg)
             elseif opcode == OPCODES.NOOP then
                 self:noop(arg)
             end
@@ -799,6 +807,173 @@ function CalibreWireless:isCalibreAtLeast(x, y, z)
         return ((a * 100000) + (b * 1000)) + c
     end
     return semanticVersion(v[1], v[2], v[3]) >= semanticVersion(x, y, z)
+end
+
+local function getCollectionHome()
+    return filemanagerutil.getHomeFolder():gsub("/+$", "")
+end
+
+local function toCollectionLpath(file)
+    if type(file) ~= "string" then
+        return nil
+    end
+
+    local home = getCollectionHome()
+
+    local prefix = home .. "/"
+
+    if file:sub(1, #prefix) == prefix then
+        return file:sub(#prefix + 1)
+    end
+
+    logger.warn(
+        "CalibreWireless: collection file outside KOReader home:",
+        file
+    )
+
+    return nil
+end
+
+local function fromCollectionLpath(lpath)
+    if type(lpath) ~= "string" or lpath == "" then
+        logger.warn(
+            "CalibreWireless: invalid collection lpath:",
+            lpath
+        )
+        return nil
+    end
+
+    if lpath:sub(1, 1) == "/" then
+        logger.warn(
+            "CalibreWireless: absolute collection lpath rejected:",
+            lpath
+        )
+        return nil
+    end
+
+    if lpath:match("(^|/)%.%.(/|$)") then
+        logger.warn(
+            "CalibreWireless: collection lpath traversal rejected:",
+            lpath
+        )
+        return nil
+    end
+
+    return getCollectionHome() .. "/" .. lpath
+end
+
+function CalibreWireless:getCollections(arg)
+    local collections = {}
+
+    for collection_name, collection in pairs(ReadCollection.coll) do
+        local files = rapidjson.array()
+
+        for file in pairs(collection) do
+            local lpath = toCollectionLpath(file)
+
+            if lpath then
+                table.insert(files, lpath)
+            end
+        end
+
+        collections[collection_name] = files
+    end
+
+    self:sendJsonData("OK", {
+        collections = collections,
+    })
+end
+
+function CalibreWireless:updateCollections(arg)
+    if not arg or type(arg) ~= "table" then
+        logger.warn("CalibreWireless: invalid UPDATE_COLLECTIONS payload")
+        return
+    end
+
+    local updated_collections = {}
+
+    -- Remove collections first so that membership changes cannot recreate
+    -- a collection which Calibre explicitly wants removed.
+    if arg.remove_collections then
+        for _, coll_name in ipairs(arg.remove_collections) do
+            if ReadCollection.coll[coll_name] then
+                ReadCollection:removeCollection(coll_name)
+            end
+            updated_collections[coll_name] = true
+        end
+    end
+
+    -- Explicit collection additions are needed for empty collections.
+    if arg.add_collections then
+        for _, coll_name in ipairs(arg.add_collections) do
+            if not ReadCollection.coll[coll_name] then
+                ReadCollection:addCollection(coll_name)
+            end
+            updated_collections[coll_name] = true
+        end
+    end
+
+    -- Add individual book memberships.
+    if arg.add then
+        for coll_name, files in pairs(arg.add) do
+            local coll = ReadCollection.coll[coll_name]
+
+            if coll then
+                for _, file in ipairs(files) do
+                    local physical_file = fromCollectionLpath(file)
+
+                    if physical_file
+                        and lfs.attributes(physical_file, "mode") == "file"
+                        and not coll[physical_file]
+                    then
+                        ReadCollection:addItem(
+                            physical_file,
+                            coll_name
+                        )
+                        updated_collections[coll_name] = true
+                    end
+                end
+            else
+                logger.warn(
+                    "CalibreWireless: collection missing for add:",
+                    coll_name
+                )
+            end
+        end
+    end
+
+    -- Remove individual book memberships.
+    if arg.remove then
+        for coll_name, files in pairs(arg.remove) do
+            local coll = ReadCollection.coll[coll_name]
+
+            if coll then
+                for _, file in ipairs(files) do
+                    local physical_file = fromCollectionLpath(file)
+
+                    if physical_file and coll[physical_file] then
+                        ReadCollection:removeItem(
+                            physical_file,
+                            coll_name,
+                            true
+                        )
+                        updated_collections[coll_name] = true
+                    end
+                end
+            else
+                logger.warn(
+                    "CalibreWireless: collection missing for remove:",
+                    coll_name
+                )
+            end
+        end
+    end
+
+    if next(updated_collections) then
+        ReadCollection:write(updated_collections)
+    end
+
+    self:sendJsonData("OK", {})
 end
 
 return CalibreWireless

--- a/spec/unit/calibre_wireless_spec.lua
+++ b/spec/unit/calibre_wireless_spec.lua
@@ -1,0 +1,550 @@
+describe("CalibreWireless collections", function()
+    local CalibreWireless
+    local ReadCollection
+    local original_readcollection
+    local original_filemanagerutil
+    local original_lfs
+    local original_package_path
+    local original_extensions
+    local original_metadata
+    local original_search
+
+    local HOME = "/koreader/home"
+
+    setup(function()
+        require("commonrequire")
+
+        original_package_path = package.path
+
+        original_extensions = package.loaded["extensions"]
+        original_metadata = package.loaded["metadata"]
+        original_search = package.loaded["search"]
+
+        original_readcollection = require("readcollection")
+        original_filemanagerutil = require("apps/filemanager/filemanagerutil")
+        original_lfs = require("libs/libkoreader-lfs")
+    end)
+
+    before_each(function()
+        local readcollection_mock = {
+            coll = {},
+            coll_settings = {},
+            coll_default = nil,
+            written = nil,
+        }
+
+        function readcollection_mock:addCollection(name)
+            self.coll[name] = {}
+            self.coll_settings[name] = {
+                order = 99,
+            }
+        end
+
+        function readcollection_mock:removeCollection(name)
+            self.coll[name] = nil
+            self.coll_settings[name] = nil
+        end
+
+        function readcollection_mock:addItem(file, collection_name)
+            self.coll[collection_name][file] = {
+                file = file,
+                order = 123,
+            }
+        end
+
+        function readcollection_mock:removeItem(file, collection_name)
+            if self.coll[collection_name]
+                and self.coll[collection_name][file]
+            then
+                self.coll[collection_name][file] = nil
+                return true
+            end
+        end
+
+        function readcollection_mock:write(updated_collections)
+            self.written = updated_collections
+        end
+
+        local filemanagerutil_mock = {}
+
+        function filemanagerutil_mock.getHomeFolder()
+            return HOME
+        end
+
+        local lfs_mock = {
+            attributes_results = {},
+        }
+
+        function lfs_mock.attributes(path, key)
+            local attrs = lfs_mock.attributes_results[path]
+
+            if not attrs then
+                return nil
+            end
+
+            if key then
+                return attrs[key]
+            end
+
+            return attrs
+        end
+
+        package.replace(
+            "readcollection",
+            readcollection_mock
+        )
+        package.replace(
+            "apps/filemanager/filemanagerutil",
+            filemanagerutil_mock
+        )
+        package.replace(
+            "libs/libkoreader-lfs",
+            lfs_mock
+        )
+
+        package.path =
+            "plugins/calibre.koplugin/?.lua;"
+            .. original_package_path
+
+        CalibreWireless = dofile(
+            "plugins/calibre.koplugin/wireless.lua"
+        )
+
+        ReadCollection = readcollection_mock
+    end)
+
+    after_each(function()
+        package.path = original_package_path
+
+        package.loaded["extensions"] = original_extensions
+        package.loaded["metadata"] = original_metadata
+        package.loaded["search"] = original_search
+
+        package.replace(
+            "readcollection",
+            original_readcollection
+        )
+        package.replace(
+            "apps/filemanager/filemanagerutil",
+            original_filemanagerutil
+        )
+        package.replace(
+            "libs/libkoreader-lfs",
+            original_lfs
+        )
+
+    end)
+
+    local function new_wireless()
+        local wireless = setmetatable(
+            {},
+            {
+                __index = CalibreWireless,
+            }
+        )
+
+        wireless.responses = {}
+
+        function wireless:sendJsonData(status, data)
+            table.insert(self.responses, {
+                status = status,
+                data = data,
+            })
+        end
+
+        return wireless
+    end
+
+    describe("GET_COLLECTIONS", function()
+        it("returns all collections including empty collections", function()
+            ReadCollection.coll = {
+                fiction = {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                },
+                empty = {},
+            }
+
+            local wireless = new_wireless()
+
+            wireless:getCollections()
+
+            assert.equals(1, #wireless.responses)
+            assert.equals("OK", wireless.responses[1].status)
+
+            local collections = wireless.responses[1].data.collections
+
+            assert.is_table(collections.fiction)
+            assert.equals(1, #collections.fiction)
+            assert.equals("books/one.epub", collections.fiction[1])
+
+            assert.is_table(collections.empty)
+            assert.equals(0, #collections.empty)
+        end)
+
+        it("ignores collection files outside the KOReader home", function()
+            ReadCollection.coll = {
+                mixed = {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                    ["/outside/book.epub"] = {
+                        file = "/outside/book.epub",
+                    },
+                },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:getCollections()
+
+            local files = wireless.responses[1].data.collections.mixed
+
+            assert.equals(1, #files)
+            assert.equals("books/one.epub", files[1])
+        end)
+    end)
+
+    describe("UPDATE_COLLECTIONS", function()
+        it("removes requested collections", function()
+            ReadCollection.coll = {
+                fiction = {},
+                history = {},
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 1 },
+                history = { order = 2 },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                remove_collections = {"fiction"},
+            }
+
+            assert.is_nil(ReadCollection.coll.fiction)
+            assert.is_not_nil(ReadCollection.coll.history)
+            assert.is_nil(ReadCollection.coll_settings.fiction)
+            assert.is_not_nil(ReadCollection.coll_settings.history)
+
+            assert.is_true(ReadCollection.written.fiction)
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("creates empty collections", function()
+            ReadCollection.coll = {}
+            ReadCollection.coll_settings = {}
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add_collections = {"new collection"},
+            }
+
+            assert.is_not_nil(
+                ReadCollection.coll["new collection"]
+            )
+            assert.same(
+                {},
+                ReadCollection.coll["new collection"]
+            )
+            assert.is_not_nil(
+                ReadCollection.coll_settings["new collection"]
+            )
+
+            assert.is_true(
+                ReadCollection.written["new collection"]
+            )
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("creates a collection and adds book memberships in one update", function()
+            ReadCollection.coll = {}
+            ReadCollection.coll_settings = {}
+
+            local lfs = require("libs/libkoreader-lfs")
+            lfs.attributes_results[HOME .. "/books/one.epub"] = {
+                mode = "file",
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add_collections = {"fiction"},
+                add = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            assert.is_not_nil(
+                ReadCollection.coll.fiction
+            )
+            assert.is_not_nil(
+                ReadCollection.coll.fiction[
+                    HOME .. "/books/one.epub"
+                ]
+            )
+            assert.is_not_nil(
+                ReadCollection.coll_settings.fiction
+            )
+
+            assert.is_true(
+                ReadCollection.written.fiction
+            )
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("removes a collection even when membership changes are also requested", function()
+            ReadCollection.coll = {
+                fiction = {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                },
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 7 },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                remove_collections = {"fiction"},
+                remove = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            assert.is_nil(
+                ReadCollection.coll.fiction
+            )
+            assert.is_nil(
+                ReadCollection.coll_settings.fiction
+            )
+
+            assert.is_true(
+                ReadCollection.written.fiction
+            )
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("does not write when requested memberships already match", function()
+            ReadCollection.coll = {
+                fiction = {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                },
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 7 },
+            }
+
+            local lfs = require("libs/libkoreader-lfs")
+            lfs.attributes_results[HOME .. "/books/one.epub"] = {
+                mode = "file",
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            assert.same(
+                {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                },
+                ReadCollection.coll.fiction
+            )
+
+            assert.is_nil(ReadCollection.written)
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("adds book memberships", function()
+            ReadCollection.coll = {
+                fiction = {},
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 7 },
+            }
+
+            local lfs = require("libs/libkoreader-lfs")
+            lfs.attributes_results[HOME .. "/books/one.epub"] = {
+                mode = "file",
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            local item = ReadCollection.coll.fiction[
+                HOME .. "/books/one.epub"
+            ]
+
+            assert.is_not_nil(item)
+            assert.equals(
+                HOME .. "/books/one.epub",
+                item.file
+            )
+
+            assert.is_true(ReadCollection.written.fiction)
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("removes book memberships", function()
+            ReadCollection.coll = {
+                fiction = {
+                    [HOME .. "/books/one.epub"] = {
+                        file = HOME .. "/books/one.epub",
+                    },
+                },
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 7 },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                remove = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            assert.is_nil(
+                ReadCollection.coll.fiction[
+                    HOME .. "/books/one.epub"
+                ]
+            )
+
+            assert.is_true(ReadCollection.written.fiction)
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("preserves collection metadata when changing memberships", function()
+            ReadCollection.coll = {
+                fiction = {},
+            }
+            ReadCollection.coll_settings = {
+                fiction = {
+                    order = 42,
+                    collate = true,
+                    custom = "preserve me",
+                },
+            }
+
+            local wireless = new_wireless()
+
+            local lfs = require("libs/libkoreader-lfs")
+            lfs.attributes_results[HOME .. "/books/one.epub"] = {
+                mode = "file",
+            }
+
+            wireless:updateCollections{
+                add = {
+                    fiction = {
+                        "books/one.epub",
+                    },
+                },
+            }
+
+            assert.same(
+                {
+                    order = 42,
+                    collate = true,
+                    custom = "preserve me",
+                },
+                ReadCollection.coll_settings.fiction
+            )
+        end)
+
+        it("does not modify unrelated collections", function()
+            ReadCollection.coll = {
+                fiction = {},
+                history = {
+                    [HOME .. "/books/history.epub"] = {
+                        file = HOME .. "/books/history.epub",
+                    },
+                },
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 1 },
+                history = { order = 2 },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add_collections = {"new"},
+            }
+
+            assert.is_not_nil(ReadCollection.coll.history)
+            assert.is_not_nil(
+                ReadCollection.coll.history[
+                    HOME .. "/books/history.epub"
+                ]
+            )
+            assert.same(
+                { order = 2 },
+                ReadCollection.coll_settings.history
+            )
+
+            assert.is_not_nil(ReadCollection.coll.fiction)
+            assert.is_not_nil(ReadCollection.coll["new"])
+        end)
+
+        it("ignores invalid or nonexistent files", function()
+            ReadCollection.coll = {
+                fiction = {},
+            }
+            ReadCollection.coll_settings = {
+                fiction = { order = 1 },
+            }
+
+            local wireless = new_wireless()
+
+            wireless:updateCollections{
+                add = {
+                    fiction = {
+                        "books/missing.epub",
+                        "../outside.epub",
+                        "/absolute/path.epub",
+                    },
+                },
+            }
+
+            assert.same({}, ReadCollection.coll.fiction)
+            assert.is_nil(ReadCollection.written)
+            assert.equals("OK", wireless.responses[1].status)
+        end)
+
+        it("does not fail on an invalid payload", function()
+            local wireless = new_wireless()
+
+            wireless:updateCollections(nil)
+
+            assert.equals(0, #wireless.responses)
+        end)
+    end)
+end)

--- a/spec/unit/calibre_wireless_spec.lua
+++ b/spec/unit/calibre_wireless_spec.lua
@@ -12,13 +12,10 @@ describe("CalibreWireless collections", function()
 
     setup(function()
         require("commonrequire")
-
         original_package_path = package.path
-
         original_extensions = package.loaded["extensions"]
         original_metadata = package.loaded["metadata"]
         original_search = package.loaded["search"]
-
         original_readcollection = require("readcollection")
         original_lfs = require("libs/libkoreader-lfs")
     end)
@@ -33,9 +30,7 @@ describe("CalibreWireless collections", function()
 
         function readcollection_mock:addCollection(name)
             self.coll[name] = {}
-            self.coll_settings[name] = {
-                order = 99,
-            }
+            self.coll_settings[name] = { order = 99 }
         end
 
         function readcollection_mock:removeCollection(name)
@@ -44,10 +39,7 @@ describe("CalibreWireless collections", function()
         end
 
         function readcollection_mock:addItem(file, collection_name)
-            self.coll[collection_name][file] = {
-                file = file,
-                order = 123,
-            }
+            self.coll[collection_name][file] = { file = file, order = 123 }
         end
 
         function readcollection_mock:isFileInCollection(file, collection_name)
@@ -70,13 +62,10 @@ describe("CalibreWireless collections", function()
             self.written = updated_collections
         end
 
-        local lfs_mock = {
-            attributes_results = {},
-        }
+        local lfs_mock = { attributes_results = {} }
 
         function lfs_mock.attributes(path, key)
             local attrs = lfs_mock.attributes_results[path]
-
             if not attrs then
                 return nil
             end
@@ -88,58 +77,27 @@ describe("CalibreWireless collections", function()
             return attrs
         end
 
-        package.replace(
-            "readcollection",
-            readcollection_mock
-        )
-        package.replace(
-            "libs/libkoreader-lfs",
-            lfs_mock
-        )
-
-        package.path =
-            "plugins/calibre.koplugin/?.lua;"
-            .. original_package_path
-
-        CalibreWireless = dofile(
-            "plugins/calibre.koplugin/wireless.lua"
-        )
-
+        package.replace("readcollection", readcollection_mock)
+        package.replace("libs/libkoreader-lfs", lfs_mock)
+        package.path = "plugins/calibre.koplugin/?.lua;" .. original_package_path
+        CalibreWireless = dofile("plugins/calibre.koplugin/wireless.lua")
         ReadCollection = readcollection_mock
     end)
 
     after_each(function()
         package.path = original_package_path
-
         package.loaded["extensions"] = original_extensions
         package.loaded["metadata"] = original_metadata
         package.loaded["search"] = original_search
-
-        package.replace(
-            "readcollection",
-            original_readcollection
-        )
-        package.replace(
-            "libs/libkoreader-lfs",
-            original_lfs
-        )
+        package.replace("readcollection", original_readcollection)
+        package.replace("libs/libkoreader-lfs", original_lfs)
     end)
 
     local function new_wireless()
-        local wireless = setmetatable(
-            {},
-            {
-                __index = CalibreWireless,
-            }
-        )
-
+        local wireless = setmetatable({}, { __index = CalibreWireless })
         wireless.responses = {}
-
         function wireless:sendJsonData(status, data)
-            table.insert(self.responses, {
-                status = status,
-                data = data,
-            })
+            table.insert(self.responses, { status = status, data = data })
         end
 
         return wireless
@@ -148,16 +106,11 @@ describe("CalibreWireless collections", function()
     describe("GET_COLLECTIONS", function()
         it("returns all collections including empty collections", function()
             ReadCollection.coll = {
-                fiction = {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                },
+                fiction = { [HOME .. "/books/one.epub"] = { file = HOME .. "/books/one.epub" } },
                 empty = {},
             }
 
             local wireless = new_wireless()
-
             wireless:getCollections()
 
             assert.equals(1, #wireless.responses)
@@ -168,7 +121,6 @@ describe("CalibreWireless collections", function()
             assert.is_table(collections.fiction)
             assert.equals(1, #collections.fiction)
             assert.equals(HOME .. "/books/one.epub", collections.fiction[1])
-
             assert.is_table(collections.empty)
             assert.equals(0, #collections.empty)
         end)
@@ -176,26 +128,16 @@ describe("CalibreWireless collections", function()
 
     describe("UPDATE_COLLECTIONS", function()
         it("removes requested collections", function()
-            ReadCollection.coll = {
-                fiction = {},
-                history = {},
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 1 },
-                history = { order = 2 },
-            }
+            ReadCollection.coll = { fiction = {}, history = {} }
+            ReadCollection.coll_settings = { fiction = { order = 1 }, history = { order = 2 } }
 
             local wireless = new_wireless()
-
-            wireless:updateCollections{
-                remove_collections = {"fiction"},
-            }
+            wireless:updateCollections{ remove_collections = {"fiction"} }
 
             assert.is_nil(ReadCollection.coll.fiction)
             assert.is_not_nil(ReadCollection.coll.history)
             assert.is_nil(ReadCollection.coll_settings.fiction)
             assert.is_not_nil(ReadCollection.coll_settings.history)
-
             assert.is_true(ReadCollection.written.fiction)
             assert.equals("OK", wireless.responses[1].status)
         end)
@@ -203,159 +145,69 @@ describe("CalibreWireless collections", function()
         it("creates empty collections", function()
             ReadCollection.coll = {}
             ReadCollection.coll_settings = {}
-
             local wireless = new_wireless()
+            wireless:updateCollections{ add_collections = {"new collection"} }
 
-            wireless:updateCollections{
-                add_collections = {"new collection"},
-            }
-
-            assert.is_not_nil(
-                ReadCollection.coll["new collection"]
-            )
-            assert.same(
-                {},
-                ReadCollection.coll["new collection"]
-            )
-            assert.is_not_nil(
-                ReadCollection.coll_settings["new collection"]
-            )
-
-            assert.is_true(
-                ReadCollection.written["new collection"]
-            )
+            assert.is_not_nil(ReadCollection.coll["new collection"])
+            assert.same({}, ReadCollection.coll["new collection"])
+            assert.is_not_nil(ReadCollection.coll_settings["new collection"])
+            assert.is_true(ReadCollection.written["new collection"])
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("creates a collection and adds book memberships in one update", function()
             ReadCollection.coll = {}
             ReadCollection.coll_settings = {}
-
             local lfs = require("libs/libkoreader-lfs")
-            lfs.attributes_results[HOME .. "/books/one.epub"] = {
-                mode = "file",
-            }
+            lfs.attributes_results[HOME .. "/books/one.epub"] = { mode = "file" }
 
             local wireless = new_wireless()
-
             wireless:updateCollections{
                 add_collections = {"fiction"},
-                add = {
-                    fiction = {
-                        HOME .. "/books/one.epub",
-                    },
-                },
+                add = { fiction = { HOME .. "/books/one.epub" } },
             }
 
-            assert.is_not_nil(
-                ReadCollection.coll.fiction
-            )
-            assert.is_not_nil(
-                ReadCollection.coll.fiction[
-                    HOME .. "/books/one.epub"
-                ]
-            )
-            assert.is_not_nil(
-                ReadCollection.coll_settings.fiction
-            )
-
-            assert.is_true(
-                ReadCollection.written.fiction
-            )
+            assert.is_not_nil(ReadCollection.coll.fiction)
+            assert.is_not_nil(ReadCollection.coll.fiction[HOME .. "/books/one.epub"])
+            assert.is_not_nil(ReadCollection.coll_settings.fiction)
+            assert.is_true(ReadCollection.written.fiction)
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("removes a collection even when membership changes are also requested", function()
-            ReadCollection.coll = {
-                fiction = {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                },
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 7 },
-            }
+            ReadCollection.coll = { fiction = { [HOME .. "/books/one.epub"] = { file = HOME .. "/books/one.epub" } } }
+            ReadCollection.coll_settings = { fiction = { order = 7 } }
 
             local wireless = new_wireless()
+            wireless:updateCollections{ remove_collections = {"fiction"}, remove = { fiction = { "books/one.epub" } } }
 
-            wireless:updateCollections{
-                remove_collections = {"fiction"},
-                remove = {
-                    fiction = {
-                        "books/one.epub",
-                    },
-                },
-            }
-
-            assert.is_nil(
-                ReadCollection.coll.fiction
-            )
-            assert.is_nil(
-                ReadCollection.coll_settings.fiction
-            )
-
-            assert.is_true(
-                ReadCollection.written.fiction
-            )
+            assert.is_nil(ReadCollection.coll.fiction)
+            assert.is_nil(ReadCollection.coll_settings.fiction)
+            assert.is_true(ReadCollection.written.fiction)
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("does not write when requested memberships already match", function()
-            ReadCollection.coll = {
-                fiction = {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                },
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 7 },
-            }
-
+            ReadCollection.coll = { fiction = { [HOME .. "/books/one.epub"] = { file = HOME .. "/books/one.epub" } } }
+            ReadCollection.coll_settings = { fiction = { order = 7 } }
             local lfs = require("libs/libkoreader-lfs")
-            lfs.attributes_results[HOME .. "/books/one.epub"] = {
-                mode = "file",
-            }
+            lfs.attributes_results[HOME .. "/books/one.epub"] = { mode = "file" }
 
             local wireless = new_wireless()
+            wireless:updateCollections{ add = { fiction = { HOME .. "/books/one.epub" } } }
 
-            wireless:updateCollections{
-                add = {
-                    fiction = {
-                        HOME .. "/books/one.epub",
-                    },
-                },
-            }
-
-            assert.same(
-                {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                },
-                ReadCollection.coll.fiction
-            )
-
+            assert.same({ [HOME .. "/books/one.epub"] = {file = HOME .. "/books/one.epub"} }, ReadCollection.coll.fiction)
             assert.is_nil(ReadCollection.written)
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("adds book memberships", function()
-            ReadCollection.coll = {
-                fiction = {},
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 7 },
-            }
-
+            ReadCollection.coll = { fiction = {} }
+            ReadCollection.coll_settings = { fiction = { order = 7 } }
             local lfs = require("libs/libkoreader-lfs")
-            lfs.attributes_results[HOME .. "/books/one.epub"] = {
-                mode = "file",
-            }
+            lfs.attributes_results[HOME .. "/books/one.epub"] = { mode = "file" }
 
             local wireless = new_wireless()
-
             wireless:updateCollections{
                 add = {
                     fiction = {
@@ -364,142 +216,62 @@ describe("CalibreWireless collections", function()
                 },
             }
 
-            local item = ReadCollection.coll.fiction[
-                HOME .. "/books/one.epub"
-            ]
+            local item = ReadCollection.coll.fiction[HOME .. "/books/one.epub"]
 
             assert.is_not_nil(item)
-            assert.equals(
-                HOME .. "/books/one.epub",
-                item.file
-            )
-
+            assert.equals(HOME .. "/books/one.epub", item.file)
             assert.is_true(ReadCollection.written.fiction)
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("removes book memberships", function()
-            ReadCollection.coll = {
-                fiction = {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                },
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 7 },
-            }
+            ReadCollection.coll = { fiction = { [HOME .. "/books/one.epub"] = { file = HOME .. "/books/one.epub" } } }
+            ReadCollection.coll_settings = { fiction = { order = 7 } }
 
             local wireless = new_wireless()
+            wireless:updateCollections{ remove = { fiction = { HOME .. "/books/one.epub" } } }
 
-            wireless:updateCollections{
-                remove = {
-                    fiction = {
-                        HOME .. "/books/one.epub",
-                    },
-                },
-            }
-
-            assert.is_nil(
-                ReadCollection.coll.fiction[
-                    HOME .. "/books/one.epub"
-                ]
-            )
-
+            assert.is_nil(ReadCollection.coll.fiction[HOME .. "/books/one.epub"])
             assert.is_true(ReadCollection.written.fiction)
             assert.equals("OK", wireless.responses[1].status)
         end)
 
         it("preserves collection metadata when changing memberships", function()
-            ReadCollection.coll = {
-                fiction = {},
-            }
-            ReadCollection.coll_settings = {
-                fiction = {
-                    order = 42,
-                    collate = true,
-                    custom = "preserve me",
-                },
-            }
+            ReadCollection.coll = { fiction = {} }
+            ReadCollection.coll_settings = { fiction = { order = 42, collate = true, custom = "preserve me" } }
 
             local wireless = new_wireless()
-
             local lfs = require("libs/libkoreader-lfs")
-            lfs.attributes_results[HOME .. "/books/one.epub"] = {
-                mode = "file",
-            }
+            lfs.attributes_results[HOME .. "/books/one.epub"] = { mode = "file" }
+            wireless:updateCollections{ add = { fiction = { HOME .. "/books/one.epub" } } }
 
-            wireless:updateCollections{
-                add = {
-                    fiction = {
-                        HOME .. "/books/one.epub",
-                    },
-                },
-            }
-
-            assert.same(
-                {
-                    order = 42,
-                    collate = true,
-                    custom = "preserve me",
-                },
-                ReadCollection.coll_settings.fiction
-            )
+            assert.same({ order = 42, collate = true, custom = "preserve me" }, ReadCollection.coll_settings.fiction)
         end)
 
         it("does not modify unrelated collections", function()
             ReadCollection.coll = {
                 fiction = {},
-                history = {
-                    [HOME .. "/books/history.epub"] = {
-                        file = HOME .. "/books/history.epub",
-                    },
-                },
+                history = { [HOME .. "/books/history.epub"] = { file = HOME .. "/books/history.epub" } },
             }
-            ReadCollection.coll_settings = {
-                fiction = { order = 1 },
-                history = { order = 2 },
-            }
+            ReadCollection.coll_settings = { fiction = { order = 1 }, history = { order = 2 } }
 
             local wireless = new_wireless()
-
-            wireless:updateCollections{
-                add_collections = {"new"},
-            }
+            wireless:updateCollections{ add_collections = {"new"} }
 
             assert.is_not_nil(ReadCollection.coll.history)
-            assert.is_not_nil(
-                ReadCollection.coll.history[
-                    HOME .. "/books/history.epub"
-                ]
-            )
-            assert.same(
-                { order = 2 },
-                ReadCollection.coll_settings.history
-            )
-
+            assert.is_not_nil(ReadCollection.coll.history[HOME .. "/books/history.epub"])
+            assert.same({ order = 2 }, ReadCollection.coll_settings.history)
             assert.is_not_nil(ReadCollection.coll.fiction)
             assert.is_not_nil(ReadCollection.coll["new"])
         end)
 
         it("ignores invalid or nonexistent files", function()
-            ReadCollection.coll = {
-                fiction = {},
-            }
-            ReadCollection.coll_settings = {
-                fiction = { order = 1 },
-            }
+            ReadCollection.coll = { fiction = {} }
+            ReadCollection.coll_settings = { fiction = { order = 1 } }
 
             local wireless = new_wireless()
-
             wireless:updateCollections{
-                add = {
-                    fiction = {
-                        HOME .. "/books/missing.epub",
-                        HOME .. "/outside.epub",
-                        "/absolute/path.epub",
-                    },
-                },
+                add = { fiction = { HOME .. "/books/missing.epub", HOME .. "/outside.epub", "/absolute/path.epub" } },
             }
 
             assert.same({}, ReadCollection.coll.fiction)
@@ -509,7 +281,6 @@ describe("CalibreWireless collections", function()
 
         it("does not fail on an invalid payload", function()
             local wireless = new_wireless()
-
             wireless:updateCollections(nil)
 
             assert.equals(0, #wireless.responses)

--- a/spec/unit/calibre_wireless_spec.lua
+++ b/spec/unit/calibre_wireless_spec.lua
@@ -2,7 +2,6 @@ describe("CalibreWireless collections", function()
     local CalibreWireless
     local ReadCollection
     local original_readcollection
-    local original_filemanagerutil
     local original_lfs
     local original_package_path
     local original_extensions
@@ -21,7 +20,6 @@ describe("CalibreWireless collections", function()
         original_search = package.loaded["search"]
 
         original_readcollection = require("readcollection")
-        original_filemanagerutil = require("apps/filemanager/filemanagerutil")
         original_lfs = require("libs/libkoreader-lfs")
     end)
 
@@ -52,6 +50,13 @@ describe("CalibreWireless collections", function()
             }
         end
 
+        function readcollection_mock:isFileInCollection(file, collection_name)
+            return self.coll[collection_name]
+                and self.coll[collection_name][file]
+                and true
+                or false
+        end
+
         function readcollection_mock:removeItem(file, collection_name)
             if self.coll[collection_name]
                 and self.coll[collection_name][file]
@@ -63,12 +68,6 @@ describe("CalibreWireless collections", function()
 
         function readcollection_mock:write(updated_collections)
             self.written = updated_collections
-        end
-
-        local filemanagerutil_mock = {}
-
-        function filemanagerutil_mock.getHomeFolder()
-            return HOME
         end
 
         local lfs_mock = {
@@ -92,10 +91,6 @@ describe("CalibreWireless collections", function()
         package.replace(
             "readcollection",
             readcollection_mock
-        )
-        package.replace(
-            "apps/filemanager/filemanagerutil",
-            filemanagerutil_mock
         )
         package.replace(
             "libs/libkoreader-lfs",
@@ -125,14 +120,9 @@ describe("CalibreWireless collections", function()
             original_readcollection
         )
         package.replace(
-            "apps/filemanager/filemanagerutil",
-            original_filemanagerutil
-        )
-        package.replace(
             "libs/libkoreader-lfs",
             original_lfs
         )
-
     end)
 
     local function new_wireless()
@@ -177,32 +167,10 @@ describe("CalibreWireless collections", function()
 
             assert.is_table(collections.fiction)
             assert.equals(1, #collections.fiction)
-            assert.equals("books/one.epub", collections.fiction[1])
+            assert.equals(HOME .. "/books/one.epub", collections.fiction[1])
 
             assert.is_table(collections.empty)
             assert.equals(0, #collections.empty)
-        end)
-
-        it("ignores collection files outside the KOReader home", function()
-            ReadCollection.coll = {
-                mixed = {
-                    [HOME .. "/books/one.epub"] = {
-                        file = HOME .. "/books/one.epub",
-                    },
-                    ["/outside/book.epub"] = {
-                        file = "/outside/book.epub",
-                    },
-                },
-            }
-
-            local wireless = new_wireless()
-
-            wireless:getCollections()
-
-            local files = wireless.responses[1].data.collections.mixed
-
-            assert.equals(1, #files)
-            assert.equals("books/one.epub", files[1])
         end)
     end)
 
@@ -274,7 +242,7 @@ describe("CalibreWireless collections", function()
                 add_collections = {"fiction"},
                 add = {
                     fiction = {
-                        "books/one.epub",
+                        HOME .. "/books/one.epub",
                     },
                 },
             }
@@ -355,7 +323,7 @@ describe("CalibreWireless collections", function()
             wireless:updateCollections{
                 add = {
                     fiction = {
-                        "books/one.epub",
+                        HOME .. "/books/one.epub",
                     },
                 },
             }
@@ -391,7 +359,7 @@ describe("CalibreWireless collections", function()
             wireless:updateCollections{
                 add = {
                     fiction = {
-                        "books/one.epub",
+                        HOME .. "/books/one.epub",
                     },
                 },
             }
@@ -427,7 +395,7 @@ describe("CalibreWireless collections", function()
             wireless:updateCollections{
                 remove = {
                     fiction = {
-                        "books/one.epub",
+                        HOME .. "/books/one.epub",
                     },
                 },
             }
@@ -464,7 +432,7 @@ describe("CalibreWireless collections", function()
             wireless:updateCollections{
                 add = {
                     fiction = {
-                        "books/one.epub",
+                        HOME .. "/books/one.epub",
                     },
                 },
             }
@@ -527,8 +495,8 @@ describe("CalibreWireless collections", function()
             wireless:updateCollections{
                 add = {
                     fiction = {
-                        "books/missing.epub",
-                        "../outside.epub",
+                        HOME .. "/books/missing.epub",
+                        HOME .. "/outside.epub",
                         "/absolute/path.epub",
                     },
                 },


### PR DESCRIPTION
## Summary

Add Calibre collection synchronization support to KOReader's Calibre wireless plugin.

This adds two protocol operations:

- `GET_COLLECTIONS` (opcode 21)
- `UPDATE_COLLECTIONS` (opcode 22)

`ReadCollection` is used as the source of truth for the current KOReader collection state.

## GET_COLLECTIONS

- Returns all KOReader collections, including empty collections.
- Returns the full paths of books in each collection.

## UPDATE_COLLECTIONS

- Creates collections requested by Calibre, including empty collections.
- Removes collections no longer present in Calibre.
- Adds and removes individual book memberships.
- Preserves existing collection metadata.
- Only adds memberships for existing book files.
- Does not modify unrelated collections.

## Tests

Adds unit tests covering collection retrieval and updates, including:

- empty collections
- collection creation and removal
- membership additions and removals
- metadata preservation
- unrelated collections
- invalid and nonexistent files
- invalid update payloads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader/16039)
<!-- Reviewable:end -->
